### PR TITLE
Updates coordinates after search

### DIFF
--- a/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -56,9 +56,10 @@ object AladinCell extends ModelOptics {
         .toCallback
 
     val gotoRaDec = (coords: Coordinates) =>
-      aladinRef.get
-        .flatMapCB(_.backend.gotoRaDec(coords))
-        .toCallback
+      $.setStateL(State.current)(coords) *>
+        aladinRef.get
+          .flatMapCB(_.backend.gotoRaDec(coords))
+          .toCallback
 
     def render(props: Props, state: State) =
       React.Fragment(

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -77,21 +77,20 @@ object AladinContainer {
         .toCallback
 
     def searchAndGo(modify: ((String, RightAscension, Declination)) => Callback)(search: String) =
-      Callback.log(search) *>
-        aladinRef.get
-          .flatMapCB(
-            _.backend
-              .gotoObject(
-                search,
-                (a, b) => {
-                  val ra  = RightAscension.fromDoubleDegrees(a.toDouble)
-                  val dec = Declination.fromDoubleDegrees(b.toDouble).getOrElse(Declination.Zero)
-                  setRa(ra) *> setDec(dec) *> modify((search, ra, dec))
-                },
-                Callback.log("error")
-              )
-          )
-          .toCallback
+      aladinRef.get
+        .flatMapCB(
+          _.backend
+            .gotoObject(
+              search,
+              (a, b) => {
+                val ra  = RightAscension.fromDoubleDegrees(a.toDouble)
+                val dec = Declination.fromDoubleDegrees(b.toDouble).getOrElse(Declination.Zero)
+                setRa(ra) *> setDec(dec) *> modify((search, ra, dec))
+              },
+              Callback.log("error")
+            )
+        )
+        .toCallback
 
     def toggleVisibility(g: Element, selector: String, option: Display): Unit =
       g.querySelectorAll(selector).foreach { case e: Element =>


### PR DESCRIPTION
Just a small bug fix. After  search result is retrieved we should update the coordinates on the aladin toolbar. This PR does that