### PR TITLE
Allow zooming into coulomb Quantity

### DIFF
--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -10,8 +10,11 @@ import cats.effect.ContextShift
 import cats.effect.Timer
 import cats.syntax.all._
 import clue._
+import crystal.ViewF
+import coulomb.Quantity
 import explore.GraphQLSchemas._
 import explore.model.AppContext
+import explore.optics._
 import io.chrisdavenport.log4cats.Logger
 import shapeless._
 
@@ -52,4 +55,8 @@ object implicits extends ShorthandTypes with ListImplicits {
     ctx: AppContext[F]
   ): GraphQLStreamingClient[F, ObservationDB] =
     ctx.clients.odb
+
+  implicit class CoulombViewOps[F[_], N, U](val self: ViewF[F, Quantity[N, U]]) extends AnyVal {
+    def stripQuantity: ViewF[F, N] = self.as(coulombIso[N, U])
+  }
 }

--- a/model/src/main/scala/explore/optics/package.scala
+++ b/model/src/main/scala/explore/optics/package.scala
@@ -139,4 +139,8 @@ package object optics {
         .filter(_.abs <= SpeedOfLight.to[BigDecimal, KilometersPerSecond].value)
         .flatMap(v => RadialVelocity(v.withUnit[KilometersPerSecond]))
     )(rv => rv.rv.toUnit[KilometersPerSecond].value)
+
+  // Iso for coulumb quantities
+  def coulombIso[N, U] = Iso[Quantity[N, U], N](_.value)(_.withUnit[U])
+
 }

--- a/model/src/test/scala/explore/model/ModelOpticsSuite.scala
+++ b/model/src/test/scala/explore/model/ModelOpticsSuite.scala
@@ -15,6 +15,9 @@ import lucuma.core.math.arb.ArbRadialVelocity
 import lucuma.core.math.arb.ArbApparentRadialVelocity
 import lucuma.core.math.arb.ArbRedshift
 import org.scalacheck.Arbitrary._
+import coulomb.accepted.Percent
+import coulomb.cats.implicits._
+import coulomb.scalacheck.ArbQuantity._
 
 class ModelOpticsSuite
     extends DisciplineSuite
@@ -30,4 +33,6 @@ class ModelOpticsSuite
   checkAll("targetRA", LensTests(ModelOptics.targetRA))
   checkAll("targetDec", LensTests(ModelOptics.targetDec))
   checkAll("redshiftBigDecimal", IsoTests(redshiftBigDecimalISO))
+
+  checkAll("coulombIso", IsoTests(coulombIso[Int, Percent]))
 }


### PR DESCRIPTION
Provides an easy way to zoom into the value contained in a coulomb Quantity.

ex: `props.zoom(<lens>).stripQuantity`

Having it as an ops method allows the types for the quantity to be inferred, rather than having to be specified at the call site. 