### PR TITLE
Use router with pass-through props.

### DIFF
--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -47,7 +47,7 @@ trait AppMain extends IOApp {
 
     implicit val gqlStreamingBackend: StreamingBackend[IO] = WebSocketJSBackend[IO]
 
-    val initialModel = RootModel(target = ExploreSiderealTarget("M81", none).some)
+    val initialModel = RootModel()
 
     AppContext.from[IO](AppConfig()).map { implicit ctx =>
       val RootComponent = AppRoot[IO](initialModel, ctx)(rootComponent, ctx.cleanup.some)

--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -17,8 +17,8 @@ import sttp.model.Uri._
 
 @Lenses
 case class RootModel(
-  id:     Option[Observation.Id] = None,
-  target: Option[ExploreSiderealTarget] = None
+  obsId:  Option[Observation.Id] = None,
+  target: Option[SiderealTarget] = None
 )
 object RootModel {
   import explore.model.reusability._

--- a/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
+++ b/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
@@ -162,7 +162,7 @@ object ConditionsPanel {
   private def mutate(observationId: Observation.Id, fields: Mutation.Fields)(implicit
     ctx:                            AppContextIO
   ): IO[Unit] =
-    ctx.clients.conditions
+    ctx.clients.programs
       .query(Mutation)(Mutation.Variables(observationId.format, fields).some)
       .void
 
@@ -210,7 +210,7 @@ object ConditionsPanel {
       .render { $ =>
         $.props.observationId.withCtx { implicit appCtx =>
           SubscriptionRenderMod[Subscription.Data, Conditions](
-            appCtx.clients.conditions
+            appCtx.clients.programs
               .subscribe(Subscription)(
                 Subscription.Variables($.props.observationId.value.format).some
               ),

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -16,14 +16,11 @@ import js.annotation._
 @JSExportTopLevel("Explore")
 object ExploreMain extends AppMain {
 
-  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement = {
-    val routing = new Routing(viewCtx) // !!! This creates a new router on each render.
+  private val router = RouterWithProps(BaseUrl.fromWindowOrigin, Routing.config)
 
-    val (router, _) = Router.componentAndCtl(BaseUrl.fromWindowOrigin, routing.config)
-
+  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement =
     <.div(
-      router()
+      router(viewCtx)
     )
-  }
 
 }

--- a/explore/src/main/scala/explore/HomeComponent.scala
+++ b/explore/src/main/scala/explore/HomeComponent.scala
@@ -54,7 +54,7 @@ object HomeComponent {
         props.withCtx { implicit ctx =>
           val obsId = Observation
             .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
-            .inCtx(ctx)
+
           <.div(
             ^.cls := "rgl-area",
             SizeMe() { s =>
@@ -72,14 +72,14 @@ object HomeComponent {
                   ^.key := "conditions",
                   ^.cls := "tile",
                   Tile("Conditions")(
-                    ConditionsPanel(obsId)
+                    ConditionsPanel(obsId.inCtx(ctx))
                   )
                 ),
                 <.div(
                   ^.key := "target",
                   ^.cls := "tile",
                   Tile("Target Position")(
-                    TargetEditor(obsId)
+                    TargetEditor(obsId, props.zoomL(RootModel.target))
                   )
                 )
               )

--- a/explore/src/main/scala/explore/Layout.scala
+++ b/explore/src/main/scala/explore/Layout.scala
@@ -12,8 +12,9 @@ import react.semanticui.As
 import react.semanticui.collections.menu._
 import react.semanticui.modules.sidebar._
 
-final case class OTLayout(c: RouterCtl[Page], r: Resolution[Page])(val model: RootModel)
-    extends ReactProps {
+final case class OTLayout(c: RouterCtl[Page], r: ResolutionWithProps[Page, ViewCtxIO[RootModel]])(
+  val viewCtxIO:             ViewCtxIO[RootModel]
+) extends ReactProps {
 
   @inline def render: VdomElement = OTLayout.component(this)
 }
@@ -54,12 +55,14 @@ object OTLayout {
               direction = SidebarDirection.Left,
               visible = s.menu
             )(
-              MenuHeader()(p.model.id.map(_.format).getOrElse[String]("No Observation")),
+              MenuHeader()(
+                p.viewCtxIO.value.get.id.map(_.format).getOrElse[String]("No Observation")
+              ),
               MenuItem(as = "a", className = "sidetab")("Targets"),
               MenuItem(as = "a", className = "sidetab")("P II")
             ),
             SidebarPusher(dimmed = false)(
-              p.r.render()
+              p.r.renderP(p.viewCtxIO)
             )
           )
         )

--- a/explore/src/main/scala/explore/Layout.scala
+++ b/explore/src/main/scala/explore/Layout.scala
@@ -56,7 +56,14 @@ object OTLayout {
               visible = s.menu
             )(
               MenuHeader()(
-                p.viewCtxIO.value.get.id.map(_.format).getOrElse[String]("No Observation")
+                <.div(
+                  p.viewCtxIO.value.get.obsId.map(_.format).getOrElse[String]("No Observation")
+                ),
+                <.div(
+                  p.viewCtxIO.value.get.target
+                    .map(_.name)
+                    .getOrElse[String]("No Target")
+                )
               ),
               MenuItem(as = "a", className = "sidetab")("Targets"),
               MenuItem(as = "a", className = "sidetab")("P II")

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -42,10 +42,10 @@ object Routing {
         .notFound(redirectToPage(HomePage)(SetRouteVia.HistoryPush))
         .verify(HomePage, ObsPage(Observation.Id.unsafeFromString("GS2020A-Q-1")))
         .onPostRenderP {
-          case (_, ObsPage(id), viewCtx) =>
-            viewCtx.zoomL(RootModel.id).set(Option(id)).runInCB *>
-              Callback.log(s"id:1 $id")
-          case _                         => Callback.empty
+          case (_, ObsPage(obsId), viewCtx) =>
+            viewCtx.zoomL(RootModel.obsId).set(Option(obsId)).runInCB *>
+              Callback.log(s"id:1 $obsId")
+          case _                            => Callback.empty
         }
         .renderWithP(layout)
         .logToConsole
@@ -55,5 +55,5 @@ object Routing {
     c: RouterCtl[Page],
     r: ResolutionWithProps[Page, ViewCtxIO[RootModel]]
   ): ViewCtxIO[RootModel] => VdomElement =
-    viewCtx => OTLayout(c, r)(viewCtx)
+    OTLayout(c, r)
 }

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -10,6 +10,7 @@ import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.extra.router._
 import monocle.Prism
+import japgolly.scalajs.react.vdom.VdomElement
 
 sealed trait ElementItem  extends Product with Serializable
 case object IconsElement  extends ElementItem
@@ -19,7 +20,7 @@ sealed trait Page    extends Product with Serializable
 case object HomePage extends Page
 final case class ObsPage(obsId: Observation.Id) extends Page
 
-class Routing(viewCtx: ViewCtxIO[RootModel]) {
+object Routing {
 
   private val obsIdP: Prism[String, ObsPage] =
     Prism[String, ObsPage] {
@@ -29,26 +30,30 @@ class Routing(viewCtx: ViewCtxIO[RootModel]) {
         Observation.Id.fromString(s).map(ObsPage(_))
     }(p => p.obsId.format)
 
-  val config: RouterConfig[Page] = RouterConfigDsl[Page].buildConfig { dsl =>
-    import dsl._
+  val config: RouterWithPropsConfig[Page, ViewCtxIO[RootModel]] =
+    RouterWithPropsConfigDsl[Page, ViewCtxIO[RootModel]].buildConfig { dsl =>
+      import dsl._
 
-    (emptyRule
-      | staticRoute(root, HomePage) ~> render(HomeComponent(viewCtx))
-      | dynamicRouteCT(("/obs" / string("[a-zA-Z0-9-]+")).pmapL(obsIdP)) ~> render(
-        HomeComponent(viewCtx)
-      ))
-      .notFound(redirectToPage(HomePage)(SetRouteVia.HistoryPush))
-      .verify(HomePage, ObsPage(Observation.Id.unsafeFromString("GS2020A-Q-1")))
-      .onPostRender {
-        case (_, ObsPage(id)) =>
-          viewCtx.zoomL(RootModel.id).set(Option(id)).runInCB *>
-            Callback.log(s"id:1 $id")
-        case _                => Callback.empty
-      }
-      .renderWith(layout)
-      .logToConsole
-  }
+      (emptyRule
+        | staticRoute(root, HomePage) ~> renderP(viewCtx => HomeComponent(viewCtx))
+        | dynamicRouteCT(("/obs" / string("[a-zA-Z0-9-]+")).pmapL(obsIdP)) ~> renderP(viewCtx =>
+          HomeComponent(viewCtx)
+        ))
+        .notFound(redirectToPage(HomePage)(SetRouteVia.HistoryPush))
+        .verify(HomePage, ObsPage(Observation.Id.unsafeFromString("GS2020A-Q-1")))
+        .onPostRenderP {
+          case (_, ObsPage(id), viewCtx) =>
+            viewCtx.zoomL(RootModel.id).set(Option(id)).runInCB *>
+              Callback.log(s"id:1 $id")
+          case _                         => Callback.empty
+        }
+        .renderWithP(layout)
+        .logToConsole
+    }
 
-  private def layout(c: RouterCtl[Page], r: Resolution[Page]) =
-    OTLayout(c, r)(viewCtx.get)
+  private def layout(
+    c: RouterCtl[Page],
+    r: ResolutionWithProps[Page, ViewCtxIO[RootModel]]
+  ): ViewCtxIO[RootModel] => VdomElement =
+    viewCtx => OTLayout(c, r)(viewCtx)
 }

--- a/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
@@ -118,12 +118,7 @@ object CoordinatesForm {
         )("Undo"),
         FormButton(onClick = props.undoCtx.redo(props.target).runInCB,
                    disabled = props.undoCtx.redoEmpty
-        )("Redo"),
-        Button( // Form submit isn't triggered without this. Remove this when submit and buttons are working again in explore.
-          ^.tpe := "submit"
-        )(
-          "Submit"
-        )
+        )("Redo")
       )
     }
   }

--- a/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
@@ -68,7 +68,7 @@ object CoordinatesForm {
 
       Form(
         size = Mini,
-        onSubmit = Callback.log(state.toString) >> props
+        onSubmit = props
           .searchAndGo(searchEV.value)
           .when(state.searchTerm =!= props.target.name)
           .void

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -7,7 +7,7 @@ import cats.effect.IO
 import cats.implicits._
 import crystal.View
 import crystal.react.implicits._
-import explore._
+// import explore._
 import explore.components.ui.GPPStyles
 import explore.components.undo.UndoRegion
 import explore.implicits._
@@ -32,10 +32,10 @@ import react.semanticui.widths._
 import gsp.math.ProperMotion
 
 final case class TargetBody(
-  observationId:    Observation.Id,
-  target:           View[IO, SiderealTarget]
-)(implicit val ctx: AppContextIO)
-    extends ReactProps {
+  observationId: Observation.Id,
+  target:        View[IO, SiderealTarget],
+  globalTarget:  ViewCtxIO[Option[SiderealTarget]]
+) extends ReactProps {
   @inline override def render: VdomElement = TargetBody.component(this)
   val aladinCoords: Coordinates            = target.get.track.baseCoordinates
   val aladinCoordsStr: String              = Coordinates.fromHmsDms.reverseGet(aladinCoords)
@@ -64,84 +64,90 @@ object TargetBody extends ModelOptics {
     private def coordinatesKey(target: SiderealTarget): String =
       s"${target.name}#${target.track.baseCoordinates.show}"
 
-    def render(props: Props) = {
-      implicit val appCtx = props.ctx
+    def render(props: Props) =
+      props.globalTarget.withCtx { implicit appCtx =>
+        val target = props.target.get
 
-      val target = props.target.get
-      UndoRegion[SiderealTarget] { undoCtx =>
-        val modifyIO    =
-          Modify(props.observationId, target, props.target.mod, undoCtx.setter)
-        def modify[A](
-          lens:   Lens[SiderealTarget, A],
-          fields: A => Mutation.Fields
-        ): A => Callback = { v: A =>
-          modifyIO(lens.get, lens.set, fields)(v).runInCB
-        }
-        val gotoRaDec   = (coords: Coordinates) =>
-          ref.get
-            .flatMapCB(
-              _.backend
-                .gotoRaDec(coords.ra.toAngle.toDoubleDegrees, coords.dec.toAngle.toDoubleDegrees)
+        UndoRegion[SiderealTarget] { undoCtx =>
+          val modifyIO    =
+            Modify(props.observationId,
+                   target,
+                   props.target.mod,
+                   (props.globalTarget.set _).compose(_.some),
+                   undoCtx.setter
             )
-            .toCallback
-        val searchAndGo = (search: String) =>
-          ref.get
-            .flatMapCB(
-              _.backend
-                .gotoObject(
-                  search,
-                  (a, b) => {
-                    val ra  = RightAscension.fromHourAngle.get(
-                      HourAngle.angle.reverseGet(Angle.fromDoubleDegrees(a.toDouble))
-                    )
-                    val dec =
-                      Declination.fromAngle
-                        .getOption(Angle.fromDoubleDegrees(b.toDouble))
-                        .getOrElse(Declination.Zero)
-                    setRa(ra) *> setDec(dec) *> modify[
-                      (String, RightAscension, Declination)
-                    ](
-                      targetPropsL,
-                      {
-                        case (n, r, d) =>
-                          Mutation.Fields(
-                            name = n.some,
-                            ra = RightAscension.fromStringHMS.reverseGet(r).some,
-                            dec = Declination.fromStringSignedDMS.reverseGet(d).some
-                          )
-                      }
-                    )((search, ra, dec))
-                  },
-                  Callback.log("error")
-                )
-            )
-            .toCallback
 
-        <.div(
-          ^.height := "100%",
-          ^.width := "100%",
-          ^.cls := "check",
-          Grid(columns = Two, stretched = true, padded = GridPadded.Horizontally)(
+          def modify[A](
+            lens:   Lens[SiderealTarget, A],
+            fields: A => Mutation.Fields
+          ): A => Callback = { v: A =>
+            modifyIO(lens.get, lens.set, fields)(v).runInCB
+          }
+          val gotoRaDec   = (coords: Coordinates) =>
+            ref.get
+              .flatMapCB(
+                _.backend
+                  .gotoRaDec(coords.ra.toAngle.toDoubleDegrees, coords.dec.toAngle.toDoubleDegrees)
+              )
+              .toCallback
+          val searchAndGo = (search: String) =>
+            ref.get
+              .flatMapCB(
+                _.backend
+                  .gotoObject(
+                    search,
+                    (a, b) => {
+                      val ra  = RightAscension.fromHourAngle.get(
+                        HourAngle.angle.reverseGet(Angle.fromDoubleDegrees(a.toDouble))
+                      )
+                      val dec =
+                        Declination.fromAngle
+                          .getOption(Angle.fromDoubleDegrees(b.toDouble))
+                          .getOrElse(Declination.Zero)
+                      setRa(ra) *> setDec(dec) *> modify[
+                        (String, RightAscension, Declination)
+                      ](
+                        targetPropsL,
+                        {
+                          case (n, r, d) =>
+                            Mutation.Fields(
+                              name = n.some,
+                              ra = RightAscension.fromStringHMS.reverseGet(r).some,
+                              dec = Declination.fromStringSignedDMS.reverseGet(d).some
+                            )
+                        }
+                      )((search, ra, dec))
+                    },
+                    Callback.log("error")
+                  )
+              )
+              .toCallback
+
+          <.div(
             ^.height := "100%",
-            GridRow(stretched = true)(
-              GridColumn(stretched = true, computer = Four, clazz = GPPStyles.GPPForm)(
-                CoordinatesForm.component.withKey(coordinatesKey(props.target.get))(
-                  CoordinatesForm(props.target.get, searchAndGo, gotoRaDec, undoCtx)
+            ^.width := "100%",
+            ^.cls := "check",
+            Grid(columns = Two, stretched = true, padded = GridPadded.Horizontally)(
+              ^.height := "100%",
+              GridRow(stretched = true)(
+                GridColumn(stretched = true, computer = Four, clazz = GPPStyles.GPPForm)(
+                  CoordinatesForm.component.withKey(coordinatesKey(props.target.get))(
+                    CoordinatesForm(props.target.get, searchAndGo, gotoRaDec, undoCtx)
+                  )
+                ),
+                GridColumn(stretched = true, computer = Nine)(
+                  AladinComp.withRef(ref) {
+                    Aladin(target = props.aladinCoordsStr, fov = 0.25, showGotoControl = false)
+                  }
+                ),
+                GridColumn(stretched = true, computer = Three, clazz = GPPStyles.GPPForm)(
+                  CataloguesForm(props.target.get)
                 )
-              ),
-              GridColumn(stretched = true, computer = Nine)(
-                AladinComp.withRef(ref) {
-                  Aladin(target = props.aladinCoordsStr, fov = 0.25, showGotoControl = false)
-                }
-              ),
-              GridColumn(stretched = true, computer = Three, clazz = GPPStyles.GPPForm)(
-                CataloguesForm(props.target.get)
               )
             )
           )
-        )
+        }
       }
-    }
 
     def newProps(currentProps: Props, nextProps: Props): Callback =
       Callback.log(currentProps.toString()) *>

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -16,9 +16,9 @@ import monocle.function.Cons.headOption
 import react.common._
 
 final case class TargetEditor(
-  observationId:    CtxIO[Observation.Id]
-)(implicit val ctx: AppContextIO)
-    extends ReactProps {
+  observationId: Observation.Id,
+  globalTarget:  ViewCtxIO[Option[SiderealTarget]]
+) extends ReactProps {
   @inline override def render: VdomElement = TargetEditor.component(this)
 }
 
@@ -29,15 +29,15 @@ object TargetEditor {
     ScalaComponent
       .builder[Props]
       .render_P { props =>
-        props.observationId.withCtx { implicit appCtx =>
+        props.globalTarget.withCtx { implicit appCtx =>
           SubscriptionRenderMod[Subscription.Data, SiderealTarget](
             appCtx.clients.programs
               .subscribe(Subscription)(
-                Subscription.Variables(props.observationId.value.format).some
+                Subscription.Variables(props.observationId.format).some
               ),
             _.map(Subscription.Data.targets.composeOptional(headOption).getOption _).unNone
-          ) { view =>
-            TargetBody(props.observationId.value, view)
+          ) { target =>
+            TargetBody(props.observationId, target, props.globalTarget)
           }
         }
       }

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -31,7 +31,7 @@ object TargetEditor {
       .render_P { props =>
         props.observationId.withCtx { implicit appCtx =>
           SubscriptionRenderMod[Subscription.Data, SiderealTarget](
-            appCtx.clients.conditions
+            appCtx.clients.programs
               .subscribe(Subscription)(
                 Subscription.Variables(props.observationId.value.format).some
               ),

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -102,7 +102,7 @@ object TargetQueries {
   private def mutate(observationId: Observation.Id, fields: Mutation.Fields)(implicit
     ctx:                            AppContextIO
   ): IO[Unit] =
-    ctx.clients.conditions
+    ctx.clients.programs
       .query(Mutation)(Mutation.Variables(observationId.format, fields).some)
       .void
 

--- a/targeteditor/src/main/scala/explore/targeteditor/Test.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/Test.scala
@@ -18,13 +18,15 @@ import japgolly.scalajs.react.vdom.html_<^._
 @JSExportTopLevel("TargetTest")
 object Test extends AppMain {
 
-  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement =
-    viewCtx.withCtx { implicit ctx =>
-      val obsId =
-        Observation
-          .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
-          .inCtx(ctx)
-      <.div(^.height := "100vh", ^.width := "100%", TargetEditor(obsId))
-    }
+  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement = {
+    val obsId =
+      Observation
+        .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
+
+    <.div(^.height := "100vh",
+          ^.width := "100%",
+          TargetEditor(obsId, viewCtx.zoomL(RootModel.target))
+    )
+  }
 
 }


### PR DESCRIPTION
New router now allows to pass through global state to components.

To test it out, I modified the target editor so that it sets a global property with the selected target.

This is mostly working except for a flicker the first time state is modified. This seems to be caused by react-grid-layout reusability logic. It doesn't happen with version 0.17.1 of react-grid-layout.

We should either find a workaround or maybe isolate the case and report a bug?