### PR TITLE
Various GraphQL changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -270,6 +270,7 @@ lazy val commonSettings = Seq(
       "-Wunused:params"
     )
   )),
+  addCompilerPlugin(("org.typelevel" % "kind-projector" % "0.11.0").cross(CrossVersion.full)),
   // don't publish anything
   publish := {},
   publishLocal := {},

--- a/common/src/main/resources/graphql/schemas/ObservationDB.graphql
+++ b/common/src/main/resources/graphql/schemas/ObservationDB.graphql
@@ -31,20 +31,13 @@ interface Asterism {
   ): [Program!]!
 }
 
-# Event sent when a new object is created
-type AsterismCreated implements Event {
-  # Newly created object
+# Event sent when a new object is created or updated
+type AsterismEdit implements Event {
+  # Type of edit
+  editType: EditType!
+
+  # Edited object
   value: Asterism!
-  id: Long!
-}
-
-# Event sent when an object is edited
-type AsterismEdited implements Event {
-  # Previous value of the edited object
-  oldValue: Asterism!
-
-  # Updated value of the edited object
-  newValue: Asterism!
   id: Long!
 }
 
@@ -76,6 +69,7 @@ input CoordinatesInput {
 
 # Default asterism parameters
 input CreateDefaultAsterismInput {
+  asterismId: AsterismId
   programIds: [ProgramId!]!
   explicitBase: CoordinatesInput
 
@@ -85,6 +79,7 @@ input CreateDefaultAsterismInput {
 
 # Nonsidereal target parameters
 input CreateNonsiderealInput {
+  targetId: TargetId
   programIds: [ProgramId!]!
   name: String!
   key: EphemerisKeyType!
@@ -93,13 +88,16 @@ input CreateNonsiderealInput {
 
 # Observation creation parameters
 input CreateObservationInput {
+  observationId: ObservationId
   programId: ProgramId!
   name: String
   asterismId: AsterismId
+  status: ObsStatus
 }
 
 # Sidereal target parameters
 input CreateSiderealInput {
+  targetId: TargetId
   programIds: [ProgramId!]!
   name: String!
   ra: RightAscensionInput!
@@ -193,6 +191,23 @@ type DefaultAsterism implements Asterism {
 # Target declination coordinate in format '[+/-]DD:MM:SS.sss'
 scalar DmsString
 
+type Duration {
+  # Duration in µs
+  microseconds: Long!
+
+  # Duration in ms
+  milliseconds: BigDecimal!
+
+  # Duration in seconds
+  seconds: BigDecimal!
+
+  # Duration in minutes
+  minutes: BigDecimal!
+
+  # Duration in hours
+  hours: BigDecimal!
+}
+
 # Default asterism edit
 input EditDefaultAsterismInput {
   asterismId: AsterismId!
@@ -208,6 +223,7 @@ input EditObservationInput {
   observationId: ObservationId!
   existence: Existence
   name: String
+  status: ObsStatus
   asterismId: AsterismId
 }
 
@@ -222,6 +238,15 @@ input EditSiderealInput {
   properVelocity: ProperVelocityInput
   radialVelocity: RadialVelocityInput
   parallax: ParallaxModelInput
+}
+
+# Type of edit that triggered an event
+enum EditType {
+  # EditType Created
+  CREATED
+
+  # EditType Updated
+  UPDATED
 }
 
 # Ephemeris key type options
@@ -355,6 +380,12 @@ type Observation {
   # Observation name
   name: String
 
+  # Observation status
+  status: ObsStatus!
+
+  # Observation planned time calculation.
+  plannedTime: PlannedTimeSummary!
+
   # The program that contains this observation
   program(
     # Set to true to include deleted values
@@ -374,25 +405,45 @@ type Observation {
   ): [Target!]!
 }
 
-# Event sent when a new object is created
-type ObservationCreated implements Event {
-  # Newly created object
+# Event sent when a new object is created or updated
+type ObservationEdit implements Event {
+  # Type of edit
+  editType: EditType!
+
+  # Edited object
   value: Observation!
-  id: Long!
-}
-
-# Event sent when an object is edited
-type ObservationEdited implements Event {
-  # Previous value of the edited object
-  oldValue: Observation!
-
-  # Updated value of the edited object
-  newValue: Observation!
   id: Long!
 }
 
 # ObservationId id formatted as `o-(0|[1-9a-f][0-9a-f]*)`
 scalar ObservationId
+
+# Observation status options
+enum ObsStatus {
+  # ObsStatus New
+  NEW
+
+  # ObsStatus Included
+  INCLUDED
+
+  # ObsStatus Proposed
+  PROPOSED
+
+  # ObsStatus Approved
+  APPROVED
+
+  # ObsStatus ForReview
+  FOR_REVIEW
+
+  # ObsStatus Ready
+  READY
+
+  # ObsStatus Ongoing
+  ONGOING
+
+  # ObsStatus Observed
+  OBSERVED
+}
 
 type Parallax {
   # Parallax in microarcseconds
@@ -437,14 +488,15 @@ enum ParallaxUnits {
   MILLIARCSECONDS
 }
 
-# Event sent when an object is edited
-type program implements Event {
-  # Previous value of the edited object
-  oldValue: Program!
+type PlannedTimeSummary {
+  # The portion of planned time that will be charged
+  pi: Duration!
 
-  # Updated value of the edited object
-  newValue: Program!
-  id: Long!
+  # The portion of planned time that will not be charged
+  uncharged: Duration!
+
+  # The total estimated execution time
+  execution: Duration!
 }
 
 type Program {
@@ -474,11 +526,20 @@ type Program {
     # Set to true to include deleted values
     includeDeleted: Boolean! = false
   ): [Target!]!
+
+  # Program planned time calculation.
+  plannedTime(
+    # Set to true to include deleted values
+    includeDeleted: Boolean! = false
+  ): PlannedTimeSummary!
 }
 
-# Event sent when a new object is created
-type ProgramCreated implements Event {
-  # Newly created object
+# Event sent when a new object is created or updated
+type ProgramEdit implements Event {
+  # Type of edit
+  editType: EditType!
+
+  # Edited object
   value: Program!
   id: Long!
 }
@@ -752,80 +813,60 @@ type Sidereal {
 }
 
 type Subscription {
-  # Subscribes to an event that is generated whenever a(n) asterism associated with the provided program id is created
-  asterismCreated(
-    # Program ID
-    programId: ProgramId
-  ): AsterismCreated!
-
-  # Subscribes to an event that is generated whenever a(n) observation associated with the provided program id is created
-  observationCreated(
-    # Program ID
-    programId: ProgramId
-  ): ObservationCreated!
-
-  # Subscribes to an event that is generated whenever a program is created
-  programCreated: ProgramCreated!
-
-  # Subscribes to an event that is generated whenever a(n) target associated with the provided program id is created
-  targetCreated(
-    # Program ID
-    programId: ProgramId
-  ): TargetCreated!
-
   #
   # Subscribes to an event that is generated whenever a(n) asterism is
-  # edited.  If a(n) asterism id is provided, the even is only generated
-  # for edits to that particular asterism.  If a program id is provided
-  # then the event must correspond to a(n) asterism referenced by that
-  # program.
+  # created or updated.  If a(n) asterism id is provided, the event is only
+  # generated for edits to that particular asterism.  If a program id is
+  # provided then the event must correspond to a(n) asterism referenced by
+  # that program.
   #
-  asterismEdited(
+  asterismEdit(
     # Asterism ID
     asterismId: AsterismId
 
     # Program ID
     programId: ProgramId
-  ): AsterismEdited!
+  ): AsterismEdit!
 
   #
   # Subscribes to an event that is generated whenever a(n) observation is
-  # edited.  If a(n) observation id is provided, the even is only generated
-  # for edits to that particular observation.  If a program id is provided
-  # then the event must correspond to a(n) observation referenced by that
-  # program.
+  # created or updated.  If a(n) observation id is provided, the event is only
+  # generated for edits to that particular observation.  If a program id is
+  # provided then the event must correspond to a(n) observation referenced by
+  # that program.
   #
-  observationEdited(
+  observationEdit(
     # Observation ID
     observationId: ObservationId
 
     # Program ID
     programId: ProgramId
-  ): ObservationEdited!
+  ): ObservationEdit!
 
   #
-  # Subscribes to an event that is generated whenever a program |is edited.
-  # A particular program id may be provided to limit events to that program.
+  # Subscribes to an event that is generated whenever a program is created
+  # or edited. A particular program id may be provided to limit events to
+  # that program.
   #
-  programEdited(
+  programEdit(
     # Program ID
     programId: ProgramId
-  ): program!
+  ): ProgramEdit!
 
   #
   # Subscribes to an event that is generated whenever a(n) target is
-  # edited.  If a(n) target id is provided, the even is only generated
-  # for edits to that particular target.  If a program id is provided
-  # then the event must correspond to a(n) target referenced by that
-  # program.
+  # created or updated.  If a(n) target id is provided, the event is only
+  # generated for edits to that particular target.  If a program id is
+  # provided then the event must correspond to a(n) target referenced by
+  # that program.
   #
-  targetEdited(
+  targetEdit(
     # Target ID
     targetId: TargetId
 
     # Program ID
     programId: ProgramId
-  ): TargetEdited!
+  ): TargetEdit!
 }
 
 type Target {
@@ -866,20 +907,13 @@ type Target {
   tracking: Tracking!
 }
 
-# Event sent when a new object is created
-type TargetCreated implements Event {
-  # Newly created object
+# Event sent when a new object is created or updated
+type TargetEdit implements Event {
+  # Type of edit
+  editType: EditType!
+
+  # Edited object
   value: Target!
-  id: Long!
-}
-
-# Event sent when an object is edited
-type TargetEdited implements Event {
-  # Previous value of the edited object
-  oldValue: Target!
-
-  # Updated value of the edited object
-  newValue: Target!
   id: Long!
 }
 

--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -1,0 +1,195 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components.graphql
+
+import cats.syntax.all._
+import cats.effect.ConcurrentEffect
+import clue.GraphQLStreamingClient
+import crystal.Pot
+import crystal.react.implicits._
+import io.chrisdavenport.log4cats.Logger
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
+import japgolly.scalajs.react.component.builder.Lifecycle.ComponentWillUnmount
+import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
+import japgolly.scalajs.react.vdom.html_<^._
+import cats.data.NonEmptyList
+import fs2.concurrent.Queue
+import cats.effect.CancelToken
+import clue.StreamingClientStatus
+import cats.effect.IO
+import cats.effect.SyncIO
+import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
+
+object Render {
+  trait Props[F[_], G[_], A] {
+    val valueRender: G[A] => VdomNode
+    val pendingRender: Long => VdomNode
+    val errorRender: Throwable => VdomNode
+    val onNewData: F[Unit]
+
+    implicit val F: ConcurrentEffect[F]
+    implicit val logger: Logger[F]
+    implicit val reuse: Reusability[A]
+  }
+
+  type StreamRendererProps[G[_], A]     = Pot[G[A]] => VdomNode
+  type StreamRendererComponent[G[_], A] =
+    CtorType.Props[StreamRendererProps[G, A], UnmountedWithRoot[
+      StreamRendererProps[G, A],
+      _,
+      _,
+      _
+    ]]
+
+  trait State[G[_], A] {
+    val renderer: StreamRendererComponent[G, A]
+  }
+
+  class RenderApplied[F[_], G[_], D, A] {
+    def apply[P <: Props[F, G, A], S <: State[G, A]](
+      $ : RenderScope[P, Option[S], Unit]
+    ): VdomNode = React.Fragment(
+      $.state.fold[VdomNode](EmptyVdom)(
+        _.renderer(_.fold($.props.pendingRender, $.props.errorRender, $.props.valueRender))
+      )
+    )
+  }
+
+  def renderFn[F[_], G[_], D, A]: RenderApplied[F, G, D, A] = new RenderApplied[F, G, D, A]
+
+  object Subscription {
+
+    trait Props[F[_], G[_], D, A] extends Render.Props[F, G, A] {
+      val subscribe: F[GraphQLStreamingClient[F, _]#Subscription[D]]
+      val streamModifier: fs2.Stream[F, D] => fs2.Stream[F, A]
+    }
+
+    trait State[F[_], G[_], D, A] extends Render.State[G, A] {
+      val subscription: GraphQLStreamingClient[F, _]#Subscription[D]
+    }
+
+    class WillUnmountApplied[F[_], G[_], D, A] {
+      def apply[P <: Props[F, G, D, A], S <: State[F, G, D, A]](
+        $ : ComponentWillUnmount[P, Option[S], Unit]
+      ): Callback = {
+        implicit val F = $.props.F
+
+        $.state.map(_.subscription.stop().runInCB).getOrEmpty
+      }
+    }
+
+    def willUnmountFn[F[_], G[_], D, A]: WillUnmountApplied[F, G, D, A] =
+      new WillUnmountApplied[F, G, D, A]
+  }
+
+  object LiveQuery {
+    trait Props[F[_], G[_], S, D, A] extends Render.Props[F, G, A] {
+      val query: F[D]
+      val extract: D => A
+      val changeSubscriptions: NonEmptyList[F[GraphQLStreamingClient[F, S]#Subscription[_]]]
+
+      implicit val client: GraphQLStreamingClient[F, S]
+    }
+
+    trait State[F[_], G[_], S, D, A] extends Render.State[G, A] {
+      val queue: Queue[F, A]
+      val subscriptions: NonEmptyList[GraphQLStreamingClient[F, S]#Subscription[_]]
+      val cancelConnectionTracker: CancelToken[F]
+    }
+
+    class DidMountApplied[F[_], G[_], S, D, A] {
+      def apply[P <: Props[F, G, S, D, A], ST <: State[F, G, S, D, A]](
+        componentName: String,
+        buildRenderer: (fs2.Stream[F, A], P) => StreamRendererComponent[G, A],
+        buildState:    (
+          Queue[F, A],
+          NonEmptyList[GraphQLStreamingClient[F, S]#Subscription[_]],
+          CancelToken[F],
+          StreamRendererComponent[G, A]
+        ) => ST
+      )($             : ComponentDidMount[P, Option[ST], Unit]): Callback = {
+        implicit val F      = $.props.F
+        implicit val logger = $.props.logger
+
+        def queryAndEnqueue(queue: Queue[F, A]): F[Unit] =
+          for {
+            result <- $.props.query.map($.props.extract)
+            _      <- queue.enqueue1(result)
+            _      <- $.props.onNewData
+          } yield ()
+
+        // Once run, this effect will end when all subscriptions end.
+        def trackChanges(
+          subscriptions: NonEmptyList[GraphQLStreamingClient[F, _]#Subscription[_]],
+          queue:         Queue[F, A]
+        ): F[Unit] =
+          subscriptions
+            .map(_.stream)
+            .reduceLeft(_ merge _)
+            .evalTap(_ => queryAndEnqueue(queue))
+            .compile
+            .drain
+
+        // Once run, this effect has to be cancelled manually.
+        def trackConnection(queue: Queue[F, A]): F[Unit] =
+          $.props.client.statusStream.tail // Skip current status. We only want future updates here.
+            .filter(_ === StreamingClientStatus.Open)
+            .evalTap(_ => queryAndEnqueue(queue))
+            .compile
+            .drain
+
+        def deferRun[B, C](unhandledRun: (Either[Throwable, C] => IO[Unit]) => SyncIO[B]): F[B] =
+          F.liftIO(unhandledRun {
+            case Left(t) => F.toIO(logger.error(t)(s"Error in deferRun of $componentName"))
+            case _       => IO.unit
+          }.toIO)
+
+        val init =
+          for {
+            queue                   <- Queue.unbounded[F, A]
+            subscriptions           <- $.props.changeSubscriptions.sequence
+            cancelConnectionTracker <- deferRun(F.runCancelable(trackConnection(queue)))
+            renderer                 = buildRenderer(queue.dequeue, $.props)
+            _                       <-
+              $.setStateIn[F](
+                buildState(queue, subscriptions, cancelConnectionTracker, renderer).some
+              )
+            _                       <- queryAndEnqueue(queue)
+            _                       <- deferRun(
+                                         F.runAsync(
+                                           trackChanges(subscriptions, queue)
+                                             .handleErrorWith(t => logger.error(t)(s"Error updating $componentName"))
+                                         )
+                                       )
+          } yield ()
+
+        init
+          .handleErrorWith(t => logger.error(t)(s"Error initializing $componentName"))
+          .runInCB
+      }
+    }
+
+    def didMountFn[F[_], G[_], S, D, A]: DidMountApplied[F, G, S, D, A] =
+      new DidMountApplied[F, G, S, D, A]
+
+    class WillUnmountApplied[F[_], G[_], S, D, A] {
+      def apply[P <: Props[F, G, S, D, A], ST <: State[F, G, S, D, A]](
+        $ : ComponentWillUnmount[P, Option[ST], Unit]
+      ): Callback = {
+        implicit val F = $.props.F
+
+        $.state
+          .map(state =>
+            (state.cancelConnectionTracker >>
+              state.subscriptions.map(_.stop()).sequence.void).runInCB
+          )
+          .getOrEmpty
+      }
+    }
+
+    def willUnmountFn[F[_], G[_], S, D, A]: WillUnmountApplied[F, G, S, D, A] =
+      new WillUnmountApplied[F, G, S, D, A]
+  }
+}

--- a/observationtree/src/main/scala/explore/observationtree/ObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ObsQueries.scala
@@ -34,21 +34,10 @@ object ObsQueries {
   }
 
   @GraphQL
-  object ProgramObservationsUpdatedSubscription extends GraphQLOperation[ObservationDB] {
+  object ProgramObservationsEditSubscription extends GraphQLOperation[ObservationDB] {
     val document = """
       subscription {
-        observationEdited(programId:"p-2") {
-          id
-        }
-      }   
-    """
-  }
-
-  @GraphQL
-  object ProgramObservationsCreatedSubscription extends GraphQLOperation[ObservationDB] {
-    val document = """
-      subscription {
-        observationCreated(programId:"p-2") {
+        observationEdit(programId:"p-2") {
           id
         }
       }   
@@ -66,9 +55,7 @@ object ObsQueries {
         LiveQueryRenderMod[ObservationDB, ProgramObservationsQuery.Data, List[ObsSummary]](
           ProgramObservationsQuery.query(),
           _.observations,
-          NonEmptyList.of(ProgramObservationsUpdatedSubscription.subscribe(),
-                          ProgramObservationsCreatedSubscription.subscribe()
-          )
+          NonEmptyList.of(ProgramObservationsEditSubscription.subscribe())
         )(render)
       }
 }

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
@@ -76,10 +76,10 @@ object TargetObsQueries {
   }
 
   @GraphQL
-  object TargetUpdatedSubscription extends GraphQLOperation[ObservationDB] {
+  object TargetEditSubscription extends GraphQLOperation[ObservationDB] {
     val document = """
       subscription {
-        targetEdited(programId: "p-2") {
+        targetEdit(programId: "p-2") {
           id
         }
       }    
@@ -87,40 +87,17 @@ object TargetObsQueries {
   }
 
   @GraphQL
-  object TargetCreatedSubscription extends GraphQLOperation[ObservationDB] {
+  object ObservationEditSubscription extends GraphQLOperation[ObservationDB] {
     val document = """
       subscription {
-        targetCreated(programId: "p-2") {
+        observationEdit(programId: "p-2") {
           id
         }
       }    
     """
   }
-
   @GraphQL
-  object ObservationUpdatedSubscription extends GraphQLOperation[ObservationDB] {
-    val document = """
-      subscription {
-        observationEdited(programId: "p-2") {
-          id
-        }
-      }    
-    """
-  }
-
-  @GraphQL
-  object ObservationCreatedSubscription extends GraphQLOperation[ObservationDB] {
-    val document = """
-      subscription {
-        observationCreated(programId: "p-2") {
-          id
-        }
-      }    
-    """
-  }
-
-  @GraphQL
-  object UpdateObservationMutation extends GraphQLOperation[ObservationDB] {
+  object UpdateObservationMutation   extends GraphQLOperation[ObservationDB] {
     val document = """
       mutation($input: EditObservationInput!) {
         updateObservation(input: $input) {
@@ -202,10 +179,8 @@ object TargetObsQueries {
           TargetsObsQuery.query(),
           TargetsObsQuery.Data.asTargetsWithObs.get,
           NonEmptyList.of(
-            TargetUpdatedSubscription.subscribe(),
-            TargetCreatedSubscription.subscribe(),
-            ObservationUpdatedSubscription.subscribe(),
-            ObservationCreatedSubscription.subscribe()
+            TargetEditSubscription.subscribe(),
+            ObservationEditSubscription.subscribe()
           )
         )(render)
       }

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -43,7 +43,7 @@ object TargetEditor {
         ](
           TargetEditQuery.query(props.id),
           _.target,
-          NonEmptyList.of(TargetUpdatedSubscription.subscribe(props.id))
+          NonEmptyList.of(TargetEditSubscription.subscribe(props.id))
         ) { targetOpt =>
           <.div(
             targetOpt.get.whenDefined { _ =>

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -99,10 +99,10 @@ object TargetQueries {
     )(s => t => targetRA.set(s._2)(targetDec.set(s._3)(t.copy(name = s._1))))
 
   @GraphQL
-  object TargetUpdatedSubscription extends GraphQLOperation[ObservationDB] {
+  object TargetEditSubscription extends GraphQLOperation[ObservationDB] {
     val document = """
       subscription($id: TargetId!) {
-        targetEdited(targetId: $id) {
+        targetEdit(targetId: $id) {
           id
         }
       }


### PR DESCRIPTION
* New ODB Schema.
* Track disconnections on live queries and requery on reconnection.
* Abstract away all common logic in GraphQL renderers: new `Render` objects groups code previously duplicated in `SubscriptionRender`, `SubscriptionRenderMod`, `LiveQueryRender` and `LiveQueryRenderMod`.