### PR TITLE
Converts the navigation items to links 

### DIFF
--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -13,9 +13,11 @@ import lucuma.core.data.EnumZipper
 import lucuma.ui.reusability._
 import react.common._
 import react.semanticui.elements.button.Button
+import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.elements.button.ButtonGroup
 import react.semanticui.elements.divider.Divider
 import react.semanticui.elements.label.Label
+import react.semanticui.elements.label.Label.LabelProps
 import react.semanticui.sizes._
 
 final case class SideTabs(
@@ -41,15 +43,22 @@ object SideTabs {
               as = <.a,
               active = tab === focus,
               clazz = ExploreStyles.SideButton,
-              onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runAsyncCB
+              onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
+                e.preventDefaultCB *> p.tabs
+                  .mod(z => z.findFocus(_ === tab).getOrElse(z))
+                  .runAsyncCB
             )(^.href := ctx.pageUrl(tab, none), tab.title)
 
           def tab(tab:                AppTab): Label        =
-            Label(as = <.a,
-                  active = tab === focus,
-                  clazz = ExploreStyles.TabSelector,
-                  size = Tiny,
-                  onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runAsyncCB
+            Label(
+              as = <.a,
+              active = tab === focus,
+              clazz = ExploreStyles.TabSelector,
+              size = Tiny,
+              onClickE = (e: ReactMouseEvent, _: LabelProps) =>
+                e.preventDefaultCB *> p.tabs
+                  .mod(z => z.findFocus(_ === tab).getOrElse(z))
+                  .runAsyncCB
             )(^.href := ctx.pageUrl(tab, none), tab.title)
 
           def makeButtonSection(tabs: List[AppTab]): TagMod = tabs match {

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -32,53 +32,58 @@ object SideTabs {
       .builder[Props]
       .stateless
       .render_P { p =>
-        val tabsL = p.tabs.get.toNel
-        val focus = p.tabs.get.focus
+        AppCtx.withCtx { ctx =>
+          val tabsL = p.tabs.get.toNel
+          val focus = p.tabs.get.focus
 
-        def tabButton(tab: AppTab): Button =
-          Button(active = tab === focus,
-                 clazz = ExploreStyles.SideButton,
-                 onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runAsyncCB
-          )(tab.title)
+          def tabButton(tab:          AppTab): Button       =
+            Button(
+              as = <.a,
+              active = tab === focus,
+              clazz = ExploreStyles.SideButton,
+              onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runAsyncCB
+            )(^.href := ctx.pageUrl(tab, none), tab.title)
 
-        def tab(tab: AppTab): Label =
-          Label(active = tab === focus,
-                clazz = ExploreStyles.TabSelector,
-                size = Tiny,
-                onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runAsyncCB
-          )(tab.title)
+          def tab(tab:                AppTab): Label        =
+            Label(as = <.a,
+                  active = tab === focus,
+                  clazz = ExploreStyles.TabSelector,
+                  size = Tiny,
+                  onClick = p.tabs.mod(z => z.findFocus(_ === tab).getOrElse(z)).runAsyncCB
+            )(^.href := ctx.pageUrl(tab, none), tab.title)
 
-        def makeButtonSection(tabs: List[AppTab]): TagMod = tabs match {
-          case justOne :: Nil => VerticalSection()(tabButton(justOne))
-          case _              =>
-            VerticalSection()(
-              ButtonGroup(tabs.reverse.map(tabButton).toTagMod)
+          def makeButtonSection(tabs: List[AppTab]): TagMod = tabs match {
+            case justOne :: Nil => VerticalSection()(tabButton(justOne))
+            case _              =>
+              VerticalSection()(
+                ButtonGroup(tabs.reverse.map(tabButton).toTagMod)
+              )
+          }
+
+          val verticalButtonsSections: List[TagMod] =
+            tabsL.toList
+              .groupBy(_.buttonGroup)
+              .toList
+              .sortBy(_._1)
+              .map(tup => makeButtonSection(tup._2))
+
+          val horizontalButtonsSections: List[TagMod] =
+            tabsL.toList.toList
+              .map(tup => tab(tup))
+
+          React.Fragment(
+            <.div(
+              ExploreStyles.SideTabsVertical,
+              verticalButtonsSections.mkTagMod(
+                Divider(hidden = true, clazz = ExploreStyles.SideTabsDivider)
+              )
+            ),
+            <.div(
+              ExploreStyles.SideTabsHorizontal,
+              horizontalButtonsSections.toTagMod
             )
-        }
-
-        val verticalButtonsSections: List[TagMod] =
-          tabsL.toList
-            .groupBy(_.buttonGroup)
-            .toList
-            .sortBy(_._1)
-            .map(tup => makeButtonSection(tup._2))
-
-        val horizontalButtonsSections: List[TagMod] =
-          tabsL.toList.toList
-            .map(tup => tab(tup))
-
-        React.Fragment(
-          <.div(
-            ExploreStyles.SideTabsVertical,
-            verticalButtonsSections.mkTagMod(
-              Divider(hidden = true, clazz = ExploreStyles.SideTabsDivider)
-            )
-          ),
-          <.div(
-            ExploreStyles.SideTabsHorizontal,
-            horizontalButtonsSections.toTagMod
           )
-        )
+        }
       }
       .configure(Reusability.shouldComponentUpdate)
       .build

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -44,9 +44,9 @@ object SideTabs {
               active = tab === focus,
               clazz = ExploreStyles.SideButton,
               onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
-                e.preventDefaultCB *> p.tabs
+                (e.preventDefaultCB *> p.tabs
                   .mod(z => z.findFocus(_ === tab).getOrElse(z))
-                  .runAsyncCB
+                  .runAsyncCB).unless_(e.ctrlKey || e.metaKey)
             )(^.href := ctx.pageUrl(tab, none), tab.title)
 
           def tab(tab:                AppTab): Label        =
@@ -56,9 +56,9 @@ object SideTabs {
               clazz = ExploreStyles.TabSelector,
               size = Tiny,
               onClickE = (e: ReactMouseEvent, _: LabelProps) =>
-                e.preventDefaultCB *> p.tabs
+                (e.preventDefaultCB *> p.tabs
                   .mod(z => z.findFocus(_ === tab).getOrElse(z))
-                  .runAsyncCB
+                  .runAsyncCB).unless_(e.ctrlKey || e.metaKey)
             )(^.href := ctx.pageUrl(tab, none), tab.title)
 
           def makeButtonSection(tabs: List[AppTab]): TagMod = tabs match {

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -13,6 +13,7 @@ import explore.components.TileButton
 import explore.components.ui.ExploreStyles
 import explore.model.Focused._
 import explore.model._
+import explore.model.enum.AppTab
 import explore.model.reusability._
 import explore.observationtree.TargetObsList
 import explore.observationtree.TargetObsQueries._
@@ -29,6 +30,7 @@ import react.common.implicits._
 import react.draggable.Axis
 import react.resizable._
 import react.semanticui.elements.button.Button
+import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.sizes._
 import react.sizeme._
 
@@ -101,12 +103,15 @@ object TargetTabContents {
             )
 
           val backButton = TileButton(
-            Button(size = Mini,
-                   clazz = ExploreStyles.TargetBackButton |+| ExploreStyles.BlendedButton,
-                   onClick = props.focused.set(none).runAsyncCB
-            )(
-              Icons.ChevronLeft.fitted(true)
-            )
+            Button(
+              as = <.a,
+              size = Mini,
+              clazz = ExploreStyles.TargetBackButton |+| ExploreStyles.BlendedButton,
+              onClickE = { (e: ReactMouseEvent, _: ButtonProps) =>
+                (e.preventDefaultCB *> props.focused.set(none).runAsyncCB)
+                  .unless_(e.ctrlKey || e.metaKey)
+              }
+            )(^.href := ctx.pageUrl(AppTab.Targets, none), Icons.ChevronLeft.fitted(true))
           )
 
           TargetObsLiveQuery { targetsWithObs =>
@@ -121,7 +126,7 @@ object TargetTabContents {
                 val coreHeight: JsNumber = Option(s.height).getOrElse(0)
 
                 val rightSide =
-                  Tile(s"Target Position", movable = false, backButton.some)(
+                  Tile(s"Target", movable = false, backButton.some)(
                     <.span(
                       targetIdOpt.whenDefined(targetId =>
                         TargetEditor(targetId).withKey(targetId.toString)

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -299,7 +299,11 @@ object TargetObsList {
                                   opIcon,
                                   target.name.value,
                                   ExploreStyles.TargetLabelTitle,
-                                  ^.onClick ==> {(e: ReactEvent) => e.preventDefaultCB}
+                                  ^.onClick ==> { (e: ReactMouseEvent) =>
+                                    (e.preventDefaultCB *> props.focused
+                                      .set(focusedTarget.some)
+                                      .runAsyncCB).unless_(e.ctrlKey || e.metaKey)
+                                  }
                                 ),
                                 Button(
                                   size = Small,

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -298,7 +298,8 @@ object TargetObsList {
                                   ^.href := ctx.pageUrl(AppTab.Targets, focusedTarget.some),
                                   opIcon,
                                   target.name.value,
-                                  ExploreStyles.TargetLabelTitle
+                                  ExploreStyles.TargetLabelTitle,
+                                  ^.onClick ==> {(e: ReactEvent) => e.preventDefaultCB}
                                 ),
                                 Button(
                                   size = Small,


### PR DESCRIPTION
This is a simple but IMHO very useful improvement.
The buttons right now are just plain buttons but we can convert them to proper links allowing actions like e.g. open in new tab or copy the url:

https://user-images.githubusercontent.com/3615303/103002747-3a01fe80-450e-11eb-89ad-c66f040205c0.mp4

