### PR TITLE
Ch645 add observation notes tile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ jobs:
         uses: wearerequired/lint-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_fix: true
           # Enable your linters herename: Lint
           stylelint: true
           stylelint_args: "common/src/main/resources/less"

--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,7 @@ lazy val common = project
     libraryDependencies ++=
       LucumaSSO.value ++
         LucumaBC.value ++
+        ReactGridLayout.value ++
         ReactClipboard.value ++
         ReactCommon.value,
     buildInfoKeys := Seq[BuildInfoKey](

--- a/common/src/main/resources/images/resize-handle.svg
+++ b/common/src/main/resources/images/resize-handle.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" style="background-color:#ffffff00" width="6" height="6">
-  <path d="M6 6H0V4.2h4.2V0H6v6z" opacity=".302" fill="#e3dedb"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="6" height="6">
+  <path d="M6 6H0V4.2h4.2V0H6v6z" fill="#e3dedb"/>
 </svg>

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -316,7 +316,7 @@ body.light-theme {
   filter: brightness(80%);
   margin-right: 0.5em;
   transform-origin: center center;
-  transition: transform .25s, filter .25s ease-in;
+  transition: transform 0.25s, filter 0.25s ease-in;
 }
 
 .proposal-tile {

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -117,6 +117,67 @@ body.light-theme {
   text-overflow: ellipsis;
 }
 
+.ui.button.active.side-button {
+  border-top: var(--explore-accent-color) solid 4px;
+  background-color: var(--under-tab-background-active-color);
+  font-weight: bold;
+}
+
+.ui.menu .item.main-user-name {
+  flex-shrink: 1;
+  display: inline-block;
+}
+
+.ui.tabular.menu .item.connection-icon {
+  padding-right: 0.5em;
+  padding-left: 0;
+}
+
+.ui.tabular.menu .item.main-menu-dropdown {
+  padding-right: 0.5em;
+  padding-left: 0;
+}
+
+.ui.menu:not(.vertical) .right.menu.main-menu {
+  margin-left: 0 !important; //SUI has !imporant
+}
+
+.explore-tile-title {
+  background-color: var(--tile-title-background);
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  & .tabular.menu .item {
+    color: var(--tile-title-color);
+    letter-spacing: 0.1em;
+  }
+}
+
+.ui.menu.explore-tile-title-menu {
+  margin-top: 0;
+  cursor: pointer;
+  min-height: 36px;
+}
+
+.ui.menu.explore-tile-title-menu .item {
+  padding-left: 0.5em;
+  letter-spacing: 2px;
+}
+
+.ui.menu.explore-tile-title-menu a.item:hover {
+  background: unset;
+  color: unset;
+}
+
+.ui.button.tile-back-button {
+  margin-right: 0;
+
+  @media (min-width: @target-grid-responsive-cutoff) {
+    display: none;
+  }
+}
+
 .main-header > .ui.tabular.menu .item {
   color: var(--main-header-color);
 }
@@ -229,67 +290,6 @@ body.light-theme {
     opacity @defaultDuration @defaultEasing,
     color @defaultDuration @defaultEasing,
     box-shadow @defaultDuration @defaultEasing;
-}
-
-.ui.button.active.side-button {
-  border-top: var(--explore-accent-color) solid 4px;
-  background-color: var(--under-tab-background-active-color);
-  font-weight: bold;
-}
-
-.ui.menu .item.main-user-name {
-  flex-shrink: 1;
-  display: inline-block;
-}
-
-.ui.tabular.menu .item.connection-icon {
-  padding-right: 0.5em;
-  padding-left: 0;
-}
-
-.ui.tabular.menu .item.main-menu-dropdown {
-  padding-right: 0.5em;
-  padding-left: 0;
-}
-
-.ui.menu:not(.vertical) .right.menu.main-menu {
-  margin-left: 0 !important; //SUI has !imporant
-}
-
-.explore-tile-title {
-  background-color: var(--tile-title-background);
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-
-  & .tabular.menu .item {
-    color: var(--tile-title-color);
-    letter-spacing: 0.1em;
-  }
-}
-
-.ui.menu.explore-tile-title-menu {
-  margin-top: 0;
-  cursor: pointer;
-  min-height: 36px;
-}
-
-.ui.menu.explore-tile-title-menu .item {
-  padding-left: 0.5em;
-  letter-spacing: 2px;
-}
-
-.ui.menu.explore-tile-title-menu a.item:hover {
-  background: unset;
-  color: unset;
-}
-
-.ui.button.tile-back-button {
-  margin-right: 0;
-
-  @media (min-width: @target-grid-responsive-cutoff) {
-    display: none;
-  }
 }
 
 .explore-tile-body {

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -117,10 +117,15 @@ body.light-theme {
   text-overflow: ellipsis;
 }
 
+.main-header > .ui.tabular.menu .item {
+  color: var(--main-header-color);
+}
+
 .main-header {
   grid-area: header;
   width: 100vw;
   min-width: 100vw;
+  background-color: var(--main-header-background-color);
 
   & > .ui.tabular.menu {
     border-bottom: none;
@@ -430,6 +435,7 @@ body.light-theme {
   padding-right: 0.2em;
   padding-left: 0.2em;
   overflow-y: auto;
+  border: solid 1px var(--under-tab-border-color);
 }
 
 .obs-item {

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -266,10 +266,12 @@ body.light-theme {
 .ui.menu.explore-tile-title-menu {
   margin-top: 0;
   cursor: pointer;
+  min-height: 36px;
 }
 
 .ui.menu.explore-tile-title-menu .item {
-  padding-left: 0;
+  padding-left: 0.5em;
+  letter-spacing: 2px;
 }
 
 .ui.menu.explore-tile-title-menu a.item:hover {
@@ -295,6 +297,21 @@ body.light-theme {
   .full-height-width();
 
   background-color: var(--tile-background);
+}
+
+.ui.basic.button.explore-tile-state-button:hover {
+  background: transparent;
+  transform: scale(1.05);
+  box-shadow: none;
+  outline: none;
+  filter: brightness(100%);
+}
+
+.explore-tile-state-button {
+  filter: brightness(80%);
+  margin-right: 0.5em;
+  transform-origin: center center;
+  transition: transform .25s, filter .25s ease-in;
 }
 
 .proposal-tile {
@@ -357,7 +374,6 @@ body.light-theme {
   // Special css to decorate the resize handle. It needs to be very specific
   .react-resizable-handle.react-resizable-handle-e {
     cursor: e-resize;
-    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiNmZmZmZmYwMCIgd2lkdGg9IjYiIGhlaWdodD0iNiI+CiAgPHBhdGggZD0iTTYgNkgwVjQuMmg0LjJWMEg2djZ6IiBvcGFjaXR5PSIuMzAyIiBmaWxsPSIjZTNkZWRiIi8+Cjwvc3ZnPgo=");
   }
 }
 
@@ -988,4 +1004,14 @@ html {
   // Required for iOS to work with 100vh
   // https://css-tricks.com/css-fix-for-100vh-in-mobile-webkit/
   height: -webkit-fill-available;
+}
+
+.observer-notes-wrapper {
+  display: flex;
+  justify-content: center;
+  align-content: center;
+}
+
+.observer-notes {
+  padding: 1em;
 }

--- a/common/src/main/resources/less/variables-dark.less
+++ b/common/src/main/resources/less/variables-dark.less
@@ -247,6 +247,7 @@
   --tile-background: var(--color-background-light-8);
   --tile-title-background: var(--color-background-light-12);
   --tile-title-color: var(--color-text-full);
+  --tile-resize-handle-brightness: 2;
 }
 
 .obs-badge-dark() {

--- a/common/src/main/resources/less/variables-dark.less
+++ b/common/src/main/resources/less/variables-dark.less
@@ -191,6 +191,8 @@
   --sidetab-background: var(--color-background-light-5);
   --explore-group-hover: var(--hover-background-color);
   --explore-group-dragging: var(--dragging-background-color);
+  --main-header-color: var(--text-color);
+  --main-header-background-color: var(--color-background);
 }
 
 .site-dark() {

--- a/common/src/main/resources/less/variables-light.less
+++ b/common/src/main/resources/less/variables-light.less
@@ -57,6 +57,8 @@
   --sidetab-background: @lightGrey;
   --explore-group-hover: @lightGrey;
   --explore-group-dragging: @grey;
+  --main-header-color: var(--negative-text-color);
+  --main-header-background-color: black;
 }
 
 .site-light() {

--- a/common/src/main/resources/less/variables-light.less
+++ b/common/src/main/resources/less/variables-light.less
@@ -112,6 +112,7 @@
   --tile-background: @lightGrey;
   --tile-title-background: darken(@lightGrey, 10%);
   --tile-title-color: var(--color-text-base);
+  --tile-resize-handle-brightness: 0;
 }
 
 .obs-badge-light() {

--- a/common/src/main/resources/less/vendor/react-grid-layout.less
+++ b/common/src/main/resources/less/vendor/react-grid-layout.less
@@ -1,16 +1,6 @@
-// React grid layout
 .react-grid-layout {
   position: relative;
   transition: height 200ms ease;
-}
-
-.non-draggable {
-  user-select: none;
-}
-
-.centered {
-  display: flex;
-  justify-content: center;
 }
 
 .react-grid-item {
@@ -33,6 +23,10 @@
   will-change: transform;
 }
 
+.react-grid-item.dropping {
+  visibility: hidden;
+}
+
 .react-grid-item.react-grid-placeholder {
   background: lightgreen;
   opacity: 0.2;
@@ -43,21 +37,6 @@
   -ms-user-select: none;
   -o-user-select: none;
   user-select: none;
-}
-
-.react-resizable-handle {
-  position: absolute;
-  width: 20px;
-  height: 20px;
-  bottom: 0;
-  right: 0;
-  background: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiNmZmZmZmYwMCIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iNnB4Ij48ZyBvcGFjaXR5PSIwLjMwMiI+PHBhdGggZD0iTSA2IDYgTCAwIDYgTCAwIDQuMiBMIDQgNC4yIEwgNC4yIDQuMiBMIDQuMiAwIEwgNiAwIEwgNiA2IEwgNiA2IFoiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+");
-  background-position: bottom right;
-  padding: 0 3px 3px 0;
-  background-repeat: no-repeat;
-  background-origin: content-box;
-  box-sizing: border-box;
-  cursor: se-resize;
 }
 
 .react-grid-item > .react-resizable-handle {
@@ -74,13 +53,12 @@
   position: absolute;
   right: 3px;
   bottom: 3px;
-  width: @gridSpace;
-  height: @gridSpace;
-  border-right: 2px solid rgba(255, 255, 255, 0.6);
-  border-bottom: 2px solid rgba(255, 255, 255, 0.6);
+  width: 5px;
+  height: 5px;
+  border-right: 2px solid rgba(0, 0, 0, 0.4);
+  border-bottom: 2px solid rgba(0, 0, 0, 0.4);
 }
 
-// React resizable
-.react-resizable {
-  position: relative;
+.react-resizable-hide > .react-resizable-handle {
+  display: none;
 }

--- a/common/src/main/resources/less/vendor/react-resizable.less
+++ b/common/src/main/resources/less/vendor/react-resizable.less
@@ -9,10 +9,11 @@
   background-repeat: no-repeat;
   background-origin: content-box;
   box-sizing: border-box;
-  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA2IDYiIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiNmZmZmZmYwMCIgeD0iMHB4IiB5PSIwcHgiIHdpZHRoPSI2cHgiIGhlaWdodD0iNnB4Ij48ZyBvcGFjaXR5PSIwLjMwMiI+PHBhdGggZD0iTSA2IDYgTCAwIDYgTCAwIDQuMiBMIDQgNC4yIEwgNC4yIDQuMiBMIDQuMiAwIEwgNiAwIEwgNiA2IEwgNiA2IFoiIGZpbGw9IiMwMDAwMDAiLz48L2c+PC9zdmc+");
+  // encoded resizable-handle.svg
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2IiBoZWlnaHQ9IjYiPgogIDxwYXRoIGQ9Ik02IDZIMFY0LjJoNC4yVjBINnY2eiIgZmlsbD0iI2UzZGVkYiIvPgo8L3N2Zz4K");
   background-position: bottom right;
   padding: 0 3px 3px 0;
-  color: white;
+  filter: brightness(var(--tile-resize-handle-brightness)) opacity(0.302);
 }
 
 .react-resizable-handle-sw {
@@ -46,7 +47,6 @@
 .react-resizable-handle-e {
   top: 50%;
   margin-top: -10px;
-  color: red;
   cursor: ew-resize;
 }
 

--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -35,4 +35,6 @@ object Icons {
   val Close               = Icon("close")
   val MousePointer        = Icon("mouse pointer")
   val Expand              = Icon("expand")
+  val Minimize            = Icon(className = "compress alt")
+  val Maximize            = Icon(className = "expand alt")
 }

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -10,12 +10,13 @@ import react.common.implicits._
 import react.common.style._
 
 object ExploreStyles {
-  val Tile: Css           = Css("explore-tile")
-  val TileTitle: Css      = Css("explore-tile-title")
-  val TileTitleMenu: Css  = Css("explore-tile-title-menu")
-  val TileBackButton: Css = Css("tile-back-button")
-  val TileBody: Css       = Css("explore-tile-body")
-  val TileButton: Css     = Css("explore-tile-button")
+  val Tile: Css            = Css("explore-tile")
+  val TileTitle: Css       = Css("explore-tile-title")
+  val TileTitleMenu: Css   = Css("explore-tile-title-menu")
+  val TileBackButton: Css  = Css("tile-back-button")
+  val TileBody: Css        = Css("explore-tile-body")
+  val TileButton: Css      = Css("explore-tile-button")
+  val TileStateButton: Css = Css("explore-tile-state-button")
 
   val TextInForm: Css = Css("explore-text-in-form")
   val Accented: Css   = Css("explore-accented")
@@ -94,6 +95,9 @@ object ExploreStyles {
   val SelectedObsItem: Css        = Css("selected-obs-item")
   val ObsItem: Css                = Css("obs-item")
   val TrashIcon: Css              = Css("trash-icon")
+
+  val ObserverNotes: Css = Css("observer-notes")
+  val NotesWrapper: Css  = Css("observer-notes-wrapper")
 
   val DraggingOver: Css = Css("dragging-over")
 

--- a/common/src/main/scala/explore/model/layout.scala
+++ b/common/src/main/scala/explore/model/layout.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import eu.timepit.refined.types.numeric.NonNegInt
+import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react.raw.JsNumber
+import lucuma.ui.reusability._
+import monocle.function.Field3._
+import monocle.function.Index._
+import monocle.macros.GenLens
+import monocle.{ Lens, Optional }
+import react.gridlayout._
+
+import scala.collection.immutable.SortedMap
+
+/**
+ * Utilities related to react-grid-layout
+ */
+object layout {
+  type LayoutEntry = (JsNumber, JsNumber, Layout)
+  type LayoutsMap  = SortedMap[BreakpointName, (JsNumber, JsNumber, Layout)]
+
+  val layoutItem       = GenLens[Layout](_.l)
+  val layoutItemHeight = GenLens[LayoutItem](_.h)
+  val layoutItemWidth  = GenLens[LayoutItem](_.w)
+  val layoutItemX      = GenLens[LayoutItem](_.x)
+  val layoutItemY      = GenLens[LayoutItem](_.y)
+
+  implicit class LayoutsOps[A](val layouts: Lens[A, LayoutsMap]) extends AnyVal {
+    def breakPoint(n:       BreakpointName): Optional[A, LayoutEntry] = layouts.composeOptional(index(n))
+    def breakPointLayout(n: BreakpointName, pos: NonNegInt): Optional[A, LayoutItem] =
+      breakPoint(n).composeLens(third).composeLens(layoutItem).composeOptional(index(pos.value))
+  }
+
+  implicit val breakpointNameReuse: Reusability[BreakpointName] = Reusability.by(_.name)
+  implicit val layoutItemReuse: Reusability[LayoutItem]         = Reusability.derive
+  implicit val layoutReuse: Reusability[Layout]                 = Reusability.by(_.l)
+  implicit val layoutsMapReuse: Reusability[LayoutsMap]         = Reusability.by(_.toList)
+}

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -12,7 +12,7 @@ import explore.components.ui.ExploreStyles
 import explore.components.{ Tile, TileButton }
 import explore.model.Focused.FocusedObs
 import explore.model._
-import explore.model.enum.{AppTab, TileSizeState}
+import explore.model.enum.{ AppTab, TileSizeState }
 import explore.model.reusability._
 import explore.observationtree.ObsList
 import explore.observationtree.ObsQueries._
@@ -24,7 +24,7 @@ import lucuma.ui.reusability._
 import lucuma.ui.utils._
 import monocle.function.Field3._
 import monocle.function.Index._
-import monocle.macros.{GenLens, Lenses}
+import monocle.macros.{ GenLens, Lenses }
 import org.scalajs.dom.window
 import react.common._
 import react.common.implicits._

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -105,7 +105,7 @@ object TargetTabContents {
                 val coreHeight: JsNumber = Option(s.height).getOrElse(0)
 
                 val rightSide =
-                  Tile(s"Target", movable = false, backButton.some)(
+                  Tile(s"Target", backButton.some)(
                     <.span(
                       targetIdOpt.whenDefined(targetId =>
                         TargetEditor(targetId).withKey(targetId.toString)

--- a/model/src/main/scala/explore/model/Constants.scala
+++ b/model/src/main/scala/explore/model/Constants.scala
@@ -11,6 +11,7 @@ trait Constants {
   val TwoPanelCutoff                = 550.0
   val InitialTreeWidth              = 300.0
   val MinLeftPanelWidth             = 270.0
+  val GridRowHeight                 = 36
 }
 
 object Constants extends Constants

--- a/model/src/main/scala/explore/model/enum/TileSizeState.scala
+++ b/model/src/main/scala/explore/model/enum/TileSizeState.scala
@@ -1,0 +1,17 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.enum
+
+import lucuma.core.util.Enumerated
+
+sealed abstract class TileSizeState extends Product with Serializable
+object TileSizeState {
+  case object Maximized extends TileSizeState
+  case object Minimized extends TileSizeState
+  case object Normal    extends TileSizeState
+
+  /** @group Typeclass Instances */
+  implicit val ExecutionEnvironmentEnumerated: Enumerated[TileSizeState] =
+    Enumerated.of(Maximized, Minimized, Normal)
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -30,7 +30,7 @@ object Settings {
     val reactClipboard    = "1.4.3"
     val reactCommon       = "0.11.3"
     val reactDatepicker   = "0.1.0"
-    val reactGridLayout   = "0.9.3"
+    val reactGridLayout   = "0.10.0"
     val reactHighcharts   = "0.2.0"
     val reactResizable    = "0.4.2"
     val reactSemanticUI   = "0.10.4"

--- a/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
@@ -162,7 +162,7 @@ object ProposalDetailsEditor {
             <.div(
               ^.key := "details",
               ExploreStyles.ProposalTile,
-              Tile("Details", movable = false, None)(
+              Tile("Details")(
                 Form(
                   <.div(
                     ExploreStyles.TwoColumnGrid,
@@ -248,7 +248,7 @@ object ProposalDetailsEditor {
               <.div(
                 ^.key := "preview",
                 ExploreStyles.ProposalTile,
-                Tile("Preview", movable = false, None)(
+                Tile("Preview")(
                   <.span("Placeholder for PDF preview.")
                 )
               ),

--- a/targeteditor/src/main/scala/explore/targeteditor/Test.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/Test.scala
@@ -22,7 +22,7 @@ object Test extends AppMain {
     IfLogged(view)((_, _) =>
       <.div(^.height := "100vh",
             ^.width := "100%",
-            Tile("Target", false, None)(
+            Tile("Target")(
               TargetEditor(id)
             )
       )


### PR DESCRIPTION
This PR adds a placeholder for the observation notes tile.
It is mostly work on the observation layout. In particular it now supports maximizing and restoring a fixed size tile

![screencast 2021-01-14 20-37-55](https://user-images.githubusercontent.com/3615303/104662153-f03dab80-56a8-11eb-9041-8850bf066e56.gif)
