### PR TITLE
Magnitude editor. Unset. UndoViews.

### DIFF
--- a/common/src/main/resources/graphql/schemas/ObservationDB.graphql
+++ b/common/src/main/resources/graphql/schemas/ObservationDB.graphql
@@ -132,9 +132,6 @@ input CreateSiderealInput {
   dec: DeclinationInput!
   epoch: EpochString
   properMotion: ProperMotionInput
-
-  # Deprecated, use properMotion instead.
-  properVelocity: ProperMotionInput
   radialVelocity: RadialVelocityInput
   parallax: ParallaxModelInput
   magnitudes: [MagnitudeInput!]
@@ -269,11 +266,17 @@ input EditSiderealInput {
   dec: DeclinationInput
   epoch: EpochString
   properMotion: ProperMotionInput
-
-  # Deprecated, use properMotion instead.
-  properVelocity: ProperMotionInput
   radialVelocity: RadialVelocityInput
   parallax: ParallaxModelInput
+
+  # Replace all magnitudes with the provided values
+  magnitudes: [MagnitudeInput!]
+
+  # Update any listed magnitudes leaving unmentioned values unchanged
+  modifyMagnitudes: [MagnitudeInput!]
+
+  # Removes any listed magnitude values
+  deleteMagnitudes: [MagnitudeBand!]
 }
 
 # Type of edit that triggered an event
@@ -693,12 +696,39 @@ type ProperMotion {
   dec: ProperMotionDeclination!
 }
 
-# ProperMotionDec, choose one of the available units
-input ProperMotionDecInput {
+# Decimal value in ProperMotionComponent
+input ProperMotionComponentDecimalInput {
+  # decimal value in associated units
+  value: BigDecimal!
+
+  # units for associated value
+  units: ProperMotionComponentUnits!
+}
+
+# Proper motion component, choose one of the available units
+input ProperMotionComponentInput {
   microarcsecondsPerYear: Long
   milliarcsecondsPerYear: BigDecimal
-  fromLong: ProperVelocityComponentLongInput
-  fromDecimal: ProperVelocityComponentDecimalInput
+  fromLong: ProperMotionComponentLongInput
+  fromDecimal: ProperMotionComponentDecimalInput
+}
+
+# Integral value in ProperMotionComponent
+input ProperMotionComponentLongInput {
+  # integral value in associated units
+  value: Long!
+
+  # units for associated value
+  units: ProperMotionComponentUnits!
+}
+
+# Unit options for proper motion components (RA and Dec)
+enum ProperMotionComponentUnits {
+  # ProperMotionComponentUnits MicroarcsecondsPerYear
+  MICROARCSECONDS_PER_YEAR
+
+  # ProperMotionComponentUnits MilliarcsecondsPerYear
+  MILLIARCSECONDS_PER_YEAR
 }
 
 type ProperMotionDeclination {
@@ -711,8 +741,8 @@ type ProperMotionDeclination {
 
 # Proper motion, choose one of the available units
 input ProperMotionInput {
-  ra: ProperMotionRaInput!
-  dec: ProperMotionDecInput!
+  ra: ProperMotionComponentInput!
+  dec: ProperMotionComponentInput!
 }
 
 type ProperMotionRA {
@@ -720,65 +750,6 @@ type ProperMotionRA {
   microarcsecondsPerYear: Long!
 
   # Proper motion in properMotion mas/year
-  milliarcsecondsPerYear: BigDecimal!
-}
-
-# ProperMotionRa, choose one of the available units
-input ProperMotionRaInput {
-  microarcsecondsPerYear: Long
-  milliarcsecondsPerYear: BigDecimal
-  fromLong: ProperVelocityComponentLongInput
-  fromDecimal: ProperVelocityComponentDecimalInput
-}
-
-type ProperVelocity {
-  # Proper motion in RA
-  ra: ProperVelocityRA!
-
-  # Proper motion in declination
-  dec: ProperVelocityDeclination!
-}
-
-# Decimal value in ProperVelocityComponent
-input ProperVelocityComponentDecimalInput {
-  # decimal value in associated units
-  value: BigDecimal!
-
-  # units for associated value
-  units: ProperVelocityComponentUnits!
-}
-
-# Integral value in ProperVelocityComponent
-input ProperVelocityComponentLongInput {
-  # integral value in associated units
-  value: Long!
-
-  # units for associated value
-  units: ProperVelocityComponentUnits!
-}
-
-# Unit options for proper velocity components (RA and Dec)
-enum ProperVelocityComponentUnits {
-  # ProperVelocityComponentUnits MicroarcsecondsPerYear
-  MICROARCSECONDS_PER_YEAR
-
-  # ProperVelocityComponentUnits MilliarcsecondsPerYear
-  MILLIARCSECONDS_PER_YEAR
-}
-
-type ProperVelocityDeclination {
-  # Proper motion in properVelocity μas/year
-  microarcsecondsPerYear: Long!
-
-  # Proper motion in properVelocity mas/year
-  milliarcsecondsPerYear: BigDecimal!
-}
-
-type ProperVelocityRA {
-  # Proper motion in properVelocity μas/year
-  microarcsecondsPerYear: Long!
-
-  # Proper motion in properVelocity mas/year
   milliarcsecondsPerYear: BigDecimal!
 }
 
@@ -966,9 +937,6 @@ type Sidereal {
 
   # Epoch, time of base observation
   epoch: EpochString!
-
-  # Proper velocity per year in right ascension and declination
-  properVelocity: ProperVelocity @deprecated(reason: "Renamed properMotion")
 
   # Proper motion per year in right ascension and declination
   properMotion: ProperMotion

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -689,7 +689,7 @@ body {
   align-content: center;
 }
 
-.target-trash-icon {
+.trash-icon {
   color: var(--negative-icon-color);
 }
 
@@ -1029,7 +1029,7 @@ img.partner-split-flag {
   }
 }
 
-.ui.button.delete-target-button {
+.ui.button.delete-button {
   padding: 0.4em 0.4em 0.4em 0.4em;
   margin: 0;
   margin-right: 0.4em;
@@ -1042,4 +1042,8 @@ img.partner-split-flag {
   &:hover {
     outline: 1px var(--site-border-color) solid;
   }
+}
+
+.ui.form .field.flat-form-field {
+  margin-bottom: 0;
 }

--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -22,7 +22,6 @@ import explore.model.RootModel
 import explore.model.enum.AppTab
 import explore.model.reusability._
 import io.chrisdavenport.log4cats.Logger
-import japgolly.scalajs.react.extra.ReusabilityOverlay
 import japgolly.scalajs.react.vdom.VdomElement
 import log4cats.loglevel.LogLevelLogger
 import lucuma.core.data.EnumZipper
@@ -56,7 +55,7 @@ trait AppMain extends IOApp {
   def runIOApp(): Unit = main(Array.empty)
 
   override final def run(args: List[String]): IO[ExitCode] = {
-    ReusabilityOverlay.overrideGloballyInDev()
+    japgolly.scalajs.react.extra.ReusabilityOverlay.overrideGloballyInDev()
 
     val initialModel = RootModel(
       tabs = EnumZipper.of[AppTab],

--- a/common/src/main/scala/explore/GraphQLSchemas.scala
+++ b/common/src/main/scala/explore/GraphQLSchemas.scala
@@ -3,9 +3,13 @@
 
 package explore
 
+import java.math.MathContext
+
+import clue.data.syntax._
 import clue.macros.GraphQLSchema
 import explore.model.SiderealTarget
 import explore.model.enum._
+import lucuma.core.model.Magnitude
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
 
@@ -28,6 +32,20 @@ object GraphQLSchemas {
     object Enums {
       type CatalogName     = lucuma.core.enum.CatalogName
       type MagnitudeSystem = lucuma.core.enum.MagnitudeSystem
+      type MagnitudeBand   = lucuma.core.enum.MagnitudeBand
+    }
+
+    object Implicits {
+      import Types._
+
+      implicit class MagnitudeOps(m: Magnitude) {
+        def toInput: MagnitudeInput =
+          MagnitudeInput(m.value.toDoubleValue,
+                         m.band,
+                         m.error.map(_.toRational.toBigDecimal(MathContext.UNLIMITED)).orIgnore,
+                         m.system.assign
+          )
+      }
     }
   }
 

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -38,16 +38,16 @@ object ExploreStyles {
   // styling and layout
   val ProposalTile: Css = Css("proposal-tile")
 
-  val MainGrid: Css           = Css("main-grid")
-  val MainHeader: Css         = Css("main-header")
-  val MainBody: Css           = Css("main-body")
-  val MainTitle: Css          = Css("main-title")
-  val SideTabs: Css           = Css("sidetabs")
-  val SideButton: Css         = Css("side-button")
-  val BlendedButton: Css      = Css("blended-button")
-  val JustifyRight: Css       = Css("justify-right")
-  val TargetLabelTitle: Css   = Css("target-label-title")
-  val DeleteTargetButton: Css = Css("delete-target-button")
+  val MainGrid: Css         = Css("main-grid")
+  val MainHeader: Css       = Css("main-header")
+  val MainBody: Css         = Css("main-body")
+  val MainTitle: Css        = Css("main-title")
+  val SideTabs: Css         = Css("sidetabs")
+  val SideButton: Css       = Css("side-button")
+  val BlendedButton: Css    = Css("blended-button")
+  val JustifyRight: Css     = Css("justify-right")
+  val TargetLabelTitle: Css = Css("target-label-title")
+  val DeleteButton: Css     = Css("delete-button")
 
   val ResizeHandle: Css       = Css("resize-handle")
   val ResizableSeparator: Css = Css("resize-separator")
@@ -82,7 +82,7 @@ object ExploreStyles {
   val ObsBadge: Css               = Css("obs-badge")
   val SelectedObsItem: Css        = Css("selected-obs-item")
   val ObsItem: Css                = Css("obs-item")
-  val TargetTrashIcon: Css        = Css("target-trash-icon")
+  val TrashIcon: Css              = Css("trash-icon")
 
   val DraggingOver: Css = Css("dragging-over")
 
@@ -119,6 +119,7 @@ object ExploreStyles {
   val Compact: Css           = Css("explore-compact")
   val ErrorLabel: Css        = Css("explore-error-label")
   val InputErrorTooltip: Css = Css("explore-input-error-tooltip")
+  val FlatFormField: Css     = Css("flat-form-field")
 
   // Clue websocket connection status
   val ConnectionOK: Css      = Css("connection-ok")

--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -10,8 +10,8 @@ import cats.effect.ContextShift
 import cats.effect.Timer
 import cats.syntax.all._
 import clue._
-import crystal.ViewF
 import coulomb.Quantity
+import crystal.ViewF
 import explore.GraphQLSchemas._
 import explore.model.AppContext
 import explore.optics._
@@ -47,12 +47,12 @@ object implicits extends ShorthandTypes with ListImplicits {
   implicit def appContext2ContextShift[F[_]](implicit ctx: AppContext[F]): ContextShift[F] = ctx.cs
   implicit def appContext2Timer[F[_]](implicit ctx:        AppContext[F]): Timer[F]        = ctx.timer
   implicit def appContext2Logger[F[_]](implicit ctx:       AppContext[F]): Logger[F]       = ctx.logger
-  implicit def appContext2ExploreDBClient[F[_]](implicit
-    ctx:                                                   AppContext[F]
-  ): GraphQLStreamingClient[F, ExploreDB] =
-    ctx.clients.exploreDB
+  // implicit def appContext2ExploreDBClient[F[_]](implicit
+  //   ctx:                                                   AppContext[F]
+  // ): GraphQLStreamingClient[F, ExploreDB] =
+  //   ctx.clients.exploreDB
   implicit def appContext2ODBClient[F[_]](implicit
-    ctx: AppContext[F]
+    ctx:                                                   AppContext[F]
   ): GraphQLStreamingClient[F, ObservationDB] =
     ctx.clients.odb
 

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -7,4 +7,12 @@ package object utils {
 
   def abbreviate(s: String, maxLength: Int): String =
     if (s.length > maxLength) s"${s.substring(0, maxLength)}\u2026" else s
+
+  implicit class ListOps[A](val list: List[A]) extends AnyVal {
+    def modFirstWhere(find: A => Boolean, mod: A => A): List[A] =
+      list.indexWhere(find) match {
+        case -1 => list
+        case n  => (list.take(n) :+ mod(list(n))) ++ list.drop(n + 1)
+      }
+  }
 }

--- a/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
+++ b/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
@@ -5,11 +5,10 @@ package explore.constraints
 
 import cats.effect.ContextShift
 import cats.effect.IO
-import cats.syntax.all._
 import clue.GraphQLOperation
+import clue.data.syntax._
 import clue.macros.GraphQL
 import crystal.ViewF
-import explore.AppCtx
 import explore.GraphQLSchemas.ExploreDB.Types._
 import explore.GraphQLSchemas._
 import explore.components.graphql.SubscriptionRenderMod
@@ -24,7 +23,6 @@ import explore.model.reusability._
 import explore.undo.Undoer
 import japgolly.scalajs.react.vdom.html_<^._
 import monocle.Lens
-import monocle.function.Cons.headOption
 import monocle.macros.Lenses
 
 object ConstraintsQueries {
@@ -83,31 +81,32 @@ object ConstraintsQueries {
   }
 
   def iqFields(iq: ImageQuality): ConstraintsSetInput =
-    ConstraintsSetInput(image_quality = iq.some)
+    ConstraintsSetInput(image_quality = iq.assign)
 
   def ccFields(cc: CloudCover): ConstraintsSetInput =
-    ConstraintsSetInput(cloud_cover = cc.some)
+    ConstraintsSetInput(cloud_cover = cc.assign)
 
   def wvFields(wv: WaterVapor): ConstraintsSetInput =
-    ConstraintsSetInput(water_vapor = wv.some)
+    ConstraintsSetInput(water_vapor = wv.assign)
 
   def sbFields(sb: SkyBackground): ConstraintsSetInput =
-    ConstraintsSetInput(sky_background = sb.some)
+    ConstraintsSetInput(sky_background = sb.assign)
 
-  private def mutate(id: Constraints.Id, fields: ConstraintsSetInput): IO[Unit] =
-    AppCtx.flatMap { implicit ctx =>
-      Mutation.execute(id, fields).void
-    }
+  private def mutate(id: Constraints.Id, fields: ConstraintsSetInput): IO[Unit] = ???
+  // AppCtx.flatMap { implicit ctx =>
+  //   Mutation.execute(id, fields).void
+  // }
 
   def ConstraintsSubscription(
     id:     Constraints.Id
   )(render: View[Constraints] => VdomNode): SubscriptionRenderMod[Subscription.Data, Constraints] =
-    AppCtx.withCtx { implicit appCtx =>
-      SubscriptionRenderMod[Subscription.Data, Constraints](
-        Subscription.subscribe(id),
-        _.map(
-          Subscription.Data.constraints.composeOptional(headOption).getOption _
-        ).unNone
-      )(render)
-    }
+    ???
+  // AppCtx.withCtx { implicit appCtx =>
+  //   SubscriptionRenderMod[Subscription.Data, Constraints](
+  //     Subscription.subscribe(id),
+  //     _.map(
+  //       Subscription.Data.constraints.composeOptional(headOption).getOption _
+  //     ).unNone
+  //   )(render)
+  // }
 }

--- a/model/src/main/scala/explore/model/display.scala
+++ b/model/src/main/scala/explore/model/display.scala
@@ -4,6 +4,8 @@
 package explore.model
 
 import explore.model.enum._
+import lucuma.core.enum.MagnitudeBand
+import lucuma.core.enum.MagnitudeSystem
 import lucuma.core.util.Display
 
 object display {
@@ -30,4 +32,10 @@ object display {
 
   implicit val displayToOActivation: Display[ToOActivation] =
     Display.byShortName(_.label)
+
+  implicit val displayMagnitudeBand: Display[MagnitudeBand] =
+    Display.by(_.shortName, _.longName)
+
+  implicit val displayMagnitudeSystem: Display[MagnitudeSystem] =
+    Display.byShortName(_.tag)
 }

--- a/model/src/main/scala/explore/undo/UndoableView.scala
+++ b/model/src/main/scala/explore/undo/UndoableView.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.undo
+
+import cats.effect.Async
+import cats.effect.ContextShift
+import cats.syntax.all._
+import crystal.ViewF
+import monocle.Lens
+
+/**
+ * Weaves `ViewF` and `Undoer` logic.
+ *
+ * When the `ViewF`'s set/mod is modified, it will be done through the provided
+ * `Undoer.Setter`, such that the change is pushed into the `Undoer` stack.
+ *
+ * The `ViewF` can be zoomed upon via the `apply` methods, which will take either
+ * a `Lens` or a `get`/`mod` pair of functions, plus a side effect (`onChange`)
+ * to be run whenever the resulting `ViewF`'s value changes, which can happen when
+ * the value is directly `set`/`mod`, or when an `undo` or `redo` is executed. This
+ * side effect could be, for example, setting the value on a remote DB.
+ */
+case class UndoableView[F[_]: Async: ContextShift, T](
+  view:   ViewF[F, T],
+  setter: Undoer.Setter[F, T]
+) {
+  def apply[A](get: T => A, mod: (A => A) => T => T, onChange: A => F[Unit]): ViewF[F, A] = {
+    val zoomed = view.zoom(get)(mod)
+    ViewF(
+      zoomed.get,
+      setter.mod(
+        view.get,
+        get,
+        a => (zoomed.set(a) >> onChange(a))
+      )
+    )
+  }
+
+  def apply[A](lens: Lens[T, A], onChange: A => F[Unit]): ViewF[F, A] =
+    apply(lens.get, lens.modify, onChange)
+}

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -296,8 +296,7 @@ object TargetObsList {
                             Button(
                               size = Small,
                               compact = true,
-                              clazz =
-                                ExploreStyles.DeleteTargetButton |+| ExploreStyles.JustifyRight,
+                              clazz = ExploreStyles.DeleteButton |+| ExploreStyles.JustifyRight,
                               onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
                                 e.stopPropagationCB *>
                                   deleteTarget(targetId, undoCtx.setter, focusOnDelete)
@@ -305,7 +304,7 @@ object TargetObsList {
                               Icons.Delete
                                 .size(Small)
                                 .fitted(true)
-                                .clazz(ExploreStyles.TargetTrashIcon)
+                                .clazz(ExploreStyles.TrashIcon)
                             ),
                             <.span(ExploreStyles.ObsCount, s"$obsCount Obs")
                           ),

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ object Settings {
     val catsEffect        = "2.3.0"
     val chimney           = "0.6.1"
     val circe             = "0.13.0"
-    val clue              = "0.3.4"
+    val clue              = "0.4.0"
     val crystal           = "0.9.1"
     val discipline        = "1.1.2"
     val disciplineMUnit   = "1.0.3"

--- a/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
@@ -14,12 +14,12 @@ import explore._
 import explore.components.FormStaticData
 import explore.components.Tile
 import explore.components.ui._
-import explore.model.enum.ProposalClass._
-import explore.model.refined._
+import explore.implicits.CoulombViewOps
 import explore.model._
 import explore.model.display._
+import explore.model.enum.ProposalClass._
+import explore.model.refined._
 import explore.model.reusability._
-import explore.implicits.CoulombViewOps
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.Reusability._
 import japgolly.scalajs.react._

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -12,7 +12,6 @@ import explore.components.ui.ExploreStyles
 import explore.model.TargetVisualOptions
 import explore.model.enum.Display
 import explore.model.reusability._
-import lucuma.svgdotjs.Svg
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -20,6 +19,7 @@ import lucuma.core.geom.jts.interpreter._
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
 import lucuma.core.math.RightAscension
+import lucuma.svgdotjs.Svg
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import org.scalajs.dom.document

--- a/targeteditor/src/main/scala/explore/targeteditor/GmosGeometry.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/GmosGeometry.scala
@@ -4,7 +4,6 @@
 package explore.targeteditor
 
 import cats.data.NonEmptyMap
-import lucuma.svgdotjs._
 import lucuma.core.enum.GmosNorthFpu
 import lucuma.core.enum.GmosSouthFpu
 import lucuma.core.enum.PortDisposition
@@ -16,6 +15,7 @@ import lucuma.core.geom.syntax.shapeexpression._
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import lucuma.core.math.syntax.int._
+import lucuma.svgdotjs._
 
 /**
  * Test object to produce a gmos geometry. it is for demo purposes only

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -3,44 +3,197 @@
 
 package explore.targeteditor
 
+import scala.collection.immutable.HashSet
+
+import cats.effect.IO
+import cats.syntax.all._
+import crystal.ViewF
+import crystal.react.implicits._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.AppCtx
+import explore.Icons
+import explore.components.ui.ExploreStyles
+import explore.implicits._
+import explore.model.display._
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.enum.MagnitudeBand
+import lucuma.core.math.MagnitudeValue
 import lucuma.core.model.Magnitude
+import lucuma.core.model.Target
+import lucuma.ui.forms.EnumViewSelect
+import lucuma.ui.forms.FormInputEV
+import lucuma.ui.optics.ChangeAuditor
+import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.reusability._
+import monocle.macros.Lenses
+import monocle.std.option.some
 import react.common.ReactProps
-import react.semanticui.collections.grid.Grid
-import react.semanticui.collections.grid.GridColumn
-import react.semanticui.collections.grid.GridDivided
-import react.semanticui.collections.grid.GridRow
+import react.semanticui.collections.form.Form
+import react.semanticui.collections.table.Table
+import react.semanticui.collections.table.TableBody
+import react.semanticui.collections.table.TableCell
+import react.semanticui.collections.table.TableCompact
+import react.semanticui.collections.table.TableFooter
+import react.semanticui.collections.table.TableHeaderCell
+import react.semanticui.collections.table.TableRow
+import react.semanticui.elements.button.Button
 import react.semanticui.elements.segment.Segment
-import react.semanticui.widths._
+import react.semanticui.sizes._
 
-final case class MagnitudeForm(magnitudes: List[Magnitude])
-    extends ReactProps[MagnitudeForm](MagnitudeForm.component)
+final case class MagnitudeForm(
+  targetId:   Target.Id,
+  magnitudes: View[List[Magnitude]]
+) extends ReactProps[MagnitudeForm](MagnitudeForm.component)
 
 object MagnitudeForm {
   type Props = MagnitudeForm
 
-  implicit val propsReuse = Reusability.derive[Props]
+  @Lenses
+  protected case class State(usedBands: Set[MagnitudeBand], newBand: Option[MagnitudeBand])
+
+  implicit val propsReuse: Reusability[Props] = Reusability.derive
+  implicit val stateReuse: Reusability[State] = Reusability.derive
 
   val component =
     ScalaComponent
       .builder[Props]
-      .render_P { props =>
-        React.Fragment(
-          <.label("Magnitudes"),
-          Segment(
-            Grid(columns = Three, divided = GridDivided.Divided)(
-              props.magnitudes.toTagMod(magnitude =>
-                GridRow(
-                  GridColumn(<.span(magnitude.value.toDoubleValue.toString)),
-                  GridColumn(<.span(magnitude.band.toString)),
-                  GridColumn(<.span(magnitude.system.toString))
-                )(^.paddingTop := "0.5rem", ^.paddingBottom := "0.5rem")
+      .getDerivedStateFromPropsAndState[State] { case (props, stateOpt) =>
+        val usedBands = HashSet.from(props.magnitudes.get.map(_.band))
+        stateOpt match {
+          case Some(state) if state.newBand.exists(b => !usedBands.contains(b)) =>
+            State.usedBands.set(usedBands)(state)
+          case _                                                                =>
+            State(usedBands, MagnitudeBand.all.diff(usedBands.toList).headOption)
+        }
+      }
+      .render { $ =>
+        val props = $.props
+        val state = $.state
+
+        AppCtx.withCtx { implicit ctx =>
+          val newBandView: Option[View[MagnitudeBand]] =
+            state.newBand.map(band =>
+              ViewF(band,
+                    (mod: MagnitudeBand => MagnitudeBand) =>
+                      $.modStateIn[IO](State.newBand.composePrism(some).modify(mod))
               )
             )
-          )(^.maxWidth := "250px")
-        )
+
+          Form(size = Small)(
+            <.div(<.label("Magnitudes")),
+            Segment(
+              Table(compact = TableCompact.Very)(
+                TableBody(
+                  props.magnitudes.get.toTagMod { magnitude =>
+                    // We are already focused in the magnitude we want
+                    val getMagnitude: List[Magnitude] => Magnitude = _ => magnitude
+
+                    def modMagnitude(mod: Magnitude => Magnitude)
+                      : List[Magnitude] => List[Magnitude] =
+                      list => list.modFirstWhere(_.band === magnitude.band, mod).sortBy(_.band)
+
+                    val magnitudeView: View[Magnitude] =
+                      props.magnitudes
+                        .zoom[Magnitude](getMagnitude)(modMagnitude)
+
+                    val magnitudeValueView: View[MagnitudeValue] =
+                      magnitudeView.zoom(Magnitude.value)
+
+                    TableRow(
+                      TableCell(
+                        <.span(
+                          FormInputEV(
+                            id = NonEmptyString
+                              .from(magnitude.band.toString + "_VALUE")
+                              .getOrElse("NEW_MAGNITUDE_VALUE"),
+                            value = magnitudeValueView,
+                            validFormat = ValidFormatInput.fromFormat(MagnitudeValue.fromString,
+                                                                      "Invalid magnitude"
+                            ),
+                            changeAuditor = ChangeAuditor
+                              .fromFormat(MagnitudeValue.fromString)
+                              .decimal(3)
+                              .allowEmpty
+                          ).withMods(^.width := "80px")
+                        )
+                      ),
+                      TableCell(
+                        <.span(
+                          EnumViewSelect(
+                            id = magnitude.band.toString + "_BAND",
+                            value = magnitudeView.zoom(Magnitude.band),
+                            exclude = state.usedBands - magnitude.band
+                          )
+                        )
+                      ),
+                      TableCell(
+                        <.span(
+                          EnumViewSelect(
+                            id = magnitude.band.toString + "_SYSTEM",
+                            value = magnitudeView.zoom(Magnitude.system)
+                          )
+                        )
+                      ),
+                      TableCell(
+                        <.span(
+                          Button(
+                            size = Small,
+                            compact = true,
+                            clazz = ExploreStyles.DeleteButton,
+                            onClick = props.magnitudes
+                              .mod(_.filterNot(_.band === magnitude.band))
+                              .runAsyncCB
+                          )(
+                            Icons.Delete
+                              .size(Small)
+                              .fitted(true)
+                              .clazz(ExploreStyles.TrashIcon)
+                          )
+                        )
+                      )
+                    )
+                  }
+                ),
+                TableFooter(
+                  TableRow(
+                    TableHeaderCell()(^.colSpan := 4)(
+                      <.span(^.display.flex, ^.justifyContent.flexEnd)(
+                        newBandView.whenDefined {
+                          view =>
+                            val addMagnitude =
+                              props.magnitudes.mod(list =>
+                                (list :+ Magnitude(MagnitudeValue(0),
+                                                   view.get,
+                                                   view.get.magnitudeSystem
+                                )).sortBy(_.band)
+                              )
+
+                            React.Fragment(
+                              EnumViewSelect(
+                                id = "NEW_BAND",
+                                value = view,
+                                exclude = state.usedBands,
+                                clazz = ExploreStyles.FlatFormField
+                              ),
+                              Button(size = Mini,
+                                     compact = true,
+                                     onClick = addMagnitude.runAsyncCB
+                              )(^.marginLeft := "5px")(
+                                Icons.New.size(Small).fitted(true)
+                              )
+                            )
+                        }
+                      )
+                    )
+                  )
+                )
+              )
+            )(^.display.`inline-block`)
+          )
+        }
       }
       .configure(Reusability.shouldComponentUpdate)
       .build

--- a/targeteditor/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -70,7 +70,7 @@ object SearchForm {
         props
           .submit(
             state.searchTerm,
-            props.searching.set(true).runAsyncCB,
+            $.setStateL(State.searchError)(none) >> props.searching.set(true).runAsyncCB,
             t =>
               searchComplete.runAsyncCB *> ($.setStateL(State.searchError)(
                 NonEmptyString


### PR DESCRIPTION
* Allow unsetting fields, by using the new functionality of the ODB (sending `null`) together with clue 0.4.0's `Input[A]` type.
* Convenience definition of `UndoableView`, which weaves `Undoer` logic into `View`'s `set`/`mod`. This simplifies and generalizes logic previously found in `UndoSet`. It is also transparent for child components that receive `View`s. Also, this is the correct way to go, the previous way of doing things updated the local model twice.
* Magnitude editor supporting undo operations. It will be refactored into an `ag-grid` once we have the facade. For simplicity, the magnitude list is treated as a single field. If different users are both editing the magnitude list of the same target at the same time, they will overwrite each other's changes. It would require profound changes and added complexity to the undo logic to support treating each band separately, especially given that the level's primary key (the band) is editable.

~This PR is a draft since requires changes in lucuma-ui and lucuma-odb which are yet to be released. Otherwise, I consider it ready to go, modulo review.~