### PR TITLE
Split some parts of the aladin container for performance reasons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -332,7 +332,6 @@ lazy val commonWDS = Seq(
     (common / Compile / sourceDirectory).value / "webpack" / "prod.webpack.config.js"
   ),
   installJsdom / version := "16.4.0",
-  fullOptJS / webpackNodeArgs += "--max_old_space_size=2560",
   webpackMonitoredDirectories += (common / Compile / resourceDirectory).value,
   webpackMonitoredDirectories += ((common / Compile / sourceDirectory).value / "webpack"),
   webpackResources := ((common / Compile / sourceDirectory).value / "webpack") * "*.js",

--- a/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
+++ b/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
@@ -43,6 +43,9 @@ object SiderealTarget {
       )
 
   implicit val siderealTargetEq: Eq[SiderealTarget] = Eq.by(x => (x.name, x.track))
+
+  val baseCoordinates = SiderealTarget.track ^|-> SiderealTracking.baseCoordinates
+
 }
 
 /**

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -22,7 +22,7 @@ object Settings {
     val monocle           = "2.1.0"
     val mouse             = "0.25"
     val mUnit             = "0.7.14"
-    val reactAladin       = "0.2.1"
+    val reactAladin       = "0.2.2"
     val reactAtlasKitTree = "0.3.0"
     val reactCommon       = "0.10.0"
     val reactDatepicker   = "0.1.0"

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -1,0 +1,104 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targeteditor
+
+import cats.syntax.all._
+import crystal.react.implicits._
+import eu.timepit.refined.auto._
+import explore.Icons
+import explore.View
+import explore.components.ui.ExploreStyles
+import explore.model.ModelOptics
+import explore.model.TargetVisualOptions
+import explore.model.reusability._
+import japgolly.scalajs.react.MonocleReact._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.math.Angle
+import lucuma.core.math.Coordinates
+import lucuma.ui.reusability._
+import monocle.macros.Lenses
+import react.aladin.Fov
+import react.common._
+import react.semanticui.elements.button.Button
+import react.semanticui.modules.popup.Popup
+import react.semanticui.sizes._
+
+final case class AladinCell(
+  target:  View[Coordinates],
+  options: View[TargetVisualOptions]
+) extends ReactProps[AladinCell](AladinCell.component) {
+  val aladinCoords: Coordinates = target.get
+}
+
+object AladinCell extends ModelOptics {
+  type Props = AladinCell
+  val AladinRef = AladinContainer.component
+
+  @Lenses
+  final case class State(fov: Fov, current: Coordinates)
+
+  object State {
+    val Zero = State(Fov(Angle.Angle0, Angle.Angle0), Coordinates.Zero)
+  }
+  implicit val propsReuse = Reusability.derive[Props]
+  implicit val stateReuse = Reusability.never[State]
+
+  class Backend($ : BackendScope[Props, State]) {
+    // Create a mutable reference
+    private val aladinRef = Ref.toScalaComponent(AladinRef)
+
+    val centerOnTarget =
+      aladinRef.get
+        .flatMapCB(_.backend.centerOnTarget)
+        .toCallback
+
+    val gotoRaDec = (coords: Coordinates) =>
+      aladinRef.get
+        .flatMapCB(_.backend.gotoRaDec(coords))
+        .toCallback
+
+    def render(props: Props, state: State) =
+      React.Fragment(
+        <.div(
+          ExploreStyles.TargetAladinCell,
+          <.div(
+            ExploreStyles.AladinContainerColumn,
+            AladinRef
+              .withRef(aladinRef) {
+                AladinContainer(
+                  props.target,
+                  props.options.get,
+                  $.setStateL(State.current)(_),
+                  $.setStateL(State.fov)(_)
+                )
+              },
+            AladinToolbar(state.fov, state.current),
+            <.div(
+              ExploreStyles.AladinCenterButton,
+              Popup(
+                content = "Center on target",
+                trigger = Button(size = Mini, icon = true, onClick = centerOnTarget)(Icons.Bullseye)
+              )
+            )
+          )
+        )
+      )
+
+    def newProps(currentProps: Props, nextProps: Props): Callback =
+      gotoRaDec(nextProps.aladinCoords)
+        .when(nextProps.aladinCoords =!= currentProps.aladinCoords)
+        .void
+  }
+
+  val component =
+    ScalaComponent
+      .builder[Props]
+      .initialStateFromProps(p => State.Zero.copy(current = p.aladinCoords))
+      .renderBackend[Backend]
+      .componentDidUpdate($ => $.backend.newProps($.prevProps, $.currentProps))
+      .configure(Reusability.shouldComponentUpdate)
+      .build
+
+}

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targeteditor
+
+import scala.math.rint
+
+import explore.components.ui.ExploreStyles
+import explore.model.reusability._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.math.Angle.DMS
+import lucuma.core.math.HourAngle.HMS
+import lucuma.core.math._
+import lucuma.ui.reusability._
+import react.aladin.Fov
+import react.aladin.reusability._
+import react.common.ReactProps
+import react.semanticui.elements.label._
+import react.semanticui.sizes.Small
+
+final case class AladinToolbar(
+  fov:     Fov,
+  current: Coordinates
+) extends ReactProps[AladinToolbar](AladinToolbar.component)
+
+object AladinToolbar {
+  type Props = AladinToolbar
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive
+
+  // TODO: We may want to move these to gsp-math
+  def formatHMS(hms: HMS): String =
+    f"${hms.hours}%02d:${hms.minutes}%02d:${hms.seconds}%02d"
+
+  def formatDMS(dms: DMS): String = {
+    val prefix = if (dms.toAngle.toMicroarcseconds < 0) "-" else "+"
+    f"$prefix${dms.degrees}%02d:${dms.arcminutes}%02d:${dms.arcseconds}%02d"
+  }
+
+  def formatCoordinates(coords: Coordinates): String = {
+    val ra  = HMS(coords.ra.toHourAngle)
+    val dec = DMS(coords.dec.toAngle)
+    s"${formatHMS(ra)} ${formatDMS(dec)}"
+  }
+
+  def formatFov(angle: Angle): String = {
+    val dms        = Angle.DMS(angle)
+    val degrees    = dms.degrees
+    val arcminutes = dms.arcminutes
+    val arcseconds = dms.arcseconds
+    val mas        = rint(dms.milliarcseconds.toDouble / 10).toInt
+    if (degrees >= 45)
+      f"$degrees%02d°"
+    else if (degrees >= 1)
+      f"$degrees%02d°$arcminutes%02d′"
+    else if (arcminutes >= 10)
+      f"$arcminutes%02d′$arcseconds%01d″"
+    else
+      f"$arcseconds%01d.$mas%02d″"
+  }
+
+  val component =
+    ScalaComponent
+      .builder[Props]
+      .render_P((props: Props) =>
+        React.Fragment(
+          Label(
+            content = "Fov:",
+            clazz = ExploreStyles.AladinFOV,
+            size = Small,
+            detail =
+              LabelDetail(clazz = ExploreStyles.AladinDetailText, content = formatFov(props.fov.x))
+          ),
+          Label(
+            content = "Cur:",
+            clazz = ExploreStyles.AladinCurrentCoords,
+            size = Small,
+            detail = LabelDetail(clazz = ExploreStyles.AladinDetailText,
+                                 content = formatCoordinates(props.current)
+            )
+          )
+        )
+      )
+      .configure(Reusability.shouldComponentUpdate)
+      .build
+}

--- a/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
@@ -11,9 +11,9 @@ import eu.timepit.refined._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.collection._
 import explore.AppCtx
+import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.implicits._
-import explore.Icons
 import explore.model.ModelOptics._
 import explore.model.SiderealTarget
 import explore.model.reusability._

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -60,11 +60,6 @@ object TargetBody extends ModelOptics {
     private def coordinatesKey(target: SiderealTarget): String =
       s"${target.name.value}#${target.track.baseCoordinates.show}"
 
-    val centerOnTarget =
-      aladinRef.get
-        .flatMapCB(_.backend.centerOnTarget)
-        .toCallback
-
     val gotoRaDec = (coords: Coordinates) =>
       aladinRef.get
         .flatMapCB(_.backend.gotoRaDec(coords))


### PR DESCRIPTION
I noted there was high cpu usage while moving the cursor over the aladin control.
We are showing the cursor coordinates and that produces too many updates.
This PR changes the structure to do less computation and also reduces the frequency of mouse events.