### PR TITLE
Remove bundler intermediate files after stage.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,16 @@ addCommandAlias(
 )
 
 // For Heroku deployment
-addCommandAlias(
-  "stage",
-  "explore/fullOptJS::webpack"
-)
+val stage = taskKey[Unit]("Stage and clean task")
+
+stage := {
+  (explore / Compile / fullOptJS / webpack).value
+  if (sys.env.getOrElse("POST_STAGE_CLEAN", "false").equals("true")) {
+    println("Cleaning up...")
+    val bundlerDir = (explore / Compile / fullOptJS / artifactPath).value.getParentFile.getParentFile
+    sbt.IO.delete(bundlerDir)
+  }
+}
 
 lazy val root =
   project

--- a/common/src/main/webpack/prod.webpack.config.js
+++ b/common/src/main/webpack/prod.webpack.config.js
@@ -36,6 +36,7 @@ const Web = Merge(
       explore: [path.resolve(parts.localResourcesDir, "./prod.js")]
     },
     output: {
+      path: parts.stageDir,
       filename: ci ? "[name].js" : "[name].[chunkhash].js",
       publicPath: "/" // Required to make url navigation work
     },

--- a/common/src/main/webpack/webpack.parts.js
+++ b/common/src/main/webpack/webpack.parts.js
@@ -13,6 +13,7 @@ const cssnano = require("cssnano");
 const rootDir = path.resolve(__dirname, "../../../../");
 module.exports.rootDir = rootDir;
 module.exports.moduleName = path.basename(rootDir);
+module.exports.stageDir = path.resolve(__dirname, "../../stage/");
 
 // Resources dir on sbt
 const resourcesDir = path.resolve(rootDir, "../common/src/main/resources");

--- a/static.json
+++ b/static.json
@@ -1,5 +1,5 @@
 {
-    "root": "explore/target/scala-2.13/scalajs-bundler/main/",
+    "root": "explore/target/scala-2.13/stage/",
     "clean_urls": false,
     "routes": {
       "/**": "index.html"


### PR DESCRIPTION
`sbt-scalajs-bundler`'s directory, which includes `node_modules` used for building, are taking more than 200MB of the maximum 500MB slug size allowed in Heroku.

These changes clean this up between building and deployment so that it's not rejected by Heroku.