### PR TITLE
Update react-grid-layout and allow moving tiles

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -99,9 +99,7 @@ object ObsTabContents {
                   margin = (5, 5),
                   containerPadding = (5, 5),
                   rowHeight = 30,
-                  draggableHandle = ".tileTitle",
-                  useCSSTransforms =
-                    false, // Not ideal, but fixes flicker on first update (0.18.3).
+                  draggableHandle = s".${GPPStyles.GPPTileTitle.htmlClass}",
                   // onLayoutChange = (a, b) => Callback.log(a.toString) *> Callback.log(b.toString),
                   layouts = layouts
                 )(

--- a/explore/yarn.lock
+++ b/explore/yarn.lock
@@ -5117,16 +5117,16 @@ react-draggable@^4.0.0, react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-grid-layout@0.18.3:
-  version "0.18.3"
-  resolved "https://registry.yarnpkg.com/react-grid-layout/-/react-grid-layout-0.18.3.tgz#4f9540199f35211077eae0aa5bc83096a672c39c"
-  integrity sha512-lHkrk941Tk5nTwZPa9uj6ttHBT0VehSHwEhWbINBJKvM1GRaFNOefvjcuxSyuCI5JWjVUP+Qm3ARt2470AlxMA==
+react-grid-layout@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-grid-layout/-/react-grid-layout-1.0.0.tgz#85495f1e9da2e5b9dad5ece82b3052d624be709d"
+  integrity sha512-0gSnLQL9dYZtAlZCjIPYIqZtswnzMhIT1uip78vs3J432FLOF6LD5PmYaRm34V/s6bEpS9cMZNMcsOanwZXBEw==
   dependencies:
     classnames "2.x"
     lodash.isequal "^4.0.0"
     prop-types "^15.0.0"
     react-draggable "^4.0.0"
-    react-resizable "^1.9.0"
+    react-resizable "^1.10.0"
 
 react-is@^16.6.3, react-is@^16.7.0, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"
@@ -5161,7 +5161,7 @@ react-redux@^7.0.3, react-redux@^7.1.1:
     prop-types "^15.7.2"
     react-is "^16.9.0"
 
-react-resizable@1.10.1, react-resizable@^1.9.0:
+react-resizable@1.10.1, react-resizable@^1.10.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/react-resizable/-/react-resizable-1.10.1.tgz#f0c2cf1d83b3470b87676ce6d6b02bbe3f4d8cd4"
   integrity sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -24,7 +24,7 @@ object Settings {
     val reactAladin       = "0.1.8"
     val reactAtlasKitTree = "0.2.3"
     val reactCommon       = "0.9.4"
-    val reactGridLayout   = "0.6.2"
+    val reactGridLayout   = "0.7.0"
     val reactResizable    = "0.1.2"
     val reactSemanticUI   = "0.5.9"
     val reactSizeMe       = "0.4.4"


### PR DESCRIPTION
This PR upgrades react grid layout and restore the ability to relocate tiles