### PR TITLE
Abstract Undoer logic from component so we can test it.

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,7 +28,7 @@
       ],
       "scripts" : {
         "test-setup": "npm install jsdom",
-        "test": "sbt scalafmtCheckAll headerCheck test:headerCheck test"
+        "test": "sbt scalafmtCheckAll headerCheck test:headerCheck compile test"
       }
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -106,16 +106,18 @@ lazy val commonLibSettings = gspScalaJsSettings ++ Seq(
     "io.github.cquiroz.react" %%% "react-semantic-ui" % "0.4.11",
     "com.github.julien-truffaut" %%% "monocle-core" % "2.0.4",
     "com.github.julien-truffaut" %%% "monocle-macro" % "2.0.4",
-    "com.rpiaggio" %%% "crystal" % "0.1.4",
+    "com.rpiaggio" %%% "crystal" % "0.1.6",
     "com.rpiaggio" %%% "clue-scalajs" % "0.0.6",
     "io.circe" %%% "circe-generic-extras" % "0.13.0",
     "io.suzaku" %%% "diode-data" % "1.1.7",
-    "io.suzaku" %%% "diode-react" % "1.1.7.160"
+    "io.suzaku" %%% "diode-react" % "1.1.7.160",
+    "com.lihaoyi" %%% "utest" % "0.7.4" % Test
   ) ++ Seq(
     "io.circe" %%% "circe-core",
     "io.circe" %%% "circe-generic",
     "io.circe" %%% "circe-parser"
-  ).map(_ % circe)
+  ).map(_ % circe),
+  testFrameworks += new TestFramework("utest.runner.Framework")
 )
 
 lazy val commonWDS = Seq(

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -66,8 +66,8 @@ object SubscriptionRenderMod {
           $.state.renderer.whenDefined(
             _ { view =>
               <.div(
-                view.value.renderPending(_ => Icon(name = "spinner", loading = true, size = Large)),
-                view.value.render(_ =>
+                view.get.renderPending(_ => Icon(name = "spinner", loading = true, size = Large)),
+                view.get.render(_ =>
                   $.props.valueRender(
                     view.zoom(_.get)(f => _.map(f))
                   )

--- a/common/src/main/scala/explore/components/undo/UndoRegion.scala
+++ b/common/src/main/scala/explore/components/undo/UndoRegion.scala
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components.undo
+
+import react.common.ReactProps
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import cats.effect.IO
+import cats.implicits._
+import monocle.macros.Lenses
+import crystal.react.implicits._
+import cats.effect.Async
+import cats.kernel.Monoid
+
+final case class UndoRegion[M](
+  renderer: Undoer.Context[IO, M] => VdomElement
+) extends UndoRegion.Props[IO, M]
+    with ReactProps {
+  @inline override def render: VdomElement =
+    UndoRegion.component(this.asInstanceOf[UndoRegion.Props[IO, Any]])
+}
+
+object UndoRegion {
+  protected trait Props[F[_], M] {
+    val renderer: Undoer.Context[F, M] => VdomElement
+  }
+
+  @Lenses
+  protected final case class State[F[_], M](
+    undoStack: Undoer.Stack[F, M] = List.empty,
+    redoStack: Undoer.Stack[F, M] = List.empty
+  )
+
+  implicit protected def propsReuse[F[_], M]: Reusability[Props[F, M]] =
+    Reusability.always
+  implicit protected def stateReuse[F[_], M]: Reusability[State[F, M]] =
+    Reusability.never
+
+  protected class Backend[F[_]: Async, M]($ : BackendScope[Props[F, M], State[F, M]])(
+    implicit monoid:                         Monoid[F[Unit]]
+  ) extends Undoer[F, M] {
+    type Stacks = State[F, M]
+
+    override lazy val getStacks: F[Stacks] = $.stateIn[F]
+
+    override def modStacks(mod: Stacks => Stacks): F[Unit] = $.modStateIn[F](mod)
+
+    override lazy val undoStack = State.undoStack
+
+    override lazy val redoStack = State.redoStack
+
+    def render(props: Props[F, M], state: State[F, M]): VdomElement =
+      // println(s"UNDO STACK: [${state.undoStack}]")
+      // println(s"REDO STACK: [${state.redoStack}]")
+      props.renderer(context(state))
+  }
+
+  protected def componentBuilder[M] =
+    ScalaComponent
+      .builder[Props[IO, M]]("Undoer")
+      .initialState(State[IO, M]())
+      .renderBackend[Backend[IO, M]]
+      .configure(Reusability.shouldComponentUpdate)
+      .build
+
+  protected val component = componentBuilder[Any]
+}

--- a/common/src/main/webpack/dev.webpack.config.js
+++ b/common/src/main/webpack/dev.webpack.config.js
@@ -9,6 +9,7 @@ const isDevServer = process.argv.some(s => s.match(/webpack-dev-server\.js$/));
 
 const Web = Merge(
   ScalaJSConfig,
+  // parts.noNode, // We will have to use this in Scala 1.x, but doesn't work with 0.6
   parts.resolve,
   parts.resolveSemanticUI,
   parts.resourceModules,

--- a/common/src/main/webpack/prod.webpack.config.js
+++ b/common/src/main/webpack/prod.webpack.config.js
@@ -11,6 +11,7 @@ const ci = process.env.CI; // When on CI don't add hashes
 
 const Web = Merge(
   ScalaJSConfig,
+  // parts.noNode, // We will have to use this in Scala 1.x, but doesn't work with 0.6
   parts.resolve,
   parts.resolveSemanticUI,
   parts.resourceModules,

--- a/common/src/main/webpack/webpack.parts.js
+++ b/common/src/main/webpack/webpack.parts.js
@@ -200,3 +200,7 @@ exports.extraAssets = {
     ]
   }
 };
+
+exports.noNode = {
+  node: false
+}

--- a/common/src/test/scala/explore/undo/TestUndoable.scala
+++ b/common/src/test/scala/explore/undo/TestUndoable.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.undo
+
+import explore.components.undo.Undoer
+import cats.effect.Sync
+import cats.Monoid
+import cats.FlatMap
+import cats.implicits._
+import monocle.macros.Lenses
+import monocle.Getter
+import cats.effect.concurrent.Ref
+
+@Lenses
+case class TestStacks[F[_], A](
+  undoStack: Undoer.Stack[F, A] = List.empty,
+  redoStack: Undoer.Stack[F, A] = List.empty
+)
+
+class TestUndoer[F[_]: Sync, M](stacks: Ref[F, TestStacks[F, M]])(
+  implicit monoid:                      Monoid[F[Unit]]
+) extends Undoer[F, M] {
+  type Stacks = TestStacks[F, M]
+
+  override lazy val getStacks: F[Stacks] = stacks.get
+
+  override def modStacks(mod: Stacks => Stacks): F[Unit] = stacks.modify(s => (mod(s), ()))
+
+  override lazy val undoStack: StackLens = TestStacks.undoStack
+
+  override lazy val redoStack: StackLens = TestStacks.redoStack
+
+  def ctx: F[Undoer.Context[F, M]] =
+    stacks.get.map(context)
+}
+
+object TestUndoer {
+  def apply[F[_]: Sync, M](implicit monoid: Monoid[F[Unit]]): F[TestUndoer[F, M]] =
+    for {
+      stacks <- Ref[F].of(TestStacks[F, M]())
+    } yield {
+      new TestUndoer(stacks)
+    }
+}
+
+class TestUndoable[F[_]: FlatMap, M](model: Ref[F, M], undoer: TestUndoer[F, M]) {
+
+  def set[A](getter: Getter[M, A], setter: A => F[Unit], value: A): F[Unit] =
+    for {
+      m <- model.get
+      c <- undoer.ctx
+      _ <- c.set[A](m, getter, setter)(value)
+    } yield ()
+
+  def get: F[M] = model.get
+
+  def undo: F[Unit] =
+    for {
+      m <- model.get
+      c <- undoer.ctx
+      _ <- c.undo(m)
+    } yield ()
+
+  def redo: F[Unit] =
+    for {
+      m <- model.get
+      c <- undoer.ctx
+      _ <- c.redo(m)
+    } yield ()
+}
+
+object TestUndoable {
+  def apply[F[_]: Sync, M](
+    model:           Ref[F, M]
+  )(implicit monoid: Monoid[F[Unit]]): F[TestUndoable[F, M]] =
+    for {
+      undoer <- TestUndoer[F, M]
+    } yield {
+      new TestUndoable(model, undoer)
+    }
+}

--- a/common/src/test/scala/explore/undo/UndoerSpec.scala
+++ b/common/src/test/scala/explore/undo/UndoerSpec.scala
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.undo
+
+import utest._
+
+import cats.effect.IO
+import cats.implicits._
+import cats.effect.concurrent.Ref
+import monocle.Iso
+import scala.concurrent._
+import ExecutionContext.Implicits.global
+
+object UndoerSpec extends TestSuite {
+
+  def id[A] = Iso.id[A].asLens.asGetter
+
+  val tests = Tests {
+    test("Undo") {
+      val io =
+        for {
+          model    <- Ref[IO].of(0)
+          undoable <- TestUndoable(model)
+          _        <- undoable.set(id[Int], model.set, 1)
+          _        <- undoable.set(id[Int], model.set, 2)
+          _        <- undoable.undo
+          v        <- undoable.get
+        } yield (v)
+      io.unsafeToFuture().map(result => assert(result == 1))
+    }
+    test("Redo") {
+      val io =
+        for {
+          model    <- Ref[IO].of(0)
+          undoable <- TestUndoable(model)
+          _        <- undoable.set(id[Int], model.set, 1)
+          _        <- undoable.set(id[Int], model.set, 2)
+          _        <- undoable.set(id[Int], model.set, 3)
+          _        <- undoable.undo
+          _        <- undoable.undo
+          _        <- undoable.redo
+          v        <- undoable.get
+        } yield (v)
+      io.unsafeToFuture().map(result => assert(result == 2))
+    }
+  }
+}

--- a/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
+++ b/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
@@ -33,8 +33,9 @@ import crystal.react.ModState
 import cats.effect.IO
 import monocle.Lens
 import react.semanticui.elements.button.Button
-import explore.components.undo.Undoer
+import explore.components.undo.UndoRegion
 import gpp.ui.forms.EnumSelect
+import explore.components.undo.Undoer
 
 /*
 query {
@@ -217,9 +218,9 @@ object ConditionsPanel {
             ),
           _.map(Subscription.Data.conditions.composeOptional(headOption).getOption _).unNone
         ) { view =>
-          val conditions = view.value
+          val conditions = view.get
 
-          Undoer[Conditions] { undoCtx =>
+          UndoRegion[Conditions] { undoCtx =>
             val modifyIO = Modify($.props.observationId, conditions, view.mod, undoCtx.set)
             def modify[A](lens: Lens[Conditions, A], fields: A => Mutation.Fields)
               : A => Callback = { v: A => modifyIO(lens, fields)(v).runInCB }

--- a/explore/src/main/scala/explore/Tpe.scala
+++ b/explore/src/main/scala/explore/Tpe.scala
@@ -51,7 +51,7 @@ object Tpe {
           ),
           <.div(
             List(Target.M81, Target.M51).toTagMod(target =>
-              renderButton(target, props.target.view.value)
+              renderButton(target, props.target.view.get)
             )
           )
         )

--- a/explore/src/main/scala/explore/Tpe.scala
+++ b/explore/src/main/scala/explore/Tpe.scala
@@ -37,7 +37,7 @@ object Tpe {
       .render_P { props =>
         def renderButton(forTarget: Target, selected: Option[Target]) = {
           val color = selected.filter(_ == forTarget).map(_ => Blue).orUndefined
-          Button(onClick = props.target.view.set(forTarget.some).runInCB, color = color)(
+          Button(onClick = props.target.set(forTarget.some).runInCB, color = color)(
             forTarget.toString
           )
         }


### PR DESCRIPTION
- Crystal update, which now supports Prisms and Optionals.
- The changes removing node shims are to better support cats-effect in Scala.js 1.x, but they don't work with 0.6 so I left them commented out.