### PR TITLE
Fix for odd shifts when hovering in FF

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -62,6 +62,19 @@ body {
   background: darkgrey;
 }
 
+// Taken from the definitíon of ui.button transition but removed background-color and background
+// When animating those two properties you see some flickering in FF
+.ui.button.side-button {
+  transition:
+  opacity @defaultDuration @defaultEasing,
+  color @defaultDuration @defaultEasing,
+  box-shadow @defaultDuration @defaultEasing,
+}
+
+// Form properties
+.gpp-form {
+}
+
 .explore-tile-title {
   border-bottom-style: solid;
   border-bottom-width: 1px;

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -23,6 +23,7 @@ object ExploreStyles {
   val MainBody: Css   = Css("main-body")
   val MainTitle: Css  = Css("main-title")
   val SideTabs: Css   = Css("sidetabs")
+  val SideButton: Css = Css("side-button")
 
   val ResizeHandle: Css    = Css("resize-handle")
   val Tree: Css            = Css("tree")

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -35,6 +35,7 @@ object SideTabs {
 
         def tabButton(tab: AppTab): Button =
           Button(active = tab === focus,
+                 clazz = GPPStyles.SideButton,
                  onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runInCB
           )(tab.title)
 

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -35,7 +35,7 @@ object SideTabs {
 
         def tabButton(tab: AppTab): Button =
           Button(active = tab === focus,
-                 clazz = GPPStyles.SideButton,
+                 clazz = ExploreStyles.SideButton,
                  onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runInCB
           )(tab.title)
 


### PR DESCRIPTION
I noted a bit of flickering when hovering on the vertical buttons on FF

This PR fixes it. Tested in FF, Chrome and Safari