### PR TITLE
API improvements and crystal update

### DIFF
--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -51,8 +51,10 @@ object AppConfig {
 case class Clients[F[_]: ConcurrentEffect: Logger](
   programs: GraphQLStreamingClient[F]
 ) {
+  protected implicit val statusReuse: Reusability[StreamingClientStatus] = Reusability.derive
+
   lazy val programsConnectionStatus =
-    StreamRenderer.build(programs.statusStream, Reusability.derive)
+    StreamRenderer.build(programs.statusStream)
 
   def close(): F[Unit] =
     programs.close()

--- a/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
+++ b/conditions/src/main/scala/explore/conditions/ConditionsPanel.scala
@@ -89,7 +89,12 @@ object ConditionsPanel {
       } yield Conditions(cc, iq, sb, wv)
   }
 
-  implicit val propsReuse: Reusability[Props] = Reusability.by(_.observationId.value.format)
+  protected implicit val propsReuse: Reusability[Props] =
+    Reusability.by(_.observationId.value.format)
+
+  protected implicit def enumReuse[A: Enumerated]: Reusability[A] =
+    Reusability.by(implicitly[Enumerated[A]].tag)
+  protected implicit val conditionsReuse: Reusability[Conditions] = Reusability.derive
 
   private object Subscription extends GraphQLQuery {
     val document = """

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ object Settings {
     val catsEffect       = "2.1.3"
     val circe            = "0.13.0"
     val clue             = "0.1.0"
-    val crystal          = "0.3.1"
+    val crystal          = "0.4.0"
     val discipline       = "1.0.2"
     val disciplineMUnit  = "0.2.2"
     val gspCore          = "0.2.0"

--- a/static.json
+++ b/static.json
@@ -3,16 +3,5 @@
     "clean_urls": false,
     "routes": {
       "/**": "index.html"
-    },
-    "proxies": {
-      "/api/conditions": {
-        "origin": "https://todo-mongo-graphql-server.herokuapp.com"
-      },
-      "/api/tasks": {
-        "origin": "https://todo-mongo-graphql-server.herokuapp.com"
-      },
-      "/api/grackle-demo": {
-        "origin": "https://${GRACKLE_DEMO_BASE}"
-      }
     }
   }

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -11,7 +11,7 @@ import explore.target.TargetQueries._
 import gem.Observation
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.CatsReact._
 import monocle.function.Cons.headOption
 import react.common._
 
@@ -24,6 +24,8 @@ final case class TargetEditor(
 
 object TargetEditor {
   type Props = TargetEditor
+
+  protected implicit val targetReuse: Reusability[SiderealTarget] = Reusability.byEq
 
   val component =
     ScalaComponent


### PR DESCRIPTION
`SubscriptionRenderer(Mod)` now:
* Use new `crystal` logic which provides `Pot`s to render function.
* Require (implicit) `Reusability` of subscribed value.
* Don't require `Monoid[F[Unit]]` anymore.