### PR TITLE
Use monocle Index in PartnerSplitsEditor

### DIFF
--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -12,6 +12,7 @@ import cats.syntax.all._
 import clue._
 import coulomb.Quantity
 import crystal.ViewF
+import crystal.ViewOptF
 import explore.GraphQLSchemas._
 import explore.model.AppContext
 import explore.optics._
@@ -58,5 +59,10 @@ object implicits extends ShorthandTypes with ListImplicits {
 
   implicit class CoulombViewOps[F[_], N, U](val self: ViewF[F, Quantity[N, U]]) extends AnyVal {
     def stripQuantity: ViewF[F, N] = self.as(coulombIso[N, U])
+  }
+
+  implicit class CoulombViewOptOps[F[_], N, U](val self: ViewOptF[F, Quantity[N, U]])
+      extends AnyVal {
+    def stripQuantity: ViewOptF[F, N] = self.as(coulombIso[N, U])
   }
 }

--- a/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
@@ -14,12 +14,12 @@ import explore.implicits._
 import explore.model._
 import explore.model.refined._
 import explore.model.reusability._
-import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.forms.FormInputEV
 import lucuma.ui.optics._
+import monocle.function.Index
 import react.common.ReactProps
 import react.semanticui.collections.form.Form
 import react.semanticui.collections.table._
@@ -54,13 +54,8 @@ object PartnerSplitsEditor {
 
   private def makeTableRows(p: Props): TagMod =
     p.splits.get.zipWithIndex.toTagMod { case (ps, idx) =>
-      // we're already looking at the one we want
-      val getSplit: List[PartnerSplit] => PartnerSplit = _ => ps
-
-      def modSplit(mod: PartnerSplit => PartnerSplit): List[PartnerSplit] => List[PartnerSplit] =
-        list => list.modFirstWhere(_.partner === ps.partner, mod)
-
-      def splitView: View[PartnerSplit] = p.splits.zoom[PartnerSplit](getSplit)(modSplit)
+      val splitView: ViewOpt[PartnerSplit] =
+        p.splits.zoom[PartnerSplit](Index.index[List[PartnerSplit], Int, PartnerSplit](idx))
 
       val id = s"${ps.partner.tag}-percent"
       React.Fragment(


### PR DESCRIPTION
I based the original version on the code in MagnitudeForm. But, what do y'all think of using a monocle Index for zooming into the list?