### PR TITLE
Switch cats imports

### DIFF
--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -3,7 +3,7 @@
 
 package explore
 
-import cats.implicits._
+import cats.syntax.all._
 import crystal.react.implicits._
 import explore.components.ui.ExploreStyles
 import explore.model.enum.AppTab

--- a/model/src/main/scala/explore/model/decoders.scala
+++ b/model/src/main/scala/explore/model/decoders.scala
@@ -3,7 +3,7 @@
 
 package explore.model
 
-import cats.implicits._
+import cats.syntax.all._
 import coulomb._
 import explore.model.enum._
 import io.circe.Decoder

--- a/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
@@ -4,7 +4,7 @@
 package explore.targeteditor
 
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._

--- a/targeteditor/src/main/scala/explore/targeteditor/SimbadSearch.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SimbadSearch.scala
@@ -7,7 +7,7 @@ import scala.concurrent.duration._
 
 import cats.data.Validated
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import eu.timepit.refined.types.string.NonEmptyString
 import fs2._
 import lucuma.catalog.VoTableParser

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -5,7 +5,7 @@ package explore.target
 
 import cats.Endo
 import cats.effect.IO
-import cats.implicits._
+import cats.syntax.all._
 import clue.GraphQLOperation
 import clue.macros.GraphQL
 import eu.timepit.refined.auto._


### PR DESCRIPTION
Starting with cats 2.3.0 it is recommended to switch to import `cats.syntax.all`