### PR TITLE
Avoid remount when switching between 1 or 2 panels

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -287,8 +287,9 @@ object ObsTabContents {
               ExploreStyles.TreeRGL,
               <.div(ExploreStyles.Tree, treeInner(observations))
                 .when(state.panels.leftPanelVisible),
-              <.div(ExploreStyles.SinglePanelTile, rightSide)
-                .when(state.panels.rightPanelVisible)
+              <.div(^.key := "obs-right-side", ExploreStyles.SinglePanelTile)(
+                <.div(rightSide)
+              ).when(state.panels.rightPanelVisible)
             )
           } else {
             <.div(
@@ -303,7 +304,11 @@ object ObsTabContents {
                 resizeHandles = List(ResizeHandleAxis.East),
                 content = tree(observations)
               ),
-              <.div(^.width := coreWidth.px, ^.left := treeWidth.px, ExploreStyles.SinglePanelTile)(
+              <.div(^.key := "obs-right-side",
+                    ^.width := coreWidth.px,
+                    ^.left := treeWidth.px,
+                    ExploreStyles.SinglePanelTile
+              )(
                 <.div(ExploreStyles.TreeRGLWrapper, rightSide)
               )
             )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -145,7 +145,9 @@ object TargetTabContents {
                 ExploreStyles.TreeRGL,
                 <.div(ExploreStyles.Tree, treeInner(objectsWithObs))
                   .when(state.leftPanelVisible),
-                <.div(ExploreStyles.SinglePanelTile, rightSide).when(state.rightPanelVisible)
+                <.div(^.key := "target-right-side", ExploreStyles.SinglePanelTile)(
+                  rightSide
+                ).when(state.rightPanelVisible)
               )
             } else {
               <.div(
@@ -161,10 +163,11 @@ object TargetTabContents {
                   content = tree(objectsWithObs),
                   clazz = ExploreStyles.ResizableSeparator
                 ),
-                <.div(
-                  ExploreStyles.SinglePanelTile,
-                  ^.width := coreWidth.px,
-                  ^.left := treeWidth.px,
+                <.div(^.key := "target-right-side",
+                      ExploreStyles.SinglePanelTile,
+                      ^.width := coreWidth.px,
+                      ^.left := treeWidth.px
+                )(
                   rightSide
                 )
               )


### PR DESCRIPTION
When a resize forced a switch between 1 and 2 panel mode, the right side was being remounted. This forced requeries of the DB and resetting the event subscriptions.

Setting a `key` + preserving the DOM structure seems to do the trick.