### PR TITLE
Reorganize imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -267,7 +267,7 @@ def clueSchemaDirSettingsTask(conf: ConfigKey): sbt.Def.Initialize[sbt.Task[Seq[
 // ***** END: Move to plugin *****
 
 lazy val commonSettings = Seq(
-  scalaVersion := "2.13.3",
+  scalaVersion := "2.13.4",
   description := "Explore",
   homepage := Some(url("https://github.com/geminihlsw/explore")),
   licenses := Seq("BSD 3-Clause License" -> url("https://opensource.org/licenses/BSD-3-Clause")),

--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -3,44 +3,31 @@
 
 package explore
 
-import java.util.concurrent.TimeUnit
-
-import scala.annotation.unused
-import scala.concurrent.duration._
-import scala.scalajs.js
-
-import cats.effect.ExitCode
-import cats.effect.IO
-import cats.effect.IOApp
+import cats.effect.{ ExitCode, IO, IOApp }
 import cats.syntax.all._
-import clue.Backend
-import clue.WebSocketReconnectionStrategy
-import clue.js.AjaxJSBackend
-import clue.js.WebSocketJSBackend
+import clue.js.{ AjaxJSBackend, WebSocketJSBackend }
+import clue.{ Backend, WebSocketReconnectionStrategy }
 import crystal.AppRootContext
 import crystal.react.AppRoot
-import explore.model.AppConfig
-import explore.model.AppContext
-import explore.model.Focused
-import explore.model.RootModel
-import explore.model.UserVault
-import explore.model.enum.AppTab
-import explore.model.enum.ExecutionEnvironment
-import explore.model.enum.Theme
+import explore.model.enum.{ AppTab, ExecutionEnvironment, Theme }
 import explore.model.reusability._
+import explore.model.{ AppConfig, AppContext, Focused, RootModel, UserVault }
 import explore.utils
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react.vdom.VdomElement
 import log4cats.loglevel.LogLevelLogger
 import lucuma.core.data.EnumZipper
 import org.scalajs.dom
-import org.scalajs.dom.experimental.RequestCache
-import org.scalajs.dom.experimental.RequestInit
-import org.scalajs.dom.experimental.{ Request => FetchRequest }
+import org.scalajs.dom.experimental.{ Request => FetchRequest, RequestCache, RequestInit }
 import org.scalajs.dom.raw.Element
 import sttp.client3._
 import sttp.client3.circe._
 import sttp.model.Uri
+
+import java.util.concurrent.TimeUnit
+import scala.annotation.unused
+import scala.concurrent.duration._
+import scala.scalajs.js
 
 import js.annotation._
 

--- a/common/src/main/scala/explore/GraphQLSchemas.scala
+++ b/common/src/main/scala/explore/GraphQLSchemas.scala
@@ -3,15 +3,13 @@
 
 package explore
 
-import java.math.MathContext
-
 import clue.data.syntax._
 import clue.macros.GraphQLSchema
 import explore.model.SiderealTarget
 import explore.model.enum._
-import lucuma.core.model.Magnitude
-import lucuma.core.model.Observation
-import lucuma.core.model.Target
+import lucuma.core.model.{ Magnitude, Observation, Target }
+
+import java.math.MathContext
 
 object GraphQLSchemas {
 

--- a/common/src/main/scala/explore/common/SSOClient.scala
+++ b/common/src/main/scala/explore/common/SSOClient.scala
@@ -3,19 +3,11 @@
 
 package explore.common
 
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.{ util => ju }
-
-import scala.concurrent.Future
-import scala.concurrent.duration._
-
 import cats.effect._
 import cats.implicits._
 import eu.timepit.refined._
 import eu.timepit.refined.collection.NonEmpty
-import explore.model.SSOConfig
-import explore.model.UserVault
+import explore.model.{ SSOConfig, UserVault }
 import io.chrisdavenport.log4cats.Logger
 import io.circe.Decoder
 import io.circe.generic.semiauto._
@@ -25,6 +17,12 @@ import lucuma.sso.client.codec.user._
 import org.scalajs.dom.experimental.RequestCredentials
 import org.scalajs.dom.window
 import sttp.client3._
+
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.{ util => ju }
+import scala.concurrent.Future
+import scala.concurrent.duration._
 
 final case class JwtOrcidProfile(exp: Long, `lucuma-user`: User)
 

--- a/common/src/main/scala/explore/components/About.scala
+++ b/common/src/main/scala/explore/components/About.scala
@@ -8,8 +8,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.ReactProps
 import react.semanticui.modules.modal.Dimmer.Blurring
-import react.semanticui.modules.modal.Modal
-import react.semanticui.modules.modal.ModalContent
+import react.semanticui.modules.modal.{ Modal, ModalContent }
 
 case class About(trigger: VdomNode, content: VdomNode) extends ReactProps[About](About.component)
 

--- a/common/src/main/scala/explore/components/ConnectionsStatus.scala
+++ b/common/src/main/scala/explore/components/ConnectionsStatus.scala
@@ -5,10 +5,7 @@ package explore.components
 
 import clue.StreamingClientStatus
 import clue.StreamingClientStatus._
-import crystal.Error
-import crystal.Pending
-import crystal.Pot
-import crystal.Ready
+import crystal.{ Error, Pending, Pot, Ready }
 import explore.AppCtx
 import explore.components.ui.ExploreStyles
 import explore.components.ui.ExploreStyles._

--- a/common/src/main/scala/explore/components/UserSelectionForm.scala
+++ b/common/src/main/scala/explore/components/UserSelectionForm.scala
@@ -6,12 +6,10 @@ package explore.components
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.AppCtx
-import explore.Icons
-import explore.WebpackResources
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.UserVault
+import explore.{ AppCtx, Icons, WebpackResources }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.utils.UAParser
@@ -21,9 +19,7 @@ import react.common.implicits._
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.image.Image
 import react.semanticui.elements.label.Label
-import react.semanticui.modules.modal.Modal
-import react.semanticui.modules.modal.ModalContent
-import react.semanticui.modules.modal.ModalSize
+import react.semanticui.modules.modal.{ Modal, ModalContent, ModalSize }
 import react.semanticui.sizes._
 
 final case class UserSelectionForm(

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
@@ -5,12 +5,9 @@ package explore.components.graphql
 
 import cats.Id
 import cats.data.NonEmptyList
-import cats.effect.CancelToken
-import cats.effect.ConcurrentEffect
-import cats.effect.IO
+import cats.effect.{ CancelToken, ConcurrentEffect, IO }
 import cats.syntax.all._
-import clue.GraphQLSubscription
-import clue.GraphQLWebSocketClient
+import clue.{ GraphQLSubscription, GraphQLWebSocketClient }
 import crystal.react._
 import fs2.concurrent.Queue
 import io.chrisdavenport.log4cats.Logger

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
@@ -3,21 +3,12 @@
 
 package explore.components.graphql
 
-import scala.concurrent.duration._
-import scala.language.postfixOps
-
 import cats.data.NonEmptyList
-import cats.effect.CancelToken
-import cats.effect.ConcurrentEffect
-import cats.effect.ContextShift
-import cats.effect.IO
-import cats.effect.Timer
+import cats.effect.{ CancelToken, ConcurrentEffect, ContextShift, IO, Timer }
 import cats.syntax.all._
-import clue.GraphQLSubscription
-import clue.GraphQLWebSocketClient
-import crystal.Pot
-import crystal.ViewF
+import clue.{ GraphQLSubscription, GraphQLWebSocketClient }
 import crystal.react._
+import crystal.{ Pot, ViewF }
 import explore._
 import fs2.concurrent.Queue
 import io.chrisdavenport.log4cats.Logger
@@ -27,6 +18,9 @@ import react.common._
 import react.semanticui.collections.message.Message
 import react.semanticui.elements.icon.Icon
 import react.semanticui.sizes._
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 final case class LiveQueryRenderMod[S, D, A](
   query:               IO[D],

--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -4,23 +4,20 @@
 package explore.components.graphql
 
 import cats.data.NonEmptyList
-import cats.effect.CancelToken
-import cats.effect.ConcurrentEffect
-import cats.effect.IO
-import cats.effect.SyncIO
+import cats.effect.{ CancelToken, ConcurrentEffect, IO, SyncIO }
 import cats.syntax.all._
-import clue.GraphQLSubscription
-import clue.GraphQLWebSocketClient
-import clue.StreamingClientStatus
+import clue.{ GraphQLSubscription, GraphQLWebSocketClient, StreamingClientStatus }
 import crystal.Pot
 import crystal.react.implicits._
 import fs2.concurrent.Queue
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
-import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
-import japgolly.scalajs.react.component.builder.Lifecycle.ComponentWillUnmount
-import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
+import japgolly.scalajs.react.component.builder.Lifecycle.{
+  ComponentDidMount,
+  ComponentWillUnmount,
+  RenderScope
+}
 import japgolly.scalajs.react.vdom.html_<^._
 
 object Render {

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
@@ -4,8 +4,7 @@
 package explore.components.graphql
 
 import cats.Id
-import cats.effect.ConcurrentEffect
-import cats.effect.IO
+import cats.effect.{ ConcurrentEffect, IO }
 import cats.syntax.all._
 import clue.GraphQLSubscription
 import crystal.react._

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -3,19 +3,12 @@
 
 package explore.components.graphql
 
-import scala.concurrent.duration._
-import scala.language.postfixOps
-
-import cats.effect.ConcurrentEffect
-import cats.effect.ContextShift
-import cats.effect.IO
-import cats.effect.Timer
+import cats.effect.{ ConcurrentEffect, ContextShift, IO, Timer }
 import cats.syntax.all._
 import clue.GraphQLSubscription
-import crystal.Pot
-import crystal.ViewF
 import crystal.react._
 import crystal.react.implicits._
+import crystal.{ Pot, ViewF }
 import explore.View
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react._
@@ -24,6 +17,9 @@ import react.common._
 import react.semanticui.collections.message.Message
 import react.semanticui.elements.icon.Icon
 import react.semanticui.sizes._
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 final case class SubscriptionRenderMod[D, A](
   subscribe:         IO[GraphQLSubscription[IO, D]],

--- a/common/src/main/scala/explore/components/state/ConnectionManager.scala
+++ b/common/src/main/scala/explore/components/state/ConnectionManager.scala
@@ -5,8 +5,7 @@ package explore.components.state
 
 import cats.effect.IO
 import cats.syntax.all._
-import clue.TerminateOptions
-import clue.WebSocketCloseParams
+import clue.{ TerminateOptions, WebSocketCloseParams }
 import crystal.react.implicits._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString

--- a/common/src/main/scala/explore/components/state/IfLogged.scala
+++ b/common/src/main/scala/explore/components/state/IfLogged.scala
@@ -7,8 +7,7 @@ import cats.effect.IO
 import cats.syntax.all._
 import explore.components.UserSelectionForm
 import explore.implicits._
-import explore.model.RootModel
-import explore.model.UserVault
+import explore.model.{ RootModel, UserVault }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.ReactProps

--- a/common/src/main/scala/explore/components/state/SSOManager.scala
+++ b/common/src/main/scala/explore/components/state/SSOManager.scala
@@ -3,8 +3,6 @@
 
 package explore.components.state
 
-import java.time.Instant
-
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
@@ -19,6 +17,8 @@ import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.common.ReactProps
+
+import java.time.Instant
 
 final case class SSOManager(
   expiration: Instant,

--- a/common/src/main/scala/explore/components/ui/PartnerFlags.scala
+++ b/common/src/main/scala/explore/components/ui/PartnerFlags.scala
@@ -3,10 +3,10 @@
 
 package explore.components.ui
 
+import lucuma.core.model.Partner
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSImport
-
-import lucuma.core.model.Partner
 
 object PartnerFlags {
   @js.native

--- a/common/src/main/scala/explore/components/undo/UndoRegion.scala
+++ b/common/src/main/scala/explore/components/undo/UndoRegion.scala
@@ -3,8 +3,7 @@
 
 package explore.components.undo
 
-import cats.effect.Async
-import cats.effect.IO
+import cats.effect.{ Async, IO }
 import crystal.react.implicits._
 import explore.undo._
 import japgolly.scalajs.react._

--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -3,22 +3,19 @@
 
 package explore
 
-import scala.annotation.unused
-
 import cats._
-import cats.effect.ContextShift
-import cats.effect.Timer
+import cats.effect.{ ContextShift, Timer }
 import cats.syntax.all._
 import clue._
 import coulomb.Quantity
-import crystal.ViewF
-import crystal.ViewOptF
+import crystal.{ ViewF, ViewOptF }
 import explore.GraphQLSchemas._
-import explore.model.AppContext
-import explore.model.RootModel
+import explore.model.{ AppContext, RootModel }
 import explore.optics._
 import io.chrisdavenport.log4cats.Logger
 import shapeless._
+
+import scala.annotation.unused
 
 trait ListImplicits {
 

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -11,8 +11,7 @@ import crystal.react.StreamRenderer
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.GraphQLSchemas._
 import explore.common.SSOClient
-import explore.model.enum.AppTab
-import explore.model.enum.ExecutionEnvironment
+import explore.model.enum.{ AppTab, ExecutionEnvironment }
 import explore.model.reusability._
 import explore.utils
 import io.chrisdavenport.log4cats.Logger

--- a/common/src/main/scala/explore/package.scala
+++ b/common/src/main/scala/explore/package.scala
@@ -2,8 +2,7 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import cats.effect.IO
-import crystal.ViewF
-import crystal.ViewOptF
+import crystal.{ ViewF, ViewOptF }
 import explore.model.AppContext
 
 package explore {

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -3,19 +3,16 @@
 
 package explore
 
-import java.time.Instant
-
-import scala.scalajs.js
-
 import cats.effect.Sync
 import cats.syntax.all._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.model.enum.ExecutionEnvironment
 import explore.model.enum.ExecutionEnvironment.Development
-import explore.model.enum.Theme
-import lucuma.ui.utils.versionDateFormatter
-import lucuma.ui.utils.versionDateTimeFormatter
+import explore.model.enum.{ ExecutionEnvironment, Theme }
+import lucuma.ui.utils.{ versionDateFormatter, versionDateTimeFormatter }
 import org.scalajs.dom
+
+import java.time.Instant
+import scala.scalajs.js
 
 package object utils {
   def setupScheme[F[_]: Sync](theme: Theme): F[Unit] =

--- a/constraints/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/constraints/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -6,8 +6,7 @@ package explore.constraints
 import crystal.react.implicits._
 import explore.AppCtx
 import explore.GraphQLSchemas.ExploreDB.Types._
-import explore.components.undo.UndoButtons
-import explore.components.undo.UndoRegion
+import explore.components.undo.{ UndoButtons, UndoRegion }
 import explore.constraints.ConstraintsQueries._
 import explore.implicits._
 import explore.model.Constraints
@@ -15,13 +14,11 @@ import explore.model.display._
 import explore.model.reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.util.Display
-import lucuma.core.util.Enumerated
+import lucuma.core.util.{ Display, Enumerated }
 import lucuma.ui.forms.EnumViewSelect
 import monocle.Lens
 import react.common._
-import react.semanticui.collections.form.Form
-import react.semanticui.collections.form.FormGroup
+import react.semanticui.collections.form.{ Form, FormGroup }
 import react.semanticui.collections.grid._
 import react.semanticui.widths._
 

--- a/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
+++ b/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
@@ -3,8 +3,7 @@
 
 package explore.constraints
 
-import cats.effect.ContextShift
-import cats.effect.IO
+import cats.effect.{ ContextShift, IO }
 import clue.GraphQLOperation
 import clue.data.syntax._
 import clue.macros.GraphQL
@@ -15,10 +14,7 @@ import explore.components.graphql.SubscriptionRenderMod
 import explore.implicits._
 import explore.model.Constraints
 import explore.model.decoders._
-import explore.model.enum.CloudCover
-import explore.model.enum.ImageQuality
-import explore.model.enum.SkyBackground
-import explore.model.enum.WaterVapor
+import explore.model.enum.{ CloudCover, ImageQuality, SkyBackground, WaterVapor }
 import explore.model.reusability._
 import explore.undo.Undoer
 import japgolly.scalajs.react.vdom.html_<^._

--- a/constraints/src/main/scala/explore/constraints/Test.scala
+++ b/constraints/src/main/scala/explore/constraints/Test.scala
@@ -3,10 +3,6 @@
 
 package explore.constraints
 
-import java.util.UUID
-
-import scala.scalajs.js
-
 import explore.AppMain
 import explore.components.state.IfLogged
 import explore.constraints.ConstraintsQueries._
@@ -14,6 +10,9 @@ import explore.implicits._
 import explore.model.RootModel
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.html_<^._
+
+import java.util.UUID
+import scala.scalajs.js
 
 import js.annotation._
 

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -3,18 +3,16 @@
 
 package explore
 
-import scala.scalajs.js
-
 import cats.effect.IO
 import crystal.react.implicits._
 import explore.Routing
-import explore.model.Focused
-import explore.model.RootModel
-import explore.model.RootModelRouting
 import explore.model.enum.AppTab
+import explore.model.{ Focused, RootModel, RootModelRouting }
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.html_<^._
+
+import scala.scalajs.js
 
 import js.annotation._
 

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -3,23 +3,21 @@
 
 package explore
 
-import scala.scalajs.LinkingInfo
-import scala.util.Random
-
 import cats.syntax.all._
 import crystal.react.implicits._
-import explore.model.Page
 import explore.model.Page._
-import explore.model._
+import explore.model.{ Page, _ }
 import explore.proposal._
 import explore.tabs._
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.vdom.VdomElement
-import lucuma.core.model.Observation
-import lucuma.core.model.Target
+import lucuma.core.model.{ Observation, Target }
 import lucuma.core.util.Gid
+
+import scala.scalajs.LinkingInfo
+import scala.util.Random
 
 sealed trait ElementItem  extends Product with Serializable
 case object IconsElement  extends ElementItem

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -14,9 +14,8 @@ import lucuma.core.data.EnumZipper
 import lucuma.ui.reusability._
 import lucuma.ui.utils._
 import react.common._
-import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
-import react.semanticui.elements.button.ButtonGroup
+import react.semanticui.elements.button.{ Button, ButtonGroup }
 import react.semanticui.elements.divider.Divider
 import react.semanticui.elements.label.Label
 import react.semanticui.elements.label.Label.LabelProps

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -6,18 +6,14 @@ package explore
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
-import explore.Icons
-import explore.WebpackResources
-import explore.components.About
-import explore.components.ConnectionsStatus
 import explore.components.ui.ExploreStyles
-import explore.model.enum.ExecutionEnvironment
-import explore.model.enum.Theme
+import explore.components.{ About, ConnectionsStatus }
+import explore.model.enum.{ ExecutionEnvironment, Theme }
+import explore.{ Icons, WebpackResources }
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.GuestRole
-import lucuma.core.model.User
+import lucuma.core.model.{ GuestRole, User }
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import org.scalajs.dom
@@ -26,10 +22,7 @@ import react.common._
 import react.semanticui.collections.menu._
 import react.semanticui.elements.image.Image
 import react.semanticui.modules.checkbox.Checkbox
-import react.semanticui.modules.dropdown.Dropdown
-import react.semanticui.modules.dropdown.DropdownDivider
-import react.semanticui.modules.dropdown.DropdownItem
-import react.semanticui.modules.dropdown.DropdownMenu
+import react.semanticui.modules.dropdown.{ Dropdown, DropdownDivider, DropdownItem, DropdownMenu }
 import react.semanticui.views.item.Item
 
 final case class TopBar(

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -3,15 +3,12 @@
 
 package explore.tabs
 
-import scala.annotation.unused
-
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
 import explore._
-import explore.components.Tile
-import explore.components.TileButton
 import explore.components.ui.ExploreStyles
+import explore.components.{ Tile, TileButton }
 import explore.model.Focused.FocusedObs
 import explore.model._
 import explore.model.enum.AppTab
@@ -34,6 +31,8 @@ import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.sizes._
 import react.sizeme._
+
+import scala.annotation.unused
 
 final case class ObsTabContents(
   focused: View[Option[Focused]]

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -3,15 +3,12 @@
 
 package explore.tabs
 
-import scala.collection.immutable.SortedSet
-
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
 import explore._
-import explore.components.Tile
-import explore.components.TileButton
 import explore.components.ui.ExploreStyles
+import explore.components.{ Tile, TileButton }
 import explore.model.Focused._
 import explore.model._
 import explore.model.enum.AppTab
@@ -35,6 +32,8 @@ import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.sizes._
 import react.sizeme._
+
+import scala.collection.immutable.SortedSet
 
 final case class TargetTabContents(
   focused:           View[Option[Focused]],

--- a/model/src/main/scala/explore/data/KeyedIndexedList.scala
+++ b/model/src/main/scala/explore/data/KeyedIndexedList.scala
@@ -3,9 +3,9 @@
 
 package explore.data
 
-import scala.collection.immutable.TreeSeqMap
-
 import cats.Eq
+
+import scala.collection.immutable.TreeSeqMap
 
 // Each element has a unique Key.
 // Efficient loookup of elements and positions by Key.

--- a/model/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -3,11 +3,10 @@
 
 package explore.data.tree
 
-import scala.collection.immutable.HashMap
-import scala.collection.immutable.HashSet
-
 import cats.kernel.Eq
 import cats.syntax.all._
+
+import scala.collection.immutable.{ HashMap, HashSet }
 
 import KeyedIndexedTree._
 

--- a/model/src/main/scala/explore/model/AppConfig.scala
+++ b/model/src/main/scala/explore/model/AppConfig.scala
@@ -3,18 +3,16 @@
 
 package explore.model
 
-import java.util.concurrent.TimeUnit
-
-import scala.concurrent.duration.FiniteDuration
-
-import cats.Eq
-import cats.Show
+import cats.{ Eq, Show }
 import explore.model.decoders._
 import explore.model.encoders._
 import explore.model.enum.ExecutionEnvironment
 import io.circe._
 import io.circe.generic.semiauto._
 import sttp.model.Uri
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
 
 case class SSOConfig(
   uri:                        Uri,

--- a/model/src/main/scala/explore/model/Constraints.scala
+++ b/model/src/main/scala/explore/model/Constraints.scala
@@ -3,11 +3,11 @@
 
 package explore.model
 
-import java.util.UUID
-
 import cats._
 import explore.model.enum._
 import monocle.macros.Lenses
+
+import java.util.UUID
 
 @Lenses
 final case class Constraints(

--- a/model/src/main/scala/explore/model/ExploreObservation.scala
+++ b/model/src/main/scala/explore/model/ExploreObservation.scala
@@ -3,12 +3,12 @@
 
 package explore.model
 
-import java.time.Duration
-import java.util.UUID
-
 import cats.Eq
 import explore.model.enum.ObsStatus
 import monocle.macros.Lenses
+
+import java.time.Duration
+import java.util.UUID
 
 @Lenses
 final case class ExploreObservation(

--- a/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
+++ b/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
@@ -3,8 +3,6 @@
 
 package explore.model
 
-import java.util.UUID
-
 import cats._
 import cats.effect.Sync
 import cats.syntax.all._
@@ -12,11 +10,11 @@ import eu.timepit.refined._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Epoch
-import lucuma.core.model.SiderealTracking
-import lucuma.core.model.Target
+import lucuma.core.math.{ Coordinates, Epoch }
+import lucuma.core.model.{ SiderealTracking, Target }
 import monocle.macros.Lenses
+
+import java.util.UUID
 
 /**
  * A refinement of gem.Tracker meant for sidereal targets

--- a/model/src/main/scala/explore/model/Focused.scala
+++ b/model/src/main/scala/explore/model/Focused.scala
@@ -5,8 +5,7 @@ package explore.model
 
 import cats.kernel.Eq
 import cats.syntax.all._
-import lucuma.core.model.Observation
-import lucuma.core.model.Target
+import lucuma.core.model.{ Observation, Target }
 import monocle.macros.Lenses
 
 sealed trait Focused extends Product with Serializable

--- a/model/src/main/scala/explore/model/ModelOptics.scala
+++ b/model/src/main/scala/explore/model/ModelOptics.scala
@@ -3,9 +3,7 @@
 
 package explore.model
 
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Declination
-import lucuma.core.math.RightAscension
+import lucuma.core.math.{ Coordinates, Declination, RightAscension }
 import lucuma.core.model.SiderealTracking
 import monocle.Lens
 

--- a/model/src/main/scala/explore/model/Page.scala
+++ b/model/src/main/scala/explore/model/Page.scala
@@ -5,8 +5,7 @@ package explore.model
 
 import cats.Eq
 import cats.syntax.all._
-import lucuma.core.model.Observation
-import lucuma.core.model.Target
+import lucuma.core.model.{ Observation, Target }
 import monocle.Iso
 
 sealed trait Page extends Product with Serializable

--- a/model/src/main/scala/explore/model/ProposalDetails.scala
+++ b/model/src/main/scala/explore/model/ProposalDetails.scala
@@ -6,8 +6,7 @@ package explore.model
 import cats._
 import explore.model.enum._
 import explore.model.refined._
-import lucuma.core.model.Partner
-import lucuma.core.model.StandardUser
+import lucuma.core.model.{ Partner, StandardUser }
 import monocle.macros.Lenses
 
 @Lenses

--- a/model/src/main/scala/explore/model/RootModel.scala
+++ b/model/src/main/scala/explore/model/RootModel.scala
@@ -5,8 +5,6 @@ package explore.model
 
 // import java.time.Instant
 
-import scala.collection.immutable.SortedSet
-
 import cats.Order._
 import cats.kernel.Eq
 import cats.syntax.all._
@@ -17,6 +15,8 @@ import lucuma.core.data.EnumZipper
 import lucuma.core.model.Target
 import lucuma.core.model.Target.Id._
 import monocle.macros.Lenses
+
+import scala.collection.immutable.SortedSet
 
 @Lenses
 case class RootModel(

--- a/model/src/main/scala/explore/model/RootModelRouting.scala
+++ b/model/src/main/scala/explore/model/RootModelRouting.scala
@@ -4,8 +4,7 @@
 package explore.model
 
 import cats.syntax.all._
-import explore.model.Focused.FocusedObs
-import explore.model.Focused.FocusedTarget
+import explore.model.Focused.{ FocusedObs, FocusedTarget }
 import explore.model.Page._
 import explore.model.enum.AppTab
 import monocle.Lens

--- a/model/src/main/scala/explore/model/UserVault.scala
+++ b/model/src/main/scala/explore/model/UserVault.scala
@@ -3,8 +3,6 @@
 
 package explore.model
 
-import java.time.Instant
-
 import cats.Eq
 import cats.implicits._
 import eu.timepit.refined.cats._
@@ -12,6 +10,8 @@ import eu.timepit.refined.types.string.NonEmptyString
 import io.chrisdavenport.cats.time.instances.instant._
 import lucuma.core.model.User
 import monocle.macros.Lenses
+
+import java.time.Instant
 
 @Lenses
 final case class UserVault(user: User, expiration: Instant, token: NonEmptyString)

--- a/model/src/main/scala/explore/model/decoders.scala
+++ b/model/src/main/scala/explore/model/decoders.scala
@@ -6,24 +6,22 @@ package explore.model
 import cats.syntax.all._
 import coulomb._
 import explore.model.enum._
-import io.circe.Decoder
-import io.circe.DecodingFailure
-import io.circe.HCursor
 import io.circe.generic.semiauto
-import lucuma.core.enum.MagnitudeBand
-import lucuma.core.enum.MagnitudeSystem
-import lucuma.core.math.Angle
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Declination
-import lucuma.core.math.Epoch
-import lucuma.core.math.MagnitudeValue
-import lucuma.core.math.Parallax
-import lucuma.core.math.ProperMotion
-import lucuma.core.math.RadialVelocity
-import lucuma.core.math.RightAscension
+import io.circe.{ Decoder, DecodingFailure, HCursor }
+import lucuma.core.enum.{ MagnitudeBand, MagnitudeSystem }
 import lucuma.core.math.units.CentimetersPerSecond
-import lucuma.core.model.Magnitude
-import lucuma.core.model.SiderealTracking
+import lucuma.core.math.{
+  Angle,
+  Coordinates,
+  Declination,
+  Epoch,
+  MagnitudeValue,
+  Parallax,
+  ProperMotion,
+  RadialVelocity,
+  RightAscension
+}
+import lucuma.core.model.{ Magnitude, SiderealTracking }
 import sttp.model.Uri
 
 object decoders {

--- a/model/src/main/scala/explore/model/display.scala
+++ b/model/src/main/scala/explore/model/display.scala
@@ -4,8 +4,7 @@
 package explore.model
 
 import explore.model.enum._
-import lucuma.core.enum.MagnitudeBand
-import lucuma.core.enum.MagnitudeSystem
+import lucuma.core.enum.{ MagnitudeBand, MagnitudeSystem }
 import lucuma.core.util.Display
 
 object display {

--- a/model/src/main/scala/explore/model/encoders.scala
+++ b/model/src/main/scala/explore/model/encoders.scala
@@ -4,12 +4,10 @@
 package explore.model
 
 import explore.model.enum._
-import io.circe.Encoder
-import io.circe.Json
 import io.circe.refined._
 import io.circe.syntax._
-import lucuma.core.math.Declination
-import lucuma.core.math.RightAscension
+import io.circe.{ Encoder, Json }
+import lucuma.core.math.{ Declination, RightAscension }
 import sttp.model.Uri
 
 import ModelOptics._

--- a/model/src/main/scala/explore/model/formats.scala
+++ b/model/src/main/scala/explore/model/formats.scala
@@ -3,19 +3,18 @@
 
 package explore.model
 
-import java.text.NumberFormat
-import java.util.Locale
-
 import cats.syntax.all._
 import coulomb._
 import eu.timepit.refined.refineV
 import explore.optics._
-import lucuma.core.math.Parallax
 import lucuma.core.math.ProperMotion.AngularVelocityComponent
-import lucuma.core.math._
 import lucuma.core.math.units._
+import lucuma.core.math.{ Parallax, _ }
 import lucuma.core.optics.Format
 import lucuma.core.syntax.string._
+
+import java.text.NumberFormat
+import java.util.Locale
 
 trait formats {
   val pxFormat: Format[String, Parallax] =

--- a/model/src/main/scala/explore/model/partial.scala
+++ b/model/src/main/scala/explore/model/partial.scala
@@ -3,15 +3,14 @@
 
 package explore.model
 
-import java.time.Duration
-import java.time.temporal.ChronoUnit
-
 import cats.syntax.all._
 import explore.model.enum.ObsStatus
-import io.circe.Decoder
-import io.circe.HCursor
+import io.circe.{ Decoder, HCursor }
 import lucuma.core.model.Observation
 import monocle.macros.Lenses
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 
 @Lenses
 final case class ConstraintsSummary(id: Constraints.Id, name: String)

--- a/model/src/main/scala/explore/optics/GetAdjust.scala
+++ b/model/src/main/scala/explore/optics/GetAdjust.scala
@@ -3,8 +3,7 @@
 
 package explore.optics
 
-import monocle.Getter
-import monocle.Lens
+import monocle.{ Getter, Lens }
 
 // Wrap a Getter and an Adjuster
 final case class GetAdjust[T, A](getter: Getter[T, A], adjuster: Adjuster[T, A]) {

--- a/model/src/main/scala/explore/optics/package.scala
+++ b/model/src/main/scala/explore/optics/package.scala
@@ -6,12 +6,9 @@ package explore
 import cats.syntax.all._
 import coulomb._
 import explore.model.utils._
-import lucuma.core.math.ApparentRadialVelocity
 import lucuma.core.math.Constants._
-import lucuma.core.math.ProperMotion
-import lucuma.core.math.RadialVelocity
-import lucuma.core.math.Redshift
 import lucuma.core.math.units._
+import lucuma.core.math.{ ApparentRadialVelocity, ProperMotion, RadialVelocity, Redshift }
 import monocle._
 import monocle.std.option.some
 

--- a/model/src/main/scala/explore/undo/IndexedCollMod.scala
+++ b/model/src/main/scala/explore/undo/IndexedCollMod.scala
@@ -4,8 +4,7 @@
 package explore.undo
 
 import cats.syntax.all._
-import explore.optics.Adjuster
-import explore.optics.GetAdjust
+import explore.optics.{ Adjuster, GetAdjust }
 import monocle._
 import monocle.function.Field1.first
 import monocle.std.option.some

--- a/model/src/main/scala/explore/undo/KIListMod.scala
+++ b/model/src/main/scala/explore/undo/KIListMod.scala
@@ -4,9 +4,7 @@
 package explore.undo
 
 import explore.data.KeyedIndexedList
-import monocle.Getter
-import monocle.Iso
-import monocle.Lens
+import monocle.{ Getter, Iso, Lens }
 
 class KIListMod[F[_], A, K](protected val keyLens: Lens[A, K])
     extends IndexedCollMod[F, KeyedIndexedList, Int, A, cats.Id, K] {

--- a/model/src/main/scala/explore/undo/KITreeMod.scala
+++ b/model/src/main/scala/explore/undo/KITreeMod.scala
@@ -4,8 +4,7 @@
 package explore.undo
 
 import explore.data.tree._
-import monocle.Getter
-import monocle.Lens
+import monocle.{ Getter, Lens }
 
 import KeyedIndexedTree.Index
 

--- a/model/src/main/scala/explore/undo/UndoableView.scala
+++ b/model/src/main/scala/explore/undo/UndoableView.scala
@@ -3,8 +3,7 @@
 
 package explore.undo
 
-import cats.effect.Async
-import cats.effect.ContextShift
+import cats.effect.{ Async, ContextShift }
 import cats.syntax.all._
 import crystal.ViewF
 import monocle.Lens

--- a/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
@@ -3,34 +3,27 @@
 
 package explore.observationtree
 
-import java.time.Duration
-import java.time.temporal.ChronoUnit._
-import java.util.UUID
-
-import scala.util.Random
-
 import cats.effect.IO
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ObsBadge
 import explore.data.tree._
-import explore.model.Constraints
-import explore.model.ExploreObservation
-import explore.model.ObsSummary
-import explore.model.SiderealTarget
-import explore.model.enum.ObsStatus
-import explore.model.enum._
+import explore.model.enum.{ ObsStatus, _ }
+import explore.model.{ Constraints, ExploreObservation, ObsSummary, SiderealTarget }
 import explore.undo.KITreeMod
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Epoch
-import lucuma.core.model.Observation
-import lucuma.core.model.SiderealTracking
+import lucuma.core.math.{ Coordinates, Epoch }
+import lucuma.core.model.{ Observation, SiderealTracking }
 import mouse.boolean._
 import react.atlasKit.tree.{ Tree => AtlasTree }
 import react.semanticui.elements.icon.Icon
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit._
+import java.util.UUID
+import scala.util.Random
 
 object AndOrTest {
   private def randomElement[A](list: List[A]): A =

--- a/observationtree/src/main/scala/explore/observationtree/ObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ObsList.scala
@@ -8,11 +8,10 @@ import crystal.react.implicits._
 import explore._
 import explore.components.ObsBadge
 import explore.components.ui.ExploreStyles
-import explore.model.Focused
 import explore.model.Focused.FocusedObs
-import explore.model.ObsSummary
 import explore.model.enum.AppTab
 import explore.model.reusability._
+import explore.model.{ Focused, ObsSummary }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.utils._

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -3,33 +3,23 @@
 
 package explore.observationtree
 
-import scala.collection.immutable.SortedSet
-import scala.util.Random
-
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined.types.numeric.PosLong
-import explore.AppCtx
-import explore.Icons
 import explore.components.ObsBadge
 import explore.components.ui.ExploreStyles
-import explore.components.undo.UndoButtons
-import explore.components.undo.UndoRegion
+import explore.components.undo.{ UndoButtons, UndoRegion }
 import explore.implicits._
-import explore.model.Constants
-import explore.model.Focused
 import explore.model.Focused._
-import explore.model.ObsSummary
 import explore.model.enum.AppTab
-import explore.optics.GetAdjust
-import explore.optics._
-import explore.undo.KIListMod
-import explore.undo.Undoer
+import explore.model.{ Constants, Focused, ObsSummary }
+import explore.optics.{ GetAdjust, _ }
+import explore.undo.{ KIListMod, Undoer }
+import explore.{ AppCtx, Icons }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.Observation
-import lucuma.core.model.Target
+import lucuma.core.model.{ Observation, Target }
 import lucuma.ui.utils._
 import monocle.Getter
 import monocle.function.Field1.first
@@ -42,6 +32,9 @@ import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.elements.icon.Icon
 import react.semanticui.elements.segment.Segment
 import react.semanticui.sizes._
+
+import scala.collection.immutable.SortedSet
+import scala.util.Random
 
 import TargetObsQueries._
 

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
@@ -20,8 +20,7 @@ import explore.model.reusability._
 import io.scalaland.chimney.dsl._
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.Observation
-import lucuma.core.model.Target
+import lucuma.core.model.{ Observation, Target }
 import lucuma.ui.reusability._
 import monocle.Getter
 import monocle.macros.Lenses

--- a/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
@@ -3,22 +3,16 @@
 
 package explore.observationtree
 
-import java.time.Duration
-import java.util.UUID
-
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.model.Constraints
-import explore.model.ExploreObservation
-import explore.model.SiderealTarget
-import explore.model.enum.ObsStatus
-import explore.model.enum._
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Declination
-import lucuma.core.math.Epoch
-import lucuma.core.math.RightAscension
+import explore.model.enum.{ ObsStatus, _ }
+import explore.model.{ Constraints, ExploreObservation, SiderealTarget }
+import lucuma.core.math.{ Coordinates, Declination, Epoch, RightAscension }
 import lucuma.core.model.SiderealTracking
+
+import java.time.Duration
+import java.util.UUID
 
 object TargetTreeTest {
 

--- a/observationtree/src/main/scala/explore/observationtree/Test.scala
+++ b/observationtree/src/main/scala/explore/observationtree/Test.scala
@@ -3,13 +3,12 @@
 
 package explore.observationtree
 
-import scala.scalajs.js.annotation.JSExportTopLevel
-
-import explore.AppMain
-import explore._
 import explore.components.state.IfLogged
 import explore.model.RootModel
+import explore.{ AppMain, _ }
 import japgolly.scalajs.react.vdom.html_<^._
+
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 import TargetObsQueries._
 

--- a/observationtree/src/main/scala/explore/observationtree/TreeComp.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TreeComp.scala
@@ -3,8 +3,6 @@
 
 package explore.observationtree
 
-import scala.scalajs.js
-
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.ModState
@@ -13,8 +11,7 @@ import explore.components.undo.UndoRegion
 import explore.data.tree.KeyedIndexedTree.Index
 import explore.data.tree._
 import explore.implicits._
-import explore.undo.KITreeMod
-import explore.undo.Undoer
+import explore.undo.{ KITreeMod, Undoer }
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -22,6 +19,8 @@ import monocle.macros.Lenses
 import react.atlasKit.tree.{ Tree => AtlasTree }
 import react.common.ReactProps
 import react.semanticui.elements.button.Button
+
+import scala.scalajs.js
 
 import js.JSConverters._
 

--- a/observationtree/src/main/scala/explore/observationtree/obsTree.scala
+++ b/observationtree/src/main/scala/explore/observationtree/obsTree.scala
@@ -3,11 +3,11 @@
 
 package explore.observationtree
 
-import java.util.UUID
-
 import explore.model.ExploreObservation
 import monocle.Lens
 import monocle.macros.Lenses
+
+import java.util.UUID
 
 sealed trait ObsNode {
   val id: UUID

--- a/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
@@ -7,9 +7,7 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.components.ui.ExploreStyles
-import explore.components.ui.FomanticStyles
-import explore.components.ui.PartnerFlags
+import explore.components.ui.{ ExploreStyles, FomanticStyles, PartnerFlags }
 import explore.implicits._
 import explore.model._
 import explore.model.refined._

--- a/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
@@ -12,17 +12,15 @@ import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
-import explore.AppCtx
-import explore.Icons
-import explore.components.FormStaticData
-import explore.components.Tile
 import explore.components.ui._
+import explore.components.{ FormStaticData, Tile }
 import explore.implicits._
 import explore.model._
 import explore.model.display._
 import explore.model.enum.ProposalClass._
 import explore.model.refined._
 import explore.model.reusability._
+import explore.{ AppCtx, Icons }
 import japgolly.scalajs.react.Reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._

--- a/proposal/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -3,8 +3,6 @@
 
 package explore.proposal
 
-import java.net.URI
-
 import cats.effect._
 import coulomb.accepted.Percent
 import coulomb.refined._
@@ -24,6 +22,8 @@ import fs2.concurrent.SignallingRef
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model._
+
+import java.net.URI
 
 object ProposalTabContents {
   type Props = View[Option[Focused]]

--- a/proposal/src/main/scala/explore/proposal/Test.scala
+++ b/proposal/src/main/scala/explore/proposal/Test.scala
@@ -3,14 +3,13 @@
 
 package explore.proposal
 
-import scala.scalajs.js
-
 import eu.timepit.refined.auto._
-import explore.AppMain
-import explore.View
 import explore.components.state.IfLogged
 import explore.model.RootModel
+import explore.{ AppMain, View }
 import japgolly.scalajs.react.vdom.VdomElement
+
+import scala.scalajs.js
 
 import js.annotation._
 

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -6,24 +6,20 @@ package explore.targeteditor
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
-import explore.Icons
-import explore.View
 import explore.components.ui.ExploreStyles
-import explore.model.ModelOptics
-import explore.model.TargetVisualOptions
 import explore.model.reusability._
+import explore.model.{ ModelOptics, TargetVisualOptions }
+import explore.{ Icons, View }
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.math.Angle
-import lucuma.core.math.Coordinates
+import lucuma.core.math.{ Angle, Coordinates }
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.aladin.Fov
 import react.common._
 import react.semanticui.elements.button.Button
-import react.semanticui.modules.popup.Popup
-import react.semanticui.modules.popup.PopupPosition
+import react.semanticui.modules.popup.{ Popup, PopupPosition }
 import react.semanticui.sizes._
 
 final case class AladinCell(

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -3,8 +3,6 @@
 
 package explore.targeteditor
 
-import scala.concurrent.duration._
-
 import cats.syntax.all._
 import crystal.react.implicits._
 import explore.View
@@ -16,9 +14,7 @@ import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.geom.jts.interpreter._
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Declination
-import lucuma.core.math.RightAscension
+import lucuma.core.math.{ Coordinates, Declination, RightAscension }
 import lucuma.svgdotjs.Svg
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
@@ -27,6 +23,8 @@ import org.scalajs.dom.ext._
 import org.scalajs.dom.raw.Element
 import react.aladin._
 import react.common._
+
+import scala.concurrent.duration._
 
 @Lenses
 final case class AladinContainer(

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -3,8 +3,6 @@
 
 package explore.targeteditor
 
-import scala.math.rint
-
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import japgolly.scalajs.react._
@@ -17,6 +15,8 @@ import react.aladin.reusability._
 import react.common.ReactProps
 import react.semanticui.elements.label._
 import react.semanticui.sizes.Small
+
+import scala.math.rint
 
 final case class AladinToolbar(
   fov:     Fov,

--- a/targeteditor/src/main/scala/explore/targeteditor/CataloguesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CataloguesForm.scala
@@ -3,8 +3,6 @@
 
 package explore.targeteditor
 
-import scala.collection.SortedMap
-
 import cats.data.NonEmptyList
 import crystal.react.implicits._
 import explore.View
@@ -22,6 +20,8 @@ import react.semanticui.collections.form.FormDropdown.FormDropdownProps
 import react.semanticui.collections.form._
 import react.semanticui.modules.dropdown.DropdownItem
 import react.semanticui.sizes._
+
+import scala.collection.SortedMap
 
 final case class CataloguesForm(
   options:          View[TargetVisualOptions]

--- a/targeteditor/src/main/scala/explore/targeteditor/GmosGeometry.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/GmosGeometry.scala
@@ -4,17 +4,12 @@
 package explore.targeteditor
 
 import cats.data.NonEmptyMap
-import lucuma.core.enum.GmosNorthFpu
-import lucuma.core.enum.GmosSouthFpu
-import lucuma.core.enum.PortDisposition
-import lucuma.core.geom.GmosOiwfsProbeArm
-import lucuma.core.geom.GmosScienceAreaGeometry
-import lucuma.core.geom.ShapeExpression
+import lucuma.core.enum.{ GmosNorthFpu, GmosSouthFpu, PortDisposition }
 import lucuma.core.geom.svg._
 import lucuma.core.geom.syntax.shapeexpression._
-import lucuma.core.math.Angle
-import lucuma.core.math.Offset
+import lucuma.core.geom.{ GmosOiwfsProbeArm, GmosScienceAreaGeometry, ShapeExpression }
 import lucuma.core.math.syntax.int._
+import lucuma.core.math.{ Angle, Offset }
 import lucuma.svgdotjs._
 
 /**

--- a/targeteditor/src/main/scala/explore/targeteditor/InputWithUnits.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/InputWithUnits.scala
@@ -13,10 +13,8 @@ import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ui.ExploreStyles
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.ui.forms.ExternalValue
-import lucuma.ui.forms.FormInputEV
-import lucuma.ui.optics.ChangeAuditor
-import lucuma.ui.optics.ValidFormatInput
+import lucuma.ui.forms.{ ExternalValue, FormInputEV }
+import lucuma.ui.optics.{ ChangeAuditor, ValidFormatInput }
 import react.common._
 import react.semanticui.elements.label.LabelPointing
 

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -3,44 +3,42 @@
 
 package explore.targeteditor
 
-import scala.collection.immutable.HashSet
-
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.AppCtx
-import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.display._
+import explore.{ AppCtx, Icons }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.MagnitudeBand
 import lucuma.core.math.MagnitudeValue
-import lucuma.core.model.Magnitude
-import lucuma.core.model.Target
-import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.forms.FormInputEV
-import lucuma.ui.optics.ChangeAuditor
-import lucuma.ui.optics.ValidFormatInput
+import lucuma.core.model.{ Magnitude, Target }
+import lucuma.ui.forms.{ EnumViewSelect, FormInputEV }
+import lucuma.ui.optics.{ ChangeAuditor, ValidFormatInput }
 import lucuma.ui.reusability._
 import lucuma.ui.utils._
 import monocle.macros.Lenses
 import monocle.std.option.some
 import react.common.ReactProps
-import react.semanticui.collections.table.Table
-import react.semanticui.collections.table.TableBody
-import react.semanticui.collections.table.TableCell
-import react.semanticui.collections.table.TableCompact
-import react.semanticui.collections.table.TableFooter
-import react.semanticui.collections.table.TableHeaderCell
-import react.semanticui.collections.table.TableRow
+import react.semanticui.collections.table.{
+  Table,
+  TableBody,
+  TableCell,
+  TableCompact,
+  TableFooter,
+  TableHeaderCell,
+  TableRow
+}
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.segment.Segment
 import react.semanticui.sizes._
+
+import scala.collection.immutable.HashSet
 
 final case class MagnitudeForm(
   targetId:   Target.Id,

--- a/targeteditor/src/main/scala/explore/targeteditor/MoonCalc.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MoonCalc.scala
@@ -3,10 +3,7 @@
 
 package explore.targeteditor
 
-import java.time.Duration
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
+import java.time.{ Duration, Instant, ZoneOffset, ZonedDateTime }
 
 object MoonCalc {
   val MeanLunationDays: Double    = 29.530588861

--- a/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
@@ -15,15 +15,10 @@ import explore.implicits._
 import explore.model.formats._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.math.ApparentRadialVelocity
-import lucuma.core.math.RadialVelocity
-import lucuma.core.math.Redshift
-import lucuma.core.util.Display
-import lucuma.core.util.Enumerated
-import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.forms.FormInputEV
-import lucuma.ui.optics.ChangeAuditor
-import lucuma.ui.optics.ValidFormatInput
+import lucuma.core.math.{ ApparentRadialVelocity, RadialVelocity, Redshift }
+import lucuma.core.util.{ Display, Enumerated }
+import lucuma.ui.forms.{ EnumViewSelect, FormInputEV }
+import lucuma.ui.optics.{ ChangeAuditor, ValidFormatInput }
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.common._

--- a/targeteditor/src/main/scala/explore/targeteditor/SimbadSearch.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SimbadSearch.scala
@@ -3,8 +3,6 @@
 
 package explore.targeteditor
 
-import scala.concurrent.duration._
-
 import cats.data.Validated
 import cats.effect._
 import cats.syntax.all._
@@ -14,6 +12,8 @@ import lucuma.catalog.VoTableParser
 import lucuma.core.enum.CatalogName
 import lucuma.core.model.Target
 import sttp.client3._
+
+import scala.concurrent.duration._
 
 object SimbadSearch {
   def search(term: NonEmptyString)(implicit cs: ContextShift[IO]): IO[Option[Target]] = {

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyCalc.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyCalc.scala
@@ -3,14 +3,12 @@
 
 package explore.targeteditor
 
-import java.time.Duration
-import java.time.Instant
-
 import cats.syntax.all._
 import lucuma.core.enum.Site
 import lucuma.core.math.Coordinates
-import lucuma.core.math.skycalc.ImprovedSkyCalc
-import lucuma.core.math.skycalc.SkyCalcResults
+import lucuma.core.math.skycalc.{ ImprovedSkyCalc, SkyCalcResults }
+
+import java.time.{ Duration, Instant }
 
 object SkyCalc {
   // TODO Cache

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyPlot.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyPlot.scala
@@ -3,30 +3,16 @@
 
 package explore.targeteditor
 
-import java.time.Duration
-import java.time.Instant
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-import java.time.format.DateTimeFormatter
-
-import scala.collection.immutable.HashSet
-import scala.scalajs.js
-
 import cats.syntax.all._
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import gpp.highcharts.highchartsStrings.line
-import gpp.highcharts.mod.XAxisLabelsOptions
-import gpp.highcharts.mod._
+import gpp.highcharts.mod.{ XAxisLabelsOptions, _ }
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.enum.Site
-import lucuma.core.enum.TwilightType
-import lucuma.core.math.Angle
-import lucuma.core.math.Coordinates
+import lucuma.core.enum.{ Site, TwilightType }
+import lucuma.core.math.{ Angle, Coordinates }
 import lucuma.core.model.ObservingNight
 import lucuma.core.util.Enumerated
 import lucuma.ui.reusability._
@@ -35,6 +21,11 @@ import react.common._
 import react.highcharts.Chart
 import reactmoon.MoonPhase
 import shapeless._
+
+import java.time.format.DateTimeFormatter
+import java.time.{ Duration, Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime }
+import scala.collection.immutable.HashSet
+import scala.scalajs.js
 
 import js.JSConverters._
 

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyPlotSection.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyPlotSection.scala
@@ -3,11 +3,6 @@
 
 package explore.targeteditor
 
-import java.time.LocalDate
-import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
-
 import cats.Eq
 import cats.syntax.all._
 import explore.components.ui.ExploreStyles
@@ -22,6 +17,8 @@ import monocle.macros.Lenses
 import react.common.ReactProps
 import react.datepicker._
 import react.semanticui.modules.checkbox.Checkbox
+
+import java.time.{ LocalDate, ZoneId, ZoneOffset, ZonedDateTime }
 
 final case class SkyPlotSection(
   coords: Coordinates

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -10,13 +10,10 @@ import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string._
-import explore.AppCtx
 import explore.GraphQLSchemas.ObservationDB.Types._
-import explore.View
 import explore.components.WIP
 import explore.components.ui.ExploreStyles
-import explore.components.undo.UndoButtons
-import explore.components.undo.UndoRegion
+import explore.components.undo.{ UndoButtons, UndoRegion }
 import explore.implicits._
 import explore.model.TargetVisualOptions
 import explore.model.formats._
@@ -24,18 +21,14 @@ import explore.model.reusability._
 import explore.model.utils._
 import explore.target.TargetQueries
 import explore.target.TargetQueries._
+import explore.{ AppCtx, View }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.math._
-import lucuma.core.model.Magnitude
-import lucuma.core.model.SiderealTracking
-import lucuma.core.model.Target
+import lucuma.core.model.{ Magnitude, SiderealTracking, Target }
 import lucuma.ui.forms.FormInputEV
 import lucuma.ui.implicits._
-import lucuma.ui.optics.ChangeAuditor
-import lucuma.ui.optics.TruncatedDec
-import lucuma.ui.optics.TruncatedRA
-import lucuma.ui.optics.ValidFormatInput
+import lucuma.ui.optics.{ ChangeAuditor, TruncatedDec, TruncatedRA, ValidFormatInput }
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.common._

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -18,20 +18,18 @@ import explore.implicits._
 import explore.model.Constants
 import explore.model.decoders._
 import explore.optics._
-import explore.undo.UndoableView
-import explore.undo.Undoer
-import lucuma.core.math.Coordinates
-import lucuma.core.math.Declination
-import lucuma.core.math.Epoch
-import lucuma.core.math.Parallax
-import lucuma.core.math.ProperMotion
-import lucuma.core.math.RadialVelocity
-import lucuma.core.math.RightAscension
+import explore.undo.{ UndoableView, Undoer }
 import lucuma.core.math.units.CentimetersPerSecond
-import lucuma.core.model.CatalogId
-import lucuma.core.model.Magnitude
-import lucuma.core.model.SiderealTracking
-import lucuma.core.model.Target
+import lucuma.core.math.{
+  Coordinates,
+  Declination,
+  Epoch,
+  Parallax,
+  ProperMotion,
+  RadialVelocity,
+  RightAscension
+}
+import lucuma.core.model.{ CatalogId, Magnitude, SiderealTracking, Target }
 import lucuma.ui.reusability._
 import monocle.Lens
 

--- a/targeteditor/src/main/scala/explore/targeteditor/Test.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/Test.scala
@@ -3,16 +3,15 @@
 
 package explore.targeteditor
 
-import scala.scalajs.js.annotation._
-
 import eu.timepit.refined.auto._
-import explore.AppMain
-import explore._
 import explore.components.Tile
 import explore.components.state.IfLogged
 import explore.model._
+import explore.{ AppMain, _ }
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Target
+
+import scala.scalajs.js.annotation._
 
 @JSExportTopLevel("TargetTest")
 object Test extends AppMain {

--- a/targeteditor/src/main/scala/explore/targeteditor/plotPeriod.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/plotPeriod.scala
@@ -3,14 +3,10 @@
 
 package explore.targeteditor
 
-import java.time.Duration
-import java.time.Instant
-import java.time.LocalDate
-
 import lucuma.core.enum.Site
-import lucuma.core.model.LocalObservingNight
-import lucuma.core.model.ObservingNight
-import lucuma.core.model.Semester
+import lucuma.core.model.{ LocalObservingNight, ObservingNight, Semester }
+
+import java.time.{ Duration, Instant, LocalDate }
 
 sealed trait PlotPeriod {
   def start(site: Site): Instant


### PR DESCRIPTION
The `OrganizeImport` scalafix changed the default sorting. This applies the new sorting.
The `OrganizeImports` scalafix changed the default imports order

This PR updates the imports. There are no other relevant code changes