### PR TITLE
Modify the way the Side Tab buttons are created.

### DIFF
--- a/common/src/main/scala/explore/components/ui/GPPStyles.scala
+++ b/common/src/main/scala/explore/components/ui/GPPStyles.scala
@@ -16,7 +16,6 @@ object GPPStyles {
   val MainBody: Css   = Css("main-body")
   val MainTitle: Css  = Css("main-title")
   val SideTabs: Css   = Css("sidetabs")
-  val SideButton: Css = Css("side-button")
 
   val ResizeHandle: Css    = Css("resize-handle")
   val Tree: Css            = Css("tree")

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -58,15 +58,14 @@ object SideTabs {
           case AppTab.Constraints    => 2
         }
 
-        def tabButton(style: Css)(tab: AppTab): Button =
+        def tabButton(tab: AppTab): Button =
           Button(active = tab === focus,
-                 clazz = style,
                  onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runInCB
           )(tab.title)
 
         def makeButtonSection(tabs: List[AppTab]): TagMod = tabs match {
-          case justOne :: Nil => VerticalSection()(tabButton(Css.Empty)(justOne))
-          case _              => VerticalSection()(ButtonGroup(tabs.reverse.map(tabButton(Css.Empty)).toTagMod))
+          case justOne :: Nil => VerticalSection()(tabButton(justOne))
+          case _              => VerticalSection()(ButtonGroup(tabs.reverse.map(tabButton).toTagMod))
         }
 
         val buttonSections: List[TagMod] =

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -3,7 +3,7 @@
 
 package explore
 
-import cats.syntax.all._
+import cats.implicits._
 import crystal.react.implicits._
 import explore.components.ui.GPPStyles
 import explore.model.enum.AppTab
@@ -40,13 +40,17 @@ object SideTabs {
 
         def makeButtonSection(tabs: List[AppTab]): TagMod = tabs match {
           case justOne :: Nil => VerticalSection()(tabButton(justOne))
-          case _              => VerticalSection()(ButtonGroup(tabs.reverse.map(tabButton).toTagMod))
+          case _              =>
+            VerticalSection()(
+              ButtonGroup(tabs.sortBy(_.groupOrder.value).reverse.map(tabButton).toTagMod)
+            )
         }
 
         val buttonSections: List[TagMod] =
           tabsL.toList
             .groupBy(_.buttonGroup)
             .toList
+            .sortBy(_._1)
             .map(tup => makeButtonSection(tup._2))
 
         <.div(

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -42,7 +42,7 @@ object SideTabs {
           case justOne :: Nil => VerticalSection()(tabButton(justOne))
           case _              =>
             VerticalSection()(
-              ButtonGroup(tabs.sortBy(_.groupOrder.value).reverse.map(tabButton).toTagMod)
+              ButtonGroup(tabs.reverse.map(tabButton).toTagMod)
             )
         }
 

--- a/model/src/main/scala/explore/model/enum/AppTab.scala
+++ b/model/src/main/scala/explore/model/enum/AppTab.scala
@@ -6,14 +6,16 @@ package explore.model.enum
 import cats.data.NonEmptyList
 import lucuma.core.util.Enumerated
 
-sealed abstract class AppTab(val title: String) extends Product with Serializable
+sealed abstract class AppTab(val title: String, val buttonGroup: Int)
+    extends Product
+    with Serializable
 
 object AppTab {
-  case object Overview       extends AppTab("Overview")
-  case object Observations   extends AppTab("Observations")
-  case object Targets        extends AppTab("Targets")
-  case object Configurations extends AppTab("Configurations")
-  case object Constraints    extends AppTab("Constraints")
+  case object Overview       extends AppTab("Overview", 1)
+  case object Observations   extends AppTab("Observations", 2)
+  case object Targets        extends AppTab("Targets", 2)
+  case object Configurations extends AppTab("Configurations", 2)
+  case object Constraints    extends AppTab("Constraints", 2)
 
   val all = NonEmptyList.of(Overview, Observations, Targets, Configurations, Constraints)
 

--- a/model/src/main/scala/explore/model/enum/AppTab.scala
+++ b/model/src/main/scala/explore/model/enum/AppTab.scala
@@ -4,22 +4,42 @@
 package explore.model.enum
 
 import cats.data.NonEmptyList
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.util.Enumerated
 
-sealed abstract class AppTab(val title: String, val buttonGroup: Int)
-    extends Product
+sealed abstract class AppTab(
+  val title:       String,
+  val buttonGroup: ButtonGroup,
+  val groupOrder:  PosInt
+) extends Product
     with Serializable
 
 object AppTab {
-  case object Overview       extends AppTab("Overview", 1)
-  case object Observations   extends AppTab("Observations", 2)
-  case object Targets        extends AppTab("Targets", 2)
-  case object Configurations extends AppTab("Configurations", 2)
-  case object Constraints    extends AppTab("Constraints", 2)
+  import ButtonGroup._
+
+  case object Overview       extends AppTab("Overview", OverviewButton, 1)
+  case object Observations   extends AppTab("Observations", ObservationGroup, 1)
+  case object Targets        extends AppTab("Targets", ObservationGroup, 2)
+  case object Configurations extends AppTab("Configurations", ObservationGroup, 3)
+  case object Constraints    extends AppTab("Constraints", ObservationGroup, 4)
 
   val all = NonEmptyList.of(Overview, Observations, Targets, Configurations, Constraints)
 
   /** @group Typeclass Instances */
   implicit val AppTabEnumerated: Enumerated[AppTab] =
+    Enumerated.of(all.head, all.tail: _*)
+}
+
+sealed abstract class ButtonGroup extends Product with Serializable
+
+object ButtonGroup {
+  case object OverviewButton   extends ButtonGroup
+  case object ObservationGroup extends ButtonGroup
+
+  // This defines the ordering of the groups.
+  val all = NonEmptyList.of(OverviewButton, ObservationGroup)
+
+  implicit val ButtonGroupEnumerated: Enumerated[ButtonGroup] =
     Enumerated.of(all.head, all.tail: _*)
 }

--- a/model/src/main/scala/explore/model/enum/AppTab.scala
+++ b/model/src/main/scala/explore/model/enum/AppTab.scala
@@ -4,42 +4,33 @@
 package explore.model.enum
 
 import cats.data.NonEmptyList
-import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.PosInt
 import lucuma.core.util.Enumerated
 
+/**
+ * Describes the application tab buttons in the sidebar
+ *
+ * @param title The text for the button
+ * @param buttonGroup Groups the buttons with the same value together
+ *
+ * Within a button group, order is determined by the AppTab Order instance,
+ * which is determined by the order in AppTab.all.
+ */
 sealed abstract class AppTab(
   val title:       String,
-  val buttonGroup: ButtonGroup,
-  val groupOrder:  PosInt
+  val buttonGroup: Int
 ) extends Product
     with Serializable
 
 object AppTab {
-  import ButtonGroup._
-
-  case object Overview       extends AppTab("Overview", OverviewButton, 1)
-  case object Observations   extends AppTab("Observations", ObservationGroup, 1)
-  case object Targets        extends AppTab("Targets", ObservationGroup, 2)
-  case object Configurations extends AppTab("Configurations", ObservationGroup, 3)
-  case object Constraints    extends AppTab("Constraints", ObservationGroup, 4)
+  case object Overview       extends AppTab("Overview", 1)
+  case object Observations   extends AppTab("Observations", 2)
+  case object Targets        extends AppTab("Targets", 2)
+  case object Configurations extends AppTab("Configurations", 2)
+  case object Constraints    extends AppTab("Constraints", 2)
 
   val all = NonEmptyList.of(Overview, Observations, Targets, Configurations, Constraints)
 
   /** @group Typeclass Instances */
   implicit val AppTabEnumerated: Enumerated[AppTab] =
-    Enumerated.of(all.head, all.tail: _*)
-}
-
-sealed abstract class ButtonGroup extends Product with Serializable
-
-object ButtonGroup {
-  case object OverviewButton   extends ButtonGroup
-  case object ObservationGroup extends ButtonGroup
-
-  // This defines the ordering of the groups.
-  val all = NonEmptyList.of(OverviewButton, ObservationGroup)
-
-  implicit val ButtonGroupEnumerated: Enumerated[ButtonGroup] =
     Enumerated.of(all.head, all.tail: _*)
 }


### PR DESCRIPTION
When I started adding the Proposal tab button, I found it was difficult to add a new button given the current implementation. I started needing things like `tabsL.tail.head`, etc.

I came up with this method of specifying tab groups, which will also allow filtering out tabs that shouldn't be shown. For example, the Proposal tab should only be shown if the user is logged in.

This is just one option. Let me know what you think.