### PR TITLE
Make the tree area resizable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,9 @@ lazy val common = project
   .settings(
     npmDependencies in Compile ++= Seq(
       "loglevel" -> "1.6.8"
-    )
+    ),
+    libraryDependencies ++=
+      ReactCommon.value
   )
   .enablePlugins(ScalaJSBundlerPlugin)
   .dependsOn(model.js)
@@ -139,6 +141,7 @@ lazy val explore: Project = project
     libraryDependencies ++=
       ReactCommon.value ++
         ReactGridLayout.value ++
+        ReactResizable.value ++
         ReactSizeMe.value
   )
   .dependsOn(conditions, targeteditor, observationtree)

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -2,10 +2,12 @@
 
 // vertical buttons
 @import "verticalbuttons.less";
+@import "vendor/react-resizable.less";
 @import "vendor/react-grid-layout.less";
 
 @gridSpace: 5px;
 @minHeight: 2.85714286em; // TODO: Calculate this on less
+@resizeHandleWidth: 5px; // Width of the tree resize handle
 
 html,
 body {
@@ -13,14 +15,6 @@ body {
   height: 100%;
   padding: 0px;
   margin: 0px;
-}
-
-.maingrid {
-  height: 100vh;
-}
-
-.rglarea {
-  width: 100%;
 }
 
 .tile {
@@ -60,7 +54,6 @@ body {
   background: darkgrey;
 }
 
-
 // Form propreties
 .gpp-form {
   padding-top: 1em;
@@ -87,3 +80,76 @@ body {
   height: 100%;
 }
 
+// Vertical handle to resize the tree
+.resize-handle {
+  width: @resizeHandleWidth;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  user-select: none;
+  cursor: ew-resize;
+  position: relative;
+  margin-left: -@resizeHandleWidth;
+  background: black;
+  z-index: 1;
+}
+
+.maingrid {
+  height: 100%;
+}
+
+// Area where the grid-layout is placed
+.rgl-area,
+.tree-rgl {
+  width: 100%;
+  height: 100%;
+}
+
+// Section on the left to place the tree
+.tree {
+  margin-right: @resizeHandleWidth;
+  height: 100%;
+  left: 0px;
+  top: 0px;
+  position: absolute;
+
+  // Special css to decorate the resize handle. It needs to be very specific
+  .react-resizable-handle.react-resizable-handle-e {
+    cursor: e-resize;
+    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjxzdmcKICAgeG1sbnM6ZGM9Imh0dHA6Ly9wdXJsLm9yZy9kYy9lbGVtZW50cy8xLjEvIgogICB4bWxuczpjYz0iaHR0cDovL2NyZWF0aXZlY29tbW9ucy5vcmcvbnMjIgogICB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiCiAgIHhtbG5zOnN2Zz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciCiAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM6c29kaXBvZGk9Imh0dHA6Ly9zb2RpcG9kaS5zb3VyY2Vmb3JnZS5uZXQvRFREL3NvZGlwb2RpLTAuZHRkIgogICB4bWxuczppbmtzY2FwZT0iaHR0cDovL3d3dy5pbmtzY2FwZS5vcmcvbmFtZXNwYWNlcy9pbmtzY2FwZSIKICAgaW5rc2NhcGU6dmVyc2lvbj0iMS4wICg0MDM1YTRmLCAyMDIwLTA1LTAxKSIKICAgc29kaXBvZGk6ZG9jbmFtZT0iaW1hZ2Uuc3ZnIgogICBpZD0ic3ZnMTQiCiAgIHZlcnNpb249IjEuMSIKICAgaGVpZ2h0PSI2cHgiCiAgIHdpZHRoPSI2cHgiCiAgIHk9IjBweCIKICAgeD0iMHB4IgogICBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjojZmZmZmZmMDAiCiAgIHZpZXdCb3g9IjAgMCA2IDYiPgogIDxtZXRhZGF0YQogICAgIGlkPSJtZXRhZGF0YTIwIj4KICAgIDxyZGY6UkRGPgogICAgICA8Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+CiAgICAgICAgPGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+CiAgICAgICAgPGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPgogICAgICA8L2NjOldvcms+CiAgICA8L3JkZjpSREY+CiAgPC9tZXRhZGF0YT4KICA8ZGVmcwogICAgIGlkPSJkZWZzMTgiIC8+CiAgPHNvZGlwb2RpOm5hbWVkdmlldwogICAgIGlua3NjYXBlOmN1cnJlbnQtbGF5ZXI9InN2ZzE0IgogICAgIGlua3NjYXBlOndpbmRvdy1tYXhpbWl6ZWQ9IjAiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjIzIgogICAgIGlua3NjYXBlOndpbmRvdy14PSIxNTciCiAgICAgaW5rc2NhcGU6Y3k9IjMiCiAgICAgaW5rc2NhcGU6Y3g9IjMiCiAgICAgaW5rc2NhcGU6em9vbT0iMTIxIgogICAgIHNob3dncmlkPSJmYWxzZSIKICAgICBpZD0ibmFtZWR2aWV3MTYiCiAgICAgaW5rc2NhcGU6d2luZG93LWhlaWdodD0iOTk4IgogICAgIGlua3NjYXBlOndpbmRvdy13aWR0aD0iMTg0MCIKICAgICBpbmtzY2FwZTpwYWdlc2hhZG93PSIyIgogICAgIGlua3NjYXBlOnBhZ2VvcGFjaXR5PSIwIgogICAgIGd1aWRldG9sZXJhbmNlPSIxMCIKICAgICBncmlkdG9sZXJhbmNlPSIxMCIKICAgICBvYmplY3R0b2xlcmFuY2U9IjEwIgogICAgIGJvcmRlcm9wYWNpdHk9IjEiCiAgICAgYm9yZGVyY29sb3I9IiM2NjY2NjYiCiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIiAvPgogIDxnCiAgICAgc3R5bGU9ImZpbGw6I2UzZGVkYiIKICAgICBpZD0iZzEyIgogICAgIG9wYWNpdHk9IjAuMzAyIj4KICAgIDxwYXRoCiAgICAgICBzdHlsZT0iZmlsbDojZTNkZWRiIgogICAgICAgaWQ9InBhdGgxMCIKICAgICAgIGZpbGw9IiMwMDAwMDAiCiAgICAgICBkPSJNIDYgNiBMIDAgNiBMIDAgNC4yIEwgNCA0LjIgTCA0LjIgNC4yIEwgNC4yIDAgTCA2IDAgTCA2IDYgTCA2IDYgWiIgLz4KICA8L2c+Cjwvc3ZnPgo=");
+  }
+}
+
+// Outor area of the body.
+.tree-body-outer {
+  // A bit narrower to fit the resize handle
+  width: ~"calc(100% - @{resizeHandleWidth})";
+  height: 100%;
+  // Add scroll on Y
+  overflow-y: scroll;
+}
+
+// Inner are of the tree
+.tree-body-inner {
+  // Only for demo purposes
+  background-image: linear-gradient(
+    45deg,
+    #302527 25%,
+    #0b2230 25%,
+    #0b2230 50%,
+    #302527 50%,
+    #302527 75%,
+    #0b2230 75%,
+    #0b2230 100%
+  );
+  background-size: 56.57px 56.57px;
+  // Only for demo purposes
+  height: 3000px;
+}
+
+.rgl-body {
+  height: 100%;
+  position: absolute;
+  top: 0px;
+}

--- a/common/src/main/resources/less/vendor/react-resizable.less
+++ b/common/src/main/resources/less/vendor/react-resizable.less
@@ -1,0 +1,69 @@
+.react-resizable {
+  position: relative;
+}
+
+.react-resizable-handle {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  background-repeat: no-repeat;
+  background-origin: content-box;
+  box-sizing: border-box;
+  background-image: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiNmZmZmZmYwMCIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iNnB4Ij48ZyBvcGFjaXR5PSIwLjMwMiI+PHBhdGggZD0iTSA2IDYgTCAwIDYgTCAwIDQuMiBMIDQgNC4yIEwgNC4yIDQuMiBMIDQuMiAwIEwgNiAwIEwgNiA2IEwgNiA2IFoiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+');
+  background-position: bottom right;
+  padding: 0 3px 3px 0;
+  color: white;
+}
+
+.react-resizable-handle-sw {
+  bottom: 0;
+  left: 0;
+  cursor: sw-resize;
+  transform: rotate(90deg);
+}
+.react-resizable-handle-se {
+  bottom: 0;
+  right: 0;
+  cursor: se-resize;
+}
+.react-resizable-handle-nw {
+  top: 0;
+  left: 0;
+  cursor: nw-resize;
+  transform: rotate(180deg);
+}
+.react-resizable-handle-ne {
+  top: 0;
+  right: 0;
+  cursor: ne-resize;
+  transform: rotate(270deg);
+}
+.react-resizable-handle-w,
+.react-resizable-handle-e {
+  top: 50%;
+  margin-top: -10px;
+  color: red;
+  cursor: ew-resize;
+}
+.react-resizable-handle-w {
+  left: 0;
+  transform: rotate(135deg);
+}
+.react-resizable-handle-e {
+  right: 0;
+  transform: rotate(315deg);
+}
+.react-resizable-handle-n,
+.react-resizable-handle-s {
+  left: 50%;
+  margin-left: -10px;
+  cursor: ns-resize;
+}
+.react-resizable-handle-n {
+  top: 0;
+  transform: rotate(225deg);
+}
+.react-resizable-handle-s {
+  bottom: 0;
+  transform: rotate(45deg);
+}

--- a/common/src/main/scala/explore/components/ui/GPPStyles.scala
+++ b/common/src/main/scala/explore/components/ui/GPPStyles.scala
@@ -15,10 +15,19 @@ object GPPStyles {
   val MainTitle: Css  = Css("main-title")
   val SideTabs: Css   = Css("sidetabs")
 
+  val ResizeHandle: Css  = Css("resize-handle")
+  val Tree: Css          = Css("tree")
+  val TreeBodyOuter: Css = Css("tree-body-outer")
+  val TreeBodyInner: Css = Css("tree-body-inner")
+  val TreeRGL: Css       = Css("tree-rgl")
+  val RGLBody: Css       = Css("rgl-body")
+  val RGLArea: Css       = Css("rgl-area")
+
   val SideTabsBody: Css         = Css("sidetabs-body")
   val VerticalButton: Css       = Css("vertical-button")
   val RotationWrapperOuter: Css = Css("rotation-wrapper-outer")
   val RotationWrapperInner: Css = Css("rotation-wrapper-inner")
 
   val HVCenter: Css = Css("horizontal-vertical-center")
+
 }

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -14,6 +14,8 @@ import gpp.util.EnumZipper
 import gpp.util.Zipper
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react.raw.JsNumber
+import react.common.implicits._
 
 /**
   * Reusability instances for model classes
@@ -30,5 +32,6 @@ object reusability {
   implicit val conditionsReuse: Reusability[Conditions]                    = Reusability.derive
   implicit def enumZipperReuse[A: Reusability]: Reusability[EnumZipper[A]] =
     Reusability.by(z => (z.lefts, z.focus, z.rights))
+  implicit val jsNumberReuse: Reusability[JsNumber]                        = Reusability.byEq
   implicit val reuse: Reusability[RootModel]                               = Reusability.derive
 }

--- a/explore/yarn.lock
+++ b/explore/yarn.lock
@@ -5097,6 +5097,14 @@ react-dom@16.13.1:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-draggable@4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.3.tgz#0727f2cae5813e36b0e4962bf11b2f9ef2b406f3"
+  integrity sha512-jV4TE59MBuWm7gb6Ns3Q1mxX8Azffb7oTtDtBgFkxRvhDp38YAARmRplrj0+XGkhOJB5XziArX+4HUUABtyZ0w==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.6.0"
+
 react-draggable@^4.0.0, react-draggable@^4.0.3:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.2.0.tgz#40cc5209082ca7d613104bf6daf31372cc0e1114"
@@ -5148,9 +5156,10 @@ react-redux@^7.0.3, react-redux@^7.1.1:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
-react-resizable@^1.9.0:
+react-resizable@1.10.1, react-resizable@^1.9.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.10.1.tgz#f0c2cf1d83b3470b87676ce6d6b02bbe3f4d8cd4"
+  integrity sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==
   dependencies:
     prop-types "15.x"
     react-draggable "^4.0.3"

--- a/model/src/test/scala/explore/ModelSuite.scala
+++ b/model/src/test/scala/explore/ModelSuite.scala
@@ -5,8 +5,8 @@ package explore.model
 
 import cats.kernel.laws.discipline._
 import explore.model.arb.all._
-import munit.DisciplineSuite
 import explore.model.enum.AppTab
+import munit.DisciplineSuite
 
 class ModelSuite extends DisciplineSuite {
   checkAll("Eq[Conditions]", EqTests[Conditions].eqv)

--- a/model/src/test/scala/explore/arb/ArbEnum.scala
+++ b/model/src/test/scala/explore/arb/ArbEnum.scala
@@ -4,11 +4,11 @@
 package explore.model.arb
 
 import explore.model.enum.AppTab
+import gem.util.Enumerated
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
-import gem.util.Enumerated
 import org.scalacheck.Gen
 
 trait ArbEnum {

--- a/model/src/test/scala/explore/undo/UndoerSpec.scala
+++ b/model/src/test/scala/explore/undo/UndoerSpec.scala
@@ -7,16 +7,16 @@ import cats.effect.IO
 import cats.effect.concurrent.Ref
 import cats.implicits._
 import cats.kernel.Eq
-import explore.undo._
 import explore.data.tree._
+import explore.undo._
 import monocle.Iso
-import monocle.macros.Lenses
-import monocle.function.all._
 import monocle.Lens
 import monocle.Setter
 import monocle.function.all._
-import monocle.macros.Lenses
+import monocle.function.all._
 import monocle.macros.GenLens
+import monocle.macros.Lenses
+import monocle.macros.Lenses
 
 class UndoerSpec extends munit.FunSuite {
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -25,6 +25,7 @@ object Settings {
     val reactAtlasKitTree = "0.2.3"
     val reactCommon       = "0.9.1"
     val reactGridLayout   = "0.5.3"
+    val reactResizable    = "0.0.1"
     val reactSemanticUI   = "0.5.6"
     val reactSizeMe       = "0.4.3"
     val scalaJsReact      = "1.7.0"
@@ -168,6 +169,12 @@ object Settings {
       deps(
         "io.github.cquiroz.react" %%% "react-grid-layout"
       )(reactGridLayout)
+    )
+
+    val ReactResizable = Def.setting(
+      deps(
+        "io.github.cquiroz.react" %%% "react-resizable"
+      )(reactResizable)
     )
 
     val ReactSizeMe = Def.setting(


### PR DESCRIPTION
This PR updates the layout to support an area on the right to place a tree eg (the targets tree). This area is as of now just a *placeholder* but it maybe used in the future
The tree area can be resized horizontally and it will always be 100% on height.
If the inner area is too big it will add a scroll bar

![screencast 2020-06-16 23-39-35](https://user-images.githubusercontent.com/3615303/84856076-acf85d00-b033-11ea-8a78-59a919c0b3a9.gif)
