### PR TITLE
Modify action to opt-in to creating a new clubhouse story.

### DIFF
--- a/.github/workflows/clubhouse.yml
+++ b/.github/workflows/clubhouse.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: singingwolfboy/create-linked-clubhouse-story@v1.5
+        if: ${{ contains(github.event.body, "[ch-new]" || contains(github.event.labels.*.name, "new clubhouse story")}}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           clubhouse-token: ${{ secrets.CLUBHOUSE_TOKEN }}

--- a/.github/workflows/clubhouse.yml
+++ b/.github/workflows/clubhouse.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: singingwolfboy/create-linked-clubhouse-story@v1.5
-        if: ${{ contains(github.event.body, "[ch-new]" || contains(github.event.labels.*.name, "new clubhouse story")}}
+        if: ${{ contains(github.event.body, "[ch-new]") || contains(github.event.labels.*.name, "new clubhouse story")}}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           clubhouse-token: ${{ secrets.CLUBHOUSE_TOKEN }}


### PR DESCRIPTION
I believe this change should only run the `create-linked-clubhouse-story` action if the body of the PR (which I believe is what I am writing now) contains the token `[ch-new]`, or the PR is given a `new clubhouse story` label. However, I don't know how to test this other than trying it. When I create this PR, I think it will use the new yaml, so that will be one test - no story should be created.

The label is a bit long but descriptive. We could name it anything, and add it to the labels for the repo.

Note that the action is only run on PR open or close, so we can't add a new story later. The story would have to be created in clubhouse and assigned via one of the clubhouse integration methods.