### PR TITLE
Allow computing URLs.

### DIFF
--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -5,6 +5,7 @@ package explore
 
 import java.util.concurrent.TimeUnit
 
+import scala.annotation.unused
 import scala.concurrent.duration._
 import scala.scalajs.js
 
@@ -20,6 +21,7 @@ import crystal.AppRootContext
 import crystal.react.AppRoot
 import explore.model.AppConfig
 import explore.model.AppContext
+import explore.model.Focused
 import explore.model.RootModel
 import explore.model.UserVault
 import explore.model.enum.AppTab
@@ -39,6 +41,7 @@ import sttp.client3.circe._
 import sttp.model.Uri
 
 import js.annotation._
+import lucuma.core.model.Observation
 
 object AppCtx extends AppRootContext[AppContextIO]
 
@@ -54,6 +57,8 @@ trait AppMain extends IOApp {
   protected def rootComponent(
     view: View[RootModel]
   ): VdomElement
+
+  protected def pageUrl(@unused tab: AppTab, @unused focused: Option[Focused]): String = "#"
 
   @JSExport
   def runIOApp(): Unit = main(Array.empty)
@@ -120,7 +125,7 @@ trait AppMain extends IOApp {
       appConfig <- fetchConfig
       _         <- logger.info(s"Git Commit: [${BuildInfo.gitHeadCommit.getOrElse("NONE")}]")
       _         <- logger.info(s"Config: ${appConfig.show}")
-      ctx       <- AppContext.from[IO](appConfig, reconnectionStrategy, IO.fromFuture)
+      ctx       <- AppContext.from[IO](appConfig, reconnectionStrategy, pageUrl, IO.fromFuture)
       vault     <- ctx.sso.whoami
       _         <- AppCtx.initIn[IO](ctx)
     } yield {

--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -41,7 +41,6 @@ import sttp.client3.circe._
 import sttp.model.Uri
 
 import js.annotation._
-import lucuma.core.model.Observation
 
 object AppCtx extends AppRootContext[AppContextIO]
 

--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -15,6 +15,7 @@ import crystal.ViewF
 import crystal.ViewOptF
 import explore.GraphQLSchemas._
 import explore.model.AppContext
+import explore.model.RootModel
 import explore.optics._
 import io.chrisdavenport.log4cats.Logger
 import shapeless._
@@ -64,5 +65,10 @@ object implicits extends ShorthandTypes with ListImplicits {
   implicit class CoulombViewOptOps[F[_], N, U](val self: ViewOptF[F, Quantity[N, U]])
       extends AnyVal {
     def stripQuantity: ViewOptF[F, N] = self.as(coulombIso[N, U])
+  }
+
+  implicit class RootModelOps(val rootModel: RootModel) extends AnyVal {
+    def url[F[_]](implicit ctx: AppContext[F]): String =
+      ctx.pageUrl(rootModel.tabs.focus, rootModel.focused)
   }
 }

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -11,6 +11,7 @@ import crystal.react.StreamRenderer
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.GraphQLSchemas._
 import explore.common.SSOClient
+import explore.model.enum.AppTab
 import explore.model.reusability._
 import explore.utils
 import io.chrisdavenport.log4cats.Logger
@@ -45,7 +46,8 @@ case class AppContext[F[_]](
   version:    NonEmptyString,
   clients:    Clients[F],
   actions:    Actions[F],
-  sso:        SSOClient[F]
+  sso:        SSOClient[F],
+  pageUrl:    (AppTab, Option[Focused]) => String
 )(implicit
   val F:      Applicative[F],
   val cs:     ContextShift[F],
@@ -57,6 +59,7 @@ object AppContext {
   def from[F[_]: ConcurrentEffect: ContextShift: Timer: Logger: Backend: WebSocketBackend](
     config:               AppConfig,
     reconnectionStrategy: WebSocketReconnectionStrategy,
+    pageUrl:              (AppTab, Option[Focused]) => String,
     fromFuture:           SSOClient.FromFuture[F, Response[Either[String, String]]]
   ): F[AppContext[F]] =
     for {
@@ -66,5 +69,5 @@ object AppContext {
       version          = utils.version(config.environment)
       clients          = Clients(exploreDBClient, odbClient)
       actions          = Actions[F]()
-    } yield AppContext[F](version, clients, actions, SSOClient(config.sso, fromFuture))
+    } yield AppContext[F](version, clients, actions, SSOClient(config.sso, fromFuture), pageUrl)
 }

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -8,8 +8,10 @@ import scala.scalajs.js
 import cats.effect.IO
 import crystal.react.implicits._
 import explore.Routing
+import explore.model.Focused
 import explore.model.RootModel
 import explore.model.RootModelRouting
+import explore.model.enum.AppTab
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.html_<^._
@@ -32,4 +34,6 @@ object ExploreMain extends AppMain {
       router(routingView(view))
     )
 
+  override protected def pageUrl(tab: AppTab, focused: Option[Focused]): String =
+    routerCtl.urlFor(RootModelRouting.getPage(tab, focused)).value
 }

--- a/model/src/main/scala/explore/model/RootModelRouting.scala
+++ b/model/src/main/scala/explore/model/RootModelRouting.scala
@@ -13,17 +13,18 @@ import monocle.Lens
 object RootModelRouting {
 
   protected def getPage(model: RootModel): Page =
-    model.tabs.focus match {
+    getPage(model.tabs.focus, model.focused)
+
+  def getPage(tab: AppTab, focused: Option[Focused]): Page =
+    tab match {
       case AppTab.Proposal       => ProposalPage
       case AppTab.Overview       => HomePage
       case AppTab.Observations   =>
-        RootModel.focused
-          .get(model)
+        focused
           .collect { case FocusedObs(obsId) => ObsPage(obsId) }
           .getOrElse(ObservationsBasePage)
       case AppTab.Targets        =>
-        RootModel.focused
-          .get(model)
+        focused
           .collect {
             case FocusedObs(obsId)       => TargetsObsPage(obsId)
             case FocusedTarget(targetId) => TargetPage(targetId)

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -5,8 +5,8 @@ package explore.targeteditor
 
 import scala.math.rint
 
-import explore.components.ui.ExploreStyles
 import explore.Icons
+import explore.components.ui.ExploreStyles
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.math.HourAngle.HMS

--- a/targeteditor/yarn.lock
+++ b/targeteditor/yarn.lock
@@ -1915,6 +1915,13 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-to-clipboard@3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-js@^3.4.1:
   version "3.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
@@ -7187,6 +7194,11 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
+
 toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
@@ -7244,6 +7256,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+ua-parser-js@0.7.23:
+  version "0.7.23"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.23.tgz#704d67f951e13195fbcd3d78818577f5bc1d547b"
+  integrity sha512-m4hvMLxgGHXG3O3fQVAyyAQpZzDOvwnhOTjYz5Xmr7r/+LpkNy3vJXdVRWgd1TkAb7NGROZuSy96CrlNVjA7KA==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Add a method `AppCtx.pageURL(AppTab, Option[Focused]): String` to allow building URLs from arbitrary (tab, focused) combinations.

This is useful if we want to provide navigation via links in the app.

Note that for subprojects, since there is no router, it will always return `#`.