### PR TITLE
Use safari hack only on safari or it triggers a chrome bug

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -78,8 +78,6 @@ body.light-theme {
 
   display: grid;
   min-height: 100vh;
-  // Required for iOS to work with 100vh
-  min-height: -webkit-fill-available;
   width: 100%;
   overflow: hidden;
   grid-template-columns: 1fr;
@@ -95,6 +93,14 @@ body.light-theme {
     grid-template-areas:
       "header header"
       "sidebar body";
+  }
+}
+
+/* Avoid Chrome to see Safari hack */
+@supports (-webkit-touch-callout: none) {
+  .main-grid {
+    /* The hack for Safari */
+    min-height: -webkit-fill-available;
   }
 }
 


### PR DESCRIPTION
To get 100vh to work in Safari iOS we used a custom safari property but it produced an issue in chrome

This fixes by making the css conditional to iOS