### PR TITLE
Login and reconnect logic within app.

### DIFF
--- a/common/src/main/resources/conf/development.conf.json
+++ b/common/src/main/resources/conf/development.conf.json
@@ -2,5 +2,10 @@
   "environment": "DEVELOPMENT",
   "odbURI": "wss://odb.gpp.lucuma.xyz/ws",
   "exploreDBURI": "wss://explore-hasura.herokuapp.com/v1/graphql",
-  "ssoURI": "https://sso.gpp.lucuma.xyz"
+  "sso": {
+    "uri": "https://sso.gpp.lucuma.xyz",
+    "readTimeoutSeconds": 10,
+    "refreshTimeoutDeltaSeconds": 10,
+    "refreshIntervalFactor": 10
+  }
 }

--- a/common/src/main/resources/conf/production.conf.json
+++ b/common/src/main/resources/conf/production.conf.json
@@ -2,5 +2,10 @@
   "environment": "PRODUCTION",
   "odbURI": "wss://lucuma-odb.herokuapp.com/ws",
   "exploreDBURI": "wss://explore-hasura.herokuapp.com/v1/graphql",
-  "ssoURI": "https://sso.gpp.gemini.edu"
+  "sso": {
+    "uri": "https://sso.gpp.gemini.edu",
+    "readTimeoutSeconds": 10,
+    "refreshTimeoutDeltaSeconds": 10,
+    "refreshIntervalFactor": 1
+  }  
 }

--- a/common/src/main/resources/conf/staging.conf.json
+++ b/common/src/main/resources/conf/staging.conf.json
@@ -2,5 +2,10 @@
   "environment": "STAGING",
   "odbURI": "wss://odb.gpp.lucuma.xyz/ws",
   "exploreDBURI": "wss://explore-hasura.herokuapp.com/v1/graphql",
-  "ssoURI": "https://sso.gpp.lucuma.xyz"
+  "sso": {
+    "uri": "https://sso.gpp.lucuma.xyz",
+    "readTimeoutSeconds": 10,
+    "refreshTimeoutDeltaSeconds": 10,
+    "refreshIntervalFactor": 1
+  }  
 }

--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -3,7 +3,6 @@
 
 package explore
 
-import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration._
@@ -26,13 +25,9 @@ import explore.model.RootModel
 import explore.model.UserVault
 import explore.model.enum.AppTab
 import explore.model.reusability._
-import explore.utils.ExploreEvent
 import io.chrisdavenport.log4cats.Logger
-import io.circe.Json
-import io.circe.syntax._
 import japgolly.scalajs.react.vdom.VdomElement
 import log4cats.loglevel.LogLevelLogger
-import lucuma.broadcastchannel._
 import lucuma.core.data.EnumZipper
 import org.scalajs.dom
 import org.scalajs.dom.experimental.RequestCache
@@ -66,7 +61,7 @@ trait AppMain extends IOApp {
   override final def run(args: List[String]): IO[ExitCode] = {
     japgolly.scalajs.react.extra.ReusabilityOverlay.overrideGloballyInDev()
 
-    def initialModel(vault: UserVault) = RootModel(
+    def initialModel(vault: Option[UserVault]) = RootModel(
       vault = vault,
       tabs = EnumZipper.of[AppTab]
     )
@@ -78,15 +73,6 @@ trait AppMain extends IOApp {
           body.classList.add("dark-theme")
         }
       }
-
-    def repeatTokenRefresh(ssoURI: Uri, expiration: Instant, v: View[UserVault]): IO[Unit] =
-      SSOClient
-        .refreshToken[IO](ssoURI, expiration, v.set, IO.fromFuture)
-        .attempt
-        .flatMap {
-          case Right(u) => repeatTokenRefresh(ssoURI, u.map(_.expiration).getOrElse(expiration), v)
-          case Left(_)  => repeatTokenRefresh(ssoURI, expiration, v)
-        }
 
     val fetchConfig: IO[AppConfig] = {
       // We want to avoid caching the static server redirect and the config files (they are not fingerprinted by webpack).
@@ -119,49 +105,25 @@ trait AppMain extends IOApp {
       IO.fromFuture(httpCall).map(_.body)
     }
 
-    def connectParameters(vault: UserVault): IO[Map[String, Json]] =
-      Map("Authorization" -> s"Bearer ${vault.token.value}".asJson).pure[IO]
-
     val reconnectionStrategy: WebSocketReconnectionStrategy =
-      (attempt, event) =>
-        if (event.code === 1000)
+      (attempt, reason) =>
+        if (reason.exists(_.code === 1000))
           none
         else // Increase the delay to get exponential backoff with a minimum of 1s and a max of 1m
           FiniteDuration(math.min(60.0, math.pow(2, attempt.toDouble - 1)).toLong,
                          TimeUnit.SECONDS
           ).some
 
-    def setupLogoutListener(bc: BroadcastChannel[ExploreEvent]): IO[Unit] =
-      IO(bc.onmessage =
-        (x: ExploreEvent) =>
-          // This is coming from the js world, we can't match the type
-          (x.event match {
-            case ExploreEvent.Logout.event =>
-              IO(
-                dom.window.location.reload()
-              ).attempt.void
-            case _                         => IO.unit
-          })
-      )
-
     for {
       _         <- setupScheme
       appConfig <- fetchConfig
-      vault     <- SSOClient.vault[IO](appConfig.ssoURI, IO.fromFuture)
+      vault     <- SSOClient.whoami[IO](appConfig.ssoURI, IO.fromFuture)
       _         <- logger.info(s"Git Commit: [${BuildInfo.gitHeadCommit.getOrElse("NONE")}]")
       _         <- logger.info(s"Config: ${appConfig.show}")
       ctx       <- AppContext.from[IO](appConfig, reconnectionStrategy)
-      _         <- ctx.clients.odb.connect(connectParameters(vault))
       _         <- AppCtx.initIn[IO](ctx)
-      _         <- setupLogoutListener(ctx.bc)
     } yield {
-      val RootComponent =
-        AppRoot[IO](initialModel(vault))(
-          rootComponent,
-          onMount = (v: View[RootModel]) =>
-            repeatTokenRefresh(appConfig.ssoURI, vault.expiration, v.zoom(RootModel.vault)),
-          onUnmount = (_: RootModel) => ctx.cleanup()
-        )
+      val RootComponent = AppRoot[IO](initialModel(vault))(rootView => rootComponent(rootView))
 
       val container = Option(dom.document.getElementById("root")).getOrElse {
         val elem = dom.document.createElement("div")

--- a/common/src/main/scala/explore/components/ConnectionsStatus.scala
+++ b/common/src/main/scala/explore/components/ConnectionsStatus.scala
@@ -26,16 +26,19 @@ object ConnectionsStatus {
   type Props = ConnectionsStatus
 
   private def renderStatus(name: String)(status: Pot[StreamingClientStatus]): VdomElement = {
-    val (message, clazz, show) = status match {
-      case Error(t)     => (t.getMessage, ConnectionError, true)
-      case Pending(_)   => ("Mounting...", ConnectionWarning, true)
+    val (message, (clazz, show)) = status match {
+      case Error(t)     => (t.getMessage, (ConnectionError, true))
+      case Pending(_)   => ("Mounting...", (ConnectionWarning, true))
       case Ready(value) =>
-        value match {
-          case Connecting    => ("Connecting...", ConnectionWarning, true)
-          case Connected     => ("Connected", ConnectionOK, false)
-          case Disconnecting => ("Disconnecting...", ConnectionWarning, true)
-          case Disconnected  => ("Disconnected", ConnectionError, true)
-        }
+        (value.toString,
+         value match {
+           case Connecting                                                        => (ConnectionWarning, true)
+           case Connected | Initializing | Initialized | Terminating | Terminated =>
+             (ConnectionOK, false)
+           case Disconnecting                                                     => (ConnectionWarning, true)
+           case Disconnected                                                      => (ConnectionError, true)
+         }
+        )
     }
 
     if (show) {

--- a/common/src/main/scala/explore/components/UserSelectionForm.scala
+++ b/common/src/main/scala/explore/components/UserSelectionForm.scala
@@ -3,14 +3,12 @@
 
 package explore.components
 
-import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.AppCtx
 import explore.Icons
 import explore.WebpackResources
-import explore.common.SSOClient
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.UserVault
@@ -32,10 +30,8 @@ final case class UserSelectionForm(
   vault:   View[Option[UserVault]],
   message: View[Option[NonEmptyString]]
 ) extends ReactProps[UserSelectionForm](UserSelectionForm.component) {
-  def guest: Callback = AppCtx.flatMap { implicit ctx =>
-    SSOClient.guest[IO](ctx.ssoURI, IO.fromFuture).flatMap(v => vault.set(v.some))
-  }.runAsyncCB
-  def login: Callback = AppCtx.flatMap(ctx => SSOClient.redirectToLogin[IO](ctx.ssoURI)).runAsyncCB
+  def guest: Callback = AppCtx.flatMap(_.sso.guest.flatMap(v => vault.set(v.some))).runAsyncCB
+  def login: Callback = AppCtx.flatMap(_.sso.redirectToLogin).runAsyncCB
 
   def supportedOrcidBrowser: CallbackTo[(Boolean, Boolean)] = CallbackTo[(Boolean, Boolean)] {
     val browser  = new UAParser(dom.window.navigator.userAgent).getBrowser()

--- a/common/src/main/scala/explore/components/state/ConnectionManager.scala
+++ b/common/src/main/scala/explore/components/state/ConnectionManager.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components.state
+
+import cats.effect.IO
+import cats.syntax.all._
+import clue.TerminateOptions
+import clue.WebSocketCloseParams
+import crystal.react.implicits._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.AppCtx
+import io.circe.syntax._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common.ReactProps
+
+final case class ConnectionManager(ssoToken: NonEmptyString)
+    extends ReactProps[ConnectionManager](ConnectionManager.component)
+
+object ConnectionManager {
+  type Props = ConnectionManager
+
+  final class Backend($ : BackendScope[Props, Unit]) {
+    val connect: IO[Unit] = AppCtx.flatMap(
+      _.clients.init(
+        $.propsIn[IO].map(props => Map("Authorization" -> s"Bearer ${props.ssoToken.value}".asJson))
+      )
+    )
+
+    // This is a "phantom" component. Doesn't render anything.
+    def render(): VdomNode = React.Fragment()
+  }
+
+  val component = ScalaComponent
+    .builder[Props]
+    .renderBackend[Backend]
+    .componentDidMount(_.backend.connect.runAsyncCB)
+    .componentDidUpdate($ =>
+      AppCtx
+        .flatMap(
+          // We should change to TerminateOptions.KeepConnection when ODB supports it.
+          _.clients.odb.terminate(TerminateOptions.Disconnect())
+        ) // This will trigger reconnection strategy and start reconnection attempts.
+        .runAsyncCB
+        .when($.prevProps.ssoToken =!= $.currentProps.ssoToken)
+        .void
+    )
+    .componentWillUnmountConst( // With code = 1000 we don't attempt reconnection.
+      AppCtx
+        .flatMap(
+          _.clients.odb
+            .terminate(TerminateOptions.Disconnect(WebSocketCloseParams(code = 1000)))
+        )
+        .runAsyncCB
+    )
+    .build
+}

--- a/common/src/main/scala/explore/components/state/IfLogged.scala
+++ b/common/src/main/scala/explore/components/state/IfLogged.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components.state
+
+import cats.effect.IO
+import cats.syntax.all._
+import explore.components.UserSelectionForm
+import explore.implicits._
+import explore.model.RootModel
+import explore.model.UserVault
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common.ReactProps
+
+final case class IfLogged(view: View[RootModel])(val render: (UserVault, IO[Unit]) => VdomNode)
+    extends ReactProps[IfLogged](IfLogged.component)
+
+object IfLogged {
+  type Props = IfLogged
+
+  private val component =
+    ScalaComponent
+      .builder[IfLogged]
+      .stateless
+      .render_P { p =>
+        val vaultView   = p.view.zoom(RootModel.vault)
+        val messageView = p.view.zoom(RootModel.userSelectionMessage)
+
+        vaultView.get.fold[VdomElement](
+          UserSelectionForm(vaultView, messageView)
+        ) { vault =>
+          React.Fragment(
+            SSOManager(vault.expiration, vaultView.set, messageView.set.compose(_.some)),
+            ConnectionManager(vault.token),
+            LogoutTracker(vaultView.set, messageView.set.compose(_.some))(onLogout =>
+              p.render(vault, onLogout)
+            )
+          )
+        }
+      }
+      .build
+}

--- a/common/src/main/scala/explore/components/state/LogoutTracker.scala
+++ b/common/src/main/scala/explore/components/state/LogoutTracker.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components.state
+
+import cats.effect.IO
+import cats.syntax.all._
+import crystal.react.implicits._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.model.UserVault
+import explore.utils.ExploreEvent
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.broadcastchannel._
+import monocle.macros.Lenses
+import react.common.ReactProps
+
+final case class LogoutTracker(
+  setVault:   Option[UserVault] => IO[Unit],
+  setMessage: NonEmptyString => IO[Unit]
+)(val render: IO[Unit] => VdomNode)
+    extends ReactProps[LogoutTracker](LogoutTracker.component)
+
+object LogoutTracker {
+  type Props = LogoutTracker
+
+  @Lenses
+  case class State(bc: Option[BroadcastChannel[ExploreEvent]])
+
+  private val component =
+    ScalaComponent
+      .builder[LogoutTracker]
+      .initialState(State(none))
+      .render { $ =>
+        React.Fragment(
+          $.state.bc.fold[VdomNode](React.Fragment())(bc =>
+            $.props.render(IO(bc.postMessage(ExploreEvent.Logout)).attempt.void)
+          )
+        )
+      }
+      .componentDidMount { $ =>
+        IO {
+          val bc = new BroadcastChannel[ExploreEvent]("explore")
+          bc.onmessage = (x: ExploreEvent) =>
+            // This is coming from the js world, we can't match the type
+            (x.event match {
+              case ExploreEvent.Logout.event =>
+                $.props.setVault(none) >> $.props.setMessage("You logged out in another instance")
+              case _                         => IO.unit
+            })
+          bc
+        }.flatMap(bc => $.modStateIn[IO](State.bc.set(bc.some))).runAsyncCB
+      }
+      .componentWillUnmount($ =>
+        // Setting vault to none is defensive. This component should actually unmount when vault is none.
+        $.state.bc.map(bc => IO(bc.close()).attempt.void).orEmpty.runAsyncCB
+      )
+      .build
+
+}

--- a/common/src/main/scala/explore/components/state/SSOManager.scala
+++ b/common/src/main/scala/explore/components/state/SSOManager.scala
@@ -1,0 +1,84 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components.state
+
+import java.time.Instant
+
+import cats.effect.IO
+import cats.syntax.all._
+import crystal.react.implicits._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.AppCtx
+import explore.common.SSOClient
+import explore.implicits._
+import explore.model.UserVault
+import explore.model.reusability._
+import io.chrisdavenport.log4cats.Logger
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import monocle.macros.Lenses
+import react.common.ReactProps
+
+final case class SSOManager(
+  expiration: Instant,
+  setVault:   Option[UserVault] => IO[Unit],
+  setMessage: NonEmptyString => IO[Unit]
+) extends ReactProps[SSOManager](SSOManager.component)
+
+object SSOManager {
+  type Props = SSOManager
+
+  @Lenses
+  case class State(cancelToken: Option[IO[Unit]])
+
+  implicit val propsReuse: Reusability[Props] = Reusability.by(_.expiration)
+  implicit val stateReuse: Reusability[State] = Reusability.never
+
+  final class Backend() {
+
+    def tokenRefresher(
+      expiration: Instant,
+      setVault:   Option[UserVault] => IO[Unit],
+      setMessage: NonEmptyString => IO[Unit]
+    ): IO[Unit] =
+      AppCtx.flatMap(implicit ctx =>
+        for {
+          vaultOpt <- SSOClient.refreshToken[IO](ctx.ssoURI, expiration, IO.fromFuture)
+          _        <- setVault(vaultOpt)
+          _        <- vaultOpt.fold(setMessage("Your session has expired"))(vault =>
+                        tokenRefresher(vault.expiration, setVault, setMessage)
+                      )
+        } yield ()
+      )
+
+    // This is a "phantom" component. Doesn't render anything.
+    def render(): VdomNode = React.Fragment()
+  }
+
+  val component = ScalaComponent
+    .builder[Props]
+    .initialState(State(none))
+    .renderBackend[Backend]
+    .componentDidMount { $ =>
+      $.backend
+        .tokenRefresher($.props.expiration, $.props.setVault, $.props.setMessage)
+        .runCancelable {
+          case Left(t) =>
+            AppCtx.flatMap(implicit ctx => Logger[IO].error(t)("Error refreshing SSO token")) >>
+              $.props.setVault(none) >>
+              $.props.setMessage("There was an error while checking the validity of your session")
+          case _       => IO.unit
+        }
+        .toIO
+        .flatMap(ct => $.modStateIn[IO](State.cancelToken.set(ct.some)))
+        .runAsyncCB
+    }
+    .componentWillUnmount($ =>
+      // Setting vault to none is defensive. This component should actually unmount when vault is none.
+      $.state.cancelToken.map(cancel => (cancel >> $.props.setVault(none))).orEmpty.runAsyncCB
+    )
+    .shouldComponentUpdateConst(false)
+    .build
+}

--- a/common/src/main/scala/explore/components/state/SSOManager.scala
+++ b/common/src/main/scala/explore/components/state/SSOManager.scala
@@ -11,7 +11,6 @@ import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.AppCtx
-import explore.common.SSOClient
 import explore.implicits._
 import explore.model.UserVault
 import explore.model.reusability._
@@ -45,7 +44,7 @@ object SSOManager {
     ): IO[Unit] =
       AppCtx.flatMap(implicit ctx =>
         for {
-          vaultOpt <- SSOClient.refreshToken[IO](ctx.ssoURI, expiration, IO.fromFuture)
+          vaultOpt <- ctx.sso.refreshToken(expiration)
           _        <- setVault(vaultOpt)
           _        <- vaultOpt.fold(setMessage("Your session has expired"))(vault =>
                         tokenRefresher(vault.expiration, setVault, setMessage)

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -10,9 +10,9 @@ import clue._
 import crystal.react.StreamRenderer
 import explore.GraphQLSchemas._
 import explore.model.reusability._
-import explore.utils.ExploreEvent
 import io.chrisdavenport.log4cats.Logger
-import lucuma.broadcastchannel.BroadcastChannel
+import io.circe.Json
+import sttp.model.Uri
 
 case class Clients[F[_]: ConcurrentEffect: Logger](
   exploreDB: GraphQLWebSocketClient[F, ExploreDB],
@@ -24,32 +24,30 @@ case class Clients[F[_]: ConcurrentEffect: Logger](
   lazy val ODBConnectionStatus: StreamRenderer.Component[StreamingClientStatus] =
     StreamRenderer.build(odb.statusStream)
 
+  def init(payload: F[Map[String, Json]]): F[Unit] =
+    exploreDB.init() >> odb.init(payload)
+
   def disconnect(): F[Unit] =
-    List(exploreDB.disconnect(), odb.disconnect()).sequence.void
+    List(
+      exploreDB.terminate(TerminateOptions.Disconnect(WebSocketCloseParams(code = 1000))),
+      odb.terminate(TerminateOptions.Disconnect(WebSocketCloseParams(code = 1000)))
+    ).sequence.void
 }
 
 case class Actions[F[_]](
   // interpreters go here
 )
 
-final case class BroadcastChannelCtx[F[_]: Sync](bc: BroadcastChannel[ExploreEvent]) {
-  def close(): F[Unit] = Sync[F].delay(bc.close()).attempt.void
-}
-
 case class AppContext[F[_]](
   clients:    Clients[F],
   actions:    Actions[F],
-  bcc:        BroadcastChannelCtx[F]
+  ssoURI:     Uri
 )(implicit
   val F:      Applicative[F],
   val cs:     ContextShift[F],
   val timer:  Timer[F],
   val logger: Logger[F]
-) {
-  val bc: BroadcastChannel[ExploreEvent] = bcc.bc
-  def cleanup(): F[Unit]                 =
-    clients.disconnect() *> bcc.close()
-}
+)
 
 object AppContext {
   def from[F[_]: ConcurrentEffect: ContextShift: Timer: Logger: Backend: WebSocketBackend](
@@ -62,8 +60,5 @@ object AppContext {
       odbClient       <- ApolloWebSocketClient.of[F, ObservationDB](config.odbURI, reconnectionStrategy)
       clients          = Clients(exploreDBClient, odbClient)
       actions          = Actions[F]()
-      bc              <-
-        Sync[F].delay(new BroadcastChannel[ExploreEvent]("explore")).map(BroadcastChannelCtx(_))
-
-    } yield AppContext[F](clients, actions, bc)
+    } yield AppContext[F](clients, actions, config.ssoURI)
 }

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -4,6 +4,7 @@
 package explore.model
 
 import java.time.Duration
+import java.time.Instant
 
 import scala.collection.immutable.SortedSet
 
@@ -31,7 +32,7 @@ object reusability {
   implicit val expObsReuse: Reusability[ExploreObservation]                                       = Reusability.derive
   implicit val jsNumberReuse: Reusability[JsNumber]                                               = Reusability.byEq
   implicit val userReuse: Reusability[User]                                                       = Reusability.byEq
-  implicit val userVaultReuse: Reusability[UserVault]                                             = Reusability.by(_.user)
+  implicit val userVaultReuse: Reusability[UserVault]                                             = Reusability.byEq
   implicit def sortedSetReuse[A]: Reusability[SortedSet[A]]                                       = Reusability.by_==
   implicit val rootModelReuse: Reusability[RootModel]                                             = Reusability.derive
   implicit def sizeReuse: Reusability[Size]                                                       = Reusability.by(x => (x.height, x.width))
@@ -44,4 +45,7 @@ object reusability {
   implicit def proposalDetailsReuse: Reusability[ProposalDetails]                                 = Reusability.byEq
   implicit def partnerSplitReuse: Reusability[PartnerSplit]                                       = Reusability.derive
   implicit val jsonReuse: Reusability[Json]                                                       = Reusability.by_==
+  // TODO Move to lucuma-ui
+  implicit val instantReuse: Reusability[Instant]                                                 =
+    Reusability.by(i => (i.getEpochSecond, i.getNano))
 }

--- a/constraints/src/main/resources/dev.js
+++ b/constraints/src/main/resources/dev.js
@@ -1,6 +1,8 @@
 import "resources/theme/semantic.less";
 import "resources/less/style.less";
 
+import "resources/conf/development.conf.json";
+
 import App from "sjs/constraints-fastopt.js";
 
 if (module.hot) {

--- a/constraints/src/main/scala/explore/constraints/Test.scala
+++ b/constraints/src/main/scala/explore/constraints/Test.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 import scala.scalajs.js
 
 import explore.AppMain
+import explore.components.state.IfLogged
 import explore.constraints.ConstraintsQueries._
 import explore.implicits._
 import explore.model.RootModel
@@ -22,8 +23,10 @@ object Test extends AppMain {
   private val constraintsId = UUID.fromString("608c8407-63a5-4d26-970c-587486af57da")
 
   override protected def rootComponent(view: View[RootModel]): VdomElement =
-    ConstraintsSubscription(constraintsId) { constraints =>
-      ConstraintsPanel(constraintsId, constraints)
-    }
+    IfLogged(view)((_, _) =>
+      ConstraintsSubscription(constraintsId) { constraints =>
+        ConstraintsPanel(constraintsId, constraints)
+      }
+    )
 
 }

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -3,6 +3,8 @@
 
 package explore
 
+import cats.syntax.all._
+import explore.components.state.IfLogged
 import explore.components.ui.ExploreStyles
 import explore.model._
 import japgolly.scalajs.react._
@@ -15,24 +17,27 @@ final case class ExploreLayout(c: RouterCtl[Page], r: ResolutionWithProps[Page, 
 ) extends ReactProps[ExploreLayout](ExploreLayout.component)
 
 object ExploreLayout {
+  type Props = ExploreLayout
 
   private val component =
     ScalaComponent
-      .builder[ExploreLayout]
+      .builder[Props]
       .stateless
       .render_P { p =>
-        <.div(
-          ExploreStyles.MainGrid,
-          TopBar(p.view.zoom(RootModel.vault)),
+        IfLogged(p.view) { (vault, onLogout) =>
           <.div(
-            ExploreStyles.SideTabs,
-            SideTabs(p.view.zoom(RootModel.tabs))
-          ),
-          <.div(
-            ExploreStyles.MainBody,
-            p.r.renderP(p.view)
+            ExploreStyles.MainGrid,
+            TopBar(vault.user, onLogout >> p.view.zoom(RootModel.vault).set(none)),
+            <.div(
+              ExploreStyles.SideTabs,
+              SideTabs(p.view.zoom(RootModel.tabs))
+            ),
+            <.div(
+              ExploreStyles.MainBody,
+              p.r.renderP(p.view)
+            )
           )
-        )
+        }
       }
       .build
 

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -37,7 +37,7 @@ object Routing {
       def id[Id](implicit gid: Gid[Id]): StaticDsl.RouteB[Id] =
         string(gid.regexPattern).pmapL(gid.fromString)
 
-      val configuration =
+      val rules =
         (emptyRule
           | staticRoute(root, HomePage) ~> render(UnderConstruction())
           | staticRoute("/proposal", ProposalPage) ~> renderP(view =>
@@ -60,6 +60,9 @@ object Routing {
           )
           | staticRoute("/configurations", ConfigurationsPage) ~> render(UnderConstruction())
           | staticRoute("/constraints", ConstraintsPage) ~> render(UnderConstruction()))
+
+      val configuration =
+        rules
           .notFound(redirectToPage(HomePage)(SetRouteVia.HistoryPush))
           .onPostRenderP {
             case (prev, next, view)

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -11,14 +11,12 @@ import explore.WebpackResources
 import explore.common.SSOClient
 import explore.components.ConnectionsStatus
 import explore.components.ui.ExploreStyles
-import explore.model.UserVault
 import explore.model.reusability._
-import explore.utils.ExploreEvent
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.GuestRole
+import lucuma.core.model.User
 import lucuma.ui.reusability._
-import org.scalajs.dom.window
 import react.common._
 import react.semanticui.collections.menu._
 import react.semanticui.elements.image.Image
@@ -27,31 +25,27 @@ import react.semanticui.modules.dropdown.DropdownItem
 import react.semanticui.modules.dropdown.DropdownMenu
 import react.semanticui.views.item.Item
 
-final case class TopBar(vault: View[UserVault]) extends ReactProps[TopBar](TopBar.component)
+final case class TopBar(
+  user:   User,
+  logout: IO[Unit]
+) extends ReactProps[TopBar](TopBar.component)
 
 object TopBar {
   type Props = TopBar
 
-  implicit val propsReuse: Reusability[Props] = Reusability.by(_.vault)
+  implicit val propsReuse: Reusability[Props] = Reusability.by(_.user)
 
   private val component =
     ScalaComponent
       .builder[TopBar]
       .render_P { p =>
-        val ssoURI = p.vault.get.ssoURI
         AppCtx.withCtx { implicit appCtx =>
           implicit val cs     = appCtx.cs
           implicit val logger = appCtx.logger
-          val user            = p.vault.zoom(UserVault.user).get
-          val role            = user.role
+          val role            = p.user.role
 
           def logout: IO[Unit] =
-            SSOClient.logout[IO](ssoURI, IO.fromFuture) *>
-              IO(
-                appCtx.bc.postMessage(ExploreEvent.Logout)
-              ).attempt *>
-              // Let's just reload rather than trying to reset the state
-              IO(window.location.reload())
+            SSOClient.logout[IO](appCtx.ssoURI, IO.fromFuture) >> p.logout
 
           <.div(
             ExploreStyles.MainHeader,
@@ -69,7 +63,7 @@ object TopBar {
               ),
               Item(
                 ExploreStyles.MainUserName,
-                user.displayName
+                p.user.displayName
               ),
               ConnectionsStatus(),
               MenuMenu(position = MenuMenuPosition.Right, clazz = ExploreStyles.MainMenu)(
@@ -81,7 +75,7 @@ object TopBar {
                 )(
                   DropdownMenu(
                     DropdownItem(
-                      onClick = SSOClient.switchToORCID[IO](ssoURI, IO.fromFuture).runAsyncCB
+                      onClick = SSOClient.switchToORCID[IO](appCtx.ssoURI, IO.fromFuture).runAsyncCB
                     )(
                       <.div(ExploreStyles.OrcidMenu)(
                         Image(clazz = ExploreStyles.OrcidIconMenu,

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -8,7 +8,6 @@ import cats.syntax.all._
 import crystal.react.implicits._
 import explore.Icons
 import explore.WebpackResources
-import explore.common.SSOClient
 import explore.components.ConnectionsStatus
 import explore.components.ui.ExploreStyles
 import explore.model.reusability._
@@ -40,12 +39,11 @@ object TopBar {
       .builder[TopBar]
       .render_P { p =>
         AppCtx.withCtx { implicit appCtx =>
-          implicit val cs     = appCtx.cs
-          implicit val logger = appCtx.logger
-          val role            = p.user.role
+          implicit val cs = appCtx.cs
+          val role        = p.user.role
 
           def logout: IO[Unit] =
-            SSOClient.logout[IO](appCtx.ssoURI, IO.fromFuture) >> p.logout
+            appCtx.sso.logout >> p.logout
 
           <.div(
             ExploreStyles.MainHeader,
@@ -75,7 +73,7 @@ object TopBar {
                 )(
                   DropdownMenu(
                     DropdownItem(
-                      onClick = SSOClient.switchToORCID[IO](appCtx.ssoURI, IO.fromFuture).runAsyncCB
+                      onClick = appCtx.sso.switchToORCID.runAsyncCB
                     )(
                       <.div(ExploreStyles.OrcidMenu)(
                         Image(clazz = ExploreStyles.OrcidIconMenu,

--- a/model/src/main/scala/explore/model/AppConfig.scala
+++ b/model/src/main/scala/explore/model/AppConfig.scala
@@ -3,6 +3,10 @@
 
 package explore.model
 
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
 import cats.Eq
 import cats.Show
 import explore.model.decoders._
@@ -12,7 +16,31 @@ import io.circe._
 import io.circe.generic.semiauto._
 import sttp.model.Uri
 
-case class AppConfig(environment: ExecutionEnvironment, exploreDBURI: Uri, odbURI: Uri, ssoURI: Uri)
+case class SSOConfig(
+  uri:                        Uri,
+  readTimeoutSeconds:         Long = 10,
+  refreshTimeoutDeltaSeconds: Long = 10, // time before expiration to renew
+  refreshIntervalFactor:      Long = 1
+) {
+  val readTimeout: FiniteDuration         = FiniteDuration(readTimeoutSeconds, TimeUnit.SECONDS)
+  val refreshTimeoutDelta: FiniteDuration =
+    FiniteDuration(refreshTimeoutDeltaSeconds, TimeUnit.SECONDS)
+}
+
+object SSOConfig {
+  implicit val eqSSOConfig: Eq[SSOConfig]     = Eq.fromUniversalEquals
+  implicit val showSSOConfig: Show[SSOConfig] = Show.fromToString
+
+  implicit val encoderSSOConfig: Encoder[SSOConfig] = deriveEncoder[SSOConfig]
+  implicit val decoderSSOConfig: Decoder[SSOConfig] = deriveDecoder[SSOConfig]
+}
+
+case class AppConfig(
+  environment:  ExecutionEnvironment,
+  exploreDBURI: Uri,
+  odbURI:       Uri,
+  sso:          SSOConfig
+)
 
 object AppConfig {
   implicit val eqAppConfig: Eq[AppConfig]     = Eq.fromUniversalEquals

--- a/model/src/main/scala/explore/model/RootModel.scala
+++ b/model/src/main/scala/explore/model/RootModel.scala
@@ -3,29 +3,29 @@
 
 package explore.model
 
-import java.time.Instant
+// import java.time.Instant
 
 import scala.collection.immutable.SortedSet
 
 import cats.Order._
 import cats.kernel.Eq
+import cats.syntax.all._
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.enum.AppTab
 import lucuma.core.data.EnumZipper
 import lucuma.core.model.Target
 import lucuma.core.model.Target.Id._
-import monocle.Lens
 import monocle.macros.Lenses
 
 @Lenses
 case class RootModel(
-  vault:             UserVault,
-  tabs:              EnumZipper[AppTab],
-  focused:           Option[Focused] = None,
-  expandedTargetIds: SortedSet[Target.Id] = SortedSet.empty
+  vault:                Option[UserVault],
+  tabs:                 EnumZipper[AppTab],
+  focused:              Option[Focused] = none,
+  expandedTargetIds:    SortedSet[Target.Id] = SortedSet.empty,
+  userSelectionMessage: Option[NonEmptyString] = none
 )
 
 object RootModel {
   implicit val eqRootModel: Eq[RootModel] = Eq.by(m => (m.vault, m.tabs, m.focused))
-
-  lazy val expiration: Lens[RootModel, Instant] = vault ^|-> UserVault.expiration
 }

--- a/model/src/main/scala/explore/model/RootModel.scala
+++ b/model/src/main/scala/explore/model/RootModel.scala
@@ -10,6 +10,7 @@ import scala.collection.immutable.SortedSet
 import cats.Order._
 import cats.kernel.Eq
 import cats.syntax.all._
+import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.enum.AppTab
 import lucuma.core.data.EnumZipper
@@ -27,5 +28,6 @@ case class RootModel(
 )
 
 object RootModel {
-  implicit val eqRootModel: Eq[RootModel] = Eq.by(m => (m.vault, m.tabs, m.focused))
+  implicit val eqRootModel: Eq[RootModel] =
+    Eq.by(m => (m.vault, m.tabs, m.focused, m.expandedTargetIds, m.userSelectionMessage))
 }

--- a/model/src/main/scala/explore/model/UserVault.scala
+++ b/model/src/main/scala/explore/model/UserVault.scala
@@ -12,13 +12,12 @@ import eu.timepit.refined.types.string.NonEmptyString
 import io.chrisdavenport.cats.time.instances.instant._
 import lucuma.core.model.User
 import monocle.macros.Lenses
-import sttp.model.Uri
 
 @Lenses
-final case class UserVault(user: User, ssoURI: Uri, expiration: Instant, token: NonEmptyString)
+final case class UserVault(user: User, expiration: Instant, token: NonEmptyString)
 
 object UserVault {
   implicit val eqUserVault: Eq[UserVault] =
-    Eq.by(x => (x.user, x.ssoURI.toString, x.expiration, x.token))
+    Eq.by(x => (x.user, x.expiration, x.token))
 
 }

--- a/model/src/test/scala/explore/model/arb/ArbRootModel.scala
+++ b/model/src/test/scala/explore/model/arb/ArbRootModel.scala
@@ -14,20 +14,21 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
 import explore.model.UserVault
+import org.scalacheck.Gen
 
 trait ArbRootModel {
   import explore.model.arb.ArbFocused._
 
   implicit val rootModelArb = Arbitrary[RootModel] {
     for {
-      vault   <- arbitrary[UserVault]
+      vault   <- Gen.option(arbitrary[UserVault])
       tabs    <- arbitrary[EnumZipper[AppTab]]
       focused <- arbitrary[Option[Focused]]
     } yield RootModel(vault, tabs, focused)
   }
 
   implicit def rootModelCogen: Cogen[RootModel] =
-    Cogen[(UserVault, EnumZipper[AppTab], Option[Focused])].contramap(m =>
+    Cogen[(Option[UserVault], EnumZipper[AppTab], Option[Focused])].contramap(m =>
       (m.vault, m.tabs, m.focused)
     )
 }

--- a/model/src/test/scala/explore/model/arb/ArbUserVault.scala
+++ b/model/src/test/scala/explore/model/arb/ArbUserVault.scala
@@ -14,21 +14,17 @@ import org.scalacheck.Cogen._
 import eu.timepit.refined.types.string.NonEmptyString
 import java.time.Instant
 import lucuma.core.model.User
-import sttp.model._
-import sttp.client3._
 
 trait ArbUserVault {
   import ArbUser._
   import ArbTime._
-  // let's use a fixed value it doesn't matter for the test and there are no arbitrary instances for Uri
-  val host: Uri = uri"https://localhost"
 
   implicit val userVaultArb = Arbitrary[UserVault] {
     for {
       user  <- arbitrary[User]
       exp   <- arbitrary[Instant]
       token <- arbitrary[NonEmptyString]
-    } yield UserVault(user, host, exp, token)
+    } yield UserVault(user, exp, token)
   }
 
   implicit def userVaultCogen: Cogen[UserVault] =

--- a/observationtree/src/main/resources/dev.js
+++ b/observationtree/src/main/resources/dev.js
@@ -1,6 +1,8 @@
 import "resources/theme/semantic.less";
 import "resources/less/style.less";
 
+import "resources/conf/development.conf.json";
+
 import App from "sjs/observationtree-fastopt.js";
 
 if (module.hot) {

--- a/observationtree/src/main/scala/explore/observationtree/Test.scala
+++ b/observationtree/src/main/scala/explore/observationtree/Test.scala
@@ -7,6 +7,7 @@ import scala.scalajs.js.annotation.JSExportTopLevel
 
 import explore.AppMain
 import explore._
+import explore.components.state.IfLogged
 import explore.model.RootModel
 import japgolly.scalajs.react.vdom.html_<^._
 
@@ -16,14 +17,16 @@ import TargetObsQueries._
 object Test extends AppMain {
 
   override def rootComponent(view: View[RootModel]): VdomElement =
-    // AndOrTest.render
-    // TargetTree(TargetTreeTest.targets, TargetTreeTest.observations)
-    TargetObsLiveQuery(targetsWithObs =>
-      <.div(^.width := "295px")(
-        TargetObsList(
-          targetsWithObs,
-          view.zoom(RootModel.focused),
-          view.zoom(RootModel.expandedTargetIds)
+    IfLogged(view)((_, _) =>
+      // AndOrTest.render
+      // TargetTree(TargetTreeTest.targets, TargetTreeTest.observations)
+      TargetObsLiveQuery(targetsWithObs =>
+        <.div(^.width := "295px")(
+          TargetObsList(
+            targetsWithObs,
+            view.zoom(RootModel.focused),
+            view.zoom(RootModel.expandedTargetIds)
+          )
         )
       )
     )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -10,7 +10,7 @@ object Settings {
     val catsEffect        = "2.3.0"
     val chimney           = "0.6.1"
     val circe             = "0.13.0"
-    val clue              = "0.7.0"
+    val clue              = "0.8.1"
     val crystal           = "0.9.1"
     val discipline        = "1.1.2"
     val disciplineMUnit   = "1.0.3"

--- a/proposal/src/main/resources/dev.js
+++ b/proposal/src/main/resources/dev.js
@@ -1,6 +1,8 @@
 import "resources/theme/semantic.less";
 import "resources/less/style.less";
 
+import "resources/conf/development.conf.json";
+
 import App from "sjs/proposal-fastopt.js";
 
 if (module.hot) {

--- a/proposal/src/main/scala/explore/proposal/Test.scala
+++ b/proposal/src/main/scala/explore/proposal/Test.scala
@@ -8,6 +8,7 @@ import scala.scalajs.js
 import eu.timepit.refined.auto._
 import explore.AppMain
 import explore.View
+import explore.components.state.IfLogged
 import explore.model.RootModel
 import japgolly.scalajs.react.vdom.VdomElement
 
@@ -17,5 +18,5 @@ import js.annotation._
 object Test extends AppMain {
 
   override protected def rootComponent(rootView: View[RootModel]): VdomElement =
-    ProposalTabContents(rootView.zoom(RootModel.focused))
+    IfLogged(rootView)((_, _) => ProposalTabContents(rootView.zoom(RootModel.focused)))
 }

--- a/targeteditor/src/main/resources/dev.js
+++ b/targeteditor/src/main/resources/dev.js
@@ -5,6 +5,8 @@ import "resources/less/vendor/aladin.less";
 import "resources/css/charts.scss";
 import "resources/css/datepicker.scss";
 
+import "resources/conf/development.conf.json";
+
 import App from "sjs/targeteditor-fastopt.js";
 
 if (module.hot) {

--- a/targeteditor/src/main/scala/explore/targeteditor/Test.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/Test.scala
@@ -9,6 +9,7 @@ import eu.timepit.refined.auto._
 import explore.AppMain
 import explore._
 import explore.components.Tile
+import explore.components.state.IfLogged
 import explore.model._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Target
@@ -19,11 +20,13 @@ object Test extends AppMain {
   override protected def rootComponent(view: View[RootModel]): VdomElement = {
     val id = Target.Id(2L)
 
-    <.div(^.height := "100vh",
-          ^.width := "100%",
-          Tile("Target", false)(
-            TargetEditor(id)
-          )
+    IfLogged(view)((_, _) =>
+      <.div(^.height := "100vh",
+            ^.width := "100%",
+            Tile("Target", false)(
+              TargetEditor(id)
+            )
+      )
     )
   }
 

--- a/targeteditor/yarn.lock
+++ b/targeteditor/yarn.lock
@@ -81,6 +81,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.6.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1116,6 +1123,11 @@ bfj@^6.1.1:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.48"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.48.tgz#8fd88bd1632cba4a1c8c3e3d7159f08bb95b4b9e"
+  integrity sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -1250,6 +1262,19 @@ braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.3.0.tgz#5541bbec6b4e9ee03f4c5462a52b0bc5ecd0690c"
+  integrity sha512-mi0xKJxdHHMb/PqIGLybPlAHMqs/ShxXSylaVYVM20ViizXEbjaXAy9Q6YalUGX5FoAls0UBNaT8mX8LR259bA==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.0.4"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -4063,6 +4088,11 @@ jquery@^3.4.0:
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4486,6 +4516,11 @@ micromatch@^3.0.4, micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
+
 miller-rabin@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/miller-rabin/-/miller-rabin-4.0.1.tgz#f080351c865b0dc562a8462966daa53543c78a4d"
@@ -4708,6 +4743,13 @@ nan@^2.12.1:
   version "2.14.2"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
   integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.1.12:
   version "3.1.12"
@@ -6230,17 +6272,17 @@ rgba-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
 
+rimraf@3.0.2, rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
-  dependencies:
-    glob "^7.1.3"
-
-rimraf@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
 
@@ -7236,6 +7278,14 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR brings login logic within the scope of the main app.

This allows for example showing messages to the user upon logout for different reasons.

Logic is working un supapps too (targeteditor, etc).

After user logs in, there are 3 phantom components that take care of:
- Refreshing SSO token.
- Establishing connection to ODB and keep token up to date (explore/clue have the capability of restarting protocol without reconnecting the web socket, but ODB doesn't have it yet).
- Track logouts on other tabs.

Lifetime of these components is confined to the user session. When a logout occurs, they are unmounted.

