### PR TITLE
Detect if using older Safari and forbid access

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val common = project
   .settings(commonJsLibSettings: _*)
   .settings(
     npmDependencies in Compile ++= Seq(
-      "loglevel" -> "1.6.8"
+      "loglevel"     -> "1.6.8"
     ),
     libraryDependencies ++=
       LucumaSSO.value ++
@@ -381,6 +381,7 @@ lazy val commonWDS = Seq(
     "prop-types"        -> "15.7.2",
     "react-moon"        -> "2.0.1",
     "styled-components" -> "5.1.1",
-    "react-popper"      -> "2.2.3"
+    "react-popper"      -> "2.2.3",
+    "ua-parser-js"      -> "0.7.23",
   )
 )

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -1218,6 +1218,8 @@ i.icon.user-astronaut:before { content: "\f4fb"; }
   white-space: wrap;
   max-width: 60%;
   text-align: center;
+  display: flex;
+  justify-items: center;
 }
 
 .ui.button.explore-login-button {

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -1211,6 +1211,15 @@ i.icon.user-astronaut:before { content: "\f4fb"; }
   align-items: center;
 }
 
+.ui.label.explore-login-button {
+  margin-bottom: 1em;
+  color: var(--negative-text-color);
+  background-color: var(--negative-background-color);
+  white-space: wrap;
+  max-width: 60%;
+  text-align: center;
+}
+
 .ui.button.explore-login-button {
   margin-bottom: 1em;
 }

--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -26,5 +26,5 @@ object Icons {
   val Ban                 = Icon("ban")
   val UserAstronaut       = Icon(className = "user-astronaut")
   val Logout              = Icon("sign out alternate")
-  val SadTear             = Icon("skull crossbones")
+  val SkullCrossBones     = Icon("skull crossbones")
 }

--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -26,4 +26,5 @@ object Icons {
   val Ban                 = Icon("ban")
   val UserAstronaut       = Icon(className = "user-astronaut")
   val Logout              = Icon("sign out alternate")
+  val SadTear             = Icon("skull crossbones")
 }

--- a/common/src/main/scala/explore/components/UserSelectionForm.scala
+++ b/common/src/main/scala/explore/components/UserSelectionForm.scala
@@ -83,7 +83,7 @@ object UserSelectionForm {
               ).when(s),
               Label(size = Large, clazz = ExploreStyles.LoginBoxButton)(
                 Icons.SkullCrossBones.size(Big),
-                "This browser isn't supported. Recent versions of Chrome or Firefox are recommended"
+                "This version of Safari isn't supported. Try a newer version (>13.1) or a recent version of Chrome or Firefox."
               ).unless(s),
               Button(content = "Continue as Guest",
                      size = Big,

--- a/common/src/main/scala/explore/components/UserSelectionForm.scala
+++ b/common/src/main/scala/explore/components/UserSelectionForm.scala
@@ -82,8 +82,8 @@ object UserSelectionForm {
                 onClick = p.login
               ).when(s),
               Label(size = Large, clazz = ExploreStyles.LoginBoxButton)(
-                Icons.SadTear.size(Big),
-                "This browser isn't supported, recent versions of Chrome or Firefox are recommended"
+                Icons.SkullCrossBones.size(Big),
+                "This browser isn't supported. Recent versions of Chrome or Firefox are recommended"
               ).unless(s),
               Button(content = "Continue as Guest",
                      size = Big,

--- a/common/src/main/scala/explore/utils/UAParser.scala
+++ b/common/src/main/scala/explore/utils/UAParser.scala
@@ -1,0 +1,16 @@
+package explore.utils
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+@js.native
+trait Browser extends js.Object {
+  val name: String    = js.native
+  val version: String = js.native
+}
+
+@js.native
+@JSImport("ua-parser-js", JSImport.Namespace)
+class UAParser(val ua: String) extends js.Object {
+  def getBrowser(): Browser = js.native
+}

--- a/common/src/main/scala/explore/utils/UAParser.scala
+++ b/common/src/main/scala/explore/utils/UAParser.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package explore.utils
 
 import scala.scalajs.js

--- a/explore/yarn.lock
+++ b/explore/yarn.lock
@@ -7372,6 +7372,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+ua-parser-js@0.7.23:
+  version "0.7.23"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.23.tgz#704d67f951e13195fbcd3d78818577f5bc1d547b"
+  integrity sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==
+
 union-value@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.1.tgz#0b6fe7b835aecda61c6ea4d4f02c14221e109847"


### PR DESCRIPTION
When logging in we detect the browser and can indicate if it isn't supported, so far we only blacklist older Safari versions

![image (11)](https://user-images.githubusercontent.com/3615303/101920136-32effd80-3baa-11eb-884f-1f9a98b0c803.png)


Parsing UA is harder than I expected so I'm bringing in a little (well maintained) js library