### PR TITLE
Use global context approach (and fix stream render's Pot[View] instead of View[Pot]). View[A] is now in IO.

### DIFF
--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -16,25 +16,4 @@ object implicits extends ShorthandTypes {
   implicit def appContext2ContextShift[F[_]](implicit ctx: AppContext[F]): ContextShift[F] = ctx.cs
   implicit def appContext2Timer[F[_]](implicit ctx:        AppContext[F]): Timer[F]        = ctx.timer
   implicit def appContext2Logger[F[_]](implicit ctx:       AppContext[F]): Logger[F]       = ctx.logger
-
-  implicit class ViewCtxOps[F[_], A](val viewCtx: Ctx[AppContext[F], View[F, A]]) extends AnyVal {
-    def actions[I[_[_]]](f: Actions[F] => ActionInterpreter[F, I, A]): I[F] =
-      viewCtx.interpreter(ctx => f(ctx.actions))
-  }
-
-  implicit class ViewOptCtxOps[F[_], A](val viewCtx: Ctx[AppContext[F], ViewOpt[F, A]])
-      extends AnyVal {
-    def actions[I[_[_]]](f: Actions[F] => ActionInterpreterOpt[F, I, A]): I[F] =
-      viewCtx.interpreter(ctx => f(ctx.actions))
-  }
-
-  @inline def ViewCtxIOReusability[A](implicit
-    r: Reusability[A]
-  ): Reusability[Ctx[AppContext[IO], View[IO, A]]] =
-    crystal.react.implicits.viewCtxReusability[IO, AppContext[IO], A]
-
-  @inline def ViewCtxOptReusability[A](implicit
-    r: Reusability[A]
-  ): Reusability[Ctx[AppContext[IO], ViewOpt[IO, A]]] =
-    crystal.react.implicits.viewOptCtxReusability[IO, AppContext[IO], A]
 }

--- a/common/src/main/scala/explore/package.scala
+++ b/common/src/main/scala/explore/package.scala
@@ -2,15 +2,13 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import cats.effect.IO
-import crystal.Ctx
-import crystal.View
+import crystal.ViewF
 import explore.model.AppContext
 
 package explore {
   trait ShorthandTypes {
     type AppContextIO = AppContext[IO]
-    type CtxIO[A]     = Ctx[AppContextIO, A]
-    type ViewCtxIO[A] = CtxIO[View[IO, A]]
+    type View[A]      = ViewF[IO, A]
   }
 }
 

--- a/conditions/src/main/scala/explore/conditions/Test.scala
+++ b/conditions/src/main/scala/explore/conditions/Test.scala
@@ -19,13 +19,10 @@ import js.annotation._
 @JSExportTopLevel("Test")
 object Test extends AppMain {
 
-  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement =
-    viewCtx.withCtx { implicit ctx =>
-      ConditionsPanel(
-        Observation
-          .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
-          .inCtx
-      )
-    }
+  override def rootComponent(view: View[RootModel]): VdomElement =
+    ConditionsPanel(
+      Observation
+        .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
+    )
 
 }

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -18,9 +18,9 @@ object ExploreMain extends AppMain {
 
   private val router = RouterWithProps(BaseUrl.fromWindowOrigin, Routing.config)
 
-  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement =
+  override def rootComponent(view: View[RootModel]): VdomElement =
     <.div(
-      router(viewCtx)
+      router(view)
     )
 
 }

--- a/explore/src/main/scala/explore/HomeComponent.scala
+++ b/explore/src/main/scala/explore/HomeComponent.scala
@@ -4,6 +4,7 @@
 package explore
 
 import crystal.implicits._
+import crystal.react.implicits._
 import explore.conditions.ConditionsPanel
 import explore.implicits._
 import explore.target.TargetEditor
@@ -42,51 +43,49 @@ object HomeComponent {
       // (BreakpointName.xs, (480, 6, layout))
     )
 
-  type Props = ViewCtxIO[RootModel]
-
-  private implicit val propsReuse: Reusability[Props] = ViewCtxIOReusability[RootModel]
+  type Props = View[RootModel]
 
   protected val component =
     ScalaComponent
       .builder[Props]
       .initialState(0)
       .render_P { props =>
-        props.withCtx { implicit ctx =>
-          val obsId = Observation
-            .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
+        // AppMain.withCtxNow { implicit ctx =>
+        val obsId = Observation
+          .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
 
-          <.div(
-            ^.cls := "rgl-area",
-            SizeMe() { s =>
-              ResponsiveReactGridLayout(
-                s.width,
-                margin = (5: JsNumber, 5: JsNumber),
-                containerPadding = (5: JsNumber, 5: JsNumber),
-                className = "layout",
-                rowHeight = 30,
-                draggableHandle = ".tileTitle",
-                useCSSTransforms = false, // Not ideal, but fixes flicker on first update (0.18.3).
-                onLayoutChange = (a, b) => Callback.log(a.toString) *> Callback.log(b.toString),
-                layouts = layouts
-              )(
-                <.div(
-                  ^.key := "conditions",
-                  ^.cls := "tile",
-                  Tile("Conditions")(
-                    ConditionsPanel(obsId.inCtx(ctx))
-                  )
-                ),
-                <.div(
-                  ^.key := "target",
-                  ^.cls := "tile",
-                  Tile("Target Position")(
-                    TargetEditor(obsId, props.zoomL(RootModel.target))
-                  )
+        <.div(
+          ^.cls := "rgl-area",
+          SizeMe() { s =>
+            ResponsiveReactGridLayout(
+              s.width,
+              margin = (5: JsNumber, 5: JsNumber),
+              containerPadding = (5: JsNumber, 5: JsNumber),
+              className = "layout",
+              rowHeight = 30,
+              draggableHandle = ".tileTitle",
+              useCSSTransforms = false, // Not ideal, but fixes flicker on first update (0.18.3).
+              onLayoutChange = (a, b) => Callback.log(a.toString) *> Callback.log(b.toString),
+              layouts = layouts
+            )(
+              <.div(
+                ^.key := "conditions",
+                ^.cls := "tile",
+                Tile("Conditions")(
+                  ConditionsPanel(obsId)
+                )
+              ),
+              <.div(
+                ^.key := "target",
+                ^.cls := "tile",
+                Tile("Target Position")(
+                  TargetEditor(obsId, props.zoomL(RootModel.target))
                 )
               )
-            }
-          )
-        }
+            )
+          }
+        )
+        // }
       }
       .configure(Reusability.shouldComponentUpdate)
       .build

--- a/explore/src/main/scala/explore/Layout.scala
+++ b/explore/src/main/scala/explore/Layout.scala
@@ -13,8 +13,8 @@ import react.semanticui.As
 import react.semanticui.collections.menu._
 import react.semanticui.modules.sidebar._
 
-final case class OTLayout(c: RouterCtl[Page], r: ResolutionWithProps[Page, ViewCtxIO[RootModel]])(
-  val viewCtxIO:             ViewCtxIO[RootModel]
+final case class OTLayout(c: RouterCtl[Page], r: ResolutionWithProps[Page, View[RootModel]])(
+  val view:                  View[RootModel]
 ) extends ReactProps[OTLayout](OTLayout.component)
 
 object OTLayout {
@@ -55,10 +55,10 @@ object OTLayout {
             )(
               MenuHeader()(
                 <.div(
-                  p.viewCtxIO.value.get.obsId.map(_.format).getOrElse[String]("No Observation")
+                  p.view.get.obsId.map(_.format).getOrElse[String]("No Observation")
                 ),
                 <.div(
-                  p.viewCtxIO.value.get.target
+                  p.view.get.target
                     .map(_.name)
                     .getOrElse[String]("No Target")
                 )
@@ -67,7 +67,7 @@ object OTLayout {
               MenuItem(as = "a", className = "sidetab")("P II")
             ),
             SidebarPusher(dimmed = false)(
-              p.r.renderP(p.viewCtxIO)
+              p.r.renderP(p.view)
             )
           )
         )

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -30,22 +30,22 @@ object Routing {
         Observation.Id.fromString(s).map(ObsPage(_))
     }(p => p.obsId.format)
 
-  val config: RouterWithPropsConfig[Page, ViewCtxIO[RootModel]] =
-    RouterWithPropsConfigDsl[Page, ViewCtxIO[RootModel]].buildConfig { dsl =>
+  val config: RouterWithPropsConfig[Page, View[RootModel]] =
+    RouterWithPropsConfigDsl[Page, View[RootModel]].buildConfig { dsl =>
       import dsl._
 
       (emptyRule
-        | staticRoute(root, HomePage) ~> renderP(viewCtx => HomeComponent(viewCtx))
-        | dynamicRouteCT(("/obs" / string("[a-zA-Z0-9-]+")).pmapL(obsIdP)) ~> renderP(viewCtx =>
-          HomeComponent(viewCtx)
+        | staticRoute(root, HomePage) ~> renderP(view => HomeComponent(view))
+        | dynamicRouteCT(("/obs" / string("[a-zA-Z0-9-]+")).pmapL(obsIdP)) ~> renderP(view =>
+          HomeComponent(view)
         ))
         .notFound(redirectToPage(HomePage)(SetRouteVia.HistoryPush))
         .verify(HomePage, ObsPage(Observation.Id.unsafeFromString("GS2020A-Q-1")))
         .onPostRenderP {
-          case (_, ObsPage(obsId), viewCtx) =>
-            viewCtx.zoomL(RootModel.obsId).set(Option(obsId)).runInCB *>
+          case (_, ObsPage(obsId), view) =>
+            view.zoomL(RootModel.obsId).set(Option(obsId)).runInCB *>
               Callback.log(s"id:1 $obsId")
-          case _                            => Callback.empty
+          case _                         => Callback.empty
         }
         .renderWithP(layout)
         .logToConsole
@@ -53,7 +53,7 @@ object Routing {
 
   private def layout(
     c: RouterCtl[Page],
-    r: ResolutionWithProps[Page, ViewCtxIO[RootModel]]
-  ): ViewCtxIO[RootModel] => VdomElement =
+    r: ResolutionWithProps[Page, View[RootModel]]
+  ): View[RootModel] => VdomElement =
     OTLayout(c, r)
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ object Settings {
     val catsEffect       = "2.1.3"
     val circe            = "0.13.0"
     val clue             = "0.1.0"
-    val crystal          = "0.4.0"
+    val crystal          = "0.5.0"
     val discipline       = "1.0.2"
     val disciplineMUnit  = "0.2.2"
     val gspCore          = "0.2.0"

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -5,7 +5,7 @@ package explore.target
 
 import cats.effect.IO
 import cats.implicits._
-import crystal.View
+import explore.View
 import crystal.react.implicits._
 import explore.components.ui.GPPStyles
 import explore.components.undo.UndoRegion
@@ -29,11 +29,12 @@ import react.aladin.Aladin
 import react.common._
 import react.semanticui.collections.grid._
 import react.semanticui.widths._
+import explore.AppCtx
 
 final case class TargetBody(
   observationId: Observation.Id,
-  target:        View[IO, SiderealTarget],
-  globalTarget:  ViewCtxIO[Option[SiderealTarget]]
+  target:        View[SiderealTarget],
+  globalTarget:  View[Option[SiderealTarget]]
 ) extends ReactProps[TargetBody](TargetBody.component) {
   val aladinCoords: Coordinates = target.get.track.baseCoordinates
   val aladinCoordsStr: String   = Coordinates.fromHmsDms.reverseGet(aladinCoords)
@@ -63,7 +64,7 @@ object TargetBody extends ModelOptics {
       s"${target.name}#${target.track.baseCoordinates.show}"
 
     def render(props: Props) =
-      props.globalTarget.withCtx { implicit appCtx =>
+      AppCtx.withCtx { implicit appCtx =>
         val target = props.target.get
 
         UndoRegion[SiderealTarget] { undoCtx =>

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -14,10 +14,11 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import monocle.function.Cons.headOption
 import react.common._
+import explore.AppCtx
 
 final case class TargetEditor(
   observationId: Observation.Id,
-  globalTarget:  ViewCtxIO[Option[SiderealTarget]]
+  globalTarget:  View[Option[SiderealTarget]]
 ) extends ReactProps[TargetEditor](TargetEditor.component)
 
 object TargetEditor {
@@ -29,7 +30,7 @@ object TargetEditor {
     ScalaComponent
       .builder[Props]
       .render_P { props =>
-        props.globalTarget.withCtx { implicit appCtx =>
+        AppCtx.withCtx { implicit appCtx =>
           SubscriptionRenderMod[Subscription.Data, SiderealTarget](
             appCtx.clients.programs
               .subscribe(Subscription)(

--- a/targeteditor/src/main/scala/explore/targeteditor/Test.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/Test.scala
@@ -18,15 +18,12 @@ import japgolly.scalajs.react.vdom.html_<^._
 @JSExportTopLevel("TargetTest")
 object Test extends AppMain {
 
-  override def rootComponent(viewCtx: ViewCtxIO[RootModel]): VdomElement = {
+  override def rootComponent(view: View[RootModel]): VdomElement = {
     val obsId =
       Observation
         .Id(ProgramId.Science.fromString.getOption("GS-2020A-DS-1").get, Index.One)
 
-    <.div(^.height := "100vh",
-          ^.width := "100%",
-          TargetEditor(obsId, viewCtx.zoomL(RootModel.target))
-    )
+    <.div(^.height := "100vh", ^.width := "100%", TargetEditor(obsId, view.zoomL(RootModel.target)))
   }
 
 }

--- a/targeteditor/yarn.lock
+++ b/targeteditor/yarn.lock
@@ -635,6 +635,14 @@ acorn@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
   integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
+aggregate-error@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.0.1.tgz#db2fe7246e536f40d9b5442a39e117d7dd6a24e0"
+  integrity sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==
+  dependencies:
+    clean-stack "^2.0.0"
+    indent-string "^4.0.0"
+
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1205,6 +1213,29 @@ cacache@^12.0.2:
     unique-filename "^1.1.1"
     y18n "^4.0.0"
 
+cacache@^15.0.3:
+  version "15.0.3"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.3.tgz#2225c2d1dd8e872339950d6a39c051e0e9334392"
+  integrity sha512-bc3jKYjqv7k4pWh7I/ixIjfcjPul4V4jme/WbjvwGS5LzoPL/GzXr4C5EgPNLO/QEZl9Oi61iGitYEdwcrwLCQ==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    infer-owner "^1.0.4"
+    lru-cache "^5.1.1"
+    minipass "^3.1.1"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^1.0.3"
+    move-file "^2.0.0"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.0"
+    tar "^6.0.2"
+    unique-filename "^1.1.1"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1322,6 +1353,11 @@ chownr@^1.1.1, chownr@^1.1.3:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 chrome-trace-event@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz#234090ee97c7d4ad1a2c4beae27505deffc608a4"
@@ -1358,6 +1394,11 @@ clean-css@^4.2.3:
   integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
   dependencies:
     source-map "~0.6.0"
+
+clean-stack@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
+  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -1468,7 +1509,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.18.0, commander@^2.20.0, commander@~2.20.3:
+commander@^2.18.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2563,7 +2604,7 @@ find-cache-dir@^2.1.0:
     make-dir "^2.0.0"
     pkg-dir "^3.0.0"
 
-find-cache-dir@^3.0.0, find-cache-dir@^3.2.0:
+find-cache-dir@^3.0.0, find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
@@ -2863,6 +2904,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbols@^1.0.0, has-symbols@^1.0.1:
   version "1.0.1"
@@ -3176,12 +3222,17 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
+  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
 indexes-of@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
   integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
 
-infer-owner@^1.0.3:
+infer-owner@^1.0.3, infer-owner@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
   integrity sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
@@ -3526,6 +3577,14 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+jest-worker@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.0.0.tgz#4920c7714f0a96c6412464718d0c58a3df3fb066"
+  integrity sha512-pPaYa2+JnwmiZjK9x7p9BoZht+47ecFCDFA/CJxspHzeDvQcfVBLWzCiWyo+EGrSiQMWZtCFo9iSvMZnAAo8vw==
+  dependencies:
+    merge-stream "^2.0.0"
+    supports-color "^7.0.0"
+
 jimp@^0.2.21:
   version "0.2.28"
   resolved "https://registry.yarnpkg.com/jimp/-/jimp-0.2.28.tgz#dd529a937190f42957a7937d1acc3a7762996ea2"
@@ -3828,7 +3887,7 @@ lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-loglevel@^1.6.8:
+loglevel@1.6.8, loglevel@^1.6.8:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
@@ -3942,6 +4001,11 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
+  integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
@@ -4050,7 +4114,28 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-minipass@^3.0.0:
+minipass-collect@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/minipass-collect/-/minipass-collect-1.0.2.tgz#22b813bf745dc6edba2576b940022ad6edc8c617"
+  integrity sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-flush@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
+  integrity sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass-pipeline@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/minipass-pipeline/-/minipass-pipeline-1.2.3.tgz#55f7839307d74859d6e8ada9c3ebe72cec216a34"
+  integrity sha512-cFOknTvng5vqnwOpDsZTWhNll6Jf8o2x+/diplafmxpuIymAjzoOolZG0VvQf3V2HgqzJNhnuKHYp2BqDgz8IQ==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass@^3.0.0, minipass@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
   integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
@@ -4108,6 +4193,11 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -4119,6 +4209,13 @@ move-concurrently@^1.0.1:
     mkdirp "^0.5.1"
     rimraf "^2.5.4"
     run-queue "^1.0.3"
+
+move-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/move-file/-/move-file-2.0.0.tgz#83ffa309b5d7f69d518b28e1333e2ffadf331e3e"
+  integrity sha512-cdkdhNCgbP5dvS4tlGxZbD+nloio9GIimP57EjqFhwLcMjnU+XJKAZzlmg/TN/AK1LuNAdTSvm3CPPP4Xkv0iQ==
+  dependencies:
+    path-exists "^4.0.0"
 
 ms@2.0.0:
   version "2.0.0"
@@ -4494,7 +4591,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0, p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -4526,6 +4623,13 @@ p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+  dependencies:
+    aggregate-error "^3.0.0"
 
 p-retry@^3.0.1:
   version "3.0.1"
@@ -5363,11 +5467,6 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-fast-compare@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
-  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
-
 react-is@^16.6.3, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -5603,6 +5702,13 @@ rimraf@^2.5.4, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -5735,15 +5841,15 @@ send@0.17.1:
     range-parser "~1.2.1"
     statuses "~1.5.0"
 
-serialize-javascript@^1.7.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.9.1.tgz#cfc200aef77b600c47da9bb8149c943e798c2fdb"
-  integrity sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A==
-
 serialize-javascript@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
   integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
+
+serialize-javascript@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-3.0.0.tgz#492e489a2d77b7b804ad391a5f5d97870952548e"
+  integrity sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw==
 
 serve-index@^1.9.1:
   version "1.9.1"
@@ -6027,6 +6133,13 @@ ssri@^6.0.1:
   dependencies:
     figgy-pudding "^3.5.1"
 
+ssri@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.0.tgz#79ca74e21f8ceaeddfcb4b90143c458b8d988808"
+  integrity sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
+  dependencies:
+    minipass "^3.1.1"
+
 stable@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
@@ -6235,6 +6348,13 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
+  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  dependencies:
+    has-flag "^4.0.0"
+
 svgo@^1.0.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.2.tgz#b6dc511c063346c9e415b81e43401145b96d4167"
@@ -6292,6 +6412,33 @@ tar@^5.0.5:
     mkdirp "^0.5.0"
     yallist "^4.0.0"
 
+tar@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.2.tgz#5df17813468a6264ff14f766886c622b84ae2f39"
+  integrity sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.0"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
+
+terser-webpack-plugin@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-3.0.1.tgz#31928c9330a582fb5ec6f90805337289b85cb8fe"
+  integrity sha512-eFDtq8qPUEa9hXcUzTwKXTnugIVtlqc1Z/ZVhG8LmRT3lgRY13+pQTnFLY2N7ATB6TKCHuW/IGjoAnZz9wOIqw==
+  dependencies:
+    cacache "^15.0.3"
+    find-cache-dir "^3.3.1"
+    jest-worker "^26.0.0"
+    p-limit "^2.3.0"
+    schema-utils "^2.6.6"
+    serialize-javascript "^3.0.0"
+    source-map "^0.6.1"
+    terser "^4.6.13"
+    webpack-sources "^1.4.3"
+
 terser-webpack-plugin@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz#5ecaf2dbdc5fb99745fd06791f46fc9ddb1c9a7c"
@@ -6311,6 +6458,15 @@ terser@^4.1.2, terser@^4.6.3:
   version "4.6.13"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.6.13.tgz#e879a7364a5e0db52ba4891ecde007422c56a916"
   integrity sha512-wMvqukYgVpQlymbnNbabVZbtM6PN63AzqexpwJL8tbh/mRT9LE5o+ruVduAGL7D6Fpjl+Q+06U5I9Ul82odAhw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
+
+terser@^4.6.13:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.7.0.tgz#15852cf1a08e3256a80428e865a2fa893ffba006"
+  integrity sha512-Lfb0RiZcjRDXCC3OSHJpEkxJ9Qeqs6mp2v4jf2MHfy8vGERmVDuvjXdd/EnP5Deme5F2yBRBymKmKHCBg2echw==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -6461,28 +6617,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
-
-uglify-js@^3.6.0:
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.3.tgz#4a285d1658b8a2ebaef9e51366b3a0f7acd79ec2"
-  integrity sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==
-  dependencies:
-    commander "~2.20.3"
-
-uglifyjs-webpack-plugin@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz#e75bc80e7f1937f725954c9b4c5a1e967ea9d0d7"
-  integrity sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==
-  dependencies:
-    cacache "^12.0.2"
-    find-cache-dir "^2.1.0"
-    is-wsl "^1.1.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.7.0"
-    source-map "^0.6.1"
-    uglify-js "^3.6.0"
-    webpack-sources "^1.4.0"
-    worker-farm "^1.7.0"
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -6827,7 +6961,7 @@ webpack-merge@4.2.2:
   dependencies:
     lodash "^4.17.15"
 
-webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
+webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1, webpack-sources@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
   integrity sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==
@@ -6901,14 +7035,6 @@ which@^1.2.14, which@^1.2.9:
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
   dependencies:
     isexe "^2.0.0"
-
-why-did-you-update@1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/why-did-you-update/-/why-did-you-update-1.0.8.tgz#3c766730824598ff65ff0d96e070ffa28c0b00f9"
-  integrity sha512-P1m7cho3o+otR8+WvHYrM+SJHCdvhS+FI6NOwZm6JNdhItbDnuZFD9uxvKIQYXxAkBV5qJtCNF/e2RwCDeAV5g==
-  dependencies:
-    lodash "^4.17.11"
-    react-fast-compare "^2.0.4"
 
 wide-align@^1.1.0:
   version "1.1.3"


### PR DESCRIPTION
Besides adapting code to the changes discussed in https://github.com/rpiaggio/crystal/pull/33, crystal's `View[F, A]` was renamed to `ViewF[F, A]` and we use a type alias here making `View[A] = View[IO, A]`. Since we are going to have a lot of mentions of `View` in properties, I found code more readable if we just have `View[A]` everywhere instead of `ViewIO[A]` or `View[IO, A]`.