### PR TITLE
Use scalajs-react-table for MagnitudesForm.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -126,11 +126,12 @@ lazy val common = project
         LucumaBC.value ++
         ReactGridLayout.value ++
         ReactClipboard.value ++
-        ReactCommon.value,
+        ReactCommon.value ++
+        ReactTable.value,
     buildInfoKeys := Seq[BuildInfoKey](
       scalaVersion,
       sbtVersion,
-      git.gitHeadCommit,
+      git.gitHeadCommit
     ),
     buildInfoKeys ++= {
       if (sys.env.contains("SBT_IGNORE_BUILDTIME")) Seq(BuildInfoKey.action("buildTime")(0L))

--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package explore.utils
 
 import cats._
@@ -6,7 +9,7 @@ import eu.timepit.refined.types.string._
 import explore._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.util.{Display, Enumerated}
+import lucuma.core.util.{ Display, Enumerated }
 import lucuma.ui.forms._
 import lucuma.ui.optics._
 import monocle.Lens

--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -1,0 +1,117 @@
+package explore.utils
+
+import cats._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string._
+import explore._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.util.{Display, Enumerated}
+import lucuma.ui.forms._
+import lucuma.ui.optics._
+import monocle.Lens
+import react.semanticui.elements.button.Button
+import reactST.reactTable.mod._
+
+import scalajs.js
+
+object ReactTableHelpers {
+
+  /**
+   * Create a AgGridColumn Builder for a column which edits the value in a FormInputEv.
+   * Since this returns a Builder, additional column configuration methods can
+   * be chained onto the return value.
+   *
+   * @param lens Lens to go between the Row value and the Cell value.
+   * @param validFormat The ValidFormatInput for the editor.
+   * @param changeAuditor The ChangeAuditor for the editor.
+   * @param disabled Whether editing should be disabled or not.
+   * @return An AgGridColumn Builder
+   */
+  def editableViewColumn[A, B](
+    lens:          Lens[A, B],
+    validFormat:   ValidFormatInput[B],
+    changeAuditor: ChangeAuditor[B] = ChangeAuditor.accept[B],
+    disabled:      Boolean = false,
+    modifiers:     Seq[TagMod] = Seq.empty
+  )(implicit eq:   Eq[B]) =
+    ScalaComponent
+      .builder[View[A]]
+      .render_P { va =>
+        FormInputEV(id = newId,
+                    value = va.zoom(lens),
+                    validFormat = validFormat,
+                    changeAuditor = changeAuditor,
+                    disabled = disabled,
+                    modifiers = modifiers
+        )
+      }
+      .build
+      .cmapCtorProps[(CellProps[View[A], _]) with js.Object](_.cell.row.original)
+      .toJsComponent
+      .raw
+
+  /**
+   * Create a AgGridColumn Builder for a column which edits the value via a EnumViewSelect.
+   * Obviously, the cell value must have an Enumerated instance.
+   * Since this returns a Builder, additional column configuration methods can
+   * be chained onto the return value.
+   *
+   * @param lens Lens to go between the Row value and the Cell value.
+   * @param disabled Whether editing should be disabled or not.
+   * @param excludeFn An optional function that determines a set of enums thst should be excluded from the dropdown.
+   * @return An AgGridColumn Builder.
+   */
+  def editableEnumViewColumn[A, B](lens: Lens[A, B])(
+    disabled:                            Boolean = false,
+    excludeFn:                           Option[View[A] => Set[B]] = None,
+    modifiers:                           Seq[TagMod] = Seq.empty
+  )(implicit enum:                       Enumerated[B], display: Display[B]) =
+    ScalaComponent
+      .builder[View[A]]
+      .render_P { va =>
+        val excluded = excludeFn.fold(Set.empty[B])(_.apply(va))
+        EnumViewSelect(id = newId,
+                       value = va.zoom(lens),
+                       exclude = excluded,
+                       disabled = disabled,
+                       modifiers = modifiers
+        )
+      }
+      .build
+      .cmapCtorProps[(CellProps[View[A], _]) with js.Object](_.cell.row.original)
+      .toJsComponent
+      .raw
+
+  /**
+   * Create a column containing a button.
+   * The button is passed in to allow maximum flexibility, but the
+   * onClick handler should not be specified for the button, since
+   * it will be added here.
+   *
+   * The [A] type is the type of the entire data row.
+   *
+   * @param button The button to put in the cell.
+   * @param onClick The onClick handler for the button.
+   * @param disabled Whether the button should be disabled.
+   * @return An AgGridColumn Builder.
+   */
+  def buttonViewColumn[A](
+    button:   Button,
+    onClick:  View[A] => Callback,
+    disabled: Boolean = false
+  ) =
+    ScalaComponent
+      .builder[View[A]]
+      .render_P { rowData =>
+        button.addModifiers(Seq(^.onClick ==> (_ => onClick(rowData)), ^.disabled := disabled))
+      }
+      .build
+      .cmapCtorProps[(CellProps[View[A], _]) with js.Object](_.cell.row.original)
+      .toJsComponent
+      .raw
+
+  private def newId: NonEmptyString = NonEmptyString
+    .from("Id" + java.util.UUID.randomUUID().toString().replace("-", ""))
+    .getOrElse("idddd")
+}

--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -21,15 +21,14 @@ import scalajs.js
 object ReactTableHelpers {
 
   /**
-   * Create a AgGridColumn Builder for a column which edits the value in a FormInputEv.
-   * Since this returns a Builder, additional column configuration methods can
-   * be chained onto the return value.
+   * Create a component which edits the value in a FormInputEv and can be passed
+   * to the TableMaker componentColumn method.
    *
    * @param lens Lens to go between the Row value and the Cell value.
    * @param validFormat The ValidFormatInput for the editor.
    * @param changeAuditor The ChangeAuditor for the editor.
    * @param disabled Whether editing should be disabled or not.
-   * @return An AgGridColumn Builder
+   * @return The component.
    */
   def editableViewColumn[A, B](
     lens:          Lens[A, B],
@@ -55,15 +54,13 @@ object ReactTableHelpers {
       .raw
 
   /**
-   * Create a AgGridColumn Builder for a column which edits the value via a EnumViewSelect.
-   * Obviously, the cell value must have an Enumerated instance.
-   * Since this returns a Builder, additional column configuration methods can
-   * be chained onto the return value.
+   * Create a component which edits the value via a EnumViewSelect and can be passed
+   * to the TableMaker componentColumn method.
    *
    * @param lens Lens to go between the Row value and the Cell value.
    * @param disabled Whether editing should be disabled or not.
    * @param excludeFn An optional function that determines a set of enums thst should be excluded from the dropdown.
-   * @return An AgGridColumn Builder.
+   * @return The component.
    */
   def editableEnumViewColumn[A, B](lens: Lens[A, B])(
     disabled:                            Boolean = false,
@@ -87,7 +84,8 @@ object ReactTableHelpers {
       .raw
 
   /**
-   * Create a column containing a button.
+   * Create a component containing a button which can be passed to the
+   * TableMaker componentColumn method.
    * The button is passed in to allow maximum flexibility, but the
    * onClick handler should not be specified for the button, since
    * it will be added here.
@@ -97,7 +95,7 @@ object ReactTableHelpers {
    * @param button The button to put in the cell.
    * @param onClick The onClick handler for the button.
    * @param disabled Whether the button should be disabled.
-   * @return An AgGridColumn Builder.
+   * @return The component.
    */
   def buttonViewColumn[A](
     button:   Button,

--- a/explore/yarn.lock
+++ b/explore/yarn.lock
@@ -2,14 +2,14 @@
 # yarn lockfile v1
 
 
-"@atlaskit/tree@8.1.1":
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/@atlaskit/tree/-/tree-8.1.1.tgz#8cb4f2ea33a54a566b9409a4ce35b439dfadc8f0"
-  integrity sha512-k4AwWgl38Bf62mCgkwoPloGVIIDpJuoWDtATp8iZl0tCnSD5vW2tDGwksF8/Jm3ZBFfLrsCqL58BSqfoRo7S5g==
+"@atlaskit/tree@8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@atlaskit/tree/-/tree-8.2.0.tgz#92acb031ad7708901adc46897ff3c4677801e845"
+  integrity sha512-5RiZxGl/EkNb4d/7bkgC/fSLW4u8l3c1pxLYsaGwuhHOW13cJUy0jCTvYSKS7iZ8fXwoTX1xuiOtt4CBPVnHvg==
   dependencies:
+    "@babel/runtime" "^7.0.0"
     css-box-model "^1.2.0"
     react-beautiful-dnd-next "11.0.5"
-    tslib "^2.0.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
@@ -91,17 +91,17 @@
     core-js "^2.6.5"
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.6.2":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.10.5", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
   integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.6.2":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
-  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -604,10 +604,40 @@
     date-fns "^2.0.1"
     popper.js "^1.14.1"
 
+"@types/react-dom@16.9.10":
+  version "16.9.10"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.10.tgz#4485b0bec3d41f856181b717f45fd7831101156f"
+  integrity sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==
+  dependencies:
+    "@types/react" "^16"
+
+"@types/react-table@7.0.26":
+  version "7.0.26"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-7.0.26.tgz#fd244f65c30697242a920d0eaef8947d85bb7755"
+  integrity sha512-LF1wKGXo5LN1MY5DqD8aaqHaIpN2atZ+NslxG0P8TNUdrZATqZ9lD6b81OQB6GjtN7n7Jw48TqfP5apOMyfulQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*":
   version "16.9.52"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.52.tgz#c46c72d1a1d8d9d666f4dd2066c0e22600ccfde1"
   integrity sha512-EHRjmnxiNivwhGdMh9sz1Yw9AUxTSZFxKqdBWAAzyZx3sufWwx6ogqHYh/WB1m/I4ZpjkoZLExF5QTy2ekVi/Q==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@16.9.56":
+  version "16.9.56"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.56.tgz#ea25847b53c5bec064933095fc366b1462e2adf0"
+  integrity sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16":
+  version "16.14.2"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.2.tgz#85dcc0947d0645349923c04ccef6018a1ab7538c"
+  integrity sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -6159,6 +6189,11 @@ react-sizeme@2.6.12:
     shallowequal "^1.1.0"
     throttle-debounce "^2.1.0"
 
+react-table@7.6.2:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-7.6.2.tgz#b60932fa6d457c2bca0da49815cd6a8fe9451f77"
+  integrity sha512-urwNZTieb+xg/+BITUIrqdH5jZfJlw7rKVAAq25iXpBPwbQojLCEKJuGycLbVwn8fzU+Ovly3y8HHNaLNrPCvQ==
+
 react@16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
@@ -7343,11 +7378,6 @@ tslib@^1.10.0, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -35,6 +35,7 @@ object Settings {
     val reactResizable    = "0.4.2"
     val reactSemanticUI   = "0.10.4"
     val reactSizeMe       = "0.6.4"
+    val reactTable        = "0.0.1"
     val scalaJsReact      = "1.7.7"
     val sttp              = "3.0.0"
   }
@@ -235,6 +236,12 @@ object Settings {
       deps(
         "io.github.cquiroz.react" %%% "react-semantic-ui"
       )(reactSemanticUI)
+    )
+
+    val ReactTable = Def.setting(
+      deps(
+        "io.github.toddburnside" %%% "scalajs-react-table"
+      )(reactTable)
     )
 
     val ScalaJSReact = Def.setting(


### PR DESCRIPTION
[ch568]
Magnitudes table should look exactly the same as the previous version with the SemanticUI table.

The code for adding controls to columns is MUCH simpler than for ag-grid (ReactTableHelpers).

<img width="477" alt="image" src="https://user-images.githubusercontent.com/6035943/105908697-66141200-5fdb-11eb-8981-5a136ecf0bf4.png">
