### PR TITLE
Modify Target Position tile to use CSS Grid

### DIFF
--- a/common/src/main/resources/less/explore-grid.less
+++ b/common/src/main/resources/less/explore-grid.less
@@ -14,6 +14,10 @@
     display: grid;
     grid-gap: 1em;
 
+    &.explore-compact {
+        grid-gap: 0.3em;
+    }
+
     /*
      You do not not to specify the row and column of each cell 
      for most simple layouts, such as most forms. It will fill 
@@ -39,8 +43,6 @@
             grid-template-columns: 1fr 1fr 1fr;
         }
     }
-
-    
 }
 
 /*

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -359,6 +359,7 @@ body {
 }
 
 .target-aladin-cell {
+  height: 100px;
   min-height: 300px; // don't collapse in single column mode.
 }
 

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -78,13 +78,13 @@ body {
 }
 
 .explore-tile-body {
-  height: ~"calc(100% - @{minHeight}/2)";
+  height: ~"calc(100% - @{minHeight})";
+  overflow-y: auto;
 }
 
 .explore-tile {
   .full-height-width();
   background: @tileBackground;
-  overflow-y: auto;
 }
 
 .proposal-tile {
@@ -344,7 +344,7 @@ body {
 }
 
 // The Target Position layout
-@target-grid-responsive-cutoff: 1350px;
+@target-grid-responsive-cutoff: 992px;
 
 .target-grid {
   display: grid;
@@ -371,8 +371,16 @@ body {
   }
 }
 
+.coordinates-form {
+  margin-bottom: 1em;
+}
+
+.catalogue-form {
+  height: max-content; // keep it from expanding to fill cell
+}
+
 // for the ra and dec inputs and the flex container
 // that holds them
 .target-ra-dec-min-width {
-  min-width: 7em;
+  min-width: 3em;
 }

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -71,10 +71,6 @@ body {
   box-shadow @defaultDuration @defaultEasing,
 }
 
-// Form properties
-.gpp-form {
-}
-
 .explore-tile-title {
   border-bottom-style: solid;
   border-bottom-width: 1px;
@@ -88,6 +84,7 @@ body {
 .explore-tile {
   .full-height-width();
   background: @tileBackground;
+  overflow-y: auto;
 }
 
 .proposal-tile {
@@ -266,9 +263,6 @@ body {
   padding-bottom: 0px;
 }
 
-.aladin-column {
-}
-
 .aladin-container-column {
   height: 100%;
   display: grid;
@@ -282,9 +276,6 @@ body {
 .aladin-container-body {
   grid-area: aladin;
   margin-bottom: 0.2em;
-}
-
-.aladin-container-status {
 }
 
 .aladin-status-fov {
@@ -350,4 +341,37 @@ body {
 
 .wip:hover .wip-warning {
   visibility: visible;
+}
+
+// The Target Position layout
+@target-grid-responsive-cutoff: 1350px;
+
+.target-grid {
+  display: grid;
+
+  grid-gap: 1em;
+  padding: 1em;
+  grid-template-columns: 1fr 2fr 1fr;
+
+  @media (max-width: @target-grid-responsive-cutoff) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.target-aladin-cell {
+  min-height: 300px; // don't collapse in single column mode.
+}
+
+.target-skyplot-cell {
+  margin: 0 1em 1em;
+
+  & > .wip {
+    display: block; // makes skyplot fill the width.
+  }
+}
+
+// for the ra and dec inputs and the flex container
+// that holds them
+.target-ra-dec-min-width {
+  min-width: 7em;
 }

--- a/common/src/main/resources/theme/globals/site.variables
+++ b/common/src/main/resources/theme/globals/site.variables
@@ -1,0 +1,2 @@
+@inputVerticalPadding   : @relative5px;
+@inputHorizontalPadding : @relative6px;

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -58,10 +58,8 @@ object ExploreStyles {
   val SkyPlotControls: Css = Css("sky-plot-controls")
   val PlotToggle: Css      = Css("plot-toggle")
 
-  val AladinColumn: Css          = Css("aladin-column")
   val AladinContainerColumn: Css = Css("aladin-container-column")
   val AladinContainerBody: Css   = Css("aladin-container-body")
-  val AladinContainerStatus: Css = Css("aladin-container-status")
   val AladinFOV: Css             = Css("aladin-status-fov")
   val AladinDetailText: Css      = Css("aladin-detail-text")
   val AladinCurrentCoords: Css   = Css("aladin-status-current-coordinates")
@@ -73,6 +71,7 @@ object ExploreStyles {
   val Grid: Css            = Css("explore-grid")
   val TwoColumnGrid: Css   = Grid |+| Css("explore-two-columns")
   val ThreeColumnGrid: Css = Grid |+| Css("explore-three-columns")
+  val Compact: Css         = Css("explore-compact")
 
   val FlexContainer: Css = Css("explore-flex-container")
   def Grow(i: Int Refined Interval.Closed[1, 4]): Css = Css(s"explore-grow-$i")
@@ -94,4 +93,10 @@ object ExploreStyles {
   // WIP
   val WIP: Css        = Css("wip")
   val WIPWarning: Css = Css("wip-warning")
+
+  // The Target tab contents
+  val TargetGrid: Css          = Css("target-grid")
+  val TargetAladinCell: Css    = Css("target-aladin-cell")
+  val TargetSkyplotCell: Css   = Css("target-skyplot-cell")
+  val TargetRaDecMinWidth: Css = Css("target-ra-dec-min-width")
 }

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -99,4 +99,6 @@ object ExploreStyles {
   val TargetAladinCell: Css    = Css("target-aladin-cell")
   val TargetSkyplotCell: Css   = Css("target-skyplot-cell")
   val TargetRaDecMinWidth: Css = Css("target-ra-dec-min-width")
+  val CoordinatesForm: Css     = Css("coordinates-form")
+  val CatalogueForm: Css       = Css("catalogue-form")
 }

--- a/explore/yarn.lock
+++ b/explore/yarn.lock
@@ -515,6 +515,11 @@
     tiny-json-http "^7.1.2"
     webpack-bundle-analyzer "^3.4.1"
 
+"@popperjs/core@^2.5.2":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.5.3.tgz#4982b0b66b7a4cf949b86f5d25a8cf757d3cfd9d"
+  integrity sha512-RFwCobxsvZ6j7twS7dHIZQZituMIDJJNHS/qY6iuthVebxS3zhRY+jaC2roEKiAYaVuTcGmX6Luc6YBcf6zJVg==
+
 "@semantic-ui-react/event-stack@^3.1.0":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@semantic-ui-react/event-stack/-/event-stack-3.1.1.tgz#3263d17511db81a743167fe45281a24b3eb6b3c8"
@@ -5997,6 +6002,11 @@ react-draggable@4.4.3, react-draggable@^4.0.0, react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-grid-layout@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-grid-layout/-/react-grid-layout-1.0.0.tgz#85495f1e9da2e5b9dad5ece82b3052d624be709d"
@@ -6023,7 +6033,7 @@ react-onclickoutside@^6.9.0:
   resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"
   integrity sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A==
 
-react-popper@^1.3.4, react-popper@^1.3.7:
+react-popper@^1.3.4:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
   integrity sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==
@@ -6034,6 +6044,14 @@ react-popper@^1.3.4, react-popper@^1.3.7:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-redux@^7.0.3, react-redux@^7.1.1:
@@ -6407,14 +6425,15 @@ selfsigned@^1.10.7:
   dependencies:
     node-forge "^0.10.0"
 
-semantic-ui-react@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-1.3.1.tgz#254a8e53f13f4e09a0a4692e971202dcb7b72834"
-  integrity sha512-3EE8Cl2Tq9re+J5An8QOZHgjRJjHqNDBq+Aoaa0TLFnd79UgYzovJPQGy3AWIxgCkxDPj4c3yxl72ImumJLyeA==
+semantic-ui-react@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/semantic-ui-react/-/semantic-ui-react-2.0.0.tgz#72f17837d3bf680b73cc39c90a6593847c18e3c3"
+  integrity sha512-LDik4s+Qbud1SapBdygFfgP5Q1tmmdScuRL1wwxjpDv1TENEwSSX1wDislrsk+HhjYYjkoIB9tt7psD/RAb1CQ==
   dependencies:
     "@babel/runtime" "^7.10.5"
     "@fluentui/react-component-event-listener" "~0.51.1"
     "@fluentui/react-component-ref" "~0.51.1"
+    "@popperjs/core" "^2.5.2"
     "@semantic-ui-react/event-stack" "^3.1.0"
     clsx "^1.1.1"
     keyboard-key "^1.1.0"
@@ -6422,7 +6441,7 @@ semantic-ui-react@1.3.1:
     lodash-es "^4.17.15"
     prop-types "^15.7.2"
     react-is "^16.8.6"
-    react-popper "^1.3.7"
+    react-popper "^2.2.3"
     shallowequal "^1.1.0"
 
 semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -42,7 +42,6 @@ import react.semanticui.sizes._
 
 @Lenses
 final case class AladinContainer(
-  s:       Size,
   target:  View[SiderealTarget],
   options: TargetVisualOptions
 ) extends ReactProps[AladinContainer](AladinContainer.component) {

--- a/targeteditor/src/main/scala/explore/targeteditor/CataloguesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CataloguesForm.scala
@@ -8,6 +8,7 @@ import scala.collection.SortedMap
 import cats.data.NonEmptyList
 import crystal.react.implicits._
 import explore.View
+import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.TargetVisualOptions
 import explore.model.enum.Display
@@ -57,7 +58,10 @@ object CataloguesForm {
       .render { $ =>
         val optionsV = $.props.options
         val options  = optionsV.get
-        Form(size = Mini)(
+        Form(size = Small)(
+          ExploreStyles.Grid,
+          ExploreStyles.Compact,
+          ExploreStyles.CatalogueForm,
           FormDropdown(
             label = "Catalogues",
             value = 0,

--- a/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
@@ -8,10 +8,12 @@ import cats.syntax.all._
 import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined._
+import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.AppCtx
+import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.ModelOptics._
 import explore.model.SiderealTarget
@@ -23,11 +25,11 @@ import lucuma.core.math.RightAscension
 import lucuma.ui.forms._
 import monocle.macros.Lenses
 import react.common._
+import react.common.implicits._
 import react.semanticui.collections.form._
 import react.semanticui.elements.icon.Icon
 import react.semanticui.modules.dropdown.DropdownItem
 import react.semanticui.sizes._
-import react.semanticui.widths._
 
 final case class CoordinatesForm(
   target:           SiderealTarget,
@@ -62,9 +64,11 @@ object CoordinatesForm {
         val stateView = ViewF.fromState[IO]($)
 
         Form(
-          size = Mini,
+          size = Small,
           onSubmit = props.submit(state.searchTerm)
         )(
+          ExploreStyles.Grid,
+          ExploreStyles.Compact,
           FormDropdown(
             label = "Type",
             value = 0,
@@ -79,26 +83,28 @@ object CoordinatesForm {
                       focus = true,
                       icon = Icon("search")
           ),
-          FormGroup(widths = FormWidths.Equal)(
+          <.div(
+            ExploreStyles.FlexContainer,
+            ExploreStyles.TargetRaDecMinWidth,
             FormInputEV(
-              width = Seven,
               id = "ra",
               value = stateView.zoom(State.raValue),
               format = RightAscension.fromStringHMS,
-              label = "RA"
+              label = "RA",
+              clazz = ExploreStyles.Grow(1) |+| ExploreStyles.TargetRaDecMinWidth
             ),
             FormInputEV(
-              width = Seven,
               id = "dec",
               value = stateView.zoom(State.decValue),
               format = Declination.fromStringSignedDMS,
-              label = "Dec"
+              label = "Dec",
+              clazz = ExploreStyles.Grow(1) |+| ExploreStyles.TargetRaDecMinWidth
             ),
-            FormButton(width = Two,
-                       size = Small,
-                       icon = true,
-                       label = "X",
-                       onClick = props.goToRaDec(Coordinates(state.raValue, state.decValue))
+            FormButton(
+              size = Small,
+              icon = true,
+              label = "X",
+              onClick = props.goToRaDec(Coordinates(state.raValue, state.decValue))
             )(
               Icon("angle right")
             )

--- a/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
@@ -69,6 +69,7 @@ object CoordinatesForm {
         )(
           ExploreStyles.Grid,
           ExploreStyles.Compact,
+          ExploreStyles.CoordinatesForm,
           FormDropdown(
             label = "Type",
             value = 0,
@@ -103,10 +104,11 @@ object CoordinatesForm {
             FormButton(
               size = Small,
               icon = true,
-              label = "X",
+              label = "Go To",
               onClick = props.goToRaDec(Coordinates(state.raValue, state.decValue))
             )(
-              Icon("angle right")
+              Icon("angle right"),
+              ExploreStyles.HideLabel
             )
           )
         )

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -98,7 +98,7 @@ object TargetBody extends ModelOptics {
           val searchAndSet: NonEmptyString => Callback =
             searchAndGo(modify.andThen(_.runInCB))
 
-          <.div(
+          React.Fragment(
             <.div(
               ExploreStyles.TargetGrid,
               <.div(

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -6,6 +6,7 @@ package explore.targeteditor
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined._
+import eu.timepit.refined.auto._
 import eu.timepit.refined.collection._
 import eu.timepit.refined.types.string._
 import explore.AppCtx
@@ -26,8 +27,6 @@ import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
 import react.common._
-import react.semanticui.collections.grid._
-import react.semanticui.widths._
 import react.sizeme.SizeMe
 import explore.GraphQLSchemas.ObservationDB.Types._
 
@@ -100,33 +99,28 @@ object TargetBody extends ModelOptics {
           val searchAndSet: NonEmptyString => Callback =
             searchAndGo(modify.andThen(_.runInCB))
 
-          Grid(columns = Three,
-               clazz = ExploreStyles.FullHeightWidth,
-               stretched = true,
-               padded = GridPadded.Horizontally
-          )(
-            GridRow(stretched = true)(
-              GridColumn(stretched = true, computer = Four)(
+          <.div(
+            <.div(
+              ExploreStyles.TargetGrid,
+              <.div(
                 CoordinatesForm(target, searchAndSet, gotoRaDec)
                   .withKey(coordinatesKey(target)),
                 UndoButtons(target, undoCtx)
               ),
-              GridColumn(stretched = true, computer = Eight, clazz = ExploreStyles.AladinColumn)(
+              <.div(
+                ExploreStyles.TargetAladinCell,
                 SizeMe(monitorHeight = true) { s =>
                   AladinRef.withRef(aladinRef) {
                     AladinContainer(s, props.target, props.options.get)
                   }
                 }
               ),
-              GridColumn(stretched = true, computer = Four)(
-                CataloguesForm(props.options)
-              )
+              CataloguesForm(props.options)
             ),
-            GridRow()(
-              GridColumn(computer = Sixteen)(
-                WIP(
-                  SkyPlotSection(target.track.baseCoordinates)
-                )
+            <.div(
+              ExploreStyles.TargetSkyplotCell,
+              WIP(
+                SkyPlotSection(target.track.baseCoordinates)
               )
             )
           )

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -27,7 +27,6 @@ import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
 import react.common._
-import react.sizeme.SizeMe
 import explore.GraphQLSchemas.ObservationDB.Types._
 
 final case class TargetBody(
@@ -109,10 +108,8 @@ object TargetBody extends ModelOptics {
               ),
               <.div(
                 ExploreStyles.TargetAladinCell,
-                SizeMe(monitorHeight = true) { s =>
-                  AladinRef.withRef(aladinRef) {
-                    AladinContainer(s, props.target, props.options.get)
-                  }
+                AladinRef.withRef(aladinRef) {
+                  AladinContainer(props.target, props.options.get)
                 }
               ),
               CataloguesForm(props.options)


### PR DESCRIPTION
This changes the `Target Position` tile, which appears on both the Targets and Observations tabs, to use a CSS grid for layout.

I made a `compact` grid layout which reduces the space between cells as compared to what is currently used on the Proposal tab and used it for the `CoordinatesForm`. I also increased the Form Size to `Small` which makes it more readable. WIth the compact grid it still takes up slightly more space than the previous version, but decreasing the padding in the inputs will maintain readability and reduce size. I have not modified the `CataloguesForm` but similar changes could be made there.