### PR TITLE
Enable packtracker for third party PRs

### DIFF
--- a/.github/workflows/packtracker.yml
+++ b/.github/workflows/packtracker.yml
@@ -32,7 +32,6 @@ jobs:
           SBT_OPTS: "-Xmx4096M -Xss2M -XX:ReservedCodeCacheSize=256M -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
           PT_COMMIT: ${{ github.event.pull_request.head.sha }}
           PT_PRIOR_COMMIT: ${{ github.event.pull_request.base.sha }}
-          PACKTRACKER_TOKEN: ${{ secrets.PACKTRACKER_TOKEN }}
       - name: Export assets to packtracker merged
         if: github.event_name == 'push'
         run: |
@@ -42,4 +41,3 @@ jobs:
         env:
           SBT_OPTS: "-Xmx4096M -Xss2M -XX:ReservedCodeCacheSize=256M -XX:+TieredCompilation -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
           PT_COMMIT: ${{ github.sha }}
-          PACKTRACKER_TOKEN: ${{ secrets.PACKTRACKER_TOKEN }}

--- a/common/src/main/webpack/packtracker.webpack.config.js
+++ b/common/src/main/webpack/packtracker.webpack.config.js
@@ -5,7 +5,7 @@ const PacktrackerPlugin = require("@packtracker/webpack-plugin");
 const PackTracker = Merge(Web, {
   plugins: [
     new PacktrackerPlugin({
-      project_token: process.env.PACKTRACKER_TOKEN,
+      project_token: '6804e495-5d60-40d7-a2cc-25875362aadc',
       upload: true,
       fail_build: true,
       branch: process.env.GITHUB_REF.split("/")[2],


### PR DESCRIPTION
packtracker fails with scala-steward as it needs the token which is a GH secret. This PR hardcodes the token. while it could be considered risky in practice the token is of little value