### PR TITLE
Updated to the new target class

### DIFF
--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -26,9 +26,9 @@ import japgolly.scalajs.react.vdom.VdomElement
 import log4cats.loglevel.LogLevelLogger
 import lucuma.core.data.EnumZipper
 import org.scalajs.dom
+import sttp.model.Uri
 
 import js.annotation._
-import sttp.model.Uri
 
 object AppCtx extends AppRootContext[AppContextIO]
 

--- a/common/src/main/scala/explore/components/ObsBadge.scala
+++ b/common/src/main/scala/explore/components/ObsBadge.scala
@@ -48,7 +48,7 @@ object ObsBadge {
             CardContent(
               CardHeader(
                 props.layout match {
-                  case NameAndConf        => obs.target.name
+                  case NameAndConf        => obs.target.name.value
                   case ConfAndConstraints => obs.conf
                 }
               ),

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -6,6 +6,7 @@ package explore.model
 import java.time.Duration
 
 import clue.StreamingClientStatus
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.data.KeyedIndexedList
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
@@ -19,6 +20,7 @@ import react.common.implicits._
  * Reusability instances for model classes
  */
 object reusability {
+  implicit val nonEmptyStrinReuse: Reusability[NonEmptyString]                                    = Reusability.by(_.value)
   implicit val statusReuse: Reusability[StreamingClientStatus]                                    = Reusability.derive
   implicit val durationReuse: Reusability[Duration]                                               = Reusability.by(_.getSeconds)
   implicit val siderealTargetReuse: Reusability[SiderealTarget]                                   = Reusability.byEq

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -20,7 +20,7 @@ import react.common.implicits._
  * Reusability instances for model classes
  */
 object reusability {
-  implicit val nonEmptyStrinReuse: Reusability[NonEmptyString]                                    = Reusability.by(_.value)
+  implicit val nonEmptyStringReuse: Reusability[NonEmptyString]                                   = Reusability.by(_.value)
   implicit val statusReuse: Reusability[StreamingClientStatus]                                    = Reusability.derive
   implicit val durationReuse: Reusability[Duration]                                               = Reusability.by(_.getSeconds)
   implicit val siderealTargetReuse: Reusability[SiderealTarget]                                   = Reusability.byEq

--- a/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
+++ b/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
@@ -8,9 +8,13 @@ import java.util.UUID
 import cats._
 import cats.effect.Sync
 import cats.syntax.all._
+import eu.timepit.refined._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Epoch
-import lucuma.core.math.ProperMotion
+import lucuma.core.model.SiderealTracking
 import lucuma.core.model.Target
 import monocle.macros.Lenses
 
@@ -18,7 +22,11 @@ import monocle.macros.Lenses
  * A refinement of gem.Tracker meant for sidereal targets
  */
 @Lenses
-final case class SiderealTarget(id: SiderealTarget.Id, name: String, track: ProperMotion)
+final case class SiderealTarget(
+  id:    SiderealTarget.Id,
+  name:  NonEmptyString,
+  track: SiderealTracking
+)
 
 object SiderealTarget {
   type Id = UUID
@@ -29,8 +37,8 @@ object SiderealTarget {
       .map(id =>
         SiderealTarget(
           id,
-          "New Target",
-          ProperMotion(Coordinates.Zero, Epoch.J2000, none, none, none)
+          refineMV[NonEmpty]("New Target"),
+          SiderealTracking(none, Coordinates.Zero, Epoch.J2000, none, none, none)
         )
       )
 
@@ -55,7 +63,7 @@ object ExploreSiderealTarget {
     target.track
       .map(pm =>
         ExploreSiderealTarget(
-          target.name,
+          target.name.value,
           SiderealTarget(UUID.randomUUID, target.name, pm).some,
           TargetVisualOptions.Default
         )

--- a/model/src/main/scala/explore/model/ModelOptics.scala
+++ b/model/src/main/scala/explore/model/ModelOptics.scala
@@ -3,10 +3,11 @@
 
 package explore.model
 
+import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
-import lucuma.core.math.ProperMotion
 import lucuma.core.math.RightAscension
+import lucuma.core.model.SiderealTracking
 import monocle.Lens
 
 /**
@@ -15,16 +16,16 @@ import monocle.Lens
 trait ModelOptics {
 
   /**
-   * Lens for right ascension of a ProperMotion
+   * Lens for right ascension of a SiderealTracking
    */
-  val properMotionRA: Lens[ProperMotion, RightAscension] =
-    ProperMotion.baseCoordinates ^|-> Coordinates.rightAscension
+  val properMotionRA: Lens[SiderealTracking, RightAscension] =
+    SiderealTracking.baseCoordinates ^|-> Coordinates.rightAscension
 
   /**
-   * Lens for declination of a ProperMotion
+   * Lens for declination of a SiderealTracking
    */
-  val properMotionDec: Lens[ProperMotion, Declination] =
-    ProperMotion.baseCoordinates ^|-> Coordinates.declination
+  val properMotionDec: Lens[SiderealTracking, Declination] =
+    SiderealTracking.baseCoordinates ^|-> Coordinates.declination
 
   /**
    * Lens to the RightAscension of a sidereal target
@@ -42,7 +43,7 @@ trait ModelOptics {
    * Lens used to change name and coordinates of a target
    */
   val targetPropsL =
-    Lens[SiderealTarget, (String, RightAscension, Declination)](t =>
+    Lens[SiderealTarget, (NonEmptyString, RightAscension, Declination)](t =>
       (t.name, targetRA.get(t), targetDec.get(t))
     )(s => t => targetRA.set(s._2)(targetDec.set(s._3)(t.copy(name = s._1))))
 }

--- a/model/src/main/scala/explore/model/decoders.scala
+++ b/model/src/main/scala/explore/model/decoders.scala
@@ -6,16 +6,18 @@ package explore.model
 import java.time.Duration
 
 import cats.syntax.all._
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.enum.ObsStatus
 import explore.model.enum._
 import io.circe.Decoder
 import io.circe.DecodingFailure
 import io.circe.HCursor
+import io.circe.refined._
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.Epoch
-import lucuma.core.math.ProperMotion
 import lucuma.core.math.RightAscension
+import lucuma.core.model.SiderealTracking
 
 object decoders {
 
@@ -43,10 +45,10 @@ object decoders {
     final def apply(c: HCursor): Decoder.Result[SiderealTarget] =
       for {
         id    <- c.downField("id").as[SiderealTarget.Id]
-        name  <- c.downField("name").as[String]
+        name  <- c.downField("name").as[NonEmptyString]
         ra    <- c.downField("ra").as[RightAscension]
         dec   <- c.downField("dec").as[Declination]
-        coords = ProperMotion(Coordinates(ra, dec), Epoch.J2000, none, none, none)
+        coords = SiderealTracking(none, Coordinates(ra, dec), Epoch.J2000, none, none, none)
       } yield SiderealTarget(id, name, coords)
   }
 

--- a/model/src/main/scala/explore/model/encoders.scala
+++ b/model/src/main/scala/explore/model/encoders.scala
@@ -5,6 +5,7 @@ package explore.model
 
 import io.circe.Encoder
 import io.circe.Json
+import io.circe.refined._
 import io.circe.syntax._
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
@@ -26,7 +27,7 @@ object encoders {
       Json.obj(
         "id"          -> target.id.asJson,
         "name"        -> target.name.asJson,
-        "object_type" -> "Sidereal".asJson,
+        "object_type" -> "SIDEREAL".asJson,
         "ra"          -> targetRA.get(target).asJson,
         "dec"         -> targetDec.get(target).asJson
       )

--- a/model/src/main/scala/explore/model/partial.scala
+++ b/model/src/main/scala/explore/model/partial.scala
@@ -5,13 +5,15 @@ package explore.model
 
 import java.time.Duration
 
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.enum.ObsStatus
 import io.circe.Decoder
 import io.circe.HCursor
+import io.circe.refined._
 import monocle.macros.Lenses
 
 @Lenses
-final case class TargetSummary(id: SiderealTarget.Id, name: String)
+final case class TargetSummary(id: SiderealTarget.Id, name: NonEmptyString)
 
 object TargetSummary {
   def fromTarget(target: SiderealTarget): TargetSummary =
@@ -21,7 +23,7 @@ object TargetSummary {
     final def apply(c: HCursor): Decoder.Result[TargetSummary] =
       for {
         id   <- c.downField("id").as[SiderealTarget.Id]
-        name <- c.downField("name").as[String]
+        name <- c.downField("name").as[NonEmptyString]
       } yield TargetSummary(id, name)
   }
 }

--- a/model/src/test/scala/explore/model/ModelOpticsSuite.scala
+++ b/model/src/test/scala/explore/model/ModelOpticsSuite.scala
@@ -7,19 +7,17 @@ import explore.model.arb.all._
 import lucuma.core.math.arb.ArbDeclination
 import lucuma.core.math.arb.ArbRightAscension
 import lucuma.core.model.arb.ArbSiderealTracking
+import eu.timepit.refined.scalacheck._
 import eu.timepit.refined.scalacheck.string._
-import eu.timepit.refined.types.string._
 import eu.timepit.refined.cats._
 import monocle.law.discipline.LensTests
 import munit.DisciplineSuite
-import org.scalacheck.Cogen
 
 class ModelOpticsSuite
     extends DisciplineSuite
     with ArbDeclination
     with ArbRightAscension
     with ArbSiderealTracking {
-  implicit val coGenNonEmptyString: Cogen[NonEmptyString] = Cogen[String].contramap(_.value)
 
   checkAll("properMotionRA", LensTests(ModelOptics.properMotionRA))
   checkAll("properMotionDec", LensTests(ModelOptics.properMotionDec))

--- a/model/src/test/scala/explore/model/ModelOpticsSuite.scala
+++ b/model/src/test/scala/explore/model/ModelOpticsSuite.scala
@@ -5,16 +5,22 @@ package explore.model
 
 import explore.model.arb.all._
 import lucuma.core.math.arb.ArbDeclination
-import lucuma.core.math.arb.ArbProperMotion
 import lucuma.core.math.arb.ArbRightAscension
+import lucuma.core.model.arb.ArbSiderealTracking
+import eu.timepit.refined.scalacheck.string._
+import eu.timepit.refined.types.string._
+import eu.timepit.refined.cats._
 import monocle.law.discipline.LensTests
 import munit.DisciplineSuite
+import org.scalacheck.Cogen
 
 class ModelOpticsSuite
     extends DisciplineSuite
     with ArbDeclination
     with ArbRightAscension
-    with ArbProperMotion {
+    with ArbSiderealTracking {
+  implicit val coGenNonEmptyString: Cogen[NonEmptyString] = Cogen[String].contramap(_.value)
+
   checkAll("properMotionRA", LensTests(ModelOptics.properMotionRA))
   checkAll("properMotionDec", LensTests(ModelOptics.properMotionDec))
   checkAll("targetRA", LensTests(ModelOptics.targetRA))

--- a/model/src/test/scala/explore/model/arb/ArbSiderealTarget.scala
+++ b/model/src/test/scala/explore/model/arb/ArbSiderealTarget.scala
@@ -7,25 +7,27 @@ import java.util.UUID
 
 import explore.model.SiderealTarget
 import explore.model.arb.CogenUUID._
-import lucuma.core.math.ProperMotion
+import lucuma.core.model.SiderealTracking
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
+import eu.timepit.refined.scalacheck.string._
+import eu.timepit.refined.types.string._
 
 trait ArbSiderealTarget {
-  import lucuma.core.math.arb.ArbProperMotion._
+  import lucuma.core.model.arb.ArbSiderealTracking._
 
   implicit val targetArb = Arbitrary[SiderealTarget] {
     for {
       i <- arbitrary[UUID]
-      n <- arbitrary[String]
-      p <- arbitrary[ProperMotion]
+      n <- arbitrary[NonEmptyString]
+      p <- arbitrary[SiderealTracking]
     } yield SiderealTarget(i, n, p)
   }
 
   implicit val siderealTargetCogen: Cogen[SiderealTarget] =
-    Cogen[(UUID, String, ProperMotion)].contramap(c => (c.id, c.name, c.track))
+    Cogen[(UUID, String, SiderealTracking)].contramap(c => (c.id, c.name.value, c.track))
 }
 
 object ArbSiderealTarget extends ArbSiderealTarget

--- a/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
@@ -11,6 +11,9 @@ import scala.util.Random
 
 import cats.effect.IO
 import cats.syntax.all._
+import eu.timepit.refined._
+import eu.timepit.refined.collection._
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ObsBadge
 import explore.data.tree._
 import explore.model.Constraints
@@ -24,7 +27,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Epoch
-import lucuma.core.math.ProperMotion
+import lucuma.core.model.SiderealTracking
 import mouse.boolean._
 import react.atlasKit.tree.{ Tree => AtlasTree }
 import react.semanticui.elements.icon.Icon
@@ -44,14 +47,14 @@ object AndOrTest {
                 WaterVapor.Any
     )
 
-  def obs(targetName: String): ObsNode =
+  def obs(targetName: NonEmptyString): ObsNode =
     ObsNode.Obs(
       UUID.randomUUID,
       ExploreObservation(
         UUID.randomUUID,
         SiderealTarget(UUID.randomUUID,
                        targetName,
-                       ProperMotion(Coordinates.Zero, Epoch.J2000, none, none, none)
+                       SiderealTracking(none, Coordinates.Zero, Epoch.J2000, none, none, none)
         ),
         randomElement(ObsStatus.ObsStatusEnumerated.all),
         "GMOS-N R831 1x 300",
@@ -69,12 +72,15 @@ object AndOrTest {
   val initialTree: KeyedIndexedTree[UUID, ObsNode] =
     KeyedIndexedTree.fromTree(
       Tree(
-        Node(obs("NGC 1055")),
-        Node(obs("NGC 7752")),
-        Node(obs("NGC 1068")),
+        Node(obs(refineMV[NonEmpty]("NGC 1055"))),
+        Node(obs(refineMV[NonEmpty]("NGC 7752"))),
+        Node(obs(refineMV[NonEmpty]("NGC 1068"))),
         Node(or(""),
-             Node(obs("NGC 1087")),
-             Node(and(""), Node(obs("NGC 1087")), Node(obs("NGC 1087")))
+             Node(obs(refineMV[NonEmpty]("NGC 1087"))),
+             Node(and(""),
+                  Node(obs(refineMV[NonEmpty]("NGC 1087"))),
+                  Node(obs(refineMV[NonEmpty]("NGC 1087")))
+             )
         )
       ),
       ObsNode.id.get

--- a/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
@@ -11,8 +11,7 @@ import scala.util.Random
 
 import cats.effect.IO
 import cats.syntax.all._
-import eu.timepit.refined._
-import eu.timepit.refined.collection._
+import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ObsBadge
 import explore.data.tree._
@@ -72,15 +71,12 @@ object AndOrTest {
   val initialTree: KeyedIndexedTree[UUID, ObsNode] =
     KeyedIndexedTree.fromTree(
       Tree(
-        Node(obs(refineMV[NonEmpty]("NGC 1055"))),
-        Node(obs(refineMV[NonEmpty]("NGC 7752"))),
-        Node(obs(refineMV[NonEmpty]("NGC 1068"))),
+        Node(obs("NGC 1055")),
+        Node(obs("NGC 7752")),
+        Node(obs("NGC 1068")),
         Node(or(""),
-             Node(obs(refineMV[NonEmpty]("NGC 1087"))),
-             Node(and(""),
-                  Node(obs(refineMV[NonEmpty]("NGC 1087"))),
-                  Node(obs(refineMV[NonEmpty]("NGC 1087")))
-             )
+             Node(obs("NGC 1087")),
+             Node(and(""), Node(obs("NGC 1087")), Node(obs("NGC 1087")))
         )
       ),
       ObsNode.id.get

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -262,7 +262,7 @@ object TargetObsList {
                       <.span(GPPStyles.ObsTreeGroupHeader)(
                         <.span(
                           opIcon,
-                          target.name
+                          target.name.value
                         ),
                         <.span(^.float.right, s"$obsCount Obs")
                       ),

--- a/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
@@ -7,8 +7,7 @@ import java.time.Duration
 import java.util.UUID
 
 import cats.syntax.all._
-import eu.timepit.refined._
-import eu.timepit.refined.collection._
+import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.Constraints
 import explore.model.ExploreObservation
@@ -41,11 +40,11 @@ object TargetTreeTest {
     )
   }
 
-  val ngc1055 = target(refineMV[NonEmpty]("NGC 1055"), "02:41:45.232999", "+00:26:35.450016")
-  val ngc7752 = target(refineMV[NonEmpty]("NGC 7752"), "23:46:58.557000", "+29:27:32.169995")
-  val ngc3705 = target(refineMV[NonEmpty]("NGC 3705"), "11:30:07.456000", "+09:16:35.870015")
-  val ngc1068 = target(refineMV[NonEmpty]("NGC 1068"), "02:42:40.771000", "-00:00:47.840004")
-  val ngc1087 = target(refineMV[NonEmpty]("NGC 1087"), "02:46:25.154457", "-00:29:55.449960")
+  val ngc1055 = target("NGC 1055", "02:41:45.232999", "+00:26:35.450016")
+  val ngc7752 = target("NGC 7752", "23:46:58.557000", "+29:27:32.169995")
+  val ngc3705 = target("NGC 3705", "11:30:07.456000", "+09:16:35.870015")
+  val ngc1068 = target("NGC 1068", "02:42:40.771000", "-00:00:47.840004")
+  val ngc1087 = target("NGC 1087", "02:46:25.154457", "-00:29:55.449960")
 
   val targets = List(
     ngc1055,

--- a/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
@@ -7,6 +7,9 @@ import java.time.Duration
 import java.util.UUID
 
 import cats.syntax.all._
+import eu.timepit.refined._
+import eu.timepit.refined.collection._
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.Constraints
 import explore.model.ExploreObservation
 import explore.model.SiderealTarget
@@ -15,20 +18,21 @@ import explore.model.enum._
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.Epoch
-import lucuma.core.math.ProperMotion
 import lucuma.core.math.RightAscension
+import lucuma.core.model.SiderealTracking
 
 object TargetTreeTest {
 
-  def target(name: String, raStr: String, decStr: String): SiderealTarget = {
+  def target(name: NonEmptyString, raStr: String, decStr: String): SiderealTarget = {
     val ra     = RightAscension.fromStringHMS.getOption(raStr)
     val dec    = Declination.fromStringSignedDMS.getOption(decStr)
     val coords =
-      ProperMotion((ra, dec).mapN(Coordinates.apply).getOrElse(Coordinates.Zero),
-                   Epoch.J2000,
-                   none,
-                   none,
-                   none
+      SiderealTracking(none,
+                       (ra, dec).mapN(Coordinates.apply).getOrElse(Coordinates.Zero),
+                       Epoch.J2000,
+                       none,
+                       none,
+                       none
       )
     SiderealTarget(
       UUID.randomUUID,
@@ -37,11 +41,11 @@ object TargetTreeTest {
     )
   }
 
-  val ngc1055 = target("NGC 1055", "02:41:45.232999", "+00:26:35.450016")
-  val ngc7752 = target("NGC 7752", "23:46:58.557000", "+29:27:32.169995")
-  val ngc3705 = target("NGC 3705", "11:30:07.456000", "+09:16:35.870015")
-  val ngc1068 = target("NGC 1068", "02:42:40.771000", "-00:00:47.840004")
-  val ngc1087 = target("NGC 1087", "02:46:25.154457", "-00:29:55.449960")
+  val ngc1055 = target(refineMV[NonEmpty]("NGC 1055"), "02:41:45.232999", "+00:26:35.450016")
+  val ngc7752 = target(refineMV[NonEmpty]("NGC 7752"), "23:46:58.557000", "+29:27:32.169995")
+  val ngc3705 = target(refineMV[NonEmpty]("NGC 3705"), "11:30:07.456000", "+09:16:35.870015")
+  val ngc1068 = target(refineMV[NonEmpty]("NGC 1068"), "02:42:40.771000", "-00:00:47.840004")
+  val ngc1087 = target(refineMV[NonEmpty]("NGC 1087"), "02:46:25.154457", "-00:29:55.449960")
 
   val targets = List(
     ngc1055,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -16,7 +16,7 @@ object Settings {
     val geminiLocales     = "0.5.0"
     val log4Cats          = "1.1.1"
     val log4CatsLogLevel  = "0.1.0"
-    val lucumaCore        = "0.4.5"
+    val lucumaCore        = "0.5.0"
     val lucumaUI          = "0.3.3"
     val monocle           = "2.1.0"
     val mouse             = "0.25"

--- a/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
@@ -6,18 +6,18 @@ package explore.proposal
 import cats.syntax.all._
 import crystal.react.implicits._
 import explore._
-import explore.components.ui.GPPStyles
 import explore.components.FormStaticData
 import explore.components.Tile
+import explore.components.ui.GPPStyles
 import explore.model._
 import explore.model.display._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.forms._
-import react.common.implicits._
 import react.common.ReactProps
-import react.semanticui.collections.form._
+import react.common.implicits._
 import react.semanticui.addons.textarea.TextArea
+import react.semanticui.collections.form._
 
 final case class ProposalDetailsEditor(proposalDetails: View[ProposalDetails])
     extends ReactProps[ProposalDetailsEditor](ProposalDetailsEditor.component)

--- a/proposal/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -13,10 +13,9 @@ import explore.model._
 import explore.model.enum._
 import explore.model.reusability._
 import fs2.concurrent.SignallingRef
-import japgolly.scalajs.react.vdom.html_<^._
-
-import lucuma.core.model._
 import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.model._
 
 object ProposalTabContents {
   type Props = View[Option[Focused]]

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -24,8 +24,8 @@ import lucuma.core.math.Angle.DMS
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.HourAngle.HMS
-import lucuma.core.math.ProperMotion
 import lucuma.core.math.RightAscension
+import lucuma.core.model.SiderealTracking
 import lucuma.ui.reusability._
 import monocle.Lens
 import monocle.macros.Lenses
@@ -105,10 +105,10 @@ object AladinContainer {
     private val aladinRef = Ref.toScalaComponent(AladinComp)
 
     private val raLens: Lens[SiderealTarget, RightAscension] =
-      SiderealTarget.track ^|-> ProperMotion.baseCoordinates ^|-> Coordinates.rightAscension
+      SiderealTarget.track ^|-> SiderealTracking.baseCoordinates ^|-> Coordinates.rightAscension
 
     private val decLens: Lens[SiderealTarget, Declination] =
-      SiderealTarget.track ^|-> ProperMotion.baseCoordinates ^|-> Coordinates.declination
+      SiderealTarget.track ^|-> SiderealTracking.baseCoordinates ^|-> Coordinates.declination
 
     def setRa(ra: RightAscension): Callback =
       $.props >>= (_.target.zoom(raLens).set(ra).runInCB)

--- a/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
@@ -37,7 +37,7 @@ final case class CoordinatesForm(
     extends ReactProps[CoordinatesForm](CoordinatesForm.component) {
   def submit(searchTerm: String): Callback =
     refineV[NonEmpty](searchTerm)
-      .fold(_ => Callback.empty, s => searchAndGo(s).when(s =!= target.name).asCBO)
+      .fold(_ => Callback.empty, s => searchAndGo(s).when_(s =!= target.name))
 }
 
 object CoordinatesForm {

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 import cats.effect.IO
 import cats.syntax.all._
 import clue.GraphQLQuery
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.implicits._
 import explore.model.SiderealTarget
 import explore.model.decoders._
@@ -15,6 +16,7 @@ import explore.undo.Undoer
 import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.JsonObject
+import io.circe.refined._
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.generic.semiauto.deriveEncoder
 import monocle.Lens
@@ -60,9 +62,9 @@ object TargetQueries {
     """
 
     case class Fields(
-      name: Option[String] = None,
-      ra:   Option[String] = None,
-      dec:  Option[String] = None
+      name: Option[NonEmptyString] = none,
+      ra:   Option[String] = none,
+      dec:  Option[String] = none
     )
     object Fields {
       implicit val jsonEncoder: Encoder[Fields] = deriveEncoder[Fields].mapJson(_.dropNullValues)


### PR DESCRIPTION
This PR updates explore to use the latest `lucuma-core` which brings non-trivial
changes to the `Target` class

Note this only fixes compilation and a few more details but still doesn't make use of
e.g. storing the catalog id and aladin searches