### PR TITLE
Show a banner in staging

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -602,6 +602,7 @@ body {
 .sidetabs {
   grid-area: sidebar;
   background: var(--sidetab-background);
+  overflow: hidden;
 }
 
 // Taken from the definitíon of ui.button transition but removed background-color and background
@@ -1228,8 +1229,6 @@ i.icon.user-astronaut:before { content: "\f4fb"; }
 
 .ui.label.explore-login-button {
   margin-bottom: 1em;
-  // color: var(--negative-text-color);
-  // background-color: var(--negative-background-color);
   white-space: wrap;
   max-width: 60%;
   text-align: center;
@@ -1259,4 +1258,19 @@ i.icon.user-astronaut:before { content: "\f4fb"; }
 
 .explore-orcid-icon-menu {
   margin-right: 0.8em;
+}
+
+#staging-banner {
+  @spacing: 20px;
+  z-index: 2000;
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
+  text-transform: uppercase;
+  text-indent: @spacing;;
+  letter-spacing: @spacing;
+  padding: 0.5em 1em;
+  font-weight: 900;
+  background-color: var(--explore-accent-color);
 }

--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -38,6 +38,7 @@ import sttp.client3.circe._
 import sttp.model.Uri
 
 import js.annotation._
+import explore.model.enum.ExecutionEnvironment
 
 object AppCtx extends AppRootContext[AppContextIO]
 
@@ -129,6 +130,12 @@ trait AppMain extends IOApp {
         val elem = dom.document.createElement("div")
         elem.id = "root"
         dom.document.body.appendChild(elem)
+        if (appConfig.environment === ExecutionEnvironment.Staging) {
+          val stagingBanner = dom.document.createElement("div")
+          stagingBanner.id = "staging-banner"
+          stagingBanner.textContent = "Staging"
+          dom.document.body.appendChild(stagingBanner)
+        }
         elem
       }
 


### PR DESCRIPTION
This  is a small improvement, it will show a banner to indicate we are in staging. I hope it makes it clear to users when they are entering data in staging

This adds a node and styles it via css. It puts it in an absolute position thus it should not alter the layout

<img width="762" alt="image" src="https://user-images.githubusercontent.com/3615303/102295776-d9315f80-3f2a-11eb-9283-9f7e1c8d8d77.png">
