### PR TITLE
Use Zipper for tabs and reorganize model

### DIFF
--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -3,29 +3,34 @@
 
 package explore
 
+import scala.scalajs.js
+
 import cats.Id
+import cats.data.NonEmptyList
 import cats.effect.ExitCode
 import cats.effect.IO
 import cats.effect.IOApp
-import cats.implicits._
 import cats.effect._
+import cats.implicits._
 import clue.Backend
 import clue.StreamingBackend
 import clue.js.AjaxJSBackend
 import clue.js.WebSocketJSBackend
+import crystal.AppRootContext
 import crystal.react.AppRoot
 import explore.model.AppConfig
 import explore.model.AppContext
 import explore.model.ExploreSiderealTarget
 import explore.model.RootModel
+import explore.model.SideButton
+import gpp.util.Zipper
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react.extra.ReusabilityOverlay
 import japgolly.scalajs.react.vdom.VdomElement
 import log4cats.loglevel.LogLevelLogger
+import org.scalactic.anyvals.NonEmptyMap
 import org.scalajs.dom
-import crystal.AppRootContext
 
-import scala.scalajs.js
 import js.annotation._
 
 object AppCtx extends AppRootContext[AppContextIO]
@@ -49,7 +54,16 @@ trait AppMain extends IOApp {
 
     implicit val gqlStreamingBackend: StreamingBackend[IO] = WebSocketJSBackend[IO]
 
-    val initialModel = RootModel()
+    val initialModel = RootModel(tabs =
+      Zipper.fromNel(
+        NonEmptyList.of(SideButton("Overview"),
+                        SideButton("Observations"),
+                        SideButton("Target"),
+                        SideButton("Configurations"),
+                        SideButton("Constraints")
+        )
+      )
+    )
 
     for {
       ctx <- AppContext.from[IO](AppConfig())

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -4,19 +4,18 @@
 package explore.components.graphql
 
 import scala.concurrent.duration._
-import scala.language.postfixOps
 
 import cats.effect.ConcurrentEffect
 import cats.effect.IO
 import cats.effect.Timer
 import cats.implicits._
 import clue.GraphQLStreamingClient
-import explore.View
 import crystal.ViewF
 import crystal.data.Pot
 import crystal.data.react._
 import crystal.react.StreamRendererMod
 import crystal.react.implicits._
+import explore.View
 import explore.model.reusability
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react._
@@ -26,6 +25,8 @@ import react.common._
 import react.semanticui.collections.message.Message
 import react.semanticui.elements.icon.Icon
 import react.semanticui.sizes._
+
+import scala.language.postfixOps
 
 final case class SubscriptionRenderMod[D, A](
   subscribe:         IO[GraphQLStreamingClient[IO]#Subscription[D]],

--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -9,6 +9,7 @@ import clue._
 import crystal.react.StreamRenderer
 import explore.model.reusability._
 import gem.Observation
+import gpp.util.Zipper
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react._
 import monocle.macros.Lenses
@@ -19,7 +20,8 @@ import sttp.model.Uri._
 @Lenses
 case class RootModel(
   obsId:  Option[Observation.Id] = None,
-  target: Option[SiderealTarget] = None
+  target: Option[SiderealTarget] = None,
+  tabs:   Zipper[SideButton]
 )
 object RootModel {
   implicit val reuse: Reusability[RootModel] = Reusability.derive
@@ -31,10 +33,10 @@ case class AppConfig(
     uri"wss://explore-hasura.herokuapp.com/v1/graphql" //AppConfig.wsBaseUri.path("/api/programs/v1/graphql"),
 )
 object AppConfig {
-  lazy val baseUri: Uri = {
-    val location = dom.window.location.toString
-    Uri.parse(location).getOrElse(throw new Exception(s"Could not parse URL [$location]"))
-  }
+  // lazy val baseUri: Uri = {
+  //   val location = dom.window.location.toString
+  //   Uri.parse(location).getOrElse(throw new Exception(s"Could not parse URL [$location]"))
+  // }
 
   /*lazy val wsBaseUri: Uri = {
     val uri = baseUri

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -3,19 +3,22 @@
 
 package explore.model
 
+import gem.Observation
+import gem.util.Enumerated
+import gpp.util.Zipper
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
-import gem.util.Enumerated
-import gem.Observation
 
 /**
   * Reusability instances for model classes
   */
 object reusability {
-  implicit val obsIdReuse: Reusability[Observation.Id]            = Reusability.by(_.format)
-  implicit val siderealTargetReuse: Reusability[SiderealTarget]   = Reusability.byEq
-  implicit val expTargetReuse: Reusability[ExploreSiderealTarget] = Reusability.derive
-  implicit def enumReuse[A: Enumerated]: Reusability[A]           =
+  implicit val obsIdReuse: Reusability[Observation.Id]             = Reusability.by(_.format)
+  implicit val siderealTargetReuse: Reusability[SiderealTarget]    = Reusability.byEq
+  implicit val expTargetReuse: Reusability[ExploreSiderealTarget]  = Reusability.derive
+  implicit def enumReuse[A: Enumerated]: Reusability[A]            =
     Reusability.by(implicitly[Enumerated[A]].tag)
-  implicit val conditionsReuse: Reusability[Conditions]           = Reusability.derive
+  implicit val conditionsReuse: Reusability[Conditions]            = Reusability.derive
+  implicit val sideButtonReuse: Reusability[SideButton]            = Reusability.byEq
+  implicit def zipperReuse[A: Reusability]: Reusability[Zipper[A]] = Reusability.derive
 }

--- a/explore/src/main/scala/explore/Layout.scala
+++ b/explore/src/main/scala/explore/Layout.scala
@@ -48,15 +48,7 @@ object OTLayout {
           ),
           <.div(
             GPPStyles.SideTabs,
-            SideTabs(p.c,
-                     SideButton("Overview").some,
-                     List(
-                       SideButton("Observations"),
-                       SideButton("Target"),
-                       SideButton("Configurations"),
-                       SideButton("Constraints")
-                     )
-            )
+            SideTabs(p.c, p.view.zoomL(RootModel.tabs).get)
           ),
           <.div(
             GPPStyles.MainBody,

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -5,6 +5,8 @@ package explore
 
 import crystal.react.implicits._
 import explore.model._
+import explore.model.Page
+import explore.model.Page._
 import gem.Observation
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.MonocleReact._
@@ -15,10 +17,6 @@ import monocle.Prism
 sealed trait ElementItem  extends Product with Serializable
 case object IconsElement  extends ElementItem
 case object LabelsElement extends ElementItem
-
-sealed trait Page    extends Product with Serializable
-case object HomePage extends Page
-final case class ObsPage(obsId: Observation.Id) extends Page
 
 object Routing {
 

--- a/explore/src/main/scala/explore/VerticalSection.scala
+++ b/explore/src/main/scala/explore/VerticalSection.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore
+
+import scala.scalajs.js.JSConverters._
+
+import cats.implicits._
+import explore.model.Page
+import explore.model.SideButton
+import explore.model.reusability._
+import explore.components.ui.GPPStyles
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.extra.router.RouterCtl
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.common.implicits._
+import react.semanticui.SemanticWidth
+import react.semanticui.sizes._
+import react.semanticui.widths._
+
+/**
+  * Component that uses css tricks to support properly rotated components
+  * respecting the layout. see:
+  * https://stackoverflow.com/questions/16301625/rotated-elements-in-css-that-affect-their-parents-height-correctly
+  * It requires css to work properly
+  */
+final case class VerticalSection()
+    extends ReactPropsWithChildren[VerticalSection](VerticalSection.component)
+
+object VerticalSection {
+  type Props = VerticalSection
+
+  implicit val reuse: Reusability[Props] = Reusability.always
+
+  private val component =
+    ScalaComponent
+      .builder[Props]
+      .stateless
+      .render_C(c =>
+        <.div(
+          GPPStyles.RotationWrapperOuter,
+          <.div(
+            GPPStyles.RotationWrapperInner,
+            <.div(GPPStyles.VerticalButton, c)
+          )
+        )
+      )
+      .configure(Reusability.shouldComponentUpdate)
+      .build
+}

--- a/model/src/main/scala/explore/model/Page.scala
+++ b/model/src/main/scala/explore/model/Page.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import gem.Observation
+import cats.Eq
+import cats.implicits._
+
+sealed trait Page extends Product with Serializable
+
+object Page {
+  case object HomePage extends Page
+  final case class ObsPage(obsId: Observation.Id) extends Page
+
+  implicit val eqPage: Eq[Page] = Eq.instance {
+    case (HomePage, HomePage)     => true
+    case (ObsPage(a), ObsPage(b)) => a === b
+    case _                        => false
+  }
+}

--- a/model/src/main/scala/explore/model/SideButton.scala
+++ b/model/src/main/scala/explore/model/SideButton.scala
@@ -1,0 +1,13 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.implicits._
+
+final case class SideButton(title: String)
+
+object SideButton {
+  implicit val eqSideButton: Eq[SideButton] = Eq.by(_.title)
+}

--- a/model/src/test/scala/explore/ModelOpticsSuite.scala
+++ b/model/src/test/scala/explore/ModelOpticsSuite.scala
@@ -4,12 +4,12 @@
 package explore.model
 
 import cats.implicits._
-import munit.DisciplineSuite
-import monocle.law.discipline.LensTests
-import gsp.math.arb.ArbRightAscension
-import gsp.math.arb.ArbProperMotion
-import gsp.math.arb.ArbDeclination
 import explore.model.arb.all._
+import gsp.math.arb.ArbDeclination
+import gsp.math.arb.ArbProperMotion
+import gsp.math.arb.ArbRightAscension
+import monocle.law.discipline.LensTests
+import munit.DisciplineSuite
 import munit.DisciplineSuite
 
 class ModelOpticsSuite

--- a/model/src/test/scala/explore/ModelSuite.scala
+++ b/model/src/test/scala/explore/ModelSuite.scala
@@ -11,4 +11,5 @@ class ModelSuite extends DisciplineSuite {
   checkAll("Eq[Conditions]", EqTests[Conditions].eqv)
   checkAll("Eq[SiderealTarget]", EqTests[SiderealTarget].eqv)
   checkAll("Eq[ExploreSiderealTarget]", EqTests[ExploreSiderealTarget].eqv)
+  checkAll("Eq[SideButton]", EqTests[SideButton].eqv)
 }

--- a/model/src/test/scala/explore/arb/ArbConditions.scala
+++ b/model/src/test/scala/explore/arb/ArbConditions.scala
@@ -3,13 +3,13 @@
 
 package explore.model.arb
 
+import explore.model.Conditions
+import explore.model.enum._
+import gem.arb.ArbEnumerated._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
-import explore.model.enum._
-import explore.model.Conditions
-import gem.arb.ArbEnumerated._
 
 trait ArbConditions {
 

--- a/model/src/test/scala/explore/arb/ArbExploreSiderealTarget.scala
+++ b/model/src/test/scala/explore/arb/ArbExploreSiderealTarget.scala
@@ -3,13 +3,13 @@
 
 package explore.model.arb
 
+import explore.model.ExploreSiderealTarget
+import explore.model.SiderealTarget
+import gem.arb.ArbEnumerated._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
-import gem.arb.ArbEnumerated._
-import explore.model.SiderealTarget
-import explore.model.ExploreSiderealTarget
 
 trait ArbExploreSiderealTarget {
   import explore.model.arb.ArbSiderealTarget._

--- a/model/src/test/scala/explore/arb/ArbSideTabs.scala
+++ b/model/src/test/scala/explore/arb/ArbSideTabs.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import explore.model.SideButton
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Cogen._
+
+trait ArbSideButton {
+
+  implicit val sideButtonArb = Arbitrary[SideButton] {
+    for {
+      n <- arbitrary[String]
+    } yield SideButton(n)
+  }
+
+  implicit val sideButtonCogen: Cogen[SideButton] =
+    Cogen[String].contramap(c => (c.title))
+
+}
+
+object ArbSideButton extends ArbSideButton

--- a/model/src/test/scala/explore/arb/ArbSiderealTarget.scala
+++ b/model/src/test/scala/explore/arb/ArbSiderealTarget.scala
@@ -3,13 +3,13 @@
 
 package explore.model.arb
 
+import explore.model.SiderealTarget
+import gem.arb.ArbEnumerated._
+import gsp.math.ProperMotion
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
-import gem.arb.ArbEnumerated._
-import explore.model.SiderealTarget
-import gsp.math.ProperMotion
 
 trait ArbSiderealTarget {
   import gsp.math.arb.ArbProperMotion._

--- a/model/src/test/scala/explore/arb/package.scala
+++ b/model/src/test/scala/explore/arb/package.scala
@@ -3,4 +3,8 @@
 
 package explore.model.arb
 
-object all extends ArbConditions with ArbSiderealTarget with ArbExploreSiderealTarget
+object all
+    extends ArbConditions
+    with ArbSiderealTarget
+    with ArbExploreSiderealTarget
+    with ArbSideButton

--- a/model/src/test/scala/explore/undo/TestUndoable.scala
+++ b/model/src/test/scala/explore/undo/TestUndoable.scala
@@ -3,13 +3,13 @@
 
 package explore.undo
 
-import explore.undo.Undoer
-import cats.effect.Sync
-import cats.Monoid
 import cats.FlatMap
-import cats.implicits._
-import monocle.macros.Lenses
+import cats.Monoid
+import cats.effect.Sync
 import cats.effect.concurrent.Ref
+import cats.implicits._
+import explore.undo.Undoer
+import monocle.macros.Lenses
 
 @Lenses
 case class TestStacks[F[_], A](

--- a/model/src/test/scala/explore/undo/UndoerSpec.scala
+++ b/model/src/test/scala/explore/undo/UndoerSpec.scala
@@ -4,16 +4,16 @@
 package explore.undo
 
 import cats.effect.IO
-import cats.implicits._
 import cats.effect.concurrent.Ref
-import monocle.Iso
+import cats.implicits._
 import cats.kernel.Eq
 import explore.undo._
 import explore.util.tree._
-import monocle.macros.Lenses
-import monocle.function.all._
+import monocle.Iso
 import monocle.Lens
 import monocle.Setter
+import monocle.function.all._
+import monocle.macros.Lenses
 
 class UndoerSpec extends munit.FunSuite {
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -86,7 +86,8 @@ object Settings {
 
     val GSPCore = Def.setting(
       deps(
-        "edu.gemini" %%% "gsp-core-model"
+        "edu.gemini" %%% "gsp-core-model",
+        "edu.gemini" %%% "gpp-core-util"
       )(gspCore)
     )
 


### PR DESCRIPTION
This puts the sidetabs in a `Zipper` where the selected one is shown as active. We still need to link this to the urls but that will come in a next PR

This PR is larger as I'm moving model classes to the shared `model` module and I re-sorted the imports
