### PR TITLE
Upgrade to crystal 0.1.4.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val commonLibSettings = gspScalaJsSettings ++ Seq(
     "io.github.cquiroz.react" %%% "react-semantic-ui" % "0.4.10",
     "com.github.julien-truffaut" %%% "monocle-core" % "2.0.4",
     "com.github.julien-truffaut" %%% "monocle-macro" % "2.0.4",
-    "com.rpiaggio" %%% "crystal" % "0.1.3",
+    "com.rpiaggio" %%% "crystal" % "0.1.4",
     "com.rpiaggio" %%% "clue-scalajs" % "0.0.6",
     "io.circe" %%% "circe-generic-extras" % "0.13.0",
     "io.suzaku" %%% "diode-data" % "1.1.7",

--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -26,7 +26,7 @@ import japgolly.scalajs.react.vdom.VdomElement
 trait AppMain extends IOApp {
 
   def rootComponent(
-    WithModelCtx: AppRoot.Component[IO, AppContextIO, RootModel]
+    viewCtx: ViewCtxIO[RootModel]
   ): VdomElement
 
   @JSExport
@@ -42,7 +42,7 @@ trait AppMain extends IOApp {
     val initialModel = RootModel(target = Target.M81.some)
 
     AppContext.from[IO](AppConfig()).map { implicit ctx =>
-      val WithModelCtx = AppRoot.component[IO](initialModel, ctx)(ctx.cleanup.some)
+      val RootComponent = AppRoot[IO](initialModel, ctx)(rootComponent, ctx.cleanup.some)
 
       val container = Option(dom.document.getElementById("root")).getOrElse {
         val elem = dom.document.createElement("div")
@@ -51,7 +51,7 @@ trait AppMain extends IOApp {
         elem
       }
 
-      rootComponent(WithModelCtx).renderIntoDOM(container)
+      RootComponent().renderIntoDOM(container)
 
       ExitCode.Success
     }

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
@@ -86,12 +86,12 @@ object SubscriptionRender {
                 .some
             )
           )
-        }.toCB
+        }.runInCB
       }
       .componentWillUnmount { $ =>
         implicit val ce = $.props.ce
 
-        $.state.subscription.map(_.stop).orEmpty.toCB
+        $.state.subscription.map(_.stop).orEmpty.runInCB
       }
       .configure(Reusability.shouldComponentUpdate)
       .build

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -97,12 +97,12 @@ object SubscriptionRenderMod {
                 .some
             )
           )
-        }.toCB
+        }.runInCB
       }
       .componentWillUnmount { $ =>
         implicit val ce = $.props.ce
 
-        $.state.subscription.map(_.stop).orEmpty.toCB
+        $.state.subscription.map(_.stop).orEmpty.runInCB
       }
       .configure(Reusability.shouldComponentUpdate)
       .build

--- a/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
+++ b/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
@@ -222,7 +222,7 @@ object ConditionsPanel {
           Undoer[Conditions] { undoCtx =>
             val modifyIO = Modify($.props.observationId, conditions, view.mod, undoCtx.set)
             def modify[A](lens: Lens[Conditions, A], fields: A => Mutation.Fields)
-              : A => Callback = { v: A => modifyIO(lens, fields)(v).toCB }
+              : A => Callback = { v: A => modifyIO(lens, fields)(v).runInCB }
 
             <.div(
               Form(
@@ -251,8 +251,12 @@ object ConditionsPanel {
                                             modify(Conditions.sb, sbFields))
                 )
               ),
-              Button(onClick = undoCtx.undo(conditions).toCB, disabled = undoCtx.undoEmpty)("Undo"),
-              Button(onClick = undoCtx.redo(conditions).toCB, disabled = undoCtx.redoEmpty)("Redo")
+              Button(onClick = undoCtx.undo(conditions).runInCB, disabled = undoCtx.undoEmpty)(
+                "Undo"
+              ),
+              Button(onClick = undoCtx.redo(conditions).runInCB, disabled = undoCtx.redoEmpty)(
+                "Redo"
+              )
             )
           }
         }

--- a/conditions/src/main/scala/explore/conditions/Test.scala
+++ b/conditions/src/main/scala/explore/conditions/Test.scala
@@ -3,29 +3,25 @@
 
 package explore.conditions
 
-import cats.effect.IO
 import scala.scalajs.js
 import js.annotation._
 import gem.Observation
 import gem.ProgramId
 import gsp.math.Index
-import crystal.react.AppRoot
 import explore.model.RootModel
 import explore.AppMain
 import japgolly.scalajs.react.vdom.VdomElement
+import explore._
 
 @JSExportTopLevel("Test")
 object Test extends AppMain {
 
-  override def rootComponent(
-    WithModelCtx: AppRoot.Component[IO, explore.AppContextIO, RootModel]
-  ): VdomElement =
-    WithModelCtx { viewCtx =>
-      implicit val ctx = viewCtx.ctx
+  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement = {
+    implicit val ctx = viewCtx.ctx
 
-      ConditionsPanel(
-        Observation.Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
-      )
-    }
+    ConditionsPanel(
+      Observation.Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
+    )
+  }
 
 }

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -3,12 +3,10 @@
 
 package explore
 
-import cats.effect.IO
 import scala.scalajs.js
 import js.annotation._
 import japgolly.scalajs.react.extra.router._
 import explore.model.RootModel
-import crystal.react.AppRoot
 import japgolly.scalajs.react.vdom.VdomElement
 import explore.Routing
 import japgolly.scalajs.react.vdom.html_<^._
@@ -17,22 +15,19 @@ import gem.Observation
 @JSExportTopLevel("Explore")
 object ExploreMain extends AppMain {
 
-  override def rootComponent(
-    WithModelCtx: AppRoot.Component[IO, explore.AppContextIO, RootModel]
-  ): VdomElement =
-    WithModelCtx { viewCtx =>
-      val routing = new Routing(viewCtx) // !!! This creates a new router on each render.
+  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement = {
+    val routing = new Routing(viewCtx) // !!! This creates a new router on each render.
 
-      // val router = Router(BaseUrl.fromWindowOrigin, routing.config)
-      val (router, routerCtl) = Router.componentAndCtl(BaseUrl.fromWindowOrigin, routing.config)
+    // val router = Router(BaseUrl.fromWindowOrigin, routing.config)
+    val (router, routerCtl) = Router.componentAndCtl(BaseUrl.fromWindowOrigin, routing.config)
 
-      <.div(
-        <.button(
-          ^.tpe := "button",
-          routerCtl.setOnClick(ObsPage(Observation.Id.unsafeFromString("GS2020A-Q-1")))
-        )("SET OBS"),
-        router()
-      )
-    }
+    <.div(
+      <.button(
+        ^.tpe := "button",
+        routerCtl.setOnClick(ObsPage(Observation.Id.unsafeFromString("GS2020A-Q-1")))
+      )("SET OBS"),
+      router()
+    )
+  }
 
 }

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -41,7 +41,7 @@ class Routing(viewCtx: ViewCtxIO[RootModel]) {
       .verify(HomePage, ObsPage(Observation.Id.unsafeFromString("GS2020A-Q-1")))
       .onPostRender {
         case (_, ObsPage(id)) =>
-          viewCtx.view.zoomL(RootModel.id).set(Option(id)).toCB *>
+          viewCtx.view.zoomL(RootModel.id).set(Option(id)).runInCB *>
             Callback.log(s"id:1 $id")
         case _ => Callback.empty
       }

--- a/explore/src/main/scala/explore/Tpe.scala
+++ b/explore/src/main/scala/explore/Tpe.scala
@@ -37,7 +37,7 @@ object Tpe {
       .render_P { props =>
         def renderButton(forTarget: Target, selected: Option[Target]) = {
           val color = selected.filter(_ == forTarget).map(_ => Blue).orUndefined
-          Button(onClick = props.target.view.set(forTarget.some).toCB, color = color)(
+          Button(onClick = props.target.view.set(forTarget.some).runInCB, color = color)(
             forTarget.toString
           )
         }

--- a/explore/src/main/scala/explore/polls/Polls.scala
+++ b/explore/src/main/scala/explore/polls/Polls.scala
@@ -63,7 +63,7 @@ object Polls {
                         disabled = disabled,
                         onClick = castingOn(poll.id)
                           .flatMap(_ => props.polls.actions(_.polls).vote(option.id))
-                          .toCB
+                          .runInCB
                       )(option.text)
                     )
                   },
@@ -83,7 +83,7 @@ object Polls {
       .builder[Props]("Polls")
       .initialState(State())
       .renderBackend[Backend]
-      .componentWillMount($ => $.props.polls.actions(_.polls).refresh.toCB)
+      .componentWillMount($ => $.props.polls.actions(_.polls).refresh.runInCB)
       .configure(Reusability.shouldComponentUpdate)
       .build
 }

--- a/explore/src/main/scala/explore/polls/PollsConnectionStatus.scala
+++ b/explore/src/main/scala/explore/polls/PollsConnectionStatus.scala
@@ -35,7 +35,7 @@ object PollsConnectionStatus {
           ),
           Button(
             negative = true,
-            onClick  = ctx.clients.polls.close().toCB
+            onClick  = ctx.clients.polls.close().runInCB
           )("Close Connection")
         )
       }

--- a/explore/src/main/scala/explore/starwars/EpisodeHero.scala
+++ b/explore/src/main/scala/explore/starwars/EpisodeHero.scala
@@ -60,7 +60,7 @@ object EpisodeHero {
     def onClickItem(
       implicit ctx: AppContextIO
     ): (ReactEvent, DropdownItem.DropdownItemProps) => Callback =
-      (_, p) => query(Episode.fromString(p.value.asInstanceOf[String])).toCB
+      (_, p) => query(Episode.fromString(p.value.asInstanceOf[String])).runInCB
 
     def render(props: Props, state: State) =
       <.div(

--- a/explore/src/main/scala/explore/todo/ToDos.scala
+++ b/explore/src/main/scala/explore/todo/ToDos.scala
@@ -48,7 +48,7 @@ object ToDos {
     .builder[Props]("ToDos")
     .initialState(State())
     .renderBackend[Backend]
-    .componentDidMount($ => onMount($.props).toCB)
+    .componentDidMount($ => onMount($.props).runInCB)
     .configure(Reusability.shouldComponentUpdate)
     .build
 }

--- a/explore/src/main/scala/explore/todo/TodoList.scala
+++ b/explore/src/main/scala/explore/todo/TodoList.scala
@@ -25,7 +25,7 @@ object TodoList {
     .render_P { p =>
       def renderItem(item: Task) =
         <.li(
-          <.input.checkbox(^.checked := item.completed, ^.onChange --> p.toggle(item.id).toCB),
+          <.input.checkbox(^.checked := item.completed, ^.onChange --> p.toggle(item.id).runInCB),
           <.span(" "),
           if (item.completed) <.s(item.title) else <.span(item.title)
         )


### PR DESCRIPTION
New crystal version has simplified `AppRoot` and more precise effect conversion methods (eg: `startInCB` instead of `toCB`.