### PR TITLE
Mag table

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -70,6 +70,10 @@ body.light-theme {
   color: var(--explore-accent-color);
 }
 
+tfoot {
+  background-color: var(--table-footer-background);
+}
+
 //----------
 // Main grid
 //----------
@@ -841,6 +845,26 @@ img.partner-split-flag {
   font-size: larger;
 }
 
+// For very small tables hide the headers and add fake "header" to the left of the row
+.tile-xs-width .explore-magnitudes-container {
+  .ui.table,
+  thead,
+  tbody,
+  th,
+  td,
+  tr {
+    // SUI already has an !ímportant
+    display: block !important;
+  }
+
+  // Hide table headers (but not display: none;, for accessibility)
+  thead tr {
+    position: absolute;
+    top: -9999px;
+    left: -9999px;
+  }
+}
+
 .ui.table.partner-splits-editor-table {
   th:last-child,
   td:last-child,
@@ -1026,4 +1050,75 @@ html {
 
 .observer-notes {
   padding: 1em;
+}
+
+.ui.segment.explore-magnitudes-container {
+  padding: 0;
+  display: inline-block;
+}
+
+// https://css-tricks.com/responsive-data-tables/
+.tile-xs-width .explore-magnitudes-container .ui.ui.ui.ui.table:not(.unstackable) {
+  tfoot {
+    display: block;
+  }
+
+  td {
+    /* Behave  like a "row" */
+    position: relative;
+    padding-left: 40%;
+    padding-right: 0.5em;
+  }
+
+  td::before {
+    /* Now like a table header */
+    position: absolute;
+
+    /* Top/left values mimic padding */
+    top: 6px;
+    left: 6px;
+    width: 45%;
+    padding-left: 0.25em;
+    white-space: nowrap;
+  }
+
+  td:first-child::before {
+    font-weight: normal;
+  }
+
+  // It is a bit unfortunate that we have to hardcode the column names here
+  td:nth-of-type(1)::before {
+    content: "Value";
+  }
+
+  td:nth-of-type(2)::before {
+    content: "Band";
+  }
+
+  td:nth-of-type(3)::before {
+    content: "System";
+  }
+
+  td:nth-of-type(4)::before {
+    content: "";
+  }
+
+  // Align the trash button
+  td:last-child button {
+    margin-left: auto;
+  }
+}
+
+.explore-magnitudes-delete-button-wrapper {
+  display: flex;
+  justify-content: center;
+
+  .ui.button.delete-button {
+    margin-right: 0.2em;
+  }
+}
+
+.explore-magnitudes-footer {
+  display: flex;
+  justify-content: flex-end;
 }

--- a/common/src/main/resources/less/variables-dark.less
+++ b/common/src/main/resources/less/variables-dark.less
@@ -302,10 +302,11 @@
 
 .table-dark() {
   --table-background: var(--color-background-light-3);
-  --table-striped-background: var(--color-background-light-6);
+  --table-striped-background: var(--color-background-light-8);
   --table-active-background-hover: var(--color-background-light-15);
-  --table-header-background: var(--color-background-dark-5);
-  --table-footer-background: var(--color-background-dark-5);
+  --table-header-background: var(--color-background-light-15);
+  --table-footer-background: var(--color-background-light-15);
+  --table-selectable-background: var(--color-background-light-12);
 }
 
 .modal-dark() {

--- a/common/src/main/resources/less/variables-light.less
+++ b/common/src/main/resources/less/variables-light.less
@@ -174,6 +174,8 @@
   --table-active-background-hover: hsl(0, 0%, 94%);
   --table-header-background: @offWhite;
   --table-footer-background: @offWhite;
+  --table-selectable-background: @transparentBlack;
+  --table-selectable-color: var(--text-color);
 }
 
 .modal-light() {

--- a/common/src/main/resources/theme/collections/table.variables
+++ b/common/src/main/resources/theme/collections/table.variables
@@ -8,3 +8,18 @@
 @border: darken(@gray-darker, 5%);
 @definitionPageBackground: transparent;
 @activeBackgroundColor: @gray;
+
+@smallPadding: 0.25em;
+@headerVerticalPadding: @smallPadding;
+@headerHorizontalPadding: @smallPadding;
+@footerVerticalPadding: @smallPadding;
+@footerHorizontalPadding: @smallPadding;
+@responsiveRowVerticalPadding: @smallPadding;
+@responsiveRowHorizontalPadding: @smallPadding;
+@headerTextTransform: capitalize;
+@headerFontWeight: normal;
+@compactHorizontalPadding: @smallPadding;
+
+@selectableBackground: var(--table-selectable-background);
+@selectableTextColor: var(--table-selectable-color);
+

--- a/common/src/main/resources/theme/elements/input.variables
+++ b/common/src/main/resources/theme/elements/input.variables
@@ -1,3 +1,11 @@
 @placeholderColor: @gray-lighter;
-@focusColor: black;
+@selectable focusColor: black;
+
+// Use a reduced padding
+@tightInputVerticalPadding: (@tightVerticalPadding + ((1em - @inputLineHeight) / 2));
+@padding: @tightInputVerticalPadding @tightHorizontalPadding;
+
+@inputBackground: var(--form-input-background);
+@inputFocusBorderColor: var(--form-input-focus-border-color);
+@inputFocusBoxShadow: var(--form-input-focus-box-shadow);
 

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -15,6 +15,7 @@ import react.common.implicits._
 import react.semanticui.collections.menu._
 import react.semanticui.elements.button.Button
 import react.sizeme._
+import explore.model.Constants
 
 final case class TileButton(body: VdomNode)
 
@@ -36,9 +37,13 @@ object Tile {
   // Explicitly never reuse as we are not considering the content
   implicit val propsReuse: Reusability[Tile] = Reusability.never
   val defaultBreakpoints                     =
-    List((384 -> TileSMW), (576 -> TileMDW), (768 -> TileLGW), (1024 -> TileXLW))
+    List((300                            -> TileXSW),
+         (Constants.TwoPanelCutoff.toInt -> TileSMW),
+         (768                            -> TileMDW),
+         (1024                           -> TileLGW)
+    )
 
-  val component                              =
+  val component =
     ScalaComponent
       .builder[Props]
       .stateless

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -18,6 +18,7 @@ object ExploreStyles {
   val TileButton: Css      = Css("explore-tile-button")
   val TileStateButton: Css = Css("explore-tile-state-button")
 
+  val TileXSW: Css = Css("tile-xs-width")
   val TileSMW: Css = Css("tile-sm-width")
   val TileMDW: Css = Css("tile-md-width")
   val TileLGW: Css = Css("tile-lg-width")
@@ -182,4 +183,8 @@ object ExploreStyles {
   // Version with copy icon
   val Version: Css         = Css("version")
   val VersionUncopied: Css = Css("uncopied")
+
+  val MagnitudesTableContainer: Css          = Css("explore-magnitudes-container")
+  val MagnitudesTableFooter: Css             = Css("explore-magnitudes-footer")
+  val MagnitudesTableDeletButtonWrapper: Css = Css("explore-magnitudes-delete-button-wrapper")
 }

--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -14,6 +14,7 @@ import lucuma.ui.forms._
 import lucuma.ui.optics._
 import monocle.Lens
 import react.semanticui.elements.button.Button
+import react.common.style.Css
 import reactST.reactTable.mod._
 
 import scalajs.js
@@ -98,14 +99,18 @@ object ReactTableHelpers {
    * @return The component.
    */
   def buttonViewColumn[A](
-    button:   Button,
-    onClick:  View[A] => Callback,
-    disabled: Boolean = false
+    button:       Button,
+    onClick:      View[A] => Callback,
+    wrapperClass: Css = Css.Empty,
+    disabled:     Boolean = false
   ) =
     ScalaComponent
       .builder[View[A]]
       .render_P { rowData =>
-        button.addModifiers(Seq(^.onClick ==> (_ => onClick(rowData)), ^.disabled := disabled))
+        <.div(
+          wrapperClass,
+          button.addModifiers(Seq(^.onClick ==> (_ => onClick(rowData)), ^.disabled := disabled))
+        )
       }
       .build
       .cmapCtorProps[(CellProps[View[A], _]) with js.Object](_.cell.row.original)

--- a/model/src/main/scala/explore/model/Constants.scala
+++ b/model/src/main/scala/explore/model/Constants.scala
@@ -10,7 +10,7 @@ import lucuma.core.math.Angle
 trait Constants {
   val UnnamedTarget: NonEmptyString   = "<UNNAMED>"
   val UnnamedAsterism: NonEmptyString = "<UNNAMED>"
-  val TwoPanelCutoff                  = 550.0
+  val TwoPanelCutoff                  = 576.0
   val InitialTreeWidth                = 300.0
   val MinLeftPanelWidth               = 270.0
   val GridRowHeight                   = 36

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -45,31 +45,6 @@ final case class MagnitudeForm(
 object MagnitudeForm {
   type Props = MagnitudeForm
 
-  sealed trait Column extends Product with Serializable {
-    def id: String
-    def label: String
-  }
-  object Column {
-    case object Value  extends Column {
-      val id    = "value"
-      val label = id
-    }
-    case object Band   extends Column {
-      val id    = "band"
-      val label = id
-    }
-    case object System extends Column {
-      val id    = "system"
-      val label = id
-    }
-    case object Delete extends Column {
-      val id    = "delete"
-      val label = ""
-    }
-
-    val all: Map[String, Column] = List(Value, Band, System, Delete).fproductLeft(_.id).toMap
-  }
-
   @Lenses
   protected case class State(usedBands: Set[MagnitudeBand], newBand: Option[MagnitudeBand])
 
@@ -158,7 +133,7 @@ object MagnitudeForm {
           val columns = tableMaker.columnArray(
             tableMaker
               .componentColumn(
-                Column.Value.id,
+                "value",
                 ReactTableHelpers
                   .editableViewColumn(
                     Magnitude.value,
@@ -170,23 +145,26 @@ object MagnitudeForm {
                       .allowEmpty,
                     disabled = props.disabled
                   )
-              ),
+              )
+              .setHeader("Value"),
             tableMaker
-              .componentColumn(Column.Band.id,
+              .componentColumn("band",
                                ReactTableHelpers.editableEnumViewColumn(Magnitude.band)(
                                  disabled = props.disabled,
                                  excludeFn = Some(excludeFn)
                                )
               )
-              .setSortByFn(_.get.band),
+              .setSortByFn(_.get.band)
+              .setHeader("Band"),
             tableMaker
-              .componentColumn(Column.System.id,
+              .componentColumn("system",
                                ReactTableHelpers.editableEnumViewColumn(Magnitude.system)(
                                  disabled = props.disabled
                                )
-              ),
+              )
+              .setHeader("System"),
             tableMaker.componentColumn(
-              Column.Delete.id,
+              "delete",
               ReactTableHelpers.buttonViewColumn(button = deleteButton,
                                                  onClick = deleteFn,
                                                  disabled = props.disabled,
@@ -211,7 +189,10 @@ object MagnitudeForm {
                 tableMaker.makeTable(
                   options = options,
                   data = props.magnitudes.toListOfViews(_.band).toJSArray,
-                  headerCellFn = Some(c => <.th(Column.all.get(c.id.toString).foldMap(_.label))),
+                  headerCellFn = Some(c =>
+                    TableMaker
+                      .basicHeaderCellFn(Css.Empty)(c)
+                  ),
                   tableClass = Css("ui very celled selectable  striped compact table"),
                   footer = footer
                 )


### PR DESCRIPTION
This PR is about making the magnitudes table more responsive.
It uses a technique described [here](https://css-tricks.com/responsive-data-tables/) to move the headers to the side to make it easier to read on narrow screens.

Some screenshots:

![screencast 2021-02-08 13-16-49](https://user-images.githubusercontent.com/3615303/107248290-e9d4f200-6a10-11eb-97b9-c5c573e71f8a.gif)

![image](https://user-images.githubusercontent.com/3615303/107248232-db86d600-6a10-11eb-8a9b-0da9d924240b.png)
