### PR TITLE
Show target magnitudes from DB and catalog.

### DIFF
--- a/common/src/main/resources/graphql/schemas/ObservationDB.graphql
+++ b/common/src/main/resources/graphql/schemas/ObservationDB.graphql
@@ -46,7 +46,7 @@ scalar AsterismId
 
 # Asterism and the programs with which they are associated
 input AsterismProgramLinks {
-  asterismId: AsterismId!
+  asterismIds: [AsterismId!]!
   programIds: [ProgramId!]!
 }
 
@@ -106,10 +106,11 @@ input CreateDefaultAsterismInput {
 # Nonsidereal target parameters
 input CreateNonsiderealInput {
   targetId: TargetId
-  programIds: [ProgramId!]!
+  programIds: [ProgramId!]
   name: String!
   key: EphemerisKeyType!
   des: String!
+  magnitudes: [MagnitudeInput!]
 }
 
 # Observation creation parameters
@@ -124,7 +125,7 @@ input CreateObservationInput {
 # Sidereal target parameters
 input CreateSiderealInput {
   targetId: TargetId
-  programIds: [ProgramId!]!
+  programIds: [ProgramId!]
   name: String!
   catalogId: CatalogIdInput
   ra: RightAscensionInput!
@@ -133,6 +134,7 @@ input CreateSiderealInput {
   properVelocity: ProperVelocityInput
   radialVelocity: RadialVelocityInput
   parallax: ParallaxModelInput
+  magnitudes: [MagnitudeInput!]
 }
 
 type Declination {
@@ -319,6 +321,100 @@ scalar HmsString
 # Long can represent values between -(2^63) and 2^63 - 1.
 scalar Long
 
+type Magnitude {
+  # Magnitude value (unitless)
+  value: BigDecimal!
+
+  # Magnitude band
+  band: MagnitudeBand!
+
+  # Magnitude System
+  system: MagnitudeSystem!
+}
+
+# Magnitude band
+enum MagnitudeBand {
+  # MagnitudeBand SloanU
+  SLOAN_U
+
+  # MagnitudeBand SloanG
+  SLOAN_G
+
+  # MagnitudeBand SloanR
+  SLOAN_R
+
+  # MagnitudeBand SloanI
+  SLOAN_I
+
+  # MagnitudeBand SloanZ
+  SLOAN_Z
+
+  # MagnitudeBand U
+  U
+
+  # MagnitudeBand B
+  B
+
+  # MagnitudeBand V
+  V
+
+  # MagnitudeBand Uc
+  UC
+
+  # MagnitudeBand R
+  R
+
+  # MagnitudeBand I
+  I
+
+  # MagnitudeBand Y
+  Y
+
+  # MagnitudeBand J
+  J
+
+  # MagnitudeBand H
+  H
+
+  # MagnitudeBand K
+  K
+
+  # MagnitudeBand L
+  L
+
+  # MagnitudeBand M
+  M
+
+  # MagnitudeBand N
+  N
+
+  # MagnitudeBand Q
+  Q
+
+  # MagnitudeBand Ap
+  AP
+}
+
+# Magnitude description
+input MagnitudeInput {
+  value: BigDecimal!
+  band: MagnitudeBand!
+  error: BigDecimal
+  system: MagnitudeSystem = VEGA
+}
+
+# Magnitude system
+enum MagnitudeSystem {
+  # MagnitudeSystem Vega
+  VEGA
+
+  # MagnitudeSystem AB
+  AB
+
+  # MagnitudeSystem Jy
+  JY
+}
+
 type Mutation {
   createDefaultAsterism(
     # Default Asterism description
@@ -336,14 +432,6 @@ type Mutation {
     # Asterism ID
     asterismId: AsterismId!
   ): Asterism!
-  shareAsterismWithPrograms(
-    # Asterism/program links
-    input: AsterismProgramLinks!
-  ): Asterism
-  unshareAsterismWithPrograms(
-    # Asterism/program links
-    input: AsterismProgramLinks!
-  ): Asterism
   createObservation(
     # Observation description
     input: CreateObservationInput!
@@ -380,14 +468,14 @@ type Mutation {
     # Target ID
     targetId: TargetId!
   ): Target!
-  shareTargetWithPrograms(
-    # Target/program links
-    input: TargetProgramLinks!
-  ): Target
-  unshareTargetWithPrograms(
-    # Target/program links
-    input: TargetProgramLinks!
-  ): Target
+  shareAsterismsWithPrograms(
+    # Asterism/program links
+    input: AsterismProgramLinks!
+  ): [Asterism!]!
+  unshareAsterismsWithPrograms(
+    # Asterism/program links
+    input: AsterismProgramLinks!
+  ): [Asterism!]!
   shareTargetsWithObservations(
     # Target/observation links
     input: TargetObservationLinks!
@@ -396,6 +484,14 @@ type Mutation {
     # Target/observation links
     input: TargetObservationLinks!
   ): [Asterism!]!
+  shareTargetsWithPrograms(
+    # Target/program links
+    input: TargetProgramLinks!
+  ): [Target!]!
+  unshareTargetsWithPrograms(
+    # Target/program links
+    input: TargetProgramLinks!
+  ): [Target!]!
 }
 
 type Nonsidereal {
@@ -944,6 +1040,9 @@ type Target {
 
   # Information required to find a target in the sky.
   tracking: Tracking!
+
+  # Target magnitudes
+  magnitudes: [Magnitude!]!
 }
 
 # Event sent when a new object is created or updated
@@ -959,15 +1058,15 @@ type TargetEdit implements Event {
 # TargetId id formatted as `t-(0|[1-9a-f][0-9a-f]*)`
 scalar TargetId
 
-# Target and the observations with which they are associated
+# Targets and the observations with which they are associated
 input TargetObservationLinks {
   targetIds: [TargetId!]!
   observationIds: [ObservationId!]!
 }
 
-# Target and the programs with which they are associated
+# Targets and the programs with which they are associated
 input TargetProgramLinks {
-  targetId: TargetId!
+  targetIds: [TargetId!]!
   programIds: [ProgramId!]!
 }
 

--- a/common/src/main/scala/explore/GraphQLSchemas.scala
+++ b/common/src/main/scala/explore/GraphQLSchemas.scala
@@ -26,7 +26,8 @@ object GraphQLSchemas {
     }
 
     object Enums {
-      type CatalogName = lucuma.core.enum.CatalogName
+      type CatalogName     = lucuma.core.enum.CatalogName
+      type MagnitudeSystem = lucuma.core.enum.MagnitudeSystem
     }
   }
 

--- a/common/src/main/scala/explore/components/ConnectionsStatus.scala
+++ b/common/src/main/scala/explore/components/ConnectionsStatus.scala
@@ -52,7 +52,7 @@ object ConnectionsStatus {
     .render(_ =>
       AppCtx.withCtx { ctx =>
         <.span(
-          ctx.clients.ExploreDBConnectionStatus(renderStatus("Hasura DB")),
+          ctx.clients.ExploreDBConnectionStatus(renderStatus("Hasura DB")).when(false),
           ctx.clients.ODBConnectionStatus(renderStatus("ODB")),
           Button(size = Tiny)(^.onClick --> ctx.clients.odb.close().runInCB)("Close ODB")
             .when(false)

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -6,14 +6,11 @@ package explore.model
 import java.time.Duration
 
 import clue.StreamingClientStatus
-import coulomb.Quantity
 import explore.data.KeyedIndexedList
 import io.circe.Json
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.raw.JsNumber
-import lucuma.core.math.MagnitudeValue
-import lucuma.core.model.Magnitude
 import lucuma.ui.reusability._
 import react.common.Size
 import react.common.implicits._
@@ -22,14 +19,6 @@ import react.common.implicits._
  * Reusability instances for model classes
  */
 object reusability {
-
-  // Reusability for coulomb quantities.
-  // TODO: Move to lucuma-ui.
-  implicit def quantityReuse[N: Reusability, U]: Reusability[Quantity[N, U]] =
-    Reusability.by(_.value)
-  implicit val magnitudeValueReuse: Reusability[MagnitudeValue]              = Reusability.byEq
-  implicit val magnitudeReuse: Reusability[Magnitude]                        = Reusability.derive
-
   implicit val statusReuse: Reusability[StreamingClientStatus]                                    = Reusability.derive
   implicit val durationReuse: Reusability[Duration]                                               = Reusability.by(_.getSeconds)
   implicit val siderealTargetReuse: Reusability[SiderealTarget]                                   = Reusability.byEq

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -12,6 +12,8 @@ import io.circe.Json
 import japgolly.scalajs.react.CatsReact._
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.raw.JsNumber
+import lucuma.core.math.MagnitudeValue
+import lucuma.core.model.Magnitude
 import lucuma.ui.reusability._
 import react.common.Size
 import react.common.implicits._
@@ -25,6 +27,8 @@ object reusability {
   // TODO: Move to lucuma-ui.
   implicit def quantityReuse[N: Reusability, U]: Reusability[Quantity[N, U]] =
     Reusability.by(_.value)
+  implicit val magnitudeValueReuse: Reusability[MagnitudeValue]              = Reusability.byEq
+  implicit val magnitudeReuse: Reusability[Magnitude]                        = Reusability.derive
 
   implicit val statusReuse: Reusability[StreamingClientStatus]                                    = Reusability.derive
   implicit val durationReuse: Reusability[Duration]                                               = Reusability.by(_.getSeconds)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -19,7 +19,7 @@ object Settings {
     val log4CatsLogLevel  = "0.1.1"
     val lucumaCore        = "0.6.6"
     val lucumaCatalog     = "0.2.0"
-    val lucumaUI          = "0.7.0"
+    val lucumaUI          = "0.7.1"
     val monocle           = "2.1.0"
     val mouse             = "0.25"
     val mUnit             = "0.7.16"

--- a/proposal/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -13,6 +13,7 @@ import crystal.react.StreamRendererMod
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
 import explore.AppCtx
+import explore.components.WIP
 import explore.implicits._
 import explore.model._
 import explore.model.enum._
@@ -53,7 +54,7 @@ object ProposalTabContents {
         val component = StreamRendererMod.build(ref.discrete)
 
         component(_ match {
-          case Ready(view) => ProposalDetailsEditor(view)
+          case Ready(view) => WIP(ProposalDetailsEditor(view))
           case _           => <.div("Ruh-Roh")
         })
       }

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -3,10 +3,10 @@
 
 package explore.targeteditor
 
-import explore.model.reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Magnitude
+import lucuma.ui.reusability._
 import react.common.ReactProps
 import react.semanticui.collections.grid.Grid
 import react.semanticui.collections.grid.GridColumn

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targeteditor
+
+import explore.model.reusability._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.model.Magnitude
+import react.common.ReactProps
+import react.semanticui.collections.grid.Grid
+import react.semanticui.collections.grid.GridColumn
+import react.semanticui.collections.grid.GridDivided
+import react.semanticui.collections.grid.GridRow
+import react.semanticui.elements.segment.Segment
+import react.semanticui.widths._
+
+final case class MagnitudeForm(magnitudes: List[Magnitude])
+    extends ReactProps[MagnitudeForm](MagnitudeForm.component)
+
+object MagnitudeForm {
+  type Props = MagnitudeForm
+
+  implicit val propsReuse = Reusability.derive[Props]
+
+  val component =
+    ScalaComponent
+      .builder[Props]
+      .render_P { props =>
+        React.Fragment(
+          <.label("Magnitudes"),
+          Segment(
+            Grid(columns = Three, divided = GridDivided.Divided)(
+              props.magnitudes.toTagMod(magnitude =>
+                GridRow(
+                  GridColumn(<.span(magnitude.value.toDoubleValue.toString)),
+                  GridColumn(<.span(magnitude.band.toString)),
+                  GridColumn(<.span(magnitude.system.toString))
+                )(^.paddingTop := "0.5rem", ^.paddingBottom := "0.5rem")
+              )
+            )
+          )(^.maxWidth := "250px")
+        )
+      }
+      .configure(Reusability.shouldComponentUpdate)
+      .build
+}

--- a/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
@@ -4,16 +4,16 @@
 package explore.targeteditor
 
 import cats.data.ValidatedNec
-import cats.implicits._
 import cats.effect.IO
+import cats.implicits._
 import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import explore.AppCtx
 import explore.components.ui.ExploreStyles
+import explore.implicits._
 import explore.model.formats._
 import explore.optics._
-import explore.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.math.ApparentRadialVelocity

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -30,6 +30,7 @@ import lucuma.core.math.Parallax
 import lucuma.core.math.ProperVelocity
 import lucuma.core.math.RadialVelocity
 import lucuma.core.math.units._
+import lucuma.core.model.Magnitude
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.Target
 import lucuma.core.optics.syntax.all._
@@ -90,15 +91,18 @@ object TargetBody {
             UndoSet(props.id, props.target, undoCtx.setter)
 
           val modify = undoSet[
-            (String, SiderealTracking)
+            (String, SiderealTracking, List[Magnitude])
           ](
             targetPropsL,
-            { case (n, t) =>
+            { case (n, t, _ /*ms*/ ) =>
               input =>
                 val update =
                   for {
                     _ <- EditSiderealInput.name := n.some
                     _ <- TargetQueries.updateSiderealTracking(t)
+                    // _ <- EditSiderealInput.magnitudes := ms.map(m =>
+                    //        MagnitudeInput(m.value.toBigDecimal, m.band, none, m.system.some)
+                    //      )
                   } yield ()
                 update.runS(input).value
             }
@@ -163,8 +167,8 @@ object TargetBody {
               .search(s.searchTerm)
               .attempt
               .runInCBAndThen {
-                case Right(r @ Some(Target(n, Right(st), _))) =>
-                  modify((n, st)).runInCB *>
+                case Right(r @ Some(Target(n, Right(st), m))) =>
+                  modify((n, st, m.values.toList)).runInCB *>
                     gotoRaDec(st.baseCoordinates) *> s.onComplete(r)
                 case Right(Some(r))                           => Callback.log(s"Unknown target type $r") *> s.onComplete(none)
                 case Right(None)                              => s.onComplete(none)
@@ -219,6 +223,7 @@ object TargetBody {
                   ),
                   RVInput(props.target.zoom(TargetQueries.rvLens), modifyRadialVelocity)
                 ),
+                MagnitudeForm(target.magnitudes),
                 UndoButtons(target, undoCtx)
               ),
               AladinRef

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -223,7 +223,7 @@ object TargetBody {
                   ),
                   RVInput(props.target.zoom(TargetQueries.rvLens), modifyRadialVelocity)
                 ),
-                MagnitudeForm(target.magnitudes),
+                MagnitudeForm(target.magnitudes).when(false),
                 UndoButtons(target, undoCtx)
               ),
               AladinRef

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -16,7 +16,6 @@ import explore.GraphQLSchemas._
 import explore.implicits._
 import explore.model.decoders._
 import explore.optics._
-import explore.model.reusability._
 import explore.undo.Undoer
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Epoch
@@ -24,6 +23,7 @@ import lucuma.core.math.Parallax
 import lucuma.core.math.ProperVelocity
 import lucuma.core.math.RadialVelocity
 import lucuma.core.math.units.CentimetersPerSecond
+import lucuma.core.model.Magnitude
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.Target
 import lucuma.core.optics.syntax.all._

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -185,16 +185,18 @@ object TargetQueries {
 
     val deci = DeclinationInput(microarcseconds = coords.dec.toAngle.toMicroarcseconds.some).some
 
-    val pvi = ProperVelocityInput(
-      ra = ProperVelocityRaInput(microarcsecondsPerYear = t.properVelocity.map(_.ra.μasy.value)),
-      dec = ProperVelocityDecInput(microarcsecondsPerYear = t.properVelocity.map(_.dec.μasy.value))
-    ).some
+    val pvi = t.properVelocity.map(pv =>
+      ProperVelocityInput(
+        ra = ProperVelocityRaInput(microarcsecondsPerYear = pv.ra.μasy.value.some),
+        dec = ProperVelocityDecInput(microarcsecondsPerYear = pv.dec.μasy.value.some)
+      )
+    )
 
-    val rvi = RadialVelocityInput(metersPerSecond =
-      t.radialVelocity.map(_.rv.withUnit[CentimetersPerSecond].value.value)
-    ).some
+    val rvi = t.radialVelocity.map(rv =>
+      RadialVelocityInput(metersPerSecond = rv.rv.withUnit[CentimetersPerSecond].value.value.some)
+    )
 
-    val pxi = ParallaxModelInput(microarcseconds = t.parallax.map(_.μas.value)).some
+    val pxi = t.parallax.map(p => ParallaxModelInput(microarcseconds = p.μas.value.some))
 
     for {
       _ <- EditSiderealInput.catalogId := cati

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -16,6 +16,7 @@ import explore.GraphQLSchemas._
 import explore.implicits._
 import explore.model.decoders._
 import explore.optics._
+import explore.model.reusability._
 import explore.undo.Undoer
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Epoch
@@ -65,13 +66,19 @@ object TargetQueries {
               }
             }
           }
+          magnitudes {
+            value
+            band
+            system
+          }
         }
       }
       """
 
     object Data {
       object Target {
-        type Tracking = lucuma.core.model.SiderealTracking
+        type Tracking   = lucuma.core.model.SiderealTracking
+        type Magnitudes = lucuma.core.model.Magnitude
       }
     }
   }
@@ -96,9 +103,13 @@ object TargetQueries {
   /**
    * Lens used to change name and coordinates of a target
    */
-  val targetPropsL: Lens[TargetResult, (String, SiderealTracking)] =
-    Lens[TargetResult, (String, SiderealTracking)](t => (t.name, TargetResult.tracking.get(t)))(s =>
-      t => TargetResult.tracking.set(s._2)(t.copy(name = s._1))
+  val targetPropsL =
+    Lens[TargetResult, (String, SiderealTracking, List[Magnitude])](t =>
+      (t.name, TargetResult.tracking.get(t), t.magnitudes)
+    )(s =>
+      TargetResult.name.set(s._1) >>>
+        TargetResult.tracking.set(s._2) >>>
+        TargetResult.magnitudes.set(s._3)
     )
 
   val pvRALens: Lens[TargetResult, Option[ProperVelocity.RA]] =


### PR DESCRIPTION
It seems we can't send magnitudes to the API yet, so it's flickering when querying the catalog (the new magnitudes come from the catalog, are shown in the UI, but a second later they are refreshed from the DB):

![Kapture 2020-11-04 at 17 07 08](https://user-images.githubusercontent.com/1895643/98162556-4da2c880-1ec0-11eb-8142-d7a46a0d93b7.gif)

Therefore I'm opening the PR as draft since I don't know if we want to include this in the milestone. Or we could tag it with "WORK IN PROGRESS".