### PR TITLE
Asterisms in target view tree

### DIFF
--- a/common/src/main/resources/conf/development.conf.json
+++ b/common/src/main/resources/conf/development.conf.json
@@ -1,6 +1,6 @@
 {
   "environment": "DEVELOPMENT",
-  "odbURI": "wss://lucuma-odb-p-obs-target-1hnxxk.herokuapp.com/ws",
+  "odbURI": "wss://lucuma-odb-staging.herokuapp.com/ws",
   "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
   "sso": {
     "uri": "https://sso.gpp.lucuma.xyz",

--- a/common/src/main/resources/conf/development.conf.json
+++ b/common/src/main/resources/conf/development.conf.json
@@ -1,11 +1,11 @@
 {
   "environment": "DEVELOPMENT",
-  "odbURI": "wss://odb.gpp.lucuma.xyz/ws",
+  "odbURI": "wss://lucuma-odb-p-obs-target-1hnxxk.herokuapp.com/ws",
   "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
   "sso": {
     "uri": "https://sso.gpp.lucuma.xyz",
     "readTimeoutSeconds": 10,
     "refreshTimeoutDeltaSeconds": 10,
-    "refreshIntervalFactor": 10
+    "refreshIntervalFactor": 1
   }
 }

--- a/common/src/main/resources/graphql/schemas/ObservationDB.graphql
+++ b/common/src/main/resources/graphql/schemas/ObservationDB.graphql
@@ -1,10 +1,13 @@
-# Common fields shared by all asterisms
-interface Asterism {
+# Collection of stars observed in a single observation
+type Asterism {
   # Asterism ID
   id: AsterismId!
 
   # Whether the asterism is deleted or present
   existence: Existence!
+
+  # Asterism name, if any.
+  name: String
 
   # When set, overrides the default base position of the asterism
   explicitBase: Coordinates
@@ -44,10 +47,28 @@ type AsterismEdit implements Event {
 # AsterismId id formatted as `a-(0|[1-9a-f][0-9a-f]*)`
 scalar AsterismId
 
+# Asterism and the observations with which they are associated
+input AsterismObservationLinks {
+  asterismId: AsterismId!
+  observationIds: [ObservationId!]!
+}
+
 # Asterism and the programs with which they are associated
 input AsterismProgramLinks {
-  asterismIds: [AsterismId!]!
+  asterismId: AsterismId!
   programIds: [ProgramId!]!
+}
+
+# Asterism and the targets with which they are associated
+input AsterismTargetLinks {
+  asterismId: AsterismId!
+  targetIds: [TargetId!]!
+}
+
+# Bias calibration step
+type Bias implements StepConfig {
+  # Step type
+  stepType: StepType!
 }
 
 # The `BigDecimal` scalar type represents signed fractional values with arbitrary precision.
@@ -79,6 +100,12 @@ enum CatalogName {
   GAIA
 }
 
+# Instrument configuration
+interface Config {
+  # Instrument type
+  instrument: InstrumentType!
+}
+
 type Coordinates {
   # Right Ascension
   ra: RightAscension!
@@ -96,11 +123,9 @@ input CoordinatesInput {
 # Default asterism parameters
 input CreateDefaultAsterismInput {
   asterismId: AsterismId
+  name: String
   programIds: [ProgramId!]!
   explicitBase: CoordinatesInput
-
-  # Targets to include in default asterism
-  targetIds: [TargetId!]!
 }
 
 # Nonsidereal target parameters
@@ -119,6 +144,7 @@ input CreateObservationInput {
   programId: ProgramId!
   name: String
   asterismId: AsterismId
+  targetId: TargetId
   status: ObsStatus
 }
 
@@ -135,6 +161,12 @@ input CreateSiderealInput {
   radialVelocity: RadialVelocityInput
   parallax: ParallaxModelInput
   magnitudes: [MagnitudeInput!]
+}
+
+# Dark calibration step
+type Dark implements StepConfig {
+  # Step type
+  stepType: StepType!
 }
 
 type Declination {
@@ -184,39 +216,6 @@ enum DeclinationUnits {
   DEGREES
 }
 
-# Default asterism
-type DefaultAsterism implements Asterism {
-  # Asterism ID
-  id: AsterismId!
-
-  # Whether the asterism is deleted or present
-  existence: Existence!
-
-  # When set, overrides the default base position of the asterism
-  explicitBase: Coordinates
-
-  # All observations associated with the asterism.
-  observations(
-    # Program ID
-    programId: ProgramId
-
-    # Set to true to include deleted values
-    includeDeleted: Boolean! = false
-  ): [Observation!]!
-
-  # All asterism targets
-  targets(
-    # Set to true to include deleted values
-    includeDeleted: Boolean! = false
-  ): [Target!]!
-
-  # The programs associated with the asterism.
-  programs(
-    # Set to true to include deleted values
-    includeDeleted: Boolean! = false
-  ): [Program!]!
-}
-
 # Target declination coordinate in format '[+/-]DD:MM:SS.sss'
 scalar DmsString
 
@@ -240,34 +239,40 @@ type Duration {
 # Default asterism edit
 input EditDefaultAsterismInput {
   asterismId: AsterismId!
-  existence: Existence
-  explicitBase: CoordinatesInput
 
-  # Targets to include in the default asterism
-  targetIds: [TargetId!]
+  # The existence field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  existence: Existence
+
+  # The name field may be unset by assigning a null value, or ignored by skipping it altogether
+  name: String
+
+  # The explicitBase field may be unset by assigning a null value, or ignored by skipping it altogether
+  explicitBase: CoordinatesInput
 }
 
 # Edit observation
 input EditObservationInput {
   observationId: ObservationId!
+
+  # The existence field must be either specified or skipped altogether.  It cannot be unset with a null value.
   existence: Existence
+
+  # The name field may be unset by assigning a null value, or ignored by skipping it altogether
   name: String
+
+  # The status field must be either specified or skipped altogether.  It cannot be unset with a null value.
   status: ObsStatus
+
+  # The asterismId field may be unset by assigning a null value, or ignored by skipping it altogether
   asterismId: AsterismId
+
+  # The targetId field may be unset by assigning a null value, or ignored by skipping it altogether
+  targetId: TargetId
 }
 
 # Sidereal target edit parameters
 input EditSiderealInput {
   targetId: TargetId!
-  existence: Existence
-  name: String
-  catalogId: CatalogIdInput
-  ra: RightAscensionInput
-  dec: DeclinationInput
-  epoch: EpochString
-  properMotion: ProperMotionInput
-  radialVelocity: RadialVelocityInput
-  parallax: ParallaxModelInput
 
   # Replace all magnitudes with the provided values
   magnitudes: [MagnitudeInput!]
@@ -277,6 +282,33 @@ input EditSiderealInput {
 
   # Removes any listed magnitude values
   deleteMagnitudes: [MagnitudeBand!]
+
+  # The existence field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  existence: Existence
+
+  # The name field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  name: String
+
+  # The catalogId field may be unset by assigning a null value, or ignored by skipping it altogether
+  catalogId: CatalogIdInput
+
+  # The ra field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  ra: RightAscensionInput
+
+  # The dec field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  dec: DeclinationInput
+
+  # The epoch field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  epoch: EpochString
+
+  # The properMotion field may be unset by assigning a null value, or ignored by skipping it altogether
+  properMotion: ProperMotionInput
+
+  # The radialVelocity field may be unset by assigning a null value, or ignored by skipping it altogether
+  radialVelocity: RadialVelocityInput
+
+  # The parallax field may be unset by assigning a null value, or ignored by skipping it altogether
+  parallax: ParallaxModelInput
 }
 
 # Type of edit that triggered an event
@@ -323,8 +355,850 @@ enum Existence {
   DELETED
 }
 
+# GCAL calibration step (flat / arc)
+type Gcal implements StepConfig {
+  # GCAL continuum, present if no arcs are used
+  continuum: GcalContinuum
+
+  # GCAL arcs, one or more present if no continuum is used
+  arcs: [GcalArc!]!
+
+  # GCAL filter
+  filter: GcalFilter!
+
+  # GCAL diffuser
+  diffuser: GcalDiffuser!
+
+  # GCAL shutter
+  shutter: GcalShutter!
+
+  # GCAL exposure time
+  exposure: Duration!
+
+  # GCAL coadds
+  coadds: Int!
+
+  # Step type
+  stepType: StepType!
+}
+
+# GCAL arc
+enum GcalArc {
+  # GcalArc ArArc
+  AR_ARC
+
+  # GcalArc ThArArc
+  TH_AR_ARC
+
+  # GcalArc CuArArc
+  CU_AR_ARC
+
+  # GcalArc XeArc
+  XE_ARC
+}
+
+# GCAL continuum
+enum GcalContinuum {
+  # GcalContinuum IrGreyBodyLow
+  IR_GREY_BODY_LOW
+
+  # GcalContinuum IrGreyBodyHigh
+  IR_GREY_BODY_HIGH
+
+  # GcalContinuum QuartzHalogen
+  QUARTZ_HALOGEN
+}
+
+# GCAL diffuser
+enum GcalDiffuser {
+  # GcalDiffuser Ir
+  IR
+
+  # GcalDiffuser Visible
+  VISIBLE
+}
+
+# GCAL filter
+enum GcalFilter {
+  # GcalFilter None
+  NONE
+
+  # GcalFilter Gmos
+  GMOS
+
+  # GcalFilter Hros
+  HROS
+
+  # GcalFilter Nir
+  NIR
+
+  # GcalFilter Nd10
+  ND10
+
+  # GcalFilter Nd16
+  ND16
+
+  # GcalFilter Nd20
+  ND20
+
+  # GcalFilter Nd30
+  ND30
+
+  # GcalFilter Nd40
+  ND40
+
+  # GcalFilter Nd45
+  ND45
+
+  # GcalFilter Nd50
+  ND50
+}
+
+# GCAL shutter
+enum GcalShutter {
+  # GcalShutter Open
+  OPEN
+
+  # GcalShutter Closed
+  CLOSED
+}
+
+# GMOS amp count
+enum GmosAmpCount {
+  # GmosAmpCount Three
+  THREE
+
+  # GmosAmpCount Six
+  SIX
+
+  # GmosAmpCount Twelve
+  TWELVE
+}
+
+# GMOS amp read mode
+enum GmosAmpReadMode {
+  # GmosAmpReadMode Slow
+  SLOW
+
+  # GmosAmpReadMode Fast
+  FAST
+}
+
+# CCD Readout Configuration
+type GmosCcdMode {
+  # GMOS X-binning
+  xBin: GmosXBinning!
+
+  # GMOS Y-binning
+  yBin: GmosYBinning!
+
+  # GMOS Amp Count
+  ampCount: GmosAmpCount!
+
+  # GMOS Amp Gain
+  ampGain: GmosAmpCount!
+
+  # GMOS Amp Read Mode
+  ampReadMode: GmosAmpReadMode!
+}
+
+# GMOS Custom Mask
+type GmosCustomMask {
+  # Custom Mask Filename
+  filename: String!
+
+  # Custom Slit Width
+  slitWidth: GmosCustomSlitWidth!
+}
+
+# GMOS Custom Slit Width
+enum GmosCustomSlitWidth {
+  # GmosCustomSlitWidth CustomWidth_0_25
+  CUSTOM_WIDTH_0_25
+
+  # GmosCustomSlitWidth CustomWidth_0_50
+  CUSTOM_WIDTH_0_50
+
+  # GmosCustomSlitWidth CustomWidth_0_75
+  CUSTOM_WIDTH_0_75
+
+  # GmosCustomSlitWidth CustomWidth_1_00
+  CUSTOM_WIDTH_1_00
+
+  # GmosCustomSlitWidth CustomWidth_1_50
+  CUSTOM_WIDTH_1_50
+
+  # GmosCustomSlitWidth CustomWidth_2_00
+  CUSTOM_WIDTH_2_00
+
+  # GmosCustomSlitWidth CustomWidth_5_00
+  CUSTOM_WIDTH_5_00
+}
+
+# Detector type
+enum GmosDetector {
+  # GmosDetector E2V
+  E2_V
+
+  # GmosDetector HAMAMATSU
+  HAMAMATSU
+}
+
+# GMOS disperser order
+enum GmosDisperserOrder {
+  # GmosDisperserOrder Zero
+  ZERO
+
+  # GmosDisperserOrder One
+  ONE
+
+  # GmosDisperserOrder Two
+  TWO
+}
+
+# GMOS Detector Translation X Offset
+enum GmosDtax {
+  # GmosDtax MinusSix
+  MINUS_SIX
+
+  # GmosDtax MinusFive
+  MINUS_FIVE
+
+  # GmosDtax MinusFour
+  MINUS_FOUR
+
+  # GmosDtax MinusThree
+  MINUS_THREE
+
+  # GmosDtax MinusTwo
+  MINUS_TWO
+
+  # GmosDtax MinusOne
+  MINUS_ONE
+
+  # GmosDtax Zero
+  ZERO
+
+  # GmosDtax One
+  ONE
+
+  # GmosDtax Two
+  TWO
+
+  # GmosDtax Three
+  THREE
+
+  # GmosDtax Four
+  FOUR
+
+  # GmosDtax Five
+  FIVE
+
+  # GmosDtax Six
+  SIX
+}
+
+# Electronic offsetting
+enum GmosEOffsetting {
+  # GmosEOffsetting On
+  ON
+
+  # GmosEOffsetting Off
+  OFF
+}
+
+# Either custom mask or builtin-FPU
+union GmosFpu = GmosCustomMask | GmosNorthBuiltinFpu
+
+type GmosNodAndShuffle {
+  # Offset position A
+  posA: Offset!
+
+  # Offset position B
+  posB: Offset!
+
+  # Whether to use electronic offsetting
+  eOffset: GmosEOffsetting!
+
+  # Shuffle offset
+  shuffleOffset: Int!
+
+  # Shuffle cycles
+  shuffleCycles: Int!
+}
+
+# GMOS North builtin-in FPU
+type GmosNorthBuiltinFpu {
+  # GMOS North builtin-fpu
+  builtin: GmosNorthFpu!
+}
+
+# GMOS North Configuration
+type GmosNorthConfig implements Config {
+  # GMOS North manual sequence configuration
+  manual: GmosNorthSequence!
+
+  # Instrument type
+  instrument: InstrumentType!
+}
+
+# GMOS North Disperser
+enum GmosNorthDisperser {
+  # GmosNorthDisperser B1200_G5301
+  B1200_G5301
+
+  # GmosNorthDisperser R831_G5302
+  R831_G5302
+
+  # GmosNorthDisperser B600_G5303
+  B600_G5303
+
+  # GmosNorthDisperser B600_G5307
+  B600_G5307
+
+  # GmosNorthDisperser R600_G5304
+  R600_G5304
+
+  # GmosNorthDisperser R400_G5305
+  R400_G5305
+
+  # GmosNorthDisperser R150_G5306
+  R150_G5306
+
+  # GmosNorthDisperser R150_G5308
+  R150_G5308
+}
+
+# GMOS North dynamic step configuration
+type GmosNorthDynamic {
+  # GMOS exposure time
+  exposure: Duration!
+
+  # GMOS CCD Readout
+  readout: GmosCcdMode!
+
+  # GMOS detector x offset
+  dtax: GmosDtax!
+
+  # GMOS region of interest
+  roi: GmosRoi!
+
+  # GMOS North grating
+  grating: GmosNorthGrating
+
+  # GMOS North filter
+  filter: GmosNorthFilter
+
+  # GMOS North FPU
+  fpu: GmosFpu
+}
+
+# GMOS North Filter
+enum GmosNorthFilter {
+  # GmosNorthFilter GPrime
+  G_PRIME
+
+  # GmosNorthFilter RPrime
+  R_PRIME
+
+  # GmosNorthFilter IPrime
+  I_PRIME
+
+  # GmosNorthFilter ZPrime
+  Z_PRIME
+
+  # GmosNorthFilter Z
+  Z
+
+  # GmosNorthFilter Y
+  Y
+
+  # GmosNorthFilter GG455
+  GG455
+
+  # GmosNorthFilter OG515
+  OG515
+
+  # GmosNorthFilter RG610
+  RG610
+
+  # GmosNorthFilter CaT
+  CA_T
+
+  # GmosNorthFilter Ha
+  HA
+
+  # GmosNorthFilter HaC
+  HA_C
+
+  # GmosNorthFilter DS920
+  DS920
+
+  # GmosNorthFilter SII
+  SII
+
+  # GmosNorthFilter OIII
+  OIII
+
+  # GmosNorthFilter OIIIC
+  OIIIC
+
+  # GmosNorthFilter HeII
+  HE_II
+
+  # GmosNorthFilter HeIIC
+  HE_IIC
+
+  # GmosNorthFilter HartmannA_RPrime
+  HARTMANN_A_R_PRIME
+
+  # GmosNorthFilter HartmannB_RPrime
+  HARTMANN_B_R_PRIME
+
+  # GmosNorthFilter GPrime_GG455
+  G_PRIME_GG455
+
+  # GmosNorthFilter GPrime_OG515
+  G_PRIME_OG515
+
+  # GmosNorthFilter RPrime_RG610
+  R_PRIME_RG610
+
+  # GmosNorthFilter IPrime_CaT
+  I_PRIME_CA_T
+
+  # GmosNorthFilter ZPrime_CaT
+  Z_PRIME_CA_T
+
+  # GmosNorthFilter UPrime
+  U_PRIME
+}
+
+# GMOS North FPU
+enum GmosNorthFpu {
+  # GmosNorthFpu Ns0
+  NS0
+
+  # GmosNorthFpu Ns1
+  NS1
+
+  # GmosNorthFpu Ns2
+  NS2
+
+  # GmosNorthFpu Ns3
+  NS3
+
+  # GmosNorthFpu Ns4
+  NS4
+
+  # GmosNorthFpu Ns5
+  NS5
+
+  # GmosNorthFpu LongSlit_0_25
+  LONG_SLIT_0_25
+
+  # GmosNorthFpu LongSlit_0_50
+  LONG_SLIT_0_50
+
+  # GmosNorthFpu LongSlit_0_75
+  LONG_SLIT_0_75
+
+  # GmosNorthFpu LongSlit_1_00
+  LONG_SLIT_1_00
+
+  # GmosNorthFpu LongSlit_1_50
+  LONG_SLIT_1_50
+
+  # GmosNorthFpu LongSlit_2_00
+  LONG_SLIT_2_00
+
+  # GmosNorthFpu LongSlit_5_00
+  LONG_SLIT_5_00
+
+  # GmosNorthFpu Ifu1
+  IFU1
+
+  # GmosNorthFpu Ifu2
+  IFU2
+
+  # GmosNorthFpu Ifu3
+  IFU3
+}
+
+# GMOS North Grating
+type GmosNorthGrating {
+  # GMOS North Disperser
+  disperser: GmosNorthDisperser!
+
+  # GMOS disperser order
+  order: GmosDisperserOrder!
+
+  # Grating wavelength
+  wavelength: Wavelength!
+}
+
+# Instrument sequence
+type GmosNorthSequence {
+  # Static/unchanging configuration
+  static: GmosNorthStaticConfig!
+
+  # Acquisition sequence
+  acquisition: [GmosNorthStep!]!
+
+  # Science sequence
+  science: [GmosNorthStep!]!
+}
+
+# GMOS North stage mode
+enum GmosNorthStageMode {
+  # GmosNorthStageMode NoFollow
+  NO_FOLLOW
+
+  # GmosNorthStageMode FollowXyz
+  FOLLOW_XYZ
+
+  # GmosNorthStageMode FollowXy
+  FOLLOW_XY
+
+  # GmosNorthStageMode FollowZ
+  FOLLOW_Z
+}
+
+# Unchanging (over the course of the sequence) configuration values
+type GmosNorthStaticConfig {
+  # Stage mode
+  stageMode: GmosNorthStageMode!
+
+  # Detector in use (always HAMAMATSU for recent and new observations)
+  detector: GmosDetector!
+
+  # Is MOS Pre-Imaging Observation
+  mosPreImaging: MosPreImaging!
+
+  # Nod-and-shuffle configuration
+  nodAndShuffle: GmosNodAndShuffle
+}
+
+# Step (bias, dark, science, etc.)
+type GmosNorthStep {
+  # Step type
+  stepType: StepType!
+
+  # Instrument configuration
+  instrumentConfig: GmosNorthDynamic!
+
+  # Step configuration
+  stepConfig: StepConfig!
+}
+
+# GMOS Region Of Interest
+enum GmosRoi {
+  # GmosRoi FullFrame
+  FULL_FRAME
+
+  # GmosRoi Ccd2
+  CCD2
+
+  # GmosRoi CentralSpectrum
+  CENTRAL_SPECTRUM
+
+  # GmosRoi CentralStamp
+  CENTRAL_STAMP
+
+  # GmosRoi TopSpectrum
+  TOP_SPECTRUM
+
+  # GmosRoi BottomSpectrum
+  BOTTOM_SPECTRUM
+
+  # GmosRoi Custom
+  CUSTOM
+}
+
+# GMOS South Configuration
+type GmosSouthConfig implements Config {
+  # GMOS South manual sequence configuration
+  manual: GmosSouthSequence!
+
+  # Instrument type
+  instrument: InstrumentType!
+}
+
+# GMOS South Disperser
+enum GmosSouthDisperser {
+  # GmosSouthDisperser B1200_G5321
+  B1200_G5321
+
+  # GmosSouthDisperser R831_G5322
+  R831_G5322
+
+  # GmosSouthDisperser B600_G5323
+  B600_G5323
+
+  # GmosSouthDisperser R600_G5324
+  R600_G5324
+
+  # GmosSouthDisperser R400_G5325
+  R400_G5325
+
+  # GmosSouthDisperser R150_G5326
+  R150_G5326
+}
+
+# GMOS South dynamic step configuration
+type GmosSouthDynamic {
+  # GMOS exposure time
+  exposure: Duration!
+
+  # GMOS CCD Readout
+  readout: GmosCcdMode!
+
+  # GMOS detector x offset
+  dtax: GmosDtax!
+
+  # GMOS region of interest
+  roi: GmosRoi!
+
+  # GMOS South grating
+  grating: GmosSouthGrating
+
+  # GMOS South filter
+  filter: GmosSouthFilter
+
+  # GMOS South FPU
+  fpu: GmosFpu
+}
+
+# GMOS South Filter
+enum GmosSouthFilter {
+  # GmosSouthFilter UPrime
+  U_PRIME
+
+  # GmosSouthFilter GPrime
+  G_PRIME
+
+  # GmosSouthFilter RPrime
+  R_PRIME
+
+  # GmosSouthFilter IPrime
+  I_PRIME
+
+  # GmosSouthFilter ZPrime
+  Z_PRIME
+
+  # GmosSouthFilter Z
+  Z
+
+  # GmosSouthFilter Y
+  Y
+
+  # GmosSouthFilter GG455
+  GG455
+
+  # GmosSouthFilter OG515
+  OG515
+
+  # GmosSouthFilter RG610
+  RG610
+
+  # GmosSouthFilter RG780
+  RG780
+
+  # GmosSouthFilter CaT
+  CA_T
+
+  # GmosSouthFilter HartmannA_RPrime
+  HARTMANN_A_R_PRIME
+
+  # GmosSouthFilter HartmannB_RPrime
+  HARTMANN_B_R_PRIME
+
+  # GmosSouthFilter GPrime_GG455
+  G_PRIME_GG455
+
+  # GmosSouthFilter GPrime_OG515
+  G_PRIME_OG515
+
+  # GmosSouthFilter RPrime_RG610
+  R_PRIME_RG610
+
+  # GmosSouthFilter IPrime_RG780
+  I_PRIME_RG780
+
+  # GmosSouthFilter IPrime_CaT
+  I_PRIME_CA_T
+
+  # GmosSouthFilter ZPrime_CaT
+  Z_PRIME_CA_T
+
+  # GmosSouthFilter Ha
+  HA
+
+  # GmosSouthFilter SII
+  SII
+
+  # GmosSouthFilter HaC
+  HA_C
+
+  # GmosSouthFilter OIII
+  OIII
+
+  # GmosSouthFilter OIIIC
+  OIIIC
+
+  # GmosSouthFilter HeII
+  HE_II
+
+  # GmosSouthFilter HeIIC
+  HE_IIC
+
+  # GmosSouthFilter Lya395
+  LYA395
+}
+
+# GMOS South Grating
+type GmosSouthGrating {
+  # GMOS South Disperser
+  disperser: GmosSouthDisperser!
+
+  # GMOS disperser order
+  order: GmosDisperserOrder!
+
+  # Grating wavelength
+  wavelength: Wavelength!
+}
+
+# Instrument sequence
+type GmosSouthSequence {
+  # Static/unchanging configuration
+  static: GmosSouthStaticConfig!
+
+  # Acquisition sequence
+  acquisition: [GmosSouthStep!]!
+
+  # Science sequence
+  science: [GmosSouthStep!]!
+}
+
+# GMOS South stage mode
+enum GmosSouthStageMode {
+  # GmosSouthStageMode NoFollow
+  NO_FOLLOW
+
+  # GmosSouthStageMode FollowXyz
+  FOLLOW_XYZ
+
+  # GmosSouthStageMode FollowXy
+  FOLLOW_XY
+
+  # GmosSouthStageMode FollowZ
+  FOLLOW_Z
+}
+
+# Unchanging (over the course of the sequence) configuration values
+type GmosSouthStaticConfig {
+  # Stage mode
+  stageMode: GmosSouthStageMode!
+
+  # Detector in use (always HAMAMATSU for recent and new observations)
+  detector: GmosDetector!
+
+  # Is MOS Pre-Imaging Observation
+  mosPreImaging: MosPreImaging!
+
+  # Nod-and-shuffle configuration
+  nodAndShuffle: GmosNodAndShuffle
+}
+
+# Step (bias, dark, science, etc.)
+type GmosSouthStep {
+  # Step type
+  stepType: StepType!
+
+  # Instrument configuration
+  instrumentConfig: GmosSouthDynamic!
+
+  # Step configuration
+  stepConfig: StepConfig!
+}
+
+# GMOS X Binning
+enum GmosXBinning {
+  # GmosXBinning One
+  ONE
+
+  # GmosXBinning Two
+  TWO
+
+  # GmosXBinning Four
+  FOUR
+}
+
+# GMOS Y Binning
+enum GmosYBinning {
+  # GmosYBinning One
+  ONE
+
+  # GmosYBinning Two
+  TWO
+
+  # GmosYBinning Four
+  FOUR
+}
+
 # Target right ascension coordinate in format 'HH:MM:SS.sss'
 scalar HmsString
+
+# Instrument
+enum InstrumentType {
+  # InstrumentType Phoenix
+  PHOENIX
+
+  # InstrumentType Michelle
+  MICHELLE
+
+  # InstrumentType Gnirs
+  GNIRS
+
+  # InstrumentType Niri
+  NIRI
+
+  # InstrumentType Trecs
+  TRECS
+
+  # InstrumentType Nici
+  NICI
+
+  # InstrumentType Nifs
+  NIFS
+
+  # InstrumentType Gpi
+  GPI
+
+  # InstrumentType Gsaoi
+  GSAOI
+
+  # InstrumentType GmosS
+  GMOS_S
+
+  # InstrumentType AcqCam
+  ACQ_CAM
+
+  # InstrumentType GmosN
+  GMOS_N
+
+  # InstrumentType Bhros
+  BHROS
+
+  # InstrumentType Visitor
+  VISITOR
+
+  # InstrumentType Flamingos2
+  FLAMINGOS2
+
+  # InstrumentType Ghost
+  GHOST
+}
 
 # The `Long` scalar type represents non-fractional signed whole numeric values.
 # Long can represent values between -(2^63) and 2^63 - 1.
@@ -424,15 +1298,24 @@ enum MagnitudeSystem {
   JY
 }
 
+# MOS pre-imaging observation
+enum MosPreImaging {
+  # MosPreImaging IsMosPreImaging
+  IS_MOS_PRE_IMAGING
+
+  # MosPreImaging IsNotMosPreImaging
+  IS_NOT_MOS_PRE_IMAGING
+}
+
 type Mutation {
-  createDefaultAsterism(
+  createAsterism(
     # Default Asterism description
     input: CreateDefaultAsterismInput!
-  ): DefaultAsterism
-  updateDefaultAsterism(
+  ): Asterism
+  updateAsterism(
     # Edit default asterism
     input: EditDefaultAsterismInput!
-  ): DefaultAsterism!
+  ): Asterism!
   deleteAsterism(
     # Asterism ID
     asterismId: AsterismId!
@@ -477,30 +1360,54 @@ type Mutation {
     # Target ID
     targetId: TargetId!
   ): Target!
-  shareAsterismsWithPrograms(
+  shareAsterismWithObservations(
+    # Asterism/observation links
+    input: AsterismObservationLinks!
+  ): Asterism!
+  unshareAsterismWithObservations(
+    # Asterism/observation links
+    input: AsterismObservationLinks!
+  ): Asterism!
+  shareAsterismWithPrograms(
     # Asterism/program links
     input: AsterismProgramLinks!
-  ): [Asterism!]!
-  unshareAsterismsWithPrograms(
+  ): Asterism!
+  unshareAsterismWithPrograms(
     # Asterism/program links
     input: AsterismProgramLinks!
-  ): [Asterism!]!
-  shareTargetsWithObservations(
+  ): Asterism!
+  shareAsterismWithTargets(
+    # Asterism/target links
+    input: AsterismTargetLinks!
+  ): Asterism!
+  unshareAsterismWithTargets(
+    # Asterism/target links
+    input: AsterismTargetLinks!
+  ): Asterism!
+  shareTargetWithAsterisms(
+    # Target/observation links
+    input: TargetAsterismLinks!
+  ): Target!
+  unshareTargetWithAsterisms(
+    # Target/observation links
+    input: TargetAsterismLinks!
+  ): Target!
+  shareTargetWithObservations(
     # Target/observation links
     input: TargetObservationLinks!
-  ): [Asterism!]!
-  unshareTargetsWithObservations(
+  ): Target!
+  unshareTargetWithObservations(
     # Target/observation links
     input: TargetObservationLinks!
-  ): [Asterism!]!
-  shareTargetsWithPrograms(
+  ): Target!
+  shareTargetWithPrograms(
     # Target/program links
     input: TargetProgramLinks!
-  ): [Target!]!
-  unshareTargetsWithPrograms(
+  ): Target!
+  unshareTargetWithPrograms(
     # Target/program links
     input: TargetProgramLinks!
-  ): [Target!]!
+  ): Target!
 }
 
 type Nonsidereal {
@@ -533,17 +1440,26 @@ type Observation {
     includeDeleted: Boolean! = false
   ): Program!
 
-  # The observation's asterism, if any
+  # The observation's asterism or target (see also `asterism` and `target` fields)
+  observationTarget(
+    # Set to true to include deleted values
+    includeDeleted: Boolean! = false
+  ): ObservationTarget
+
+  # The observation's asterism, if a multi-target observation
   asterism(
     # Set to true to include deleted values
     includeDeleted: Boolean! = false
   ): Asterism
 
-  # The observation's targets, if any
-  targets(
+  # The observation's target, if a single-target observation
+  target(
     # Set to true to include deleted values
     includeDeleted: Boolean! = false
-  ): [Target!]!
+  ): Target
+
+  # Instrument configuration
+  config: Config
 }
 
 # Event sent when a new object is created or updated
@@ -558,6 +1474,9 @@ type ObservationEdit implements Event {
 
 # ObservationId id formatted as `o-(0|[1-9a-f][0-9a-f]*)`
 scalar ObservationId
+
+# Either asterism or target
+union ObservationTarget = Asterism | Target
 
 # Observation status options
 enum ObsStatus {
@@ -584,6 +1503,25 @@ enum ObsStatus {
 
   # ObsStatus Observed
   OBSERVED
+}
+
+type Offset {
+  # Offset in p
+  p: p!
+
+  # Offset in q
+  q: q!
+}
+
+type p {
+  # p offset in µas
+  microarcseconds: Long!
+
+  # p offset in mas
+  milliarcseconds: BigDecimal!
+
+  # p offset in arcsec
+  arcseconds: BigDecimal!
 }
 
 type Parallax {
@@ -751,6 +1689,17 @@ type ProperMotionRA {
 
   # Proper motion in properMotion mas/year
   milliarcsecondsPerYear: BigDecimal!
+}
+
+type q {
+  # q offset in µas
+  microarcseconds: Long!
+
+  # q offset in mas
+  milliarcseconds: BigDecimal!
+
+  # q offset in arcsec
+  arcseconds: BigDecimal!
 }
 
 type Query {
@@ -928,6 +1877,15 @@ enum RightAscensionUnits {
   HOURS
 }
 
+# Science step
+type Science implements StepConfig {
+  # Offset
+  offset: Offset!
+
+  # Step type
+  stepType: StepType!
+}
+
 type Sidereal {
   # Catalog id, if any, describing from where the information in this target was obtained
   catalogId: CatalogId
@@ -946,6 +1904,30 @@ type Sidereal {
 
   # Parallax
   parallax: Parallax
+}
+
+# Step (bias, dark, science, etc.)
+interface StepConfig {
+  # Step type
+  stepType: StepType!
+}
+
+# Step type
+enum StepType {
+  # StepType Bias
+  BIAS
+
+  # StepType Dark
+  DARK
+
+  # StepType Gcal
+  GCAL
+
+  # StepType Science
+  SCIENCE
+
+  # StepType SmartGcal
+  SMART_GCAL
 }
 
 type Subscription {
@@ -1046,6 +2028,12 @@ type Target {
   magnitudes: [Magnitude!]!
 }
 
+# Targets and the asterisms with which they are associated
+input TargetAsterismLinks {
+  targetId: TargetId!
+  asterismIds: [AsterismId!]!
+}
+
 # Event sent when a new object is created or updated
 type TargetEdit implements Event {
   # Type of edit
@@ -1061,16 +2049,30 @@ scalar TargetId
 
 # Targets and the observations with which they are associated
 input TargetObservationLinks {
-  targetIds: [TargetId!]!
+  targetId: TargetId!
   observationIds: [ObservationId!]!
 }
 
 # Targets and the programs with which they are associated
 input TargetProgramLinks {
-  targetIds: [TargetId!]!
+  targetId: TargetId!
   programIds: [ProgramId!]!
 }
 
 # Either Nonsidereal ephemeris lookup key or Sidereal proper motion.
 union Tracking = Nonsidereal | Sidereal
+
+type Wavelength {
+  # Wavelength in pm
+  picometers: Int!
+
+  # Wavelength in Å
+  angstroms: BigDecimal!
+
+  # Wavelength in nm
+  nanometers: BigDecimal!
+
+  # Wavelength in µm
+  micrometers: BigDecimal!
+}
 

--- a/common/src/main/resources/graphql/schemas/ObservationDB.graphql
+++ b/common/src/main/resources/graphql/schemas/ObservationDB.graphql
@@ -1,5 +1,5 @@
-# Collection of stars observed in a single observation
-type Asterism {
+# Common fields shared by all asterisms
+interface Asterism {
   # Asterism ID
   id: AsterismId!
 
@@ -47,22 +47,10 @@ type AsterismEdit implements Event {
 # AsterismId id formatted as `a-(0|[1-9a-f][0-9a-f]*)`
 scalar AsterismId
 
-# Asterism and the observations with which they are associated
-input AsterismObservationLinks {
-  asterismId: AsterismId!
-  observationIds: [ObservationId!]!
-}
-
 # Asterism and the programs with which they are associated
 input AsterismProgramLinks {
-  asterismId: AsterismId!
+  asterismIds: [AsterismId!]!
   programIds: [ProgramId!]!
-}
-
-# Asterism and the targets with which they are associated
-input AsterismTargetLinks {
-  asterismId: AsterismId!
-  targetIds: [TargetId!]!
 }
 
 # Bias calibration step
@@ -126,6 +114,9 @@ input CreateDefaultAsterismInput {
   name: String
   programIds: [ProgramId!]!
   explicitBase: CoordinatesInput
+
+  # Targets to include in default asterism
+  targetIds: [TargetId!]!
 }
 
 # Nonsidereal target parameters
@@ -144,7 +135,6 @@ input CreateObservationInput {
   programId: ProgramId!
   name: String
   asterismId: AsterismId
-  targetId: TargetId
   status: ObsStatus
 }
 
@@ -216,6 +206,42 @@ enum DeclinationUnits {
   DEGREES
 }
 
+# Default asterism
+type DefaultAsterism implements Asterism {
+  # Asterism ID
+  id: AsterismId!
+
+  # Whether the asterism is deleted or present
+  existence: Existence!
+
+  # Asterism name, if any.
+  name: String
+
+  # When set, overrides the default base position of the asterism
+  explicitBase: Coordinates
+
+  # All observations associated with the asterism.
+  observations(
+    # Program ID
+    programId: ProgramId
+
+    # Set to true to include deleted values
+    includeDeleted: Boolean! = false
+  ): [Observation!]!
+
+  # All asterism targets
+  targets(
+    # Set to true to include deleted values
+    includeDeleted: Boolean! = false
+  ): [Target!]!
+
+  # The programs associated with the asterism.
+  programs(
+    # Set to true to include deleted values
+    includeDeleted: Boolean! = false
+  ): [Program!]!
+}
+
 # Target declination coordinate in format '[+/-]DD:MM:SS.sss'
 scalar DmsString
 
@@ -248,6 +274,9 @@ input EditDefaultAsterismInput {
 
   # The explicitBase field may be unset by assigning a null value, or ignored by skipping it altogether
   explicitBase: CoordinatesInput
+
+  # Targets to include in the default asterism
+  targetIds: [TargetId!]
 }
 
 # Edit observation
@@ -265,9 +294,6 @@ input EditObservationInput {
 
   # The asterismId field may be unset by assigning a null value, or ignored by skipping it altogether
   asterismId: AsterismId
-
-  # The targetId field may be unset by assigning a null value, or ignored by skipping it altogether
-  targetId: TargetId
 }
 
 # Sidereal target edit parameters
@@ -1308,14 +1334,14 @@ enum MosPreImaging {
 }
 
 type Mutation {
-  createAsterism(
+  createDefaultAsterism(
     # Default Asterism description
     input: CreateDefaultAsterismInput!
-  ): Asterism
-  updateAsterism(
+  ): DefaultAsterism
+  updateDefaultAsterism(
     # Edit default asterism
     input: EditDefaultAsterismInput!
-  ): Asterism!
+  ): DefaultAsterism!
   deleteAsterism(
     # Asterism ID
     asterismId: AsterismId!
@@ -1360,54 +1386,30 @@ type Mutation {
     # Target ID
     targetId: TargetId!
   ): Target!
-  shareAsterismWithObservations(
-    # Asterism/observation links
-    input: AsterismObservationLinks!
-  ): Asterism!
-  unshareAsterismWithObservations(
-    # Asterism/observation links
-    input: AsterismObservationLinks!
-  ): Asterism!
-  shareAsterismWithPrograms(
+  shareAsterismsWithPrograms(
     # Asterism/program links
     input: AsterismProgramLinks!
-  ): Asterism!
-  unshareAsterismWithPrograms(
+  ): [Asterism!]!
+  unshareAsterismsWithPrograms(
     # Asterism/program links
     input: AsterismProgramLinks!
-  ): Asterism!
-  shareAsterismWithTargets(
-    # Asterism/target links
-    input: AsterismTargetLinks!
-  ): Asterism!
-  unshareAsterismWithTargets(
-    # Asterism/target links
-    input: AsterismTargetLinks!
-  ): Asterism!
-  shareTargetWithAsterisms(
-    # Target/observation links
-    input: TargetAsterismLinks!
-  ): Target!
-  unshareTargetWithAsterisms(
-    # Target/observation links
-    input: TargetAsterismLinks!
-  ): Target!
-  shareTargetWithObservations(
+  ): [Asterism!]!
+  shareTargetsWithObservations(
     # Target/observation links
     input: TargetObservationLinks!
-  ): Target!
-  unshareTargetWithObservations(
+  ): [Asterism!]!
+  unshareTargetsWithObservations(
     # Target/observation links
     input: TargetObservationLinks!
-  ): Target!
-  shareTargetWithPrograms(
+  ): [Asterism!]!
+  shareTargetsWithPrograms(
     # Target/program links
     input: TargetProgramLinks!
-  ): Target!
-  unshareTargetWithPrograms(
+  ): [Target!]!
+  unshareTargetsWithPrograms(
     # Target/program links
     input: TargetProgramLinks!
-  ): Target!
+  ): [Target!]!
 }
 
 type Nonsidereal {
@@ -1440,23 +1442,17 @@ type Observation {
     includeDeleted: Boolean! = false
   ): Program!
 
-  # The observation's asterism or target (see also `asterism` and `target` fields)
-  observationTarget(
-    # Set to true to include deleted values
-    includeDeleted: Boolean! = false
-  ): ObservationTarget
-
-  # The observation's asterism, if a multi-target observation
+  # The observation's asterism, if any
   asterism(
     # Set to true to include deleted values
     includeDeleted: Boolean! = false
   ): Asterism
 
-  # The observation's target, if a single-target observation
-  target(
+  # The observation's targets, if any
+  targets(
     # Set to true to include deleted values
     includeDeleted: Boolean! = false
-  ): Target
+  ): [Target!]!
 
   # Instrument configuration
   config: Config
@@ -1474,9 +1470,6 @@ type ObservationEdit implements Event {
 
 # ObservationId id formatted as `o-(0|[1-9a-f][0-9a-f]*)`
 scalar ObservationId
-
-# Either asterism or target
-union ObservationTarget = Asterism | Target
 
 # Observation status options
 enum ObsStatus {
@@ -2028,12 +2021,6 @@ type Target {
   magnitudes: [Magnitude!]!
 }
 
-# Targets and the asterisms with which they are associated
-input TargetAsterismLinks {
-  targetId: TargetId!
-  asterismIds: [AsterismId!]!
-}
-
 # Event sent when a new object is created or updated
 type TargetEdit implements Event {
   # Type of edit
@@ -2049,13 +2036,13 @@ scalar TargetId
 
 # Targets and the observations with which they are associated
 input TargetObservationLinks {
-  targetId: TargetId!
+  targetIds: [TargetId!]!
   observationIds: [ObservationId!]!
 }
 
 # Targets and the programs with which they are associated
 input TargetProgramLinks {
-  targetId: TargetId!
+  targetIds: [TargetId!]!
   programIds: [ProgramId!]!
 }
 

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -487,7 +487,7 @@ body.light-theme {
   display: flex;
   flex-wrap: nowrap;
   width: 100%;
-  padding-bottom: 1px;
+  padding: 0.5em 0.5em !important;
   align-content: center;
 }
 
@@ -504,8 +504,8 @@ body.light-theme {
 }
 
 .vertical.segment.obs-tree-group {
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding-top: 0;
+  padding-bottom: 0;
   padding-right: 5px;
   user-select: none;
 }
@@ -644,7 +644,7 @@ body.light-theme {
 
 .wip .wip-warning {
   visibility: hidden;
-  width: 120;
+  width: 120px;
   background-color: yellow;
   color: black;
   text-align: center;
@@ -654,7 +654,7 @@ body.light-theme {
   /* Position the tooltip */
   position: absolute;
   z-index: 3;
-  top: 30;
+  top: 30px;
   left: calc(50% - 60px);
 }
 

--- a/common/src/main/scala/explore/GraphQLSchemas.scala
+++ b/common/src/main/scala/explore/GraphQLSchemas.scala
@@ -8,7 +8,7 @@ import clue.data.syntax._
 import clue.macros.GraphQLSchema
 import explore.model.enum._
 import explore.model.{ ResizableSection, SiderealTarget }
-import lucuma.core.model.{ Magnitude, Observation, Target, User }
+import lucuma.core.model.{ Asterism, Magnitude, Observation, Target, User }
 
 import java.math.MathContext
 
@@ -17,7 +17,7 @@ object GraphQLSchemas {
   @GraphQLSchema(debug = false)
   object ObservationDB {
     object Scalars {
-      type AsterismId    = String
+      type AsterismId    = Asterism.Id
       type BigDecimal    = scala.BigDecimal
       type DmsString     = String
       type EpochString   = String

--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -55,7 +55,28 @@ trait ListImplicits {
   }
 }
 
-object implicits extends ShorthandTypes with ListImplicits {
+trait OpticsImplicits {
+  implicit class ViewOpticsOps[F[_], A](val view: ViewF[F, A]) {
+    def zoomGetAdjust[B](getAdjust: GetAdjust[A, B]): ViewF[F, B] =
+      view.zoom(getAdjust.get)(getAdjust.mod)
+
+    // Helps type inference by sidestepping overloaded "zoom".
+    def zoomPrism[B](prism: monocle.Prism[A, B]): ViewOptF[F, B] =
+      view.zoom(prism)
+
+    // Helps type inference by sidestepping overloaded "zoom".
+    def zoomLens[B](lens: monocle.Lens[A, B]): ViewF[F, B] =
+      view.zoom(lens)
+  }
+
+  implicit class ViewOptOpticsOps[F[_], A](val viewOpt: ViewOptF[F, A]) {
+    // Helps type inference by sidestepping overloaded "zoom".
+    def zoomLens[B](lens: monocle.Lens[A, B]): ViewOptF[F, B] =
+      viewOpt.zoom(lens)
+  }
+}
+
+object implicits extends ShorthandTypes with ListImplicits with OpticsImplicits {
   implicit def appContext2ContextShift[F[_]](implicit ctx: AppContext[F]): ContextShift[F] = ctx.cs
   implicit def appContext2Timer[F[_]](implicit ctx:        AppContext[F]): Timer[F]        = ctx.timer
   implicit def appContext2Logger[F[_]](implicit ctx:       AppContext[F]): Logger[F]       = ctx.logger

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -21,7 +21,8 @@ object reusability {
   implicit val constraintsReuse: Reusability[Constraints]                                         = Reusability.derive
   implicit val expObsReuse: Reusability[ExploreObservation]                                       = Reusability.derive
   implicit val userVaultReuse: Reusability[UserVault]                                             = Reusability.byEq
-  implicit val rootModelReuse: Reusability[RootModel]                                             = Reusability.derive
+  implicit val targetViewExpandedIdsReuse: Reusability[TargetViewExpandedIds]                     = Reusability.byEq
+  implicit val rootModelReuse: Reusability[RootModel]                                             = Reusability.byEq
   implicit def sizeReuse: Reusability[Size]                                                       = Reusability.by(x => (x.height, x.width))
   implicit def focusedReuse: Reusability[Focused]                                                 = Reusability.derive
   implicit def idListReuse[Id: Reusability, A: Reusability]: Reusability[KeyedIndexedList[Id, A]] =

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -33,7 +33,7 @@ package object utils {
         case Development => versionDateTimeFormatter.format(instant)
         case _           =>
           versionDateFormatter.format(instant) +
-            "-" + BuildInfo.gitHeadCommit.map(_.takeRight(7)).getOrElse("NONE")
+            "-" + BuildInfo.gitHeadCommit.map(_.take(7)).getOrElse("NONE")
       })
         + environment.suffix
           .map(suffix => s"-$suffix")

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -28,7 +28,7 @@ object Routing {
   private def targetTab(model: View[RootModel]): TargetTabContents =
     TargetTabContents(model.zoom(RootModel.userId),
                       model.zoom(RootModel.focused),
-                      model.zoom(RootModel.expandedTargetIds)
+                      model.zoom(RootModel.targetViewExpandedIds)
     )
 
   private def obsTab(model: View[RootModel]): ObsTabContents =

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -18,6 +18,7 @@ import lucuma.core.util.Gid
 
 import scala.scalajs.LinkingInfo
 import scala.util.Random
+import lucuma.core.model.Asterism
 
 sealed trait ElementItem  extends Product with Serializable
 case object IconsElement  extends ElementItem
@@ -53,6 +54,11 @@ object Routing {
           )
           | staticRoute("/targets", TargetsBasePage) ~> renderP(targetTab)
           | dynamicRouteCT(("/target" / id[Target.Id]).xmapL(TargetPage.targetId)) ~> renderP(
+            targetTab
+          )
+          | dynamicRouteCT(
+            ("/asterism" / id[Asterism.Id]).xmapL(TargetsAsterismPage.asterismId)
+          ) ~> renderP(
             targetTab
           )
           | dynamicRouteCT(

--- a/model/src/main/scala/explore/data/KeyedIndexedList.scala
+++ b/model/src/main/scala/explore/data/KeyedIndexedList.scala
@@ -69,6 +69,8 @@ case class KeyedIndexedList[K, A] private (private val list: TreeSeqMap[K, (A, I
 }
 
 object KeyedIndexedList {
+  def empty[K, A]: KeyedIndexedList[K, A] = KeyedIndexedList[K, A](TreeSeqMap.empty)
+
   def fromList[K, A](list: List[A], getKey: A => K): KeyedIndexedList[K, A] =
     KeyedIndexedList(TreeSeqMap.from(list.distinctBy(getKey).zipWithIndex.map { case (a, idx) =>
       (getKey(a), (a, idx))

--- a/model/src/main/scala/explore/model/Constants.scala
+++ b/model/src/main/scala/explore/model/Constants.scala
@@ -7,11 +7,12 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
 
 trait Constants {
-  val UnnamedTarget: NonEmptyString = "<UNNAMED>"
-  val TwoPanelCutoff                = 550.0
-  val InitialTreeWidth              = 300.0
-  val MinLeftPanelWidth             = 270.0
-  val GridRowHeight                 = 36
+  val UnnamedTarget: NonEmptyString   = "<UNNAMED>"
+  val UnnamedAsterism: NonEmptyString = "<UNNAMED>"
+  val TwoPanelCutoff                  = 550.0
+  val InitialTreeWidth                = 300.0
+  val MinLeftPanelWidth               = 270.0
+  val GridRowHeight                   = 36
 }
 
 object Constants extends Constants

--- a/model/src/main/scala/explore/model/Focused.scala
+++ b/model/src/main/scala/explore/model/Focused.scala
@@ -7,19 +7,22 @@ import cats.kernel.Eq
 import cats.syntax.all._
 import lucuma.core.model.{ Observation, Target }
 import monocle.macros.Lenses
+import lucuma.core.model.Asterism
 
 sealed trait Focused extends Product with Serializable
 object Focused {
   @Lenses case class FocusedObs(obsId: Observation.Id) extends Focused
   @Lenses case class FocusedTarget(targetId: Target.Id) extends Focused
+  @Lenses case class FocusedAsterism(asterismId: Asterism.Id) extends Focused
   // @Lenses case class FocusedConstraint(constraint: ???) extends Focused
   // @Lenses case class FocusedConfiguration(configuraton: ???) extends Focused
 
   implicit val eqFocused: Eq[Focused] = Eq.instance {
-    case (FocusedObs(a), FocusedObs(b))       => a === b
-    case (FocusedTarget(a), FocusedTarget(b)) => a === b
+    case (FocusedObs(a), FocusedObs(b))           => a === b
+    case (FocusedTarget(a), FocusedTarget(b))     => a === b
+    case (FocusedAsterism(a), FocusedAsterism(b)) => a === b
     // case (FocusedConstraint(a), FocusedConstraint(b))       => a === b
     // case (FocusedConfiguration(a), FocusedConfiguration(b)) => a === b
-    case _                                    => false
+    case _                                        => false
   }
 }

--- a/model/src/main/scala/explore/model/Page.scala
+++ b/model/src/main/scala/explore/model/Page.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.syntax.all._
 import lucuma.core.model.{ Observation, Target }
 import monocle.Iso
+import lucuma.core.model.Asterism
 
 sealed trait Page extends Product with Serializable
 
@@ -17,21 +18,23 @@ object Page {
   final case class ObsPage(obsId: Observation.Id) extends Page
   final case object TargetsBasePage      extends Page
   final case class TargetPage(targetId: Target.Id) extends Page
+  final case class TargetsAsterismPage(asterismId: Asterism.Id) extends Page
   final case class TargetsObsPage(obsId: Observation.Id) extends Page
   case object ConfigurationsPage         extends Page
   case object ConstraintsPage            extends Page
 
   implicit val eqPage: Eq[Page] = Eq.instance {
-    case (HomePage, HomePage)                         => true
-    case (ProposalPage, ProposalPage)                 => true
-    case (ObservationsBasePage, ObservationsBasePage) => true
-    case (ObsPage(a), ObsPage(b))                     => a === b
-    case (TargetsBasePage, TargetsBasePage)           => true
-    case (TargetPage(a), TargetPage(b))               => a === b
-    case (TargetsObsPage(a), TargetsObsPage(b))       => a === b
-    case (ConfigurationsPage, ConfigurationsPage)     => true
-    case (ConstraintsPage, ConstraintsPage)           => true
-    case _                                            => false
+    case (HomePage, HomePage)                             => true
+    case (ProposalPage, ProposalPage)                     => true
+    case (ObservationsBasePage, ObservationsBasePage)     => true
+    case (ObsPage(a), ObsPage(b))                         => a === b
+    case (TargetsBasePage, TargetsBasePage)               => true
+    case (TargetPage(a), TargetPage(b))                   => a === b
+    case (TargetsAsterismPage(a), TargetsAsterismPage(b)) => a === b
+    case (TargetsObsPage(a), TargetsObsPage(b))           => a === b
+    case (ConfigurationsPage, ConfigurationsPage)         => true
+    case (ConstraintsPage, ConstraintsPage)               => true
+    case _                                                => false
   }
 
   object ObsPage {
@@ -42,6 +45,11 @@ object Page {
   object TargetPage {
     final val targetId: Iso[Target.Id, TargetPage] =
       Iso[Target.Id, TargetPage](TargetPage.apply)(_.targetId)
+  }
+
+  object TargetsAsterismPage {
+    final val asterismId: Iso[Asterism.Id, TargetsAsterismPage] =
+      Iso[Asterism.Id, TargetsAsterismPage](TargetsAsterismPage.apply)(_.asterismId)
   }
 
   object TargetsObsPage {

--- a/model/src/main/scala/explore/model/RootModel.scala
+++ b/model/src/main/scala/explore/model/RootModel.scala
@@ -3,30 +3,24 @@
 
 package explore.model
 
-// import java.time.Instant
-
-import cats.Order._
 import cats.kernel.Eq
 import cats.syntax.all._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.enum.AppTab
 import lucuma.core.data.EnumZipper
-import lucuma.core.model.Target.Id._
-import lucuma.core.model.{ GuestUser, ServiceUser, StandardUser, Target, User }
+import lucuma.core.model.{ GuestUser, ServiceUser, StandardUser, User }
 import monocle.Lens
 import monocle.macros.Lenses
 import monocle.std.option
 
-import scala.collection.immutable.SortedSet
-
 @Lenses
 case class RootModel(
-  vault:                Option[UserVault],
-  tabs:                 EnumZipper[AppTab],
-  focused:              Option[Focused] = none,
-  expandedTargetIds:    SortedSet[Target.Id] = SortedSet.empty,
-  userSelectionMessage: Option[NonEmptyString] = none
+  vault:                 Option[UserVault],
+  tabs:                  EnumZipper[AppTab],
+  focused:               Option[Focused] = none,
+  targetViewExpandedIds: TargetViewExpandedIds = TargetViewExpandedIds(),
+  userSelectionMessage:  Option[NonEmptyString] = none
 )
 
 object RootModel {
@@ -46,5 +40,5 @@ object RootModel {
       .composeLens(userUserId)
 
   implicit val eqRootModel: Eq[RootModel] =
-    Eq.by(m => (m.vault, m.tabs, m.focused, m.expandedTargetIds, m.userSelectionMessage))
+    Eq.by(m => (m.vault, m.tabs, m.focused, m.targetViewExpandedIds, m.userSelectionMessage))
 }

--- a/model/src/main/scala/explore/model/RootModelRouting.scala
+++ b/model/src/main/scala/explore/model/RootModelRouting.scala
@@ -8,6 +8,7 @@ import explore.model.Focused.{ FocusedObs, FocusedTarget }
 import explore.model.Page._
 import explore.model.enum.AppTab
 import monocle.Lens
+import explore.model.Focused.FocusedAsterism
 
 object RootModelRouting {
 
@@ -25,8 +26,9 @@ object RootModelRouting {
       case AppTab.Targets        =>
         focused
           .collect {
-            case FocusedObs(obsId)       => TargetsObsPage(obsId)
-            case FocusedTarget(targetId) => TargetPage(targetId)
+            case FocusedObs(obsId)           => TargetsObsPage(obsId)
+            case FocusedAsterism(asterismId) => TargetsAsterismPage(asterismId)
+            case FocusedTarget(targetId)     => TargetPage(targetId)
           }
           .getOrElse(TargetsBasePage)
       case AppTab.Configurations => ConfigurationsPage
@@ -38,22 +40,24 @@ object RootModelRouting {
 
   protected def setPage(page: Page): RootModel => RootModel =
     page match {
-      case ProposalPage          => setTab(AppTab.Proposal) >>> RootModel.focused.set(none)
-      case ObservationsBasePage  =>
+      case ProposalPage                    => setTab(AppTab.Proposal) >>> RootModel.focused.set(none)
+      case ObservationsBasePage            =>
         setTab(AppTab.Observations) >>> RootModel.focused.set(none)
-      case ObsPage(obsId)        =>
+      case ObsPage(obsId)                  =>
         setTab(AppTab.Observations) >>> RootModel.focused.set(FocusedObs(obsId).some)
-      case TargetsBasePage       =>
+      case TargetsBasePage                 =>
         setTab(AppTab.Targets) >>> RootModel.focused.set(none)
-      case TargetPage(targetId)  =>
+      case TargetPage(targetId)            =>
         setTab(AppTab.Targets) >>> RootModel.focused.set(FocusedTarget(targetId).some)
-      case TargetsObsPage(obsId) =>
+      case TargetsAsterismPage(asterismId) =>
+        setTab(AppTab.Targets) >>> RootModel.focused.set(FocusedAsterism(asterismId).some)
+      case TargetsObsPage(obsId)           =>
         setTab(AppTab.Targets) >>> RootModel.focused.set(FocusedObs(obsId).some)
-      case ConstraintsPage       =>
+      case ConstraintsPage                 =>
         setTab(AppTab.Constraints)
-      case ConfigurationsPage    =>
+      case ConfigurationsPage              =>
         setTab(AppTab.Configurations)
-      case HomePage              =>
+      case HomePage                        =>
         setTab(AppTab.Overview)
     }
 

--- a/model/src/main/scala/explore/model/expandedIds.scala
+++ b/model/src/main/scala/explore/model/expandedIds.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package explore.model
 
 import cats._

--- a/model/src/main/scala/explore/model/expandedIds.scala
+++ b/model/src/main/scala/explore/model/expandedIds.scala
@@ -1,0 +1,19 @@
+package explore.model
+
+import cats._
+import cats.Order._
+import scala.collection.immutable.SortedSet
+import lucuma.core.model.Target
+import lucuma.core.model.Asterism
+import monocle.macros.Lenses
+
+@Lenses
+case class TargetViewExpandedIds(
+  targetIds:   SortedSet[Target.Id] = SortedSet.empty,
+  asterismIds: SortedSet[Asterism.Id] = SortedSet.empty
+)
+
+object TargetViewExpandedIds {
+  implicit val eqTargetViewExpandedIds: Eq[TargetViewExpandedIds] =
+    Eq.by(m => (m.targetIds, m.asterismIds))
+}

--- a/model/src/test/scala/explore/model/arb/ArbFocused.scala
+++ b/model/src/test/scala/explore/model/arb/ArbFocused.scala
@@ -16,6 +16,7 @@ import org.scalacheck.Gen._
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
 import lucuma.core.util.arb.ArbGid._
+import lucuma.core.model.Asterism
 
 trait ArbFocused {
   implicit val focusedArb: Arbitrary[Focused] =
@@ -35,11 +36,16 @@ trait ArbFocused {
   implicit val focusedTargetCogen: Cogen[Focused.FocusedTarget] =
     Cogen[Target.Id].contramap(_.targetId)
 
+  implicit val focusedAsterismCogen: Cogen[Focused.FocusedAsterism] =
+    Cogen[Asterism.Id].contramap(_.asterismId)
+
   implicit val focusedCogen: Cogen[Focused] =
-    Cogen[Either[Focused.FocusedObs, Focused.FocusedTarget]].contramap {
-      case a: Focused.FocusedObs    => a.asLeft
-      case a: Focused.FocusedTarget => a.asRight
-    }
+    Cogen[Either[Either[Focused.FocusedObs, Focused.FocusedTarget], Focused.FocusedAsterism]]
+      .contramap {
+        case a: Focused.FocusedObs      => a.asLeft.asLeft
+        case a: Focused.FocusedTarget   => a.asRight.asLeft
+        case a: Focused.FocusedAsterism => a.asRight
+      }
 }
 
 object ArbFocused extends ArbFocused

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -3,6 +3,7 @@
 
 package explore.observationtree
 
+import cats._
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
@@ -12,17 +13,16 @@ import explore.components.ui.ExploreStyles
 import explore.components.undo.{ UndoButtons, UndoRegion }
 import explore.implicits._
 import explore.model.Focused._
-import explore.model.enum.AppTab
-import explore.model.{ Constants, Focused, ObsSummary }
+import explore.model.{ Constants, Focused, ObsSummary, TargetViewExpandedIds }
 import explore.optics.{ GetAdjust, _ }
 import explore.undo.{ KIListMod, Undoer }
-import explore.{ AppCtx, Icons }
+import explore.Icons
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.{ Observation, Target }
-import lucuma.ui.utils._
 import monocle.Getter
 import monocle.function.Field1.first
+import monocle.std.option.some
 import mouse.boolean._
 import react.beautifuldnd._
 import react.common._
@@ -31,97 +31,136 @@ import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.elements.icon.Icon
 import react.semanticui.elements.segment.Segment
+import react.semanticui.elements.segment.SegmentGroup
 import react.semanticui.sizes._
 
 import scala.collection.immutable.SortedSet
 import scala.util.Random
 
 import TargetObsQueries._
+import lucuma.core.model.Asterism
 
 final case class TargetObsList(
-  targetsWithObs:    View[TargetsWithObs],
-  focused:           View[Option[Focused]],
-  expandedTargetIds: View[SortedSet[Target.Id]]
+  objectsWithObs: View[TargetsAndAsterismsWithObs],
+  focused:        View[Option[Focused]],
+  expandedIds:    View[TargetViewExpandedIds]
 ) extends ReactProps[TargetObsList](TargetObsList.component)
 
 object TargetObsList {
   type Props = TargetObsList
 
-  val obsListMod    =
-    new KIListMod[IO, ObsIdNameTarget, Observation.Id](ObsIdNameTarget.id)
-  val targetListMod = new KIListMod[IO, TargetIdName, Target.Id](TargetIdName.id)
+  val obsListMod      =
+    new KIListMod[IO, ObsAttached, Observation.Id](ObsAttached.id)
+  val targetListMod   = new KIListMod[IO, TargetIdName, Target.Id](TargetIdName.id)
+  val asterismListMod = new KIListMod[IO, AsterismIdName, Asterism.Id](AsterismIdName.id)
 
   class Backend($ : BackendScope[Props, Unit]) {
 
-    private def getTargetForObsWithId(
+    private def getObjectForObsWithId(
       obsWithIndexGetter: Getter[ObsList, obsListMod.ElemWithIndex]
-    ): Getter[TargetsWithObs, Option[TargetIdName]] =
-      Getter { two =>
-        val targetSummary =
-          TargetsWithObs.obs
-            .composeGetter(
-              obsWithIndexGetter
-                .composeOptionLens(first)
-                .composeOptionLens(ObsIdNameTarget.target)
-            )
-            .get(two)
-        targetSummary.flatMap(ts => two.targets.getElement(ts.id))
-      }
+    ): Getter[TargetsAndAsterismsWithObs, Option[ObjectId]] =
+      TargetsAndAsterismsWithObs.obs
+        .composeGetter(
+          obsWithIndexGetter
+            .composeOptionLens(first)
+            .composeOptionLens(ObsAttached.attached)
+        )
 
-    private def setTargetForObsWithId(
-      targetsWithObs:        View[TargetsWithObs],
+    private def setObjectForObsWithId(
+      objectsWithObs:        View[TargetsAndAsterismsWithObs],
       obsId:                 Observation.Id,
       obsWithIndexGetAdjust: GetAdjust[ObsList, obsListMod.ElemWithIndex]
-    ): Option[TargetIdName] => IO[Unit] =
-      targetOpt => {
+    ): Option[ObjectId] => IO[Unit] =
+      objectOpt => {
         val obsTargetAdjuster = obsWithIndexGetAdjust
           .composeOptionLens(first) // Focus on Observation within ElemWithIndex
-          .composeOptionLens(ObsIdNameTarget.target)
+          .composeOptionLens(ObsAttached.attached)
 
-        val observationsView = targetsWithObs
-          .zoom(TargetsWithObs.obs)
+        val observationsView = objectsWithObs
+          .zoom(TargetsAndAsterismsWithObs.obs)
 
-        val oldTarget = obsTargetAdjuster.get(observationsView.get)
+        val oldTargetId = obsTargetAdjuster.get(observationsView.get)
 
         // 1) Update internal model
-        observationsView.mod(obsTargetAdjuster.set(targetOpt)) >>
+        observationsView.mod(obsTargetAdjuster.set(objectOpt)) >>
           // 2) Send mutation
-          oldTarget
-            .flatMap(oldTarget =>
-              targetOpt.map(newTarget => moveObs(obsId, oldTarget.id, newTarget.id))
+          oldTargetId
+            .flatMap(oldTargetId =>
+              objectOpt.map(newObjectId => moveObs(obsId, oldTargetId, newObjectId))
             )
             .orEmpty
       }
 
     protected def onDragEnd(
-      setter:            Undoer.Setter[IO, TargetsWithObs],
-      expandedTargetIds: View[SortedSet[Target.Id]]
+      setter:      Undoer.Setter[IO, TargetsAndAsterismsWithObs],
+      expandedIds: View[TargetViewExpandedIds]
     ): (DropResult, ResponderProvided) => Callback =
       (result, _) =>
         $.props >>= { props =>
-          (for {
-            newTargetIdStr <- result.destination.toOption.map(_.droppableId)
-            newTargetId    <- Target.Id.parse(newTargetIdStr)
-            target         <- props.targetsWithObs.get.targets.getElement(newTargetId)
-            obsId          <- Observation.Id.parse(result.draggableId)
-          } yield {
-            val obsWithId: GetAdjust[ObsList, obsListMod.ElemWithIndex] =
-              obsListMod.withKey(obsId)
+          println(scalajs.js.JSON.stringify(result))
+          // We can drag:
+          //  - An observation from a target or an asterism to another target or asterism.
+          //  - A target into an asterism.
 
-            val set: Option[TargetIdName] => IO[Unit] =
-              setter
-                .set[Option[TargetIdName]](
-                  props.targetsWithObs.get,
-                  getTargetForObsWithId(obsWithId.getter).get,
-                  setTargetForObsWithId(props.targetsWithObs, obsId, obsWithId)
-                )
+          result.destination.toOption
+            .map(destination =>
+              (Observation.Id.parse(result.draggableId) match {
+                case Some(obsId) =>
+                  Target.Id.parse(destination.droppableId) match {
+                    case Some(newTargetId) =>
+                      // Observation dragged to a target.
+                      val obsWithId: GetAdjust[ObsList, obsListMod.ElemWithIndex] =
+                        obsListMod.withKey(obsId)
 
-            (expandedTargetIds.mod(_ + newTargetId) >> set(target.some)).runAsyncCB
-          }).getOrEmpty
+                      val set: Option[ObjectId] => IO[Unit] =
+                        setter
+                          .set[Option[ObjectId]](
+                            props.objectsWithObs.get,
+                            getObjectForObsWithId(obsWithId.getter).get,
+                            setObjectForObsWithId(props.objectsWithObs, obsId, obsWithId)
+                          )
+
+                      expandedIds.zoom(TargetViewExpandedIds.targetIds).mod(_ + newTargetId) >>
+                        set(newTargetId.asLeft.some)
+                    case None              => IO.unit // TODO: To/From asterism
+                  }
+                case None        =>
+                  Target.Id.parse(result.draggableId) match {
+                    case Some(targetId) =>
+                      Asterism.Id.parse(destination.droppableId) match {
+                        case Some(asterismId) =>
+                          props.objectsWithObs.get.targets
+                            .getElement(targetId)
+                            .foldMap(target =>
+                              addTargetToAsterism(props.objectsWithObs, target, asterismId, setter)
+                            )
+                        // protected def addTargetToAsterism(
+                        //   target:     TargetIdName,
+                        //   asterismId: Asterism.Id,
+                        //   setter:     Undoer.Setter[IO, TargetsAndAsterismsWithObs]
+
+                        // asterismMod(setter, props.objectsWithObs, asterismId)(
+                        //   asterismListMod
+                        //     .mod(
+                        //       AsterismIdName.targets.modify(targets =>
+                        //         if (!targets.exists(_.id === targetId))
+                        //           targets ++ props.objectsWithObs.get.targets.getElement(targetId)
+                        //         else
+                        //           targets
+                        //       )
+                        //     )
+                        // )
+                        case None             => IO.unit
+                      }
+                    case None           => IO.unit
+                  }
+              }).runAsyncCB
+            )
+            .getOrEmpty
         }
 
     private def setTargetWithIndex(
-      targetsWithObs:        View[TargetsWithObs],
+      objectsWithObs:        View[TargetsAndAsterismsWithObs],
       focused:               View[Option[Focused]],
       targetId:              Target.Id,
       targetWithIndexSetter: Adjuster[TargetList, targetListMod.ElemWithIndex],
@@ -129,8 +168,8 @@ object TargetObsList {
     ): targetListMod.ElemWithIndex => IO[Unit] =
       targetWithIndex =>
         // 1) Update internal model
-        targetsWithObs
-          .zoom(TargetsWithObs.targets)
+        objectsWithObs
+          .zoom(TargetsAndAsterismsWithObs.targets)
           .mod(targetWithIndexSetter.set(targetWithIndex)) >>
           // 2) Send mutation & adjust focus
           targetWithIndex.fold(
@@ -140,8 +179,8 @@ object TargetObsList {
           }
 
     private def targetMod(
-      setter:         Undoer.Setter[IO, TargetsWithObs],
-      targetsWithObs: View[TargetsWithObs],
+      setter:         Undoer.Setter[IO, TargetsAndAsterismsWithObs],
+      objectsWithObs: View[TargetsAndAsterismsWithObs],
       focused:        View[Option[Focused]],
       targetId:       Target.Id,
       focusOnDelete:  Option[TargetIdName]
@@ -151,11 +190,11 @@ object TargetObsList {
 
       setter
         .mod[targetListMod.ElemWithIndex](
-          targetsWithObs.get,
-          TargetsWithObs.targets
+          objectsWithObs.get,
+          TargetsAndAsterismsWithObs.targets
             .composeGetter(targetWithId.getter)
             .get,
-          setTargetWithIndex(targetsWithObs,
+          setTargetWithIndex(objectsWithObs,
                              focused,
                              targetId,
                              targetWithId.adjuster,
@@ -164,7 +203,7 @@ object TargetObsList {
         )
     }
 
-    protected def newTarget(setter: Undoer.Setter[IO, TargetsWithObs]): Callback =
+    protected def newTarget(setter: Undoer.Setter[IO, TargetsAndAsterismsWithObs]): Callback =
       $.props >>= { props =>
         // Temporary measure until we have id pools.
         val newTarget =
@@ -174,36 +213,145 @@ object TargetObsList {
 
         val upsert =
           targetListMod
-            .upsert(newTarget, props.targetsWithObs.get.targets.length)
+            .upsert(newTarget, props.objectsWithObs.get.targets.length)
 
-        targetMod(setter, props.targetsWithObs, props.focused, newTarget.id, none)(
+        targetMod(setter, props.objectsWithObs, props.focused, newTarget.id, none)(
           upsert
         ).runAsyncCB
       }
 
     protected def deleteTarget(
       targetId:      Target.Id,
-      setter:        Undoer.Setter[IO, TargetsWithObs],
+      setter:        Undoer.Setter[IO, TargetsAndAsterismsWithObs],
       focusOnDelete: Option[TargetIdName]
     ): Callback =
       $.props.flatMap { props =>
-        targetMod(setter, props.targetsWithObs, props.focused, targetId, focusOnDelete)(
+        targetMod(setter, props.objectsWithObs, props.focused, targetId, focusOnDelete)(
           targetListMod.delete
         ).runAsyncCB
       }
 
-    def toggleExpanded(
-      targetId:          Target.Id,
-      expandedTargetIds: View[SortedSet[Target.Id]]
+    private def setAsterismTargetWithIndex(
+      objectsWithObs:        View[TargetsAndAsterismsWithObs],
+      targetId:              Target.Id,
+      asterismId:            Asterism.Id,
+      targetWithIndexSetter: Adjuster[TargetList, targetListMod.ElemWithIndex]
+    ): targetListMod.ElemWithIndex => IO[Unit] =
+      targetWithIndex =>
+        // 1) Update internal model
+        objectsWithObs
+          .zoom(TargetsAndAsterismsWithObs.asterisms)
+          .zoomGetAdjust(asterismListMod.withKey(asterismId))
+          .zoomPrism(some)
+          .zoomLens(first)
+          .zoom(AsterismIdName.targets)
+          .mod(targetWithIndexSetter.set(targetWithIndex)) >>
+          // 2) Send mutation & adjust focus
+          targetWithIndex.fold(
+            unshareTargetWithAsterism(targetId, asterismId)
+          ) { case (target, _) =>
+            shareTargetWithAsterism(target.id, asterismId)
+          }
+
+    private def asterismTargetMod(
+      setter:         Undoer.Setter[IO, TargetsAndAsterismsWithObs],
+      objectsWithObs: View[TargetsAndAsterismsWithObs],
+      targetId:       Target.Id,
+      asterismId:     Asterism.Id
+    ): targetListMod.Operation => IO[Unit] = {
+      val targetWithId: GetAdjust[TargetList, targetListMod.ElemWithIndex] =
+        targetListMod.withKey(targetId)
+
+      setter
+        .mod[targetListMod.ElemWithIndex](
+          objectsWithObs.get,
+          TargetsAndAsterismsWithObs.asterisms
+            .composeGetter(asterismListMod.withKey(asterismId).getter)
+            .map(_.map(_._1.targets).map(targetWithId.getter.get).flatten)
+            .get,
+          setAsterismTargetWithIndex(objectsWithObs, targetId, asterismId, targetWithId.adjuster)
+        )
+    }
+
+    // private def setAsterismWithIndex(
+    //   objectsWithObs:          View[TargetsAndAsterismsWithObs],
+    //   asterismId:              Asterism.Id,
+    //   asterismWithIndexSetter: Adjuster[AsterismList, asterismListMod.ElemWithIndex]
+    // ): asterismListMod.ElemWithIndex => IO[Unit] = { asterismWithIndex =>
+    //   val view = objectsWithObs
+    //     .zoom(TargetsAndAsterismsWithObs.asterisms)
+
+    //   val isNew = view.get.getElement(asterismId).isEmpty
+
+    //   // 1) Update internal model
+    //   view
+    //     .mod(asterismWithIndexSetter.set(asterismWithIndex)) >>
+    //     // 2) Send mutation & adjust focus
+    //     asterismWithIndex.fold(
+    //       IO(println(s"DELETE ASTERISM $asterismId"))
+    //     ) { case (asterism, _) =>
+    //       if (isNew)
+    //         IO(println(s"CREATE ASTERISM $asterism"))
+    //       else
+    //         IO(println(s"UPDATE ASTERISM $asterism")) >>
+    //           updateAsterism(asterism)
+    //     }
+    // }
+
+    // private def asterismMod(
+    //   setter:         Undoer.Setter[IO, TargetsAndAsterismsWithObs],
+    //   objectsWithObs: View[TargetsAndAsterismsWithObs],
+    //   asterismId:     Asterism.Id
+    // ): asterismListMod.Operation => IO[Unit] = {
+    //   val asterismWithId: GetAdjust[AsterismList, asterismListMod.ElemWithIndex] =
+    //     asterismListMod.withKey(asterismId)
+
+    //   setter
+    //     .mod[asterismListMod.ElemWithIndex](
+    //       objectsWithObs.get,
+    //       TargetsAndAsterismsWithObs.asterisms
+    //         .composeGetter(asterismWithId.getter)
+    //         .get,
+    //       setAsterismWithIndex(objectsWithObs, asterismId, asterismWithId.adjuster)
+    //     )
+    // }
+
+    protected def addTargetToAsterism(
+      objectsWithObs: View[TargetsAndAsterismsWithObs],
+      target:         TargetIdName,
+      asterismId:     Asterism.Id,
+      setter:         Undoer.Setter[IO, TargetsAndAsterismsWithObs]
+    ): IO[Unit] =
+      asterismTargetMod(setter, objectsWithObs, target.id, asterismId)(
+        targetListMod.upsert(
+          target,
+          objectsWithObs.get.asterisms.getElement(asterismId).foldMap(_.targets.length)
+        )
+      )
+
+    protected def deleteTargetFromAsterism(
+      targetId:   Target.Id,
+      asterismId: Asterism.Id,
+      setter:     Undoer.Setter[IO, TargetsAndAsterismsWithObs]
     ): Callback =
-      expandedTargetIds.mod { expanded =>
+      $.props.flatMap { props =>
+        asterismTargetMod(setter, props.objectsWithObs, targetId, asterismId)(
+          targetListMod.delete
+        ).runAsyncCB
+      }
+
+    def toggleExpanded[A: Eq](
+      id:          A,
+      expandedIds: View[SortedSet[A]]
+    ): Callback =
+      expandedIds.mod { expanded =>
         expanded
-          .exists(_ === targetId)
-          .fold(expanded - targetId, expanded + targetId)
+          .exists(_ === id)
+          .fold(expanded - id, expanded + id)
       }.runAsyncCB
 
     // Adapted from https://github.com/atlassian/react-beautiful-dnd/issues/374#issuecomment-569817782
-    def getObsStyle(style:       TagMod, snapshot: Draggable.StateSnapshot): TagMod =
+    def getDraggedStyle(style:   TagMod, snapshot: Draggable.StateSnapshot): TagMod =
       if (!snapshot.isDragging)
         TagMod.empty
       else if (!snapshot.isDropAnimating)
@@ -214,16 +362,46 @@ object TargetObsList {
     def getListStyle(isDragging: Boolean): TagMod =
       ExploreStyles.DraggingOver.when(isDragging)
 
-    def render(props: Props): VdomElement = {
-      val obsByTarget = props.targetsWithObs.get.obs.toList.groupBy(_.target.id)
+    def renderObsBadge(focused: View[Option[Focused]])(obs: ObsAttached, idx: Int): TagMod =
+      <.div(ExploreStyles.ObsTreeItem)(
+        Draggable(obs.id.toString, idx) { case (provided, snapshot, _) =>
+          <.div(
+            provided.innerRef,
+            provided.draggableProps,
+            getDraggedStyle(
+              provided.draggableStyle,
+              snapshot
+            ),
+            ^.onClick ==> { e: ReactEvent =>
+              e.stopPropagationCB >>
+                focused.set(FocusedObs(obs.id).some).runAsyncCB
+            }
+          )(
+            <.span(provided.dragHandleProps)(
+              ObsBadge(
+                ObsSummary(obs.id, obs.name.orEmpty),
+                ObsBadge.Layout.ConfAndConstraints,
+                selected = focused.get.exists(_ === FocusedObs(obs.id))
+              )
+            )
+          )
+        }
+      )
 
-      val targets    = props.targetsWithObs.get.targets.toList
+    def render(props: Props): VdomElement = try {
+      val obsByObject = props.objectsWithObs.get.obs.toList.groupBy(_.attached)
+
+      val targets    = props.objectsWithObs.get.targets.toList
       val targetIds  = targets.map(_.id)
       val targetIdxs = targets.zipWithIndex
 
+      val asterisms = props.objectsWithObs.get.asterisms.toList
+      // val asterismIds  = asterisms.map(_.id)
+      // val asterimsIdxs = asterisms.zipWithIndex
+
       React.Fragment(
-        UndoRegion[TargetsWithObs] { undoCtx =>
-          DragDropContext(onDragEnd = onDragEnd(undoCtx.setter, props.expandedTargetIds))(
+        UndoRegion[TargetsAndAsterismsWithObs] { undoCtx =>
+          DragDropContext(onDragEnd = onDragEnd(undoCtx.setter, props.expandedIds))(
             <.div(ExploreStyles.ObsTreeWrapper)(
               <.div(ExploreStyles.TreeToolbar)(
                 <.div(
@@ -231,126 +409,238 @@ object TargetObsList {
                     Icons.New.size(Small).fitted(true)
                   )
                 ),
-                UndoButtons(props.targetsWithObs.get, undoCtx, size = Mini)
+                UndoButtons(props.objectsWithObs.get, undoCtx, size = Mini)
               ),
               <.div(ExploreStyles.ObsTree)(
                 <.div(ExploreStyles.ObsScrollTree)(
-                  targets
-                    .toTagMod { target =>
-                      val targetId      = target.id
-                      val currIdx       = targetIds.indexOf(targetId)
-                      val nextToSelect  = targetIdxs.find(_._2 === currIdx + 1).map(_._1)
-                      val prevToSelect  = targetIdxs.find(_._2 === currIdx - 1).map(_._1)
-                      val focusOnDelete = nextToSelect.orElse(prevToSelect)
+                  Droppable("targetList") { case (targetListProvided, targetListSnapshot) =>
+                    <.div(
+                      targetListProvided.innerRef,
+                      targetListProvided.droppableProps,
+                      getListStyle(targetListSnapshot.isDraggingOver)
+                    )(
+                      targets.zipWithIndex
+                        .toTagMod { case (target, targetIdx) =>
+                          val targetId      = target.id
+                          val currIdx       = targetIds.indexOf(targetId)
+                          val nextToSelect  = targetIdxs.find(_._2 === currIdx + 1).map(_._1)
+                          val prevToSelect  = targetIdxs.find(_._2 === currIdx - 1).map(_._1)
+                          val focusOnDelete = nextToSelect.orElse(prevToSelect)
 
-                      val targetObs     = obsByTarget.get(targetId).orEmpty
-                      val obsCount      = targetObs.length
-                      val focusedTarget = FocusedTarget(targetId)
+                          val targetObs = obsByObject.get(targetId.asLeft).orEmpty
+                          val obsCount  = targetObs.length
 
-                      val opIcon =
-                        targetObs.nonEmpty.fold(
-                          Icon(
-                            "chevron " + props.expandedTargetIds.get
-                              .exists(_ === targetId)
-                              .fold("down", "right")
-                          )(^.cursor.pointer,
-                            ^.onClick ==> { e: ReactEvent =>
-                              e.stopPropagationCB >>
-                                toggleExpanded(targetId, props.expandedTargetIds)
-                                  .asEventDefault(e)
-                                  .void
-                            }
-                          ),
-                          Icons.ChevronRight
-                        )
-
-                      val memberObsSelected = props.focused.get
-                        .exists(f => targetObs.map(obs => FocusedObs(obs.id)).exists(f === _))
-                      AppCtx.withCtx { ctx =>
-                        Droppable(target.id.toString) { case (provided, snapshot) =>
-                          <.div(
-                            provided.innerRef,
-                            provided.droppableProps,
-                            getListStyle(snapshot.isDraggingOver)
-                          )(
-                            Segment(
-                              vertical = true,
-                              clazz = ExploreStyles.ObsTreeGroup |+| Option
-                                .when(
-                                  memberObsSelected || props.focused.get
-                                    .exists(_ === focusedTarget)
-                                )(ExploreStyles.SelectedObsTreeGroup)
-                                .getOrElse(ExploreStyles.UnselectedObsTreeGroup)
-                            )(
-                              ^.cursor.pointer,
-                              ^.onClick --> props.focused
-                                .set(focusedTarget.some)
-                                .runAsyncCB
-                            )(
-                              <.span(ExploreStyles.ObsTreeGroupHeader)(
-                                <.a(
-                                  ^.href := ctx.pageUrl(AppTab.Targets, focusedTarget.some),
-                                  opIcon,
-                                  target.name.value,
-                                  ExploreStyles.TargetLabelTitle,
-                                  ^.onClick ==> linkOverride(props.focused.set(focusedTarget.some))
-                                ),
-                                Button(
-                                  size = Small,
-                                  compact = true,
-                                  clazz = ExploreStyles.DeleteButton |+| ExploreStyles.JustifyRight,
-                                  onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
-                                    e.stopPropagationCB *>
-                                      deleteTarget(targetId, undoCtx.setter, focusOnDelete)
-                                )(
-                                  Icons.Delete
-                                    .size(Small)
-                                    .fitted(true)
-                                    .clazz(ExploreStyles.TrashIcon)
-                                ),
-                                <.span(ExploreStyles.ObsCount, s"$obsCount Obs")
-                              ),
-                              TagMod.when(props.expandedTargetIds.get.contains(targetId))(
-                                targetObs.zipWithIndex.toTagMod { case (obs, idx) =>
-                                  <.div(ExploreStyles.ObsTreeItem)(
-                                    Draggable(obs.id.toString, idx) {
-                                      case (provided, snapshot, _) =>
-                                        <.div(
-                                          provided.innerRef,
-                                          provided.draggableProps,
-                                          getObsStyle(provided.draggableStyle, snapshot),
-                                          ^.onClick ==> { e: ReactEvent =>
-                                            e.stopPropagationCB >>
-                                              props.focused
-                                                .set(FocusedObs(obs.id).some)
-                                                .runAsyncCB
-                                          }
-                                        )(
-                                          <.span(provided.dragHandleProps)(
-                                            ObsBadge(
-                                              ObsSummary(obs.id, obs.target.name.value),
-                                              ObsBadge.Layout.ConfAndConstraints,
-                                              selected =
-                                                props.focused.get.exists(_ === FocusedObs(obs.id))
-                                            )
-                                          )
-                                        )
-                                    }
-                                  )
+                          val expandedTargetIds =
+                            props.expandedIds.zoom(TargetViewExpandedIds.targetIds)
+                          val opIcon            =
+                            targetObs.nonEmpty.fold(
+                              Icon(
+                                "chevron " + expandedTargetIds.get
+                                  .exists(_ === targetId)
+                                  .fold("down", "right")
+                              )(^.cursor.pointer,
+                                ^.onClick ==> { e: ReactEvent =>
+                                  e.stopPropagationCB >>
+                                    toggleExpanded(targetId, expandedTargetIds)
+                                      .asEventDefault(e)
+                                      .void
                                 }
                               ),
-                              provided.placeholder
+                              Icons.ChevronRight
                             )
-                          )
-                        }
-                      }
+
+                          val memberObsSelected = props.focused.get
+                            .exists(f => targetObs.map(obs => FocusedObs(obs.id)).exists(f === _))
+
+                          // TODO: Collapse the target while dragging it (and then restore its collapsed state)
+                          Draggable(targetId.toString, targetIdx) {
+                            case (targetProvided, targetSnapshot, _) =>
+                              <.div(
+                                targetProvided.innerRef,
+                                targetProvided.draggableProps,
+                                getDraggedStyle(targetProvided.draggableStyle, targetSnapshot)
+                              )(
+                                <.span(targetProvided.dragHandleProps)(
+                                  Droppable(targetId.toString) { case (provided, snapshot) =>
+                                    <.div(
+                                      provided.innerRef,
+                                      provided.droppableProps,
+                                      getListStyle(snapshot.isDraggingOver)
+                                    )(
+                                      Segment(
+                                        vertical = true,
+                                        clazz = ExploreStyles.ObsTreeGroup |+| Option
+                                          .when(
+                                            memberObsSelected || props.focused.get
+                                              .exists(_ === FocusedTarget(target.id))
+                                          )(ExploreStyles.SelectedObsTreeGroup)
+                                          .getOrElse(ExploreStyles.UnselectedObsTreeGroup)
+                                      )(
+                                        ^.cursor.pointer,
+                                        ^.onClick --> props.focused
+                                          .set(FocusedTarget(targetId).some)
+                                          .runAsyncCB
+                                      )(
+                                        <.span(ExploreStyles.ObsTreeGroupHeader)(
+                                          <.span(
+                                            opIcon,
+                                            target.name.value,
+                                            ExploreStyles.TargetLabelTitle
+                                          ),
+                                          Button(
+                                            size = Small,
+                                            compact = true,
+                                            clazz =
+                                              ExploreStyles.DeleteButton |+| ExploreStyles.JustifyRight,
+                                            onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
+                                              e.stopPropagationCB *>
+                                                deleteTarget(targetId,
+                                                             undoCtx.setter,
+                                                             focusOnDelete
+                                                )
+                                          )(
+                                            Icons.Delete
+                                              .size(Small)
+                                              .fitted(true)
+                                              .clazz(ExploreStyles.TrashIcon)
+                                          ),
+                                          <.span(ExploreStyles.ObsCount, s"$obsCount Obs")
+                                        ),
+                                        TagMod
+                                          .when(expandedTargetIds.get.contains(targetId))(
+                                            targetObs.zipWithIndex.toTagMod(
+                                              (renderObsBadge(props.focused) _).tupled
+                                            )
+                                          ),
+                                        <.span(provided.placeholder)
+                                      )
+                                    )
+                                  }
+                                )
+                              )
+                          }
+
+                        },
+                      <.span(targetListProvided.placeholder, ^.display.none)
+                    )
+                  }
+                )
+              ),
+              <.div(ExploreStyles.ObsTree)(
+                <.div(ExploreStyles.ObsScrollTree)(
+                  asterisms.toTagMod { asterism =>
+                    val asterismId = asterism.id
+
+                    val asterismTargets = asterism.targets.toList
+                    val asterismObs     = obsByObject.get(asterismId.asRight).orEmpty
+                    val obsCount        = asterismObs.length
+
+                    val expandedAsterismIds =
+                      props.expandedIds.zoom(TargetViewExpandedIds.asterismIds)
+                    val opIcon              =
+                      (asterismObs.nonEmpty || asterismTargets.nonEmpty).fold(
+                        Icon(
+                          "chevron " + expandedAsterismIds.get
+                            .exists(_ === asterismId)
+                            .fold("down", "right")
+                        )(^.cursor.pointer,
+                          ^.onClick ==> { e: ReactEvent =>
+                            e.stopPropagationCB >>
+                              toggleExpanded(asterismId, expandedAsterismIds)
+                                .asEventDefault(e)
+                                .void
+                          }
+                        ),
+                        Icons.ChevronRight
+                      )
+
+                    Droppable(asterismId.toString) { case (provided, snapshot) =>
+                      <.div(
+                        provided.innerRef,
+                        provided.droppableProps,
+                        getListStyle(snapshot.isDraggingOver)
+                      )(
+                        Segment(
+                          vertical = true,
+                          clazz = ExploreStyles.ObsTreeGroup |+| None
+                            // Option
+                            //   .when(
+                            //     memberObsSelected || props.focused.get
+                            //       .exists(_ === FocusedTarget(target.id))
+                            //   )(ExploreStyles.SelectedObsTreeGroup)
+                            .getOrElse(ExploreStyles.UnselectedObsTreeGroup)
+                        )(
+                          ^.cursor.pointer,
+                          ^.onClick --> props.focused
+                            .set(FocusedAsterism(asterismId).some)
+                            .runAsyncCB
+                        )(
+                          <.span(ExploreStyles.ObsTreeGroupHeader)(
+                            <.span(
+                              opIcon,
+                              asterism.name.value,
+                              ExploreStyles.TargetLabelTitle
+                            ),
+                            Button(
+                              size = Small,
+                              compact = true,
+                              clazz = ExploreStyles.DeleteButton |+| ExploreStyles.JustifyRight
+                              // onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
+                              //   e.stopPropagationCB *>
+                              //     deleteTarget(targetId, undoCtx.setter, focusOnDelete)
+                            )(
+                              Icons.Delete
+                                .size(Small)
+                                .fitted(true)
+                                .clazz(ExploreStyles.TrashIcon)
+                            ),
+                            <.span(ExploreStyles.ObsCount, s"$obsCount Obs")
+                          ),
+                          TagMod.when(expandedAsterismIds.get.contains(asterismId))(
+                            <.div(ExploreStyles.ObsTreeItem)(
+                              SegmentGroup(
+                                asterismTargets.toTagMod(target =>
+                                  Segment(basic = true, clazz = ExploreStyles.ObsTreeGroupHeader)(
+                                    <.span(ExploreStyles.TargetLabelTitle)(target.name.value),
+                                    Button(
+                                      size = Small,
+                                      compact = true,
+                                      clazz =
+                                        ExploreStyles.DeleteButton |+| ExploreStyles.JustifyRight,
+                                      onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
+                                        e.stopPropagationCB *>
+                                          deleteTargetFromAsterism(target.id,
+                                                                   asterismId,
+                                                                   undoCtx.setter
+                                          )
+                                    )(
+                                      Icons.Delete
+                                        .size(Small)
+                                        .fitted(true)
+                                        .clazz(ExploreStyles.TrashIcon)
+                                    )
+                                  )
+                                // )
+                                )
+                              ).when(asterismTargets.nonEmpty),
+                              asterismObs.zipWithIndex.toTagMod(
+                                (renderObsBadge(props.focused) _).tupled
+                              )
+                            )
+                          ),
+                          provided.placeholder
+                        )
+                      )
                     }
+                  }
                 )
               )
             )
           )
         }
       )
+    } catch {
+      case t: Throwable => t.printStackTrace(); throw t
     }
   }
 
@@ -359,13 +649,22 @@ object TargetObsList {
       .builder[Props]
       .renderBackend[Backend]
       .componentDidMount { $ =>
-        // Remove targets from expanded set which are no longer present.
-        ($.props.expandedTargetIds.get -- $.props.targetsWithObs.get.targets.toList
+        // Remove objects from expanded set which are no longer present.
+        val expandedTargetIds   = $.props.expandedIds.zoom(TargetViewExpandedIds.targetIds)
+        val expandedAsterismIds = $.props.expandedIds.zoom(TargetViewExpandedIds.asterismIds)
+
+        (expandedTargetIds.get -- $.props.objectsWithObs.get.targets.toList
           .map(_.id)).toNes
           .map(removedTargetIds =>
-            $.props.expandedTargetIds.mod(_ -- removedTargetIds.toSortedSet).runAsyncCB
+            expandedTargetIds.mod(_ -- removedTargetIds.toSortedSet).runAsyncCB
           )
-          .getOrEmpty
+          .getOrEmpty >>
+          (expandedAsterismIds.get -- $.props.objectsWithObs.get.asterisms.toList
+            .map(_.id)).toNes
+            .map(removedAsterismIds =>
+              expandedAsterismIds.mod(_ -- removedAsterismIds.toSortedSet).runAsyncCB
+            )
+            .getOrEmpty
       }
       .build
 }

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -137,22 +137,6 @@ object TargetObsList {
                             .foldMap(target =>
                               addTargetToAsterism(props.objectsWithObs, target, asterismId, setter)
                             )
-                        // protected def addTargetToAsterism(
-                        //   target:     TargetIdName,
-                        //   asterismId: Asterism.Id,
-                        //   setter:     Undoer.Setter[IO, TargetsAndAsterismsWithObs]
-
-                        // asterismMod(setter, props.objectsWithObs, asterismId)(
-                        //   asterismListMod
-                        //     .mod(
-                        //       AsterismIdName.targets.modify(targets =>
-                        //         if (!targets.exists(_.id === targetId))
-                        //           targets ++ props.objectsWithObs.get.targets.getElement(targetId)
-                        //         else
-                        //           targets
-                        //       )
-                        //     )
-                        // )
                         case None             => IO.unit
                       }
                     case None           => IO.unit
@@ -276,49 +260,6 @@ object TargetObsList {
         )
     }
 
-    // private def setAsterismWithIndex(
-    //   objectsWithObs:          View[TargetsAndAsterismsWithObs],
-    //   asterismId:              Asterism.Id,
-    //   asterismWithIndexSetter: Adjuster[AsterismList, asterismListMod.ElemWithIndex]
-    // ): asterismListMod.ElemWithIndex => IO[Unit] = { asterismWithIndex =>
-    //   val view = objectsWithObs
-    //     .zoom(TargetsAndAsterismsWithObs.asterisms)
-
-    //   val isNew = view.get.getElement(asterismId).isEmpty
-
-    //   // 1) Update internal model
-    //   view
-    //     .mod(asterismWithIndexSetter.set(asterismWithIndex)) >>
-    //     // 2) Send mutation & adjust focus
-    //     asterismWithIndex.fold(
-    //       IO(println(s"DELETE ASTERISM $asterismId"))
-    //     ) { case (asterism, _) =>
-    //       if (isNew)
-    //         IO(println(s"CREATE ASTERISM $asterism"))
-    //       else
-    //         IO(println(s"UPDATE ASTERISM $asterism")) >>
-    //           updateAsterism(asterism)
-    //     }
-    // }
-
-    // private def asterismMod(
-    //   setter:         Undoer.Setter[IO, TargetsAndAsterismsWithObs],
-    //   objectsWithObs: View[TargetsAndAsterismsWithObs],
-    //   asterismId:     Asterism.Id
-    // ): asterismListMod.Operation => IO[Unit] = {
-    //   val asterismWithId: GetAdjust[AsterismList, asterismListMod.ElemWithIndex] =
-    //     asterismListMod.withKey(asterismId)
-
-    //   setter
-    //     .mod[asterismListMod.ElemWithIndex](
-    //       objectsWithObs.get,
-    //       TargetsAndAsterismsWithObs.asterisms
-    //         .composeGetter(asterismWithId.getter)
-    //         .get,
-    //       setAsterismWithIndex(objectsWithObs, asterismId, asterismWithId.adjuster)
-    //     )
-    // }
-
     protected def addTargetToAsterism(
       objectsWithObs: View[TargetsAndAsterismsWithObs],
       target:         TargetIdName,
@@ -399,8 +340,6 @@ object TargetObsList {
       val targetIdxs = targets.zipWithIndex
 
       val asterisms = props.objectsWithObs.get.asterisms.toList
-      // val asterismIds  = asterisms.map(_.id)
-      // val asterimsIdxs = asterisms.zipWithIndex
 
       React.Fragment(
         UndoRegion[TargetsAndAsterismsWithObs] { undoCtx =>

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
@@ -251,19 +251,6 @@ object TargetObsQueries {
     """
   }
 
-  // @GraphQL
-  // object UnshareTargetWithObs extends GraphQLOperation[ObservationDB] {
-  //   val document = """
-  //     mutation($targetId: TargetId!, $obsId: ObservationId!) {
-  //       unshareTargetWithObservations(
-  //         input: { targetId: $targetId, observationIds: [$obsId] }
-  //       ) {
-  //         id
-  //       }
-  //     }
-  //   """
-  // }
-
   @GraphQL
   object ShareTargetWithAsterisms extends GraphQLOperation[ObservationDB] {
     val document = """
@@ -288,11 +275,6 @@ object TargetObsQueries {
 
   def moveObs(obsId: Observation.Id, to: ObjectId): IO[Unit] =
     AppCtx.withCtx { implicit appCtx =>
-      // (fromTarget match {
-      //   case Left(targetId)           => UnshareTargetWithObs.execute(targetId, obsId)
-      //   case Right(_ /*asterismId*/ ) =>
-      //     IO.unit // UnshareAsterismWithObs.execute(asterismId, obsId)
-      // }) >>
       (to match {
         case Left(targetId)    => ShareTargetWithObs.execute(targetId, obsId)
         case Right(asterismId) => ShareAsterismWithObs.execute(asterismId, obsId)

--- a/observationtree/src/main/scala/explore/observationtree/Test.scala
+++ b/observationtree/src/main/scala/explore/observationtree/Test.scala
@@ -24,7 +24,7 @@ object Test extends AppMain {
           TargetObsList(
             targetsWithObs,
             view.zoom(RootModel.focused),
-            view.zoom(RootModel.expandedTargetIds)
+            view.zoom(RootModel.targetViewExpandedIds)
           )
         )
       )


### PR DESCRIPTION
Allows:
 * Dragging observations between targets and asterisms.
 * Dragging targets into asterisms.
 * Removing targets from asterisms.
 * Create/delete asterisms.
 * Undo/redo of all of the above.
 * URLs for asterisms.
 * Auto expand target or observation if URL with observation assigned to them is invoked.

Pending (future PR):
 * Unassigned observations list.
 * Collapse target while dragging it into an asterism (we don't care about the target's observations in that case, and it may be confusing).
