### PR TITLE
Update queries to read/write proper motion

### DIFF
--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -3,24 +3,24 @@
 
 package explore.components.graphql
 
-import cats.syntax.all._
+import cats.data.NonEmptyList
+import cats.effect.CancelToken
 import cats.effect.ConcurrentEffect
+import cats.effect.IO
+import cats.effect.SyncIO
+import cats.syntax.all._
 import clue.GraphQLStreamingClient
+import clue.StreamingClientStatus
 import crystal.Pot
 import crystal.react.implicits._
+import fs2.concurrent.Queue
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
+import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
 import japgolly.scalajs.react.component.builder.Lifecycle.ComponentWillUnmount
 import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.vdom.html_<^._
-import cats.data.NonEmptyList
-import fs2.concurrent.Queue
-import cats.effect.CancelToken
-import clue.StreamingClientStatus
-import cats.effect.IO
-import cats.effect.SyncIO
-import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
 
 object Render {
   trait Props[F[_], G[_], A] {

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -3,9 +3,23 @@
 
 package explore
 
+import cats.data.State
+import monocle.Lens
+import monocle.state.all._
+
 package object utils {
 
   def abbreviate(s: String, maxLength: Int): String =
     if (s.length > maxLength) s"${s.substring(0, maxLength)}\u2026" else s
 
+  implicit final class LensEditorOps[S, A](self: Lens[S, A]) {
+    def edit(a: A): State[S, A]         =
+      self.assign(a)
+    def :=(a:   A): State[S, A]         =
+      edit(a)
+    def edit(a: Option[A]): State[S, A] =
+      a.fold(self.st)(self.assign)
+    def :=(a:   Option[A]): State[S, A] =
+      edit(a)
+  }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -137,6 +137,7 @@ object Settings {
     val Monocle = Def.setting(
       deps(
         "com.github.julien-truffaut" %%% "monocle-core",
+        "com.github.julien-truffaut" %%% "monocle-state",
         "com.github.julien-truffaut" %%% "monocle-macro"
       )(monocle)
     )

--- a/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CoordinatesForm.scala
@@ -23,6 +23,7 @@ import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
+import lucuma.core.model.SiderealTracking
 import lucuma.core.model.Target
 import lucuma.ui.forms._
 import lucuma.ui.reusability._
@@ -57,15 +58,25 @@ object CoordinatesForm {
   @Lenses
   final case class State(
     searchTerm:  String,
-    raValue:     RightAscension,
-    decValue:    Declination,
+    tracking:    SiderealTracking,
     searching:   Boolean,
     searchError: Option[String]
   )
 
+  object State {
+    val baseCoordinates =
+      State.tracking ^|-> SiderealTracking.baseCoordinates
+
+    val raValue =
+      baseCoordinates ^|-> Coordinates.rightAscension
+
+    val decValue =
+      baseCoordinates ^|-> Coordinates.declination
+  }
+
   def initialState(p: Props): State = {
     val r = targetPropsL.get(p.target)
-    Function.tupled(State.apply _)((r._1, r._2, r._3, false, none))
+    Function.tupled(State.apply _)((r._1, r._2, false, none))
   }
 
   implicit val stateReuse                     = Reusability.derive[State]
@@ -146,7 +157,7 @@ object CoordinatesForm {
               size = Small,
               icon = true,
               label = "Go To",
-              onClick = props.goToRaDec(Coordinates(state.raValue, state.decValue))
+              onClick = props.goToRaDec(State.baseCoordinates.get(state))
             )(
               Icon("angle right"),
               ExploreStyles.HideLabel

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -3,8 +3,7 @@
 
 package explore.target
 
-import cats.Eval
-import cats.data.IndexedStateT
+import cats.data.State
 import cats.effect.IO
 import cats.implicits._
 import clue.GraphQLOperation
@@ -147,9 +146,7 @@ object TargetQueries {
   /**
    * Updates all the fields of sideral tracking
    */
-  def updateSiderealTracking(
-    t: SiderealTracking
-  ): IndexedStateT[Eval, EditSiderealInput, EditSiderealInput, Unit] = {
+  def updateSiderealTracking(t: SiderealTracking): State[EditSiderealInput, Unit] = {
     val coords = t.baseCoordinates
 
     val rai = RightAscensionInput(microarcseconds = coords.ra.toAngle.toMicroarcseconds.some).some


### PR DESCRIPTION
This PR updates the graphql queries to include all `SiderealTracking` fields and also supports updating them.
When a simbad query is successful all fields will be populated.

This is also a chance to learn about the GraphQL backend and frontend implementations. It seems great, congrats @rpiaggio @swalker