### PR TITLE
Visual improvements in Target View tree

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -424,6 +424,7 @@ body.light-theme {
   align-items: stretch;
   min-height: 0;
   height: 100%;
+  overflow: hidden;
 }
 
 .obs-tree {
@@ -432,6 +433,7 @@ body.light-theme {
   min-height: 0;
   justify-content: center;
   flex-grow: 1;
+  overflow: hidden;
 }
 
 .obs-scroll-tree {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -26,7 +26,7 @@ object Settings {
     val mouse             = "0.26.2"
     val mUnit             = "0.7.21"
     val reactAladin       = "0.4.2"
-    val reactAtlasKitTree = "0.3.2"
+    val reactAtlasKitTree = "0.4.0"
     val reactClipboard    = "1.4.3"
     val reactCommon       = "0.11.3"
     val reactDatepicker   = "0.1.0"


### PR DESCRIPTION
A few visual improvements to the target view tree:

* Only show asterisms panel if there are asterisms.
* Only make targets draggable if there are asterisms.
* Show number of targets in asterisms.
* When dragging a target to an asterism:
  * Don't "move" it but instead "copy" it. In other words, the original target is still rendered in its place while dragging.
  * Show only a card with the target name. Don't show target's observations anymore.
  * Don't paint other targets while hovering over them.

**BEFORE:**
<img src="https://user-images.githubusercontent.com/1895643/107252602-47b70900-6a14-11eb-848c-f010e8f6ee6b.gif" width="250"/>

**AFTER:**
<img src="https://user-images.githubusercontent.com/1895643/107253025-a8dedc80-6a14-11eb-87d7-906c237e429f.gif" width="250"/>

[skip-ch]