### PR TITLE
Setup the target tile on the observations tab

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -677,17 +677,31 @@ tfoot {
 .target-grid {
   display: grid;
   grid-gap: 1em;
-  padding: 1em;
-  grid-template-columns: 1fr 2fr;
-
-  @media (max-width: @target-grid-responsive-cutoff) {
-    grid-template-columns: 1fr;
-  }
+  padding: 0.5em;
 }
 
 .target-aladin-cell {
   height: 100;
   min-height: 300; // don't collapse in single column mode.
+}
+
+.tile-xl-width,
+.tile-lg-width,
+.tile-md-width,
+.tile-sm-width {
+  .target-grid {
+    grid-template-columns: repeat(auto-fit, minmax(40ch, 1fr));
+  }
+
+  @supports (grid-template-rows: masonry) {
+    .target-grid {
+      grid-template-rows: masonry;
+    }
+  }
+
+  .target-aladin-cell {
+    grid-row: span 2;
+  }
 }
 
 .target-skyplot-cell {
@@ -698,18 +712,9 @@ tfoot {
   }
 }
 
-.target-search-form,
-.target-properties-form {
-  margin-bottom: 1em;
-}
-
 .target-properties-form {
   grid-template-columns: [field] 6fr [units] auto;
   justify-items: stretch;
-
-  @media (max-width: @target-grid-responsive-cutoff) {
-    display: none;
-  }
 }
 
 .catalogue-form {
@@ -850,22 +855,34 @@ img.partner-split-flag {
 }
 
 // For very small tables hide the headers and add fake "header" to the left of the row
-.tile-xs-width .explore-magnitudes-container {
-  .ui.table,
-  thead,
-  tbody,
-  th,
-  td,
-  tr {
-    // SUI already has an !ímportant
-    display: block !important;
+.tile-xs-width {
+  .target-grid {
+    grid-template-columns: 1fr;
   }
 
-  // Hide table headers (but not display: none;, for accessibility)
-  thead tr {
-    position: absolute;
-    top: -9999px;
-    left: -9999px;
+  .explore-magnitudes-container {
+    .ui.table,
+    thead,
+    tbody,
+    th,
+    td,
+    tr {
+      // SUI already has an !important
+      display: block !important;
+    }
+
+    // Hide table headers (but not display: none;, for accessibility)
+    thead tr {
+      position: absolute;
+      top: -9999px;
+      left: -9999px;
+    }
+  }
+}
+
+.tile-xs-height {
+  .explore-magnitudes-section {
+    display: none;
   }
 }
 

--- a/common/src/main/scala/explore/AppMain.scala
+++ b/common/src/main/scala/explore/AppMain.scala
@@ -4,25 +4,37 @@
 package explore
 
 import cats.data.OptionT
-import cats.effect.{ ExitCode, IO, IOApp }
+import cats.effect.ExitCode
+import cats.effect.IO
+import cats.effect.IOApp
 import cats.syntax.all._
+import clue.Backend
+import clue.WebSocketReconnectionStrategy
 import clue.data.Input
-import clue.js.{ AjaxJSBackend, WebSocketJSBackend }
-import clue.{ Backend, WebSocketReconnectionStrategy }
+import clue.js.AjaxJSBackend
+import clue.js.WebSocketJSBackend
 import crystal.AppRootContext
 import crystal.react.AppRoot
 import explore.common.UserPreferencesQueries._
 import explore.implicits._
-import explore.model.enum.{ AppTab, ExecutionEnvironment, Theme }
+import explore.model.AppConfig
+import explore.model.AppContext
+import explore.model.Focused
+import explore.model.RootModel
+import explore.model.UserVault
+import explore.model.enum.AppTab
+import explore.model.enum.ExecutionEnvironment
+import explore.model.enum.Theme
 import explore.model.reusability._
-import explore.model.{ AppConfig, AppContext, Focused, RootModel, UserVault }
 import explore.utils
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react.vdom.VdomElement
 import log4cats.loglevel.LogLevelLogger
 import lucuma.core.data.EnumZipper
 import org.scalajs.dom
-import org.scalajs.dom.experimental.{ Request => FetchRequest, RequestCache, RequestInit }
+import org.scalajs.dom.experimental.RequestCache
+import org.scalajs.dom.experimental.RequestInit
+import org.scalajs.dom.experimental.{ Request => FetchRequest }
 import org.scalajs.dom.raw.Element
 import sttp.client3._
 import sttp.client3.circe._

--- a/common/src/main/scala/explore/GraphQLSchemas.scala
+++ b/common/src/main/scala/explore/GraphQLSchemas.scala
@@ -6,9 +6,14 @@ package explore
 import clue.data._
 import clue.data.syntax._
 import clue.macros.GraphQLSchema
+import explore.model.ResizableSection
+import explore.model.SiderealTarget
 import explore.model.enum._
-import explore.model.{ ResizableSection, SiderealTarget }
-import lucuma.core.model.{ Asterism, Magnitude, Observation, Target, User }
+import lucuma.core.model.Asterism
+import lucuma.core.model.Magnitude
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import lucuma.core.model.User
 
 import java.math.MathContext
 

--- a/common/src/main/scala/explore/common/SSOClient.scala
+++ b/common/src/main/scala/explore/common/SSOClient.scala
@@ -7,7 +7,8 @@ import cats.effect._
 import cats.implicits._
 import eu.timepit.refined._
 import eu.timepit.refined.collection.NonEmpty
-import explore.model.{ SSOConfig, UserVault }
+import explore.model.SSOConfig
+import explore.model.UserVault
 import io.chrisdavenport.log4cats.Logger
 import io.circe.Decoder
 import io.circe.generic.semiauto._

--- a/common/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/common/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -7,18 +7,20 @@ import cats.MonadError
 import cats.data.OptionT
 import cats.effect.Effect
 import cats.syntax.all._
-import clue.macros.GraphQL
-import clue.{ GraphQLClient, GraphQLOperation }
+import clue.GraphQLClient
+import clue.GraphQLOperation
 import clue.data.syntax._
+import clue.macros.GraphQL
 import explore.GraphQLSchemas.UserPreferencesDB
-import explore.model.ResizableSection
 import explore.model.GridLayoutSection
+import explore.model.ResizableSection
 import explore.model.layout._
-import lucuma.core.model.User
-import lucuma.core.model.Target
-import react.gridlayout.{ BreakpointName => _, _ }
-import scala.collection.immutable.SortedMap
 import lucuma.core.math.Angle
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import react.gridlayout.{ BreakpointName => _, _ }
+
+import scala.collection.immutable.SortedMap
 
 object UserPreferencesQueries {
 

--- a/common/src/main/scala/explore/components/About.scala
+++ b/common/src/main/scala/explore/components/About.scala
@@ -8,7 +8,8 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.ReactProps
 import react.semanticui.modules.modal.Dimmer.Blurring
-import react.semanticui.modules.modal.{ Modal, ModalContent }
+import react.semanticui.modules.modal.Modal
+import react.semanticui.modules.modal.ModalContent
 
 case class About(trigger: VdomNode, content: VdomNode) extends ReactProps[About](About.component)
 

--- a/common/src/main/scala/explore/components/ConnectionsStatus.scala
+++ b/common/src/main/scala/explore/components/ConnectionsStatus.scala
@@ -5,7 +5,10 @@ package explore.components
 
 import clue.StreamingClientStatus
 import clue.StreamingClientStatus._
-import crystal.{ Error, Pending, Pot, Ready }
+import crystal.Error
+import crystal.Pending
+import crystal.Pot
+import crystal.Ready
 import explore.AppCtx
 import explore.components.ui.ExploreStyles
 import explore.components.ui.ExploreStyles._

--- a/common/src/main/scala/explore/components/ResponsiveComponent.scala
+++ b/common/src/main/scala/explore/components/ResponsiveComponent.scala
@@ -1,0 +1,41 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import cats.syntax.all._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import react.common._
+import react.common.implicits._
+import react.resizeDetector.ResizeDetector
+
+final case class ResponsiveComponent(
+  widthBreakpoints:  List[(Int, Css)],
+  heightBreakpoints: List[(Int, Css)] = Nil,
+  clazz:             Css = Css.Empty
+) extends ReactPropsWithChildren[ResponsiveComponent](ResponsiveComponent.component)
+
+object ResponsiveComponent {
+  type Props = ResponsiveComponent
+
+  // Explicitly never reuse as we are not considering the content
+  implicit val propsReuse: Reusability[ResponsiveComponent] = Reusability.never
+
+  val component =
+    ScalaComponent
+      .builder[Props]
+      .stateless
+      .render_PC { (p, c) =>
+        ResizeDetector() { s =>
+          val heightClass =
+            p.heightBreakpoints.findLast(_._1 < s.height.orEmpty).foldMap(_._2)
+          val widthClass  =
+            p.widthBreakpoints.findLast(_._1 < s.width.orEmpty).foldMap(_._2)
+          <.div(p.clazz |+| widthClass |+| heightClass, s.targetRef, c)
+        }
+      }
+      .configure(Reusability.shouldComponentUpdate)
+      .build
+
+}

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -7,7 +7,6 @@ import cats.syntax.all._
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.components.ui.ExploreStyles._
-import explore.model.Constants
 import explore.model.enum.TileSizeState
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -16,6 +15,7 @@ import react.common.implicits._
 import react.resizeDetector.ResizeDetector
 import react.semanticui.collections.menu._
 import react.semanticui.elements.button.Button
+import explore.model.Constants
 
 final case class TileButton(body: VdomNode)
 
@@ -36,7 +36,10 @@ object Tile {
 
   // Explicitly never reuse as we are not considering the content
   implicit val propsReuse: Reusability[Tile] = Reusability.never
-  val defaultBreakpoints                     =
+  val heightBreakpoints                      =
+    List((200, TileXSH), (700 -> TileSMH), (1024 -> TileMDH))
+
+  val widthBreakpoints                       =
     List((300                            -> TileXSW),
          (Constants.TwoPanelCutoff.toInt -> TileSMW),
          (768                            -> TileMDW),
@@ -49,8 +52,6 @@ object Tile {
       .stateless
       .render_PC { (p, c) =>
         ResizeDetector() { s =>
-          val widthClass     =
-            defaultBreakpoints.findLast(_._1 < s.width.getOrElse(0)).map(_._2).getOrElse(TileSMW)
           val maximizeButton =
             Button(
               as = <.a,
@@ -86,8 +87,10 @@ object Tile {
               minimizeButton.when(p.showMinimize),
               maximizeButton.when(p.showMaximize)
             ),
-            <.div(ExploreStyles.TileBody |+| widthClass, c)
-              .when(p.state =!= TileSizeState.Minimized)
+            ResponsiveComponent(widthBreakpoints,
+                                heightBreakpoints,
+                                clazz = ExploreStyles.TileBody
+            )(c).when(p.state =!= TileSizeState.Minimized)
           )
         }
       }

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.components.ui.ExploreStyles._
+import explore.model.Constants
 import explore.model.enum.TileSizeState
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -14,7 +15,6 @@ import react.common._
 import react.common.implicits._
 import react.semanticui.collections.menu._
 import react.semanticui.elements.button.Button
-import explore.model.Constants
 
 final case class TileButton(body: VdomNode)
 

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -12,7 +12,6 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
 import react.common.implicits._
-import react.resizeDetector.ResizeDetector
 import react.semanticui.collections.menu._
 import react.semanticui.elements.button.Button
 import explore.model.Constants
@@ -51,48 +50,45 @@ object Tile {
       .builder[Props]
       .stateless
       .render_PC { (p, c) =>
-        ResizeDetector() { s =>
-          val maximizeButton =
-            Button(
-              as = <.a,
-              basic = true,
-              compact = true,
-              clazz = ExploreStyles.TileStateButton |+| ExploreStyles.BlendedButton,
-              onClick = p.sizeStateCallback(TileSizeState.Maximized)
-            )(Icons.Maximize.fitted(true))
+        val maximizeButton =
+          Button(
+            as = <.a,
+            basic = true,
+            compact = true,
+            clazz = ExploreStyles.TileStateButton |+| ExploreStyles.BlendedButton,
+            onClick = p.sizeStateCallback(TileSizeState.Maximized)
+          )(Icons.Maximize.fitted(true))
 
-          val minimizeButton =
-            Button(
-              as = <.a,
-              basic = true,
-              compact = true,
-              clazz = ExploreStyles.TileStateButton |+| ExploreStyles.BlendedButton,
-              onClick = p.sizeStateCallback(TileSizeState.Minimized)
-            )(Icons.Minimize.fitted(true))
+        val minimizeButton =
+          Button(
+            as = <.a,
+            basic = true,
+            compact = true,
+            clazz = ExploreStyles.TileStateButton |+| ExploreStyles.BlendedButton,
+            onClick = p.sizeStateCallback(TileSizeState.Minimized)
+          )(Icons.Minimize.fitted(true))
 
-          <.div(ExploreStyles.Tile, s.targetRef)(
-            <.div(
-              ExploreStyles.TileTitle,
-              p.back.map(b => <.div(ExploreStyles.TileButton, b.body)),
-              Menu(
-                attached = MenuAttached.Top,
-                compact = true,
-                borderless = true,
-                secondary = true,
-                clazz = ExploreStyles.TileTitleMenu,
-                tabular = MenuTabular.Right
-              )(
-                MenuItem(as = <.a)(p.title)
-              ),
-              minimizeButton.when(p.showMinimize),
-              maximizeButton.when(p.showMaximize)
+        <.div(ExploreStyles.Tile)(
+          <.div(
+            ExploreStyles.TileTitle,
+            p.back.map(b => <.div(ExploreStyles.TileButton, b.body)),
+            Menu(
+              attached = MenuAttached.Top,
+              compact = true,
+              borderless = true,
+              secondary = true,
+              clazz = ExploreStyles.TileTitleMenu,
+              tabular = MenuTabular.Right
+            )(
+              MenuItem(as = <.a)(p.title)
             ),
-            ResponsiveComponent(widthBreakpoints,
-                                heightBreakpoints,
-                                clazz = ExploreStyles.TileBody
-            )(c).when(p.state =!= TileSizeState.Minimized)
-          )
-        }
+            minimizeButton.when(p.showMinimize),
+            maximizeButton.when(p.showMaximize)
+          ),
+          ResponsiveComponent(widthBreakpoints, heightBreakpoints, clazz = ExploreStyles.TileBody)(
+            c
+          ).when(p.state =!= TileSizeState.Minimized)
+        )
       }
       .configure(Reusability.shouldComponentUpdate)
       .build

--- a/common/src/main/scala/explore/components/UserSelectionForm.scala
+++ b/common/src/main/scala/explore/components/UserSelectionForm.scala
@@ -6,10 +6,12 @@ package explore.components
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined.types.string.NonEmptyString
+import explore.AppCtx
+import explore.Icons
+import explore.WebpackResources
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.UserVault
-import explore.{ AppCtx, Icons, WebpackResources }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.utils.UAParser
@@ -19,7 +21,9 @@ import react.common.implicits._
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.image.Image
 import react.semanticui.elements.label.Label
-import react.semanticui.modules.modal.{ Modal, ModalContent, ModalSize }
+import react.semanticui.modules.modal.Modal
+import react.semanticui.modules.modal.ModalContent
+import react.semanticui.modules.modal.ModalSize
 import react.semanticui.sizes._
 
 final case class UserSelectionForm(

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
@@ -5,9 +5,12 @@ package explore.components.graphql
 
 import cats.Id
 import cats.data.NonEmptyList
-import cats.effect.{ CancelToken, ConcurrentEffect, IO }
+import cats.effect.CancelToken
+import cats.effect.ConcurrentEffect
+import cats.effect.IO
 import cats.syntax.all._
-import clue.{ GraphQLSubscription, GraphQLWebSocketClient }
+import clue.GraphQLSubscription
+import clue.GraphQLWebSocketClient
 import crystal.react._
 import fs2.concurrent.Queue
 import io.chrisdavenport.log4cats.Logger

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
@@ -4,11 +4,17 @@
 package explore.components.graphql
 
 import cats.data.NonEmptyList
-import cats.effect.{ CancelToken, ConcurrentEffect, ContextShift, IO, Timer }
+import cats.effect.CancelToken
+import cats.effect.ConcurrentEffect
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Timer
 import cats.syntax.all._
-import clue.{ GraphQLSubscription, GraphQLWebSocketClient }
+import clue.GraphQLSubscription
+import clue.GraphQLWebSocketClient
+import crystal.Pot
+import crystal.ViewF
 import crystal.react._
-import crystal.{ Pot, ViewF }
 import explore._
 import fs2.concurrent.Queue
 import io.chrisdavenport.log4cats.Logger

--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -4,20 +4,23 @@
 package explore.components.graphql
 
 import cats.data.NonEmptyList
-import cats.effect.{ CancelToken, ConcurrentEffect, IO, SyncIO }
+import cats.effect.CancelToken
+import cats.effect.ConcurrentEffect
+import cats.effect.IO
+import cats.effect.SyncIO
 import cats.syntax.all._
-import clue.{ GraphQLSubscription, GraphQLWebSocketClient, StreamingClientStatus }
+import clue.GraphQLSubscription
+import clue.GraphQLWebSocketClient
+import clue.StreamingClientStatus
 import crystal.Pot
 import crystal.react.implicits._
 import fs2.concurrent.Queue
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
-import japgolly.scalajs.react.component.builder.Lifecycle.{
-  ComponentDidMount,
-  ComponentWillUnmount,
-  RenderScope
-}
+import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
+import japgolly.scalajs.react.component.builder.Lifecycle.ComponentWillUnmount
+import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.vdom.html_<^._
 
 object Render {

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
@@ -4,7 +4,8 @@
 package explore.components.graphql
 
 import cats.Id
-import cats.effect.{ ConcurrentEffect, IO }
+import cats.effect.ConcurrentEffect
+import cats.effect.IO
 import cats.syntax.all._
 import clue.GraphQLSubscription
 import crystal.react._

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -3,12 +3,16 @@
 
 package explore.components.graphql
 
-import cats.effect.{ ConcurrentEffect, ContextShift, IO, Timer }
+import cats.effect.ConcurrentEffect
+import cats.effect.ContextShift
+import cats.effect.IO
+import cats.effect.Timer
 import cats.syntax.all._
 import clue.GraphQLSubscription
+import crystal.Pot
+import crystal.ViewF
 import crystal.react._
 import crystal.react.implicits._
-import crystal.{ Pot, ViewF }
 import explore.View
 import io.chrisdavenport.log4cats.Logger
 import japgolly.scalajs.react._

--- a/common/src/main/scala/explore/components/state/ConnectionManager.scala
+++ b/common/src/main/scala/explore/components/state/ConnectionManager.scala
@@ -5,17 +5,18 @@ package explore.components.state
 
 import cats.effect.IO
 import cats.syntax.all._
-import clue.{ TerminateOptions, WebSocketCloseParams }
+import clue.TerminateOptions
+import clue.WebSocketCloseParams
 import crystal.react.implicits._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.AppCtx
 import explore.implicits._
+import io.chrisdavenport.log4cats.Logger
 import io.circe.syntax._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.ReactProps
-import io.chrisdavenport.log4cats.Logger
 
 final case class ConnectionManager(ssoToken: NonEmptyString)
     extends ReactProps[ConnectionManager](ConnectionManager.component)

--- a/common/src/main/scala/explore/components/state/IfLogged.scala
+++ b/common/src/main/scala/explore/components/state/IfLogged.scala
@@ -7,7 +7,8 @@ import cats.effect.IO
 import cats.syntax.all._
 import explore.components.UserSelectionForm
 import explore.implicits._
-import explore.model.{ RootModel, UserVault }
+import explore.model.RootModel
+import explore.model.UserVault
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common.ReactProps

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -17,12 +17,14 @@ object ExploreStyles {
   val TileBody: Css        = Css("explore-tile-body")
   val TileButton: Css      = Css("explore-tile-button")
   val TileStateButton: Css = Css("explore-tile-state-button")
-
-  val TileXSW: Css = Css("tile-xs-width")
-  val TileSMW: Css = Css("tile-sm-width")
-  val TileMDW: Css = Css("tile-md-width")
-  val TileLGW: Css = Css("tile-lg-width")
-  val TileXLW: Css = Css("tile-xl-width")
+  val TileXSW: Css         = Css("tile-xs-width")
+  val TileSMW: Css         = Css("tile-sm-width")
+  val TileMDW: Css         = Css("tile-md-width")
+  val TileLGW: Css         = Css("tile-lg-width")
+  val TileXLW: Css         = Css("tile-xl-width")
+  val TileXSH: Css         = Css("tile-xs-height")
+  val TileSMH: Css         = Css("tile-sm-height")
+  val TileMDH: Css         = Css("tile-md-height")
 
   val TextInForm: Css = Css("explore-text-in-form")
   val Accented: Css   = Css("explore-accented")
@@ -187,4 +189,5 @@ object ExploreStyles {
   val MagnitudesTableContainer: Css          = Css("explore-magnitudes-container")
   val MagnitudesTableFooter: Css             = Css("explore-magnitudes-footer")
   val MagnitudesTableDeletButtonWrapper: Css = Css("explore-magnitudes-delete-button-wrapper")
+  val MagnitudesTableSection: Css            = Css("explore-magnitudes-section")
 }

--- a/common/src/main/scala/explore/components/undo/UndoRegion.scala
+++ b/common/src/main/scala/explore/components/undo/UndoRegion.scala
@@ -3,7 +3,8 @@
 
 package explore.components.undo
 
-import cats.effect.{ Async, IO }
+import cats.effect.Async
+import cats.effect.IO
 import crystal.react.implicits._
 import explore.undo._
 import japgolly.scalajs.react._

--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -4,13 +4,16 @@
 package explore
 
 import cats._
-import cats.effect.{ ContextShift, Timer }
+import cats.effect.ContextShift
+import cats.effect.Timer
 import cats.syntax.all._
 import clue._
 import coulomb.Quantity
-import crystal.{ ViewF, ViewOptF }
+import crystal.ViewF
+import crystal.ViewOptF
 import explore.GraphQLSchemas._
-import explore.model.{ AppContext, RootModel }
+import explore.model.AppContext
+import explore.model.RootModel
 import explore.optics._
 import io.chrisdavenport.log4cats.Logger
 import lucuma.ui.utils._

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -11,7 +11,8 @@ import crystal.react.StreamRenderer
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.GraphQLSchemas._
 import explore.common.SSOClient
-import explore.model.enum.{ AppTab, ExecutionEnvironment }
+import explore.model.enum.AppTab
+import explore.model.enum.ExecutionEnvironment
 import explore.model.reusability._
 import explore.utils
 import io.chrisdavenport.log4cats.Logger

--- a/common/src/main/scala/explore/model/layout.scala
+++ b/common/src/main/scala/explore/model/layout.scala
@@ -8,10 +8,11 @@ import cats.syntax.all._
 import eu.timepit.refined.types.numeric.NonNegInt
 import japgolly.scalajs.react.Reusability
 import lucuma.ui.reusability._
+import monocle.Lens
+import monocle.Optional
 import monocle.function.Field3._
 import monocle.function.Index._
 import monocle.macros.GenLens
-import monocle.{ Lens, Optional }
 import react.gridlayout._
 
 import scala.collection.immutable.SortedMap

--- a/common/src/main/scala/explore/model/layout.scala
+++ b/common/src/main/scala/explore/model/layout.scala
@@ -65,7 +65,15 @@ object layout {
 
   object unsafe {
     implicit val layoutSemigroup: Semigroup[Layout] = Semigroup.instance { case (a, b) =>
-      Layout(a.l |+| b.l)
+      val result = a.l.foldLeft(List.empty[LayoutItem]) { case (l, la) =>
+        b.l
+          .find(_.i.exists(_ === la.i.get))
+          .map { lb =>
+            la |+| lb
+          }
+          .getOrElse(la) :: l
+      }
+      Layout(result)
     }
 
     implicit val layoutItemSemigroup: Semigroup[LayoutItem] = Semigroup.instance { case (a, b) =>

--- a/common/src/main/scala/explore/package.scala
+++ b/common/src/main/scala/explore/package.scala
@@ -2,7 +2,8 @@
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
 import cats.effect.IO
-import crystal.{ ViewF, ViewOptF }
+import crystal.ViewF
+import crystal.ViewOptF
 import explore.model.AppContext
 
 package explore {

--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -75,6 +75,7 @@ object ReactTableHelpers {
         EnumViewSelect(id = newId,
                        value = va.zoom(lens),
                        exclude = excluded,
+                       compact = true,
                        disabled = disabled,
                        modifiers = modifiers
         )

--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -9,12 +9,13 @@ import eu.timepit.refined.types.string._
 import explore._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.util.{ Display, Enumerated }
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
 import lucuma.ui.forms._
 import lucuma.ui.optics._
 import monocle.Lens
-import react.semanticui.elements.button.Button
 import react.common.style.Css
+import react.semanticui.elements.button.Button
 import reactST.reactTable.mod._
 
 import scalajs.js

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -6,9 +6,11 @@ package explore
 import cats.effect.Sync
 import cats.syntax.all._
 import eu.timepit.refined.types.string.NonEmptyString
+import explore.model.enum.ExecutionEnvironment
 import explore.model.enum.ExecutionEnvironment.Development
-import explore.model.enum.{ ExecutionEnvironment, Theme }
-import lucuma.ui.utils.{ versionDateFormatter, versionDateTimeFormatter }
+import explore.model.enum.Theme
+import lucuma.ui.utils.versionDateFormatter
+import lucuma.ui.utils.versionDateTimeFormatter
 import org.scalajs.dom
 
 import java.time.Instant

--- a/constraints/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/constraints/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -6,7 +6,8 @@ package explore.constraints
 import crystal.react.implicits._
 import explore.AppCtx
 import explore.GraphQLSchemas.ExploreDB.Types._
-import explore.components.undo.{ UndoButtons, UndoRegion }
+import explore.components.undo.UndoButtons
+import explore.components.undo.UndoRegion
 import explore.constraints.ConstraintsQueries._
 import explore.implicits._
 import explore.model.Constraints
@@ -14,11 +15,13 @@ import explore.model.display._
 import explore.model.reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.util.{ Display, Enumerated }
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
 import lucuma.ui.forms.EnumViewSelect
 import monocle.Lens
 import react.common._
-import react.semanticui.collections.form.{ Form, FormGroup }
+import react.semanticui.collections.form.Form
+import react.semanticui.collections.form.FormGroup
 import react.semanticui.collections.grid._
 import react.semanticui.widths._
 

--- a/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
+++ b/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
@@ -3,7 +3,8 @@
 
 package explore.constraints
 
-import cats.effect.{ ContextShift, IO }
+import cats.effect.ContextShift
+import cats.effect.IO
 import clue.GraphQLOperation
 import clue.data.syntax._
 import clue.macros.GraphQL
@@ -14,7 +15,10 @@ import explore.components.graphql.SubscriptionRenderMod
 import explore.implicits._
 import explore.model.Constraints
 import explore.model.decoders._
-import explore.model.enum.{ CloudCover, ImageQuality, SkyBackground, WaterVapor }
+import explore.model.enum.CloudCover
+import explore.model.enum.ImageQuality
+import explore.model.enum.SkyBackground
+import explore.model.enum.WaterVapor
 import explore.model.reusability._
 import explore.undo.Undoer
 import japgolly.scalajs.react.vdom.html_<^._

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -6,8 +6,10 @@ package explore
 import cats.effect.IO
 import crystal.react.implicits._
 import explore.Routing
+import explore.model.Focused
+import explore.model.RootModel
+import explore.model.RootModelRouting
 import explore.model.enum.AppTab
-import explore.model.{ Focused, RootModel, RootModelRouting }
 import japgolly.scalajs.react.extra.router._
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.html_<^._

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -14,8 +14,9 @@ import lucuma.core.data.EnumZipper
 import lucuma.ui.reusability._
 import lucuma.ui.utils._
 import react.common._
+import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
-import react.semanticui.elements.button.{ Button, ButtonGroup }
+import react.semanticui.elements.button.ButtonGroup
 import react.semanticui.elements.divider.Divider
 import react.semanticui.elements.label.Label
 import react.semanticui.elements.label.Label.LabelProps

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -6,14 +6,18 @@ package explore
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
+import explore.Icons
+import explore.WebpackResources
+import explore.components.About
+import explore.components.ConnectionsStatus
 import explore.components.ui.ExploreStyles
-import explore.components.{ About, ConnectionsStatus }
-import explore.model.enum.{ ExecutionEnvironment, Theme }
-import explore.{ Icons, WebpackResources }
+import explore.model.enum.ExecutionEnvironment
+import explore.model.enum.Theme
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.{ GuestRole, User }
+import lucuma.core.model.GuestRole
+import lucuma.core.model.User
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import org.scalajs.dom
@@ -22,7 +26,10 @@ import react.common._
 import react.semanticui.collections.menu._
 import react.semanticui.elements.image.Image
 import react.semanticui.modules.checkbox.Checkbox
-import react.semanticui.modules.dropdown.{ Dropdown, DropdownDivider, DropdownItem, DropdownMenu }
+import react.semanticui.modules.dropdown.Dropdown
+import react.semanticui.modules.dropdown.DropdownDivider
+import react.semanticui.modules.dropdown.DropdownItem
+import react.semanticui.modules.dropdown.DropdownMenu
 import react.semanticui.views.item.Item
 
 final case class TopBar(

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -273,27 +273,24 @@ object ObsTabContents {
             ),
             <.div(
               ^.key := "target",
-              <.div(
-                ^.key := s"target-$targetId",
-                Tile("Target")(
-                  targetId
-                    .map { targetId =>
-                      LiveQueryRenderMod[ObservationDB,
-                                         TargetEditQuery.Data,
-                                         Option[TargetEditQuery.Data.Target]
-                      ](
-                        TargetEditQuery.query(targetId),
-                        _.target,
-                        NonEmptyList.of(TargetEditSubscription.subscribe[IO](targetId))
-                      ) { targetOpt =>
-                        (props.userId.get, targetOpt.get).mapN { case (uid, _) =>
-                          val stateView = ViewF.fromState[IO]($).zoom(State.options)
-                          TargetBody(uid, targetId, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
-                        }
-
+              Tile("Target")(
+                targetId
+                  .map { targetId =>
+                    LiveQueryRenderMod[ObservationDB,
+                                       TargetEditQuery.Data,
+                                       Option[TargetEditQuery.Data.Target]
+                    ](
+                      TargetEditQuery.query(targetId),
+                      _.target,
+                      NonEmptyList.of(TargetEditSubscription.subscribe[IO](targetId))
+                    ) { targetOpt =>
+                      (props.userId.get, targetOpt.get).mapN { case (uid, _) =>
+                        val stateView = ViewF.fromState[IO]($).zoom(State.options)
+                        TargetBody(uid, targetId, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
                       }
-                    }
-                )
+
+                    }.withKey(s"target-$targetId")
+                  }
               )
             )
           )

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -74,7 +74,7 @@ object ObsTabContents {
                  isResizable = false,
                  resizeHandles = List("")
       ),
-      LayoutItem(x = 0, y = NotesMaxHeight.value, w = 12, h = 8, i = "target")
+      LayoutItem(x = 0, y = NotesMaxHeight.value, w = 12, h = 12, i = "target")
     )
   )
 
@@ -88,7 +88,7 @@ object ObsTabContents {
                  isResizable = false,
                  resizeHandles = List("")
       ),
-      LayoutItem(x = 0, y = NotesMaxHeight.value, w = 12, h = 8, i = "target")
+      LayoutItem(x = 0, y = NotesMaxHeight.value, w = 12, h = 12, i = "target")
     )
   )
 
@@ -102,7 +102,7 @@ object ObsTabContents {
                  isResizable = false,
                  resizeHandles = List("")
       ),
-      LayoutItem(x = 0, y = NotesMaxHeight.value, w = 12, h = 8, i = "target")
+      LayoutItem(x = 0, y = NotesMaxHeight.value, w = 12, h = 12, i = "target")
     )
   )
 
@@ -128,6 +128,7 @@ object ObsTabContents {
   object State {
     val panelsWidth   = State.panels.composeLens(TwoPanelState.treeWidth)
     val panelSelected = State.panels.composeLens(TwoPanelState.elementSelected)
+    val fovAngle      = State.options.composeLens(TargetVisualOptions.fovAngle)
 
     def breakPointNote(n: BreakpointName) =
       layouts.breakPointLayout(n, NotesIndex)
@@ -155,8 +156,21 @@ object ObsTabContents {
             )
         }
         .runAsyncAndThenCB { case (w, l) =>
-          $.setStateL(State.panelsWidth)(w) *> $.setStateL(State.layouts)(l)
+          $.modState((s: State) => State.panelsWidth.set(w)(s.updateLayouts(l)))
         }
+
+    def readTargetPreferences(targetId: Target.Id): Callback =
+      $.props.flatMap { p =>
+        p.userId.get.map { uid =>
+          AppCtx
+            .withCtx { implicit ctx =>
+              UserTargetPreferencesQuery
+                .queryWithDefault[IO](uid, targetId, Constants.InitialFov)
+                .flatMap(v => $.modStateIn[IO](State.fovAngle.set(v)))
+                .runAsyncAndForgetCB
+            }
+        }.getOrEmpty
+      }
 
     def render(props: Props, state: State) = {
       AppCtx.withCtx { implicit ctx =>
@@ -197,9 +211,15 @@ object ObsTabContents {
             .debounce(1.second)
 
         ObsLiveQuery { observations =>
-          val obsSummaryOpt = props.focused.get.collect { case FocusedObs(obsId) =>
-            observations.get.find(_.id === obsId)
+          val obsSummaryOpt: Option[ObsSummary] = props.focused.get.collect {
+            case FocusedObs(obsId) =>
+              observations.get.find(_.id === obsId)
           }.flatten
+
+          val targetId = obsSummaryOpt.collect {
+            case ObsSummary(_, _, _, _, _, _, Some(Right(tid))) =>
+              tid
+          }
 
           val backButton = TileButton(
             Button(
@@ -212,15 +232,13 @@ object ObsTabContents {
             )(^.href := ctx.pageUrl(AppTab.Observations, none), Icons.ChevronLeft.fitted(true))
           )
 
-          // Use a fixed target id until observations have a real target
-          val targetId = Target.Id(2L)
-
           val coreWidth =
             if (window.innerWidth <= Constants.TwoPanelCutoff) {
               props.size.width.getOrElse(0)
             } else {
               props.size.width.getOrElse(0) - treeWidth
             }
+
           val rightSide = ResponsiveReactGridLayout(
             width = coreWidth,
             margin = (5, 5),
@@ -233,7 +251,7 @@ object ObsTabContents {
             <.div(
               ^.key := "notes",
               Tile(
-                s"Note for Observer ${obsSummaryOpt}",
+                s"Note for Observer",
                 backButton.some,
                 canMinimize = true,
                 canMaximize = true,
@@ -255,24 +273,27 @@ object ObsTabContents {
             ),
             <.div(
               ^.key := "target",
-              Tile("Target")(
-                LiveQueryRenderMod[ObservationDB,
-                                   TargetEditQuery.Data,
-                                   Option[TargetEditQuery.Data.Target]
-                ](
-                  TargetEditQuery.query(targetId),
-                  _.target,
-                  NonEmptyList.of(TargetEditSubscription.subscribe[IO](targetId))
-                ) { targetOpt =>
-                  <.div(
-                    <.div(
-                      (props.userId.get, targetOpt.get).mapN { case (uid, _) =>
-                        val stateView = ViewF.fromState[IO]($).zoom(State.options)
-                        TargetBody(uid, targetId, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
+              <.div(
+                ^.key := s"target-$targetId",
+                Tile("Target")(
+                  targetId
+                    .map { targetId =>
+                      LiveQueryRenderMod[ObservationDB,
+                                         TargetEditQuery.Data,
+                                         Option[TargetEditQuery.Data.Target]
+                      ](
+                        TargetEditQuery.query(targetId),
+                        _.target,
+                        NonEmptyList.of(TargetEditSubscription.subscribe[IO](targetId))
+                      ) { targetOpt =>
+                        (props.userId.get, targetOpt.get).mapN { case (uid, _) =>
+                          val stateView = ViewF.fromState[IO]($).zoom(State.options)
+                          TargetBody(uid, targetId, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
+                        }
+
                       }
-                    ).when(false)
-                  )
-                }
+                    }
+                )
               )
             )
           )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -130,11 +130,9 @@ object TargetTabContents {
 
             val rightSide =
               Tile(s"Target", backButton.some)(
-                <.span(
-                  (props.userId.get, targetIdOpt).mapN { case (uid, tid) =>
-                    TargetEditor(uid, tid).withKey(tid.show)
-                  }
-                )
+                (props.userId.get, targetIdOpt).mapN { case (uid, tid) =>
+                  TargetEditor(uid, tid).withKey(tid.show)
+                }
               )
 
             // It would be nice to make a single component here but it gets hard when you

--- a/model/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -6,7 +6,8 @@ package explore.data.tree
 import cats.kernel.Eq
 import cats.syntax.all._
 
-import scala.collection.immutable.{ HashMap, HashSet }
+import scala.collection.immutable.HashMap
+import scala.collection.immutable.HashSet
 
 import KeyedIndexedTree._
 

--- a/model/src/main/scala/explore/model/AppConfig.scala
+++ b/model/src/main/scala/explore/model/AppConfig.scala
@@ -3,7 +3,8 @@
 
 package explore.model
 
-import cats.{ Eq, Show }
+import cats.Eq
+import cats.Show
 import explore.model.decoders._
 import explore.model.encoders._
 import explore.model.enum.ExecutionEnvironment

--- a/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
+++ b/model/src/main/scala/explore/model/ExploreSiderealTarget.scala
@@ -10,8 +10,10 @@ import eu.timepit.refined._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.collection.NonEmpty
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.core.math.{ Coordinates, Epoch }
-import lucuma.core.model.{ SiderealTracking, Target }
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Epoch
+import lucuma.core.model.SiderealTracking
+import lucuma.core.model.Target
 import monocle.macros.Lenses
 
 import java.util.UUID

--- a/model/src/main/scala/explore/model/Focused.scala
+++ b/model/src/main/scala/explore/model/Focused.scala
@@ -5,9 +5,10 @@ package explore.model
 
 import cats.kernel.Eq
 import cats.syntax.all._
-import lucuma.core.model.{ Observation, Target }
-import monocle.macros.Lenses
 import lucuma.core.model.Asterism
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import monocle.macros.Lenses
 
 sealed trait Focused extends Product with Serializable
 object Focused {

--- a/model/src/main/scala/explore/model/ModelOptics.scala
+++ b/model/src/main/scala/explore/model/ModelOptics.scala
@@ -3,7 +3,9 @@
 
 package explore.model
 
-import lucuma.core.math.{ Coordinates, Declination, RightAscension }
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
 import lucuma.core.model.SiderealTracking
 import monocle.Lens
 

--- a/model/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/src/main/scala/explore/model/ObsSummary.scala
@@ -6,10 +6,11 @@ package explore.model
 import cats._
 import explore.model.enum.ObsStatus
 import io.circe.Decoder
+import io.circe.DecodingFailure
 import io.circe.Encoder
 import io.circe.HCursor
 import io.circe.Json
-import io.circe.DecodingFailure
+import io.circe.JsonObject
 import io.circe.syntax._
 import lucuma.core.model.Asterism
 import lucuma.core.model.Observation
@@ -18,7 +19,6 @@ import monocle.macros.Lenses
 
 import java.time.Duration
 import java.time.temporal.ChronoUnit
-import io.circe.JsonObject
 
 @Lenses
 final case class ObsSummary(

--- a/model/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/src/main/scala/explore/model/ObsSummary.scala
@@ -1,0 +1,71 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats._
+import explore.model.enum.ObsStatus
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+import io.circe.syntax._
+import lucuma.core.model.Asterism
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import monocle.macros.Lenses
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+
+@Lenses
+final case class ObsSummary(
+  id:                Observation.Id,
+  name:              Option[String],
+  status:            ObsStatus = ObsStatus.New,
+  conf:              String = "GMOS-N R831 1x300",
+  constraints:       String = "<0.7\" <0.3 mag Bright",
+  duration:          Duration = Duration.of(93, ChronoUnit.MINUTES),
+  observationTarget: Option[Either[Asterism.Id, Target.Id]]
+)
+
+object ObsSummary {
+  implicit val eqObsSummary: Eq[ObsSummary] = Eq.by(x => (x.id, x.name, x.observationTarget))
+
+  implicit val obsSummaryEncoder: Encoder[ObsSummary] = new Encoder[ObsSummary] {
+    final def apply(c: ObsSummary): Json = {
+      val common = Json.obj(("id", c.id.asJson), ("name", c.name.asJson))
+      c.observationTarget match {
+        case None             => common
+        case Some(Right(tid)) =>
+          common.deepMerge(Json.obj(("observationTarget", Json.obj(("target_id", tid.asJson)))))
+        case Some(Left(aid))  =>
+          common.deepMerge(Json.obj(("observationTarget", Json.obj(("asterism_id", aid.asJson)))))
+      }
+    }
+
+  }
+
+  implicit val obsTargetDecoder: Decoder[Either[Asterism.Id, Target.Id]] =
+    new Decoder[Either[Asterism.Id, Target.Id]] {
+      final def apply(c: HCursor): Decoder.Result[Either[Asterism.Id, Target.Id]] =
+        for {
+          aid <- c.downField("asterism_id").as[Option[Asterism.Id]]
+          tid <- c.downField("target_id").as[Option[Target.Id]]
+        } yield (aid, tid) match {
+          case (Some(aid), _)    => Left(aid)
+          case (None, Some(tid)) => Right(tid)
+          case _                 => sys.error("graphql schema doesn't allow this")
+        }
+
+    }
+
+  implicit val obsSummaryDecoder: Decoder[ObsSummary] = new Decoder[ObsSummary] {
+    final def apply(c: HCursor): Decoder.Result[ObsSummary] =
+      for {
+        id   <- c.downField("id").as[Observation.Id]
+        name <- c.downField("name").as[Option[String]]
+        ot   <- c.downField("observationTarget").as[Option[Either[Asterism.Id, Target.Id]]]
+      } yield ObsSummary(id = id, name = name, observationTarget = ot)
+  }
+}

--- a/model/src/main/scala/explore/model/Page.scala
+++ b/model/src/main/scala/explore/model/Page.scala
@@ -5,9 +5,10 @@ package explore.model
 
 import cats.Eq
 import cats.syntax.all._
-import lucuma.core.model.{ Observation, Target }
-import monocle.Iso
 import lucuma.core.model.Asterism
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
+import monocle.Iso
 
 sealed trait Page extends Product with Serializable
 

--- a/model/src/main/scala/explore/model/ProposalDetails.scala
+++ b/model/src/main/scala/explore/model/ProposalDetails.scala
@@ -6,7 +6,8 @@ package explore.model
 import cats._
 import explore.model.enum._
 import explore.model.refined._
-import lucuma.core.model.{ Partner, StandardUser }
+import lucuma.core.model.Partner
+import lucuma.core.model.StandardUser
 import monocle.macros.Lenses
 
 @Lenses

--- a/model/src/main/scala/explore/model/RootModel.scala
+++ b/model/src/main/scala/explore/model/RootModel.scala
@@ -9,7 +9,10 @@ import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.enum.AppTab
 import lucuma.core.data.EnumZipper
-import lucuma.core.model.{ GuestUser, ServiceUser, StandardUser, User }
+import lucuma.core.model.GuestUser
+import lucuma.core.model.ServiceUser
+import lucuma.core.model.StandardUser
+import lucuma.core.model.User
 import monocle.Lens
 import monocle.macros.Lenses
 import monocle.std.option

--- a/model/src/main/scala/explore/model/RootModelRouting.scala
+++ b/model/src/main/scala/explore/model/RootModelRouting.scala
@@ -4,11 +4,12 @@
 package explore.model
 
 import cats.syntax.all._
-import explore.model.Focused.{ FocusedObs, FocusedTarget }
+import explore.model.Focused.FocusedAsterism
+import explore.model.Focused.FocusedObs
+import explore.model.Focused.FocusedTarget
 import explore.model.Page._
 import explore.model.enum.AppTab
 import monocle.Lens
-import explore.model.Focused.FocusedAsterism
 
 object RootModelRouting {
 

--- a/model/src/main/scala/explore/model/decoders.scala
+++ b/model/src/main/scala/explore/model/decoders.scala
@@ -23,6 +23,8 @@ import lucuma.core.math.{
 }
 import lucuma.core.model.{ Magnitude, SiderealTracking }
 import sttp.model.Uri
+import lucuma.core.model.Target
+import lucuma.core.model.Asterism
 
 object decoders {
   implicit val uriDecoder: Decoder[Uri] = Decoder.decodeString.emap(Uri.parse)
@@ -134,4 +136,8 @@ object decoders {
         s <- c.downField("system").as[MagnitudeSystem]
       } yield Magnitude(v, b, s)
   }
+
+  implicit val eitherDecoder: Decoder[Either[Asterism.Id, Target.Id]] =
+    Decoder.decodeEither("target_id", "asterism_id")
+
 }

--- a/model/src/main/scala/explore/model/decoders.scala
+++ b/model/src/main/scala/explore/model/decoders.scala
@@ -23,8 +23,6 @@ import lucuma.core.math.{
 }
 import lucuma.core.model.{ Magnitude, SiderealTracking }
 import sttp.model.Uri
-import lucuma.core.model.Target
-import lucuma.core.model.Asterism
 
 object decoders {
   implicit val uriDecoder: Decoder[Uri] = Decoder.decodeString.emap(Uri.parse)
@@ -136,8 +134,5 @@ object decoders {
         s <- c.downField("system").as[MagnitudeSystem]
       } yield Magnitude(v, b, s)
   }
-
-  implicit val eitherDecoder: Decoder[Either[Asterism.Id, Target.Id]] =
-    Decoder.decodeEither("target_id", "asterism_id")
 
 }

--- a/model/src/main/scala/explore/model/decoders.scala
+++ b/model/src/main/scala/explore/model/decoders.scala
@@ -6,22 +6,24 @@ package explore.model
 import cats.syntax.all._
 import coulomb._
 import explore.model.enum._
+import io.circe.Decoder
+import io.circe.DecodingFailure
+import io.circe.HCursor
 import io.circe.generic.semiauto
-import io.circe.{ Decoder, DecodingFailure, HCursor }
-import lucuma.core.enum.{ MagnitudeBand, MagnitudeSystem }
+import lucuma.core.enum.MagnitudeBand
+import lucuma.core.enum.MagnitudeSystem
+import lucuma.core.math.Angle
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.Epoch
+import lucuma.core.math.MagnitudeValue
+import lucuma.core.math.Parallax
+import lucuma.core.math.ProperMotion
+import lucuma.core.math.RadialVelocity
+import lucuma.core.math.RightAscension
 import lucuma.core.math.units.CentimetersPerSecond
-import lucuma.core.math.{
-  Angle,
-  Coordinates,
-  Declination,
-  Epoch,
-  MagnitudeValue,
-  Parallax,
-  ProperMotion,
-  RadialVelocity,
-  RightAscension
-}
-import lucuma.core.model.{ Magnitude, SiderealTracking }
+import lucuma.core.model.Magnitude
+import lucuma.core.model.SiderealTracking
 import sttp.model.Uri
 
 object decoders {

--- a/model/src/main/scala/explore/model/display.scala
+++ b/model/src/main/scala/explore/model/display.scala
@@ -4,7 +4,8 @@
 package explore.model
 
 import explore.model.enum._
-import lucuma.core.enum.{ MagnitudeBand, MagnitudeSystem }
+import lucuma.core.enum.MagnitudeBand
+import lucuma.core.enum.MagnitudeSystem
 import lucuma.core.util.Display
 
 object display {

--- a/model/src/main/scala/explore/model/encoders.scala
+++ b/model/src/main/scala/explore/model/encoders.scala
@@ -4,10 +4,12 @@
 package explore.model
 
 import explore.model.enum._
+import io.circe.Encoder
+import io.circe.Json
 import io.circe.refined._
 import io.circe.syntax._
-import io.circe.{ Encoder, Json }
-import lucuma.core.math.{ Declination, RightAscension }
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
 import sttp.model.Uri
 
 import ModelOptics._

--- a/model/src/main/scala/explore/model/expandedIds.scala
+++ b/model/src/main/scala/explore/model/expandedIds.scala
@@ -3,12 +3,13 @@
 
 package explore.model
 
-import cats._
 import cats.Order._
-import scala.collection.immutable.SortedSet
-import lucuma.core.model.Target
+import cats._
 import lucuma.core.model.Asterism
+import lucuma.core.model.Target
 import monocle.macros.Lenses
+
+import scala.collection.immutable.SortedSet
 
 @Lenses
 case class TargetViewExpandedIds(

--- a/model/src/main/scala/explore/model/formats.scala
+++ b/model/src/main/scala/explore/model/formats.scala
@@ -7,9 +7,10 @@ import cats.syntax.all._
 import coulomb._
 import eu.timepit.refined.refineV
 import explore.optics._
+import lucuma.core.math.Parallax
 import lucuma.core.math.ProperMotion.AngularVelocityComponent
+import lucuma.core.math._
 import lucuma.core.math.units._
-import lucuma.core.math.{ Parallax, _ }
 import lucuma.core.optics.Format
 import lucuma.core.syntax.string._
 

--- a/model/src/main/scala/explore/model/partial.scala
+++ b/model/src/main/scala/explore/model/partial.scala
@@ -3,7 +3,8 @@
 
 package explore.model
 
-import io.circe.{ Decoder, HCursor }
+import io.circe.Decoder
+import io.circe.HCursor
 import monocle.macros.Lenses
 
 @Lenses

--- a/model/src/main/scala/explore/model/partial.scala
+++ b/model/src/main/scala/explore/model/partial.scala
@@ -3,14 +3,8 @@
 
 package explore.model
 
-import cats.syntax.all._
-import explore.model.enum.ObsStatus
 import io.circe.{ Decoder, HCursor }
-import lucuma.core.model.Observation
 import monocle.macros.Lenses
-
-import java.time.Duration
-import java.time.temporal.ChronoUnit
 
 @Lenses
 final case class ConstraintsSummary(id: Constraints.Id, name: String)
@@ -26,21 +20,4 @@ object ConstraintsSummary {
         name <- c.downField("name").as[String]
       } yield ConstraintsSummary(id, name)
   }
-}
-
-trait ObsSummary {
-  val id: Observation.Id
-  val name: Option[String]
-  val status: ObsStatus   = ObsStatus.New
-  val conf: String        = "GMOS-N R831 1x300"
-  val constraints: String = "<0.7\" <0.3 mag Bright"
-  val duration: Duration  = Duration.of(93, ChronoUnit.MINUTES)
-}
-
-object ObsSummary {
-  def apply(_id: Observation.Id, _name: String): ObsSummary =
-    new ObsSummary {
-      val id   = _id
-      val name = _name.some
-    }
 }

--- a/model/src/main/scala/explore/optics/GetAdjust.scala
+++ b/model/src/main/scala/explore/optics/GetAdjust.scala
@@ -3,7 +3,8 @@
 
 package explore.optics
 
-import monocle.{ Getter, Lens }
+import monocle.Getter
+import monocle.Lens
 
 // Wrap a Getter and an Adjuster
 final case class GetAdjust[T, A](getter: Getter[T, A], adjuster: Adjuster[T, A]) {

--- a/model/src/main/scala/explore/optics/package.scala
+++ b/model/src/main/scala/explore/optics/package.scala
@@ -6,9 +6,12 @@ package explore
 import cats.syntax.all._
 import coulomb._
 import explore.model.utils._
+import lucuma.core.math.ApparentRadialVelocity
 import lucuma.core.math.Constants._
+import lucuma.core.math.ProperMotion
+import lucuma.core.math.RadialVelocity
+import lucuma.core.math.Redshift
 import lucuma.core.math.units._
-import lucuma.core.math.{ ApparentRadialVelocity, ProperMotion, RadialVelocity, Redshift }
 import monocle._
 import monocle.std.option.some
 

--- a/model/src/main/scala/explore/undo/IndexedCollMod.scala
+++ b/model/src/main/scala/explore/undo/IndexedCollMod.scala
@@ -4,7 +4,8 @@
 package explore.undo
 
 import cats.syntax.all._
-import explore.optics.{ Adjuster, GetAdjust }
+import explore.optics.Adjuster
+import explore.optics.GetAdjust
 import monocle._
 import monocle.function.Field1.first
 import monocle.std.option.some

--- a/model/src/main/scala/explore/undo/KIListMod.scala
+++ b/model/src/main/scala/explore/undo/KIListMod.scala
@@ -4,7 +4,9 @@
 package explore.undo
 
 import explore.data.KeyedIndexedList
-import monocle.{ Getter, Iso, Lens }
+import monocle.Getter
+import monocle.Iso
+import monocle.Lens
 
 class KIListMod[F[_], A, K](protected val keyLens: Lens[A, K])
     extends IndexedCollMod[F, KeyedIndexedList, Int, A, cats.Id, K] {

--- a/model/src/main/scala/explore/undo/KITreeMod.scala
+++ b/model/src/main/scala/explore/undo/KITreeMod.scala
@@ -4,7 +4,8 @@
 package explore.undo
 
 import explore.data.tree._
-import monocle.{ Getter, Lens }
+import monocle.Getter
+import monocle.Lens
 
 import KeyedIndexedTree.Index
 

--- a/model/src/main/scala/explore/undo/UndoableView.scala
+++ b/model/src/main/scala/explore/undo/UndoableView.scala
@@ -3,7 +3,8 @@
 
 package explore.undo
 
-import cats.effect.{ Async, ContextShift }
+import cats.effect.Async
+import cats.effect.ContextShift
 import cats.syntax.all._
 import crystal.ViewF
 import monocle.Lens

--- a/model/src/test/scala/explore/model/ObsSummarySuite.scala
+++ b/model/src/test/scala/explore/model/ObsSummarySuite.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.kernel.laws.discipline.EqTests
+import explore.model.arb.all._
+import io.circe.testing.CodecTests
+import io.circe.testing.ArbitraryInstances
+import munit.DisciplineSuite
+
+class ObsSummarySuite extends DisciplineSuite with ArbitraryInstances {
+  checkAll("Eq[ObsSummarySuite]", EqTests[ObsSummary].eqv)
+  checkAll("Codec[ObsSummary]", CodecTests[ObsSummary].codec)
+}

--- a/model/src/test/scala/explore/model/arb/ArbObsSummary.scala
+++ b/model/src/test/scala/explore/model/arb/ArbObsSummary.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2020 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import lucuma.core.util.arb.ArbEnumerated._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Cogen._
+import lucuma.core.model.Asterism
+import lucuma.core.model.Target
+import explore.model.ObsSummary
+import lucuma.core.model.Observation
+import lucuma.core.util.arb.ArbGid._
+
+trait ArbObsSummary {
+
+  implicit val obsSummaryArb = Arbitrary[ObsSummary] {
+    for {
+      id <- arbitrary[Observation.Id]
+      nm <- arbitrary[Option[String]]
+      ta <- arbitrary[Option[Either[Asterism.Id, Target.Id]]]
+    } yield ObsSummary(id = id, name = nm, observationTarget = ta)
+  }
+
+  implicit val obsSummaryCogen: Cogen[ObsSummary] =
+    Cogen[(Observation.Id, Option[String], Option[Either[Asterism.Id, Target.Id]])].contramap(c =>
+      (c.id, c.name, c.observationTarget)
+    )
+
+}
+
+object ArbObsSummary extends ArbObsSummary

--- a/model/src/test/scala/explore/model/arb/package.scala
+++ b/model/src/test/scala/explore/model/arb/package.scala
@@ -15,3 +15,4 @@ object all
     with ArbTree
     with ArbKeyedIndexedTree
     with ArbUserVault
+    with ArbObsSummary

--- a/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
@@ -87,8 +87,9 @@ object AndOrTest {
   def renderObs(obs: ExploreObservation, dragIcon: VdomNode): VdomNode =
     wrap(^.width := "200px", ^.margin := "5px")(
       ObsBadge(
-        ObsSummary(Observation.Id.parse(s"o-${obs.id.toString.filter(_.isDigit).take(4)}").get,
-                   obs.target.name
+        ObsSummary(id = Observation.Id.parse(s"o-${obs.id.toString.filter(_.isDigit).take(4)}").get,
+                   name = obs.target.name.value.some,
+                   observationTarget = None
         ),
         ObsBadge.Layout.NameAndConf
       ),

--- a/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
@@ -9,13 +9,19 @@ import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ObsBadge
 import explore.data.tree._
-import explore.model.enum.{ ObsStatus, _ }
-import explore.model.{ Constraints, ExploreObservation, ObsSummary, SiderealTarget }
+import explore.model.Constraints
+import explore.model.ExploreObservation
+import explore.model.ObsSummary
+import explore.model.SiderealTarget
+import explore.model.enum.ObsStatus
+import explore.model.enum._
 import explore.undo.KITreeMod
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.math.{ Coordinates, Epoch }
-import lucuma.core.model.{ Observation, SiderealTracking }
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Epoch
+import lucuma.core.model.Observation
+import lucuma.core.model.SiderealTracking
 import mouse.boolean._
 import react.atlasKit.tree.{ Tree => AtlasTree }
 import react.semanticui.elements.icon.Icon

--- a/observationtree/src/main/scala/explore/observationtree/ObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ObsList.scala
@@ -8,10 +8,11 @@ import crystal.react.implicits._
 import explore._
 import explore.components.ObsBadge
 import explore.components.ui.ExploreStyles
+import explore.model.Focused
 import explore.model.Focused.FocusedObs
+import explore.model.ObsSummary
 import explore.model.enum.AppTab
 import explore.model.reusability._
-import explore.model.{ Focused, ObsSummary }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.utils._

--- a/observationtree/src/main/scala/explore/observationtree/ObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ObsQueries.scala
@@ -25,12 +25,20 @@ object ObsQueries {
         observations(programId: "p-2") {
           id
           name
+          observationTarget {
+            ... on Asterism {
+              asterism_id: id
+            }
+            ... on Target {
+              target_id: id
+            }
+          }
         }
-      }    
+      }
     """
 
     object Data {
-      trait Observations extends ObsSummary
+      type Observations = ObsSummary
     }
   }
 
@@ -41,7 +49,7 @@ object ObsQueries {
         observationEdit(programId:"p-2") {
           id
         }
-      }   
+      }
     """
   }
 

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -410,7 +410,10 @@ object TargetObsList {
 
       def renderObsBadge(obs: ObsAttached): TagMod =
         ObsBadge(
-          ObsSummary(obs.id, obs.name.orEmpty),
+          ObsSummary(id = obs.id,
+                     name = obs.name,
+                     observationTarget = None
+          ), // FIXME Add the target id
           ObsBadge.Layout.ConfAndConstraints,
           selected = props.focused.get.exists(_ === FocusedObs(obs.id))
         )

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -8,22 +8,31 @@ import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined.types.numeric.PosLong
+import explore.Icons
 import explore.components.ObsBadge
 import explore.components.ui.ExploreStyles
-import explore.components.undo.{ UndoButtons, UndoRegion }
+import explore.components.undo.UndoButtons
+import explore.components.undo.UndoRegion
 import explore.data.KeyedIndexedList
 import explore.implicits._
+import explore.model.Constants
+import explore.model.Focused
 import explore.model.Focused._
-import explore.model.{ Constants, Focused, ObsSummary, TargetViewExpandedIds }
-import explore.optics.{ GetAdjust, _ }
-import explore.undo.{ KIListMod, Undoer }
-import explore.Icons
-import japgolly.scalajs.react._
+import explore.model.ObsSummary
+import explore.model.TargetViewExpandedIds
+import explore.optics.GetAdjust
+import explore.optics._
+import explore.undo.KIListMod
+import explore.undo.Undoer
 import japgolly.scalajs.react.MonocleReact._
+import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.{ Observation, Target }
+import lucuma.core.model.Asterism
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
 import monocle.Getter
 import monocle.function.Field1.first
+import monocle.macros.Lenses
 import monocle.std.option.some
 import mouse.boolean._
 import react.beautifuldnd._
@@ -35,15 +44,13 @@ import react.semanticui.elements.icon.Icon
 import react.semanticui.elements.segment.Segment
 import react.semanticui.elements.segment.SegmentGroup
 import react.semanticui.sizes._
+import react.semanticui.views.card.Card
+import react.semanticui.views.card.CardContent
 
 import scala.collection.immutable.SortedSet
 import scala.util.Random
 
 import TargetObsQueries._
-import lucuma.core.model.Asterism
-import react.semanticui.views.card.Card
-import react.semanticui.views.card.CardContent
-import monocle.macros.Lenses
 
 final case class TargetObsList(
   objectsWithObs: View[TargetsAndAsterismsWithObs],

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
@@ -20,11 +20,12 @@ import explore.model.reusability._
 import io.scalaland.chimney.dsl._
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.{ Observation, Target }
+import lucuma.core.model.Asterism
+import lucuma.core.model.Observation
+import lucuma.core.model.Target
 import lucuma.ui.reusability._
 import monocle.Getter
 import monocle.macros.Lenses
-import lucuma.core.model.Asterism
 
 object TargetObsQueries {
 

--- a/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetTreeTest.scala
@@ -6,9 +6,15 @@ package explore.observationtree
 import cats.syntax.all._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.model.enum.{ ObsStatus, _ }
-import explore.model.{ Constraints, ExploreObservation, SiderealTarget }
-import lucuma.core.math.{ Coordinates, Declination, Epoch, RightAscension }
+import explore.model.Constraints
+import explore.model.ExploreObservation
+import explore.model.SiderealTarget
+import explore.model.enum.ObsStatus
+import explore.model.enum._
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.Epoch
+import lucuma.core.math.RightAscension
 import lucuma.core.model.SiderealTracking
 
 import java.time.Duration

--- a/observationtree/src/main/scala/explore/observationtree/Test.scala
+++ b/observationtree/src/main/scala/explore/observationtree/Test.scala
@@ -3,9 +3,10 @@
 
 package explore.observationtree
 
+import explore.AppMain
+import explore._
 import explore.components.state.IfLogged
 import explore.model.RootModel
-import explore.{ AppMain, _ }
 import japgolly.scalajs.react.vdom.html_<^._
 
 import scala.scalajs.js.annotation.JSExportTopLevel

--- a/observationtree/src/main/scala/explore/observationtree/TreeComp.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TreeComp.scala
@@ -11,7 +11,8 @@ import explore.components.undo.UndoRegion
 import explore.data.tree.KeyedIndexedTree.Index
 import explore.data.tree._
 import explore.implicits._
-import explore.undo.{ KITreeMod, Undoer }
+import explore.undo.KITreeMod
+import explore.undo.Undoer
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._

--- a/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
@@ -7,7 +7,9 @@ import cats.syntax.all._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.components.ui.{ ExploreStyles, FomanticStyles, PartnerFlags }
+import explore.components.ui.ExploreStyles
+import explore.components.ui.FomanticStyles
+import explore.components.ui.PartnerFlags
 import explore.implicits._
 import explore.model._
 import explore.model.refined._

--- a/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
@@ -12,15 +12,17 @@ import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
+import explore.AppCtx
+import explore.Icons
+import explore.components.FormStaticData
+import explore.components.Tile
 import explore.components.ui._
-import explore.components.{ FormStaticData, Tile }
 import explore.implicits._
 import explore.model._
 import explore.model.display._
 import explore.model.enum.ProposalClass._
 import explore.model.refined._
 import explore.model.reusability._
-import explore.{ AppCtx, Icons }
 import japgolly.scalajs.react.Reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._

--- a/proposal/src/main/scala/explore/proposal/Test.scala
+++ b/proposal/src/main/scala/explore/proposal/Test.scala
@@ -4,9 +4,10 @@
 package explore.proposal
 
 import eu.timepit.refined.auto._
+import explore.AppMain
+import explore.View
 import explore.components.state.IfLogged
 import explore.model.RootModel
-import explore.{ AppMain, View }
 import japgolly.scalajs.react.vdom.VdomElement
 
 import scala.scalajs.js

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -3,30 +3,35 @@
 
 package explore.targeteditor
 
+import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
+import explore.AppCtx
+import explore.Icons
+import explore.View
 import explore.common.UserPreferencesQueries._
 import explore.components.ui.ExploreStyles
+import explore.implicits._
+import explore.model.ModelOptics
+import explore.model.TargetVisualOptions
 import explore.model.reusability._
-import explore.model.{ ModelOptics, TargetVisualOptions }
-import explore.{ Icons, View }
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import explore.implicits._
-import lucuma.core.math.{ Angle, Coordinates }
-import lucuma.ui.reusability._
-import lucuma.core.model.User
+import lucuma.core.math.Angle
+import lucuma.core.math.Coordinates
 import lucuma.core.model.Target
+import lucuma.core.model.User
+import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.aladin.Fov
 import react.common._
 import react.semanticui.elements.button.Button
-import react.semanticui.modules.popup.{ Popup, PopupPosition }
+import react.semanticui.modules.popup.Popup
+import react.semanticui.modules.popup.PopupPosition
 import react.semanticui.sizes._
-import cats.effect.IO
-import explore.AppCtx
+
 import scala.concurrent.duration._
 
 final case class AladinCell(

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -14,7 +14,9 @@ import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.geom.jts.interpreter._
-import lucuma.core.math.{ Coordinates, Declination, RightAscension }
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.RightAscension
 import lucuma.svgdotjs.Svg
 import lucuma.ui.reusability._
 import monocle.macros.Lenses

--- a/targeteditor/src/main/scala/explore/targeteditor/GmosGeometry.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/GmosGeometry.scala
@@ -4,12 +4,17 @@
 package explore.targeteditor
 
 import cats.data.NonEmptyMap
-import lucuma.core.enum.{ GmosNorthFpu, GmosSouthFpu, PortDisposition }
+import lucuma.core.enum.GmosNorthFpu
+import lucuma.core.enum.GmosSouthFpu
+import lucuma.core.enum.PortDisposition
+import lucuma.core.geom.GmosOiwfsProbeArm
+import lucuma.core.geom.GmosScienceAreaGeometry
+import lucuma.core.geom.ShapeExpression
 import lucuma.core.geom.svg._
 import lucuma.core.geom.syntax.shapeexpression._
-import lucuma.core.geom.{ GmosOiwfsProbeArm, GmosScienceAreaGeometry, ShapeExpression }
+import lucuma.core.math.Angle
+import lucuma.core.math.Offset
 import lucuma.core.math.syntax.int._
-import lucuma.core.math.{ Angle, Offset }
 import lucuma.svgdotjs._
 
 /**

--- a/targeteditor/src/main/scala/explore/targeteditor/InputWithUnits.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/InputWithUnits.scala
@@ -13,8 +13,10 @@ import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ui.ExploreStyles
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.ui.forms.{ ExternalValue, FormInputEV }
-import lucuma.ui.optics.{ ChangeAuditor, ValidFormatInput }
+import lucuma.ui.forms.ExternalValue
+import lucuma.ui.forms.FormInputEV
+import lucuma.ui.optics.ChangeAuditor
+import lucuma.ui.optics.ValidFormatInput
 import react.common._
 import react.semanticui.elements.label.LabelPointing
 

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -35,6 +35,7 @@ import scala.collection.immutable.HashSet
 
 import scalajs.js.JSConverters._
 import react.semanticui.elements.segment.SegmentAttached
+import react.semanticui.collections.form.Form
 
 final case class MagnitudeForm(
   targetId:   Target.Id,
@@ -179,8 +180,10 @@ object MagnitudeForm {
             .options(rowIdFn = _.get.band.tag, columns = columns)
             .setInitialStateFull(tableState)
 
-          React.Fragment(
+          // Put it inside a form to get the SUI styles right
+          Form(as = <.div, size = Small)(
             <.div(
+              ExploreStyles.MagnitudesTableSection,
               <.label("Magnitudes"),
               Segment(attached = SegmentAttached.Attached,
                       compact = true,

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -8,25 +8,33 @@ import cats.syntax.all._
 import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
+import explore.AppCtx
+import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.display._
 import explore.utils.ReactTableHelpers
-import explore.{ AppCtx, Icons }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.MagnitudeBand
 import lucuma.core.math.MagnitudeValue
-import lucuma.core.model.{ Magnitude, Target }
+import lucuma.core.model.Magnitude
+import lucuma.core.model.Target
 import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.optics.{ ChangeAuditor, ValidFormatInput }
+import lucuma.ui.optics.ChangeAuditor
+import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import monocle.std.option.some
-import react.common.{ Css, ReactProps }
-import react.semanticui.collections.table.{ TableFooter, TableHeaderCell, TableRow }
+import react.common.Css
+import react.common.ReactProps
+import react.semanticui.collections.form.Form
+import react.semanticui.collections.table.TableFooter
+import react.semanticui.collections.table.TableHeaderCell
+import react.semanticui.collections.table.TableRow
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.segment.Segment
+import react.semanticui.elements.segment.SegmentAttached
 import react.semanticui.sizes._
 import reactST.reactTable.TableMaker
 import reactST.reactTable.mod._
@@ -34,8 +42,6 @@ import reactST.reactTable.mod._
 import scala.collection.immutable.HashSet
 
 import scalajs.js.JSConverters._
-import react.semanticui.elements.segment.SegmentAttached
-import react.semanticui.collections.form.Form
 
 final case class MagnitudeForm(
   targetId:   Target.Id,

--- a/targeteditor/src/main/scala/explore/targeteditor/MoonCalc.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MoonCalc.scala
@@ -3,7 +3,10 @@
 
 package explore.targeteditor
 
-import java.time.{ Duration, Instant, ZoneOffset, ZonedDateTime }
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 object MoonCalc {
   val MeanLunationDays: Double    = 29.530588861

--- a/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
@@ -15,10 +15,15 @@ import explore.implicits._
 import explore.model.formats._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.math.{ ApparentRadialVelocity, RadialVelocity, Redshift }
-import lucuma.core.util.{ Display, Enumerated }
-import lucuma.ui.forms.{ EnumViewSelect, FormInputEV }
-import lucuma.ui.optics.{ ChangeAuditor, ValidFormatInput }
+import lucuma.core.math.ApparentRadialVelocity
+import lucuma.core.math.RadialVelocity
+import lucuma.core.math.Redshift
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
+import lucuma.ui.forms.EnumViewSelect
+import lucuma.ui.forms.FormInputEV
+import lucuma.ui.optics.ChangeAuditor
+import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.common._

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyCalc.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyCalc.scala
@@ -6,9 +6,11 @@ package explore.targeteditor
 import cats.syntax.all._
 import lucuma.core.enum.Site
 import lucuma.core.math.Coordinates
-import lucuma.core.math.skycalc.{ ImprovedSkyCalc, SkyCalcResults }
+import lucuma.core.math.skycalc.ImprovedSkyCalc
+import lucuma.core.math.skycalc.SkyCalcResults
 
-import java.time.{ Duration, Instant }
+import java.time.Duration
+import java.time.Instant
 
 object SkyCalc {
   // TODO Cache

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyPlot.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyPlot.scala
@@ -7,12 +7,15 @@ import cats.syntax.all._
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import gpp.highcharts.highchartsStrings.line
-import gpp.highcharts.mod.{ XAxisLabelsOptions, _ }
+import gpp.highcharts.mod.XAxisLabelsOptions
+import gpp.highcharts.mod._
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.enum.{ Site, TwilightType }
-import lucuma.core.math.{ Angle, Coordinates }
+import lucuma.core.enum.Site
+import lucuma.core.enum.TwilightType
+import lucuma.core.math.Angle
+import lucuma.core.math.Coordinates
 import lucuma.core.model.ObservingNight
 import lucuma.core.util.Enumerated
 import lucuma.ui.reusability._
@@ -22,8 +25,13 @@ import react.highcharts.Chart
 import reactmoon.MoonPhase
 import shapeless._
 
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.time.{ Duration, Instant, LocalDate, ZoneId, ZoneOffset, ZonedDateTime }
 import scala.collection.immutable.HashSet
 import scala.scalajs.js
 

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyPlotSection.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyPlotSection.scala
@@ -18,7 +18,10 @@ import react.common.ReactProps
 import react.datepicker._
 import react.semanticui.modules.checkbox.Checkbox
 
-import java.time.{ LocalDate, ZoneId, ZoneOffset, ZonedDateTime }
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 final case class SkyPlotSection(
   coords: Coordinates

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -10,10 +10,13 @@ import crystal.ViewF
 import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.string._
+import explore.AppCtx
 import explore.GraphQLSchemas.ObservationDB.Types._
+import explore.View
 import explore.components.WIP
 import explore.components.ui.ExploreStyles
-import explore.components.undo.{ UndoButtons, UndoRegion }
+import explore.components.undo.UndoButtons
+import explore.components.undo.UndoRegion
 import explore.implicits._
 import explore.model.TargetVisualOptions
 import explore.model.formats._
@@ -21,14 +24,19 @@ import explore.model.reusability._
 import explore.model.utils._
 import explore.target.TargetQueries
 import explore.target.TargetQueries._
-import explore.{ AppCtx, View }
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.math._
-import lucuma.core.model.{ Magnitude, SiderealTracking, Target, User }
+import lucuma.core.model.Magnitude
+import lucuma.core.model.SiderealTracking
+import lucuma.core.model.Target
+import lucuma.core.model.User
 import lucuma.ui.forms.FormInputEV
 import lucuma.ui.implicits._
-import lucuma.ui.optics.{ ChangeAuditor, TruncatedDec, TruncatedRA, ValidFormatInput }
+import lucuma.ui.optics.ChangeAuditor
+import lucuma.ui.optics.TruncatedDec
+import lucuma.ui.optics.TruncatedRA
+import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.common._

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -150,102 +150,99 @@ object TargetBody {
           React.Fragment(
             <.div(
               ExploreStyles.TargetGrid,
-              <.div(
+              Form(as = <.div, size = Small)(
+                ExploreStyles.Grid,
+                ExploreStyles.Compact,
+                // Keep the search field and the coords always together
                 SearchForm(
                   nameView,
                   stateView,
                   searchAndSet
                 ),
-                Form(as = <.div, size = Small)(
-                  ExploreStyles.Grid,
-                  ExploreStyles.Compact,
-                  <.div(
-                    ExploreStyles.FlexContainer,
-                    ExploreStyles.TargetRaDecMinWidth,
-                    FormInputEV(
-                      id = "ra",
-                      value = coordsRAView.zoomSplitEpi(TruncatedRA.rightAscension),
-                      validFormat = ValidFormatInput.truncatedRA,
-                      changeAuditor = ChangeAuditor.truncatedRA,
-                      label = "RA",
-                      clazz = ExploreStyles.FlexGrow(1) |+| ExploreStyles.TargetRaDecMinWidth,
-                      errorPointing = LabelPointing.Below,
-                      errorClazz = ExploreStyles.InputErrorTooltip,
-                      disabled = stateView.get
-                    ),
-                    FormInputEV(
-                      id = "dec",
-                      value = coordsDecView.zoomSplitEpi(TruncatedDec.declination),
-                      validFormat = ValidFormatInput.truncatedDec,
-                      changeAuditor = ChangeAuditor.truncatedDec,
-                      label = "Dec",
-                      clazz = ExploreStyles.FlexGrow(1) |+| ExploreStyles.TargetRaDecMinWidth,
-                      errorPointing = LabelPointing.Below,
-                      errorClazz = ExploreStyles.InputErrorTooltip,
-                      disabled = stateView.get
-                    )
+                <.div(
+                  ExploreStyles.FlexContainer,
+                  ExploreStyles.TargetRaDecMinWidth,
+                  FormInputEV(
+                    id = "ra",
+                    value = coordsRAView.zoomSplitEpi(TruncatedRA.rightAscension),
+                    validFormat = ValidFormatInput.truncatedRA,
+                    changeAuditor = ChangeAuditor.truncatedRA,
+                    label = "RA",
+                    clazz = ExploreStyles.FlexGrow(1) |+| ExploreStyles.TargetRaDecMinWidth,
+                    errorPointing = LabelPointing.Below,
+                    errorClazz = ExploreStyles.InputErrorTooltip,
+                    disabled = stateView.get
                   ),
-                  <.div(
-                    ExploreStyles.Grid,
-                    ExploreStyles.Compact,
-                    ExploreStyles.TargetPropertiesForm,
-                    InputWithUnits(
-                      epochView,
-                      ValidFormatInput.fromFormat(Epoch.fromStringNoScheme, "Invalid Epoch"),
-                      ChangeAuditor.maxLength(8).decimal(3).deny("-").as[Epoch],
-                      id = "epoch",
-                      label = "Epoch",
-                      units = "years",
-                      disabled = stateView.get
-                    ),
-                    InputWithUnits(
-                      properMotionRAView,
-                      ValidFormatInput.fromFormatOptional(pmRAFormat, "Must be a number"),
-                      ChangeAuditor.fromFormat(pmRAFormat).decimal(3).optional,
-                      id = "raPM",
-                      label = "µ RA",
-                      units = "mas/y",
-                      disabled = stateView.get
-                    ),
-                    InputWithUnits(
-                      properMotionDecView,
-                      ValidFormatInput.fromFormatOptional(pmDecFormat, "Must be a number"),
-                      ChangeAuditor.fromFormat(pmDecFormat).decimal(3).optional,
-                      id = "raDec",
-                      label = "µ Dec",
-                      units = "mas/y",
-                      disabled = stateView.get
-                    ),
-                    InputWithUnits[IO, Option[Parallax]](
-                      parallaxView,
-                      ValidFormatInput.fromFormatOptional(pxFormat, "Must be a number"),
-                      ChangeAuditor.fromFormat(pxFormat).decimal(3).optional,
-                      id = "parallax",
-                      label = "Parallax",
-                      units = "mas",
-                      disabled = stateView.get
-                    ),
-                    RVInput(radialVelocityView, stateView)
-                  ),
-                  MagnitudeForm(target.id, magnitudesView, disabled = stateView.get),
-                  UndoButtons(target, undoCtx, disabled = stateView.get)
+                  FormInputEV(
+                    id = "dec",
+                    value = coordsDecView.zoomSplitEpi(TruncatedDec.declination),
+                    validFormat = ValidFormatInput.truncatedDec,
+                    changeAuditor = ChangeAuditor.truncatedDec,
+                    label = "Dec",
+                    clazz = ExploreStyles.FlexGrow(1) |+| ExploreStyles.TargetRaDecMinWidth,
+                    errorPointing = LabelPointing.Below,
+                    errorClazz = ExploreStyles.InputErrorTooltip,
+                    disabled = stateView.get
+                  )
                 )
               ),
-              <.div(
-                AladinCell(
-                  props.uid,
-                  props.target.get.id,
-                  props.target.zoom(TargetQueries.baseCoordinates),
-                  props.options
-                ),
-                CataloguesForm(props.options).when(false)
+              AladinCell(
+                props.uid,
+                props.target.get.id,
+                props.target.zoom(TargetQueries.baseCoordinates),
+                props.options
               ),
+              CataloguesForm(props.options).when(false),
+              Form(as = <.div, size = Small)(
+                ExploreStyles.Grid,
+                ExploreStyles.Compact,
+                ExploreStyles.TargetPropertiesForm,
+                InputWithUnits(
+                  epochView,
+                  ValidFormatInput.fromFormat(Epoch.fromStringNoScheme, "Invalid Epoch"),
+                  ChangeAuditor.maxLength(8).decimal(3).deny("-").as[Epoch],
+                  id = "epoch",
+                  label = "Epoch",
+                  units = "years",
+                  disabled = stateView.get
+                ),
+                InputWithUnits(
+                  properMotionRAView,
+                  ValidFormatInput.fromFormatOptional(pmRAFormat, "Must be a number"),
+                  ChangeAuditor.fromFormat(pmRAFormat).decimal(3).optional,
+                  id = "raPM",
+                  label = "µ RA",
+                  units = "mas/y",
+                  disabled = stateView.get
+                ),
+                InputWithUnits(
+                  properMotionDecView,
+                  ValidFormatInput.fromFormatOptional(pmDecFormat, "Must be a number"),
+                  ChangeAuditor.fromFormat(pmDecFormat).decimal(3).optional,
+                  id = "raDec",
+                  label = "µ Dec",
+                  units = "mas/y",
+                  disabled = stateView.get
+                ),
+                InputWithUnits[IO, Option[Parallax]](
+                  parallaxView,
+                  ValidFormatInput.fromFormatOptional(pxFormat, "Must be a number"),
+                  ChangeAuditor.fromFormat(pxFormat).decimal(3).optional,
+                  id = "parallax",
+                  label = "Parallax",
+                  units = "mas",
+                  disabled = stateView.get
+                ),
+                RVInput(radialVelocityView, stateView)
+              ),
+              MagnitudeForm(target.id, magnitudesView, disabled = stateView.get),
+              UndoButtons(target, undoCtx, disabled = stateView.get),
               <.div(
                 ExploreStyles.TargetSkyplotCell,
                 WIP(
                   SkyPlotSection(props.baseCoordinates)
-                )
-              ).when(false)
+                ).when(false)
+              )
             )
           )
         }

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -53,12 +53,10 @@ object TargetEditor {
           _.target,
           NonEmptyList.of(TargetEditSubscription.subscribe[IO](props.tid))
         ) { targetOpt =>
-          <.div(
-            targetOpt.get.whenDefined { _ =>
-              val stateView = ViewF.fromState[IO]($).zoom(State.options)
-              TargetBody(props.uid, props.tid, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
-            }
-          )
+          targetOpt.get.map { _ =>
+            val stateView = ViewF.fromState[IO]($).zoom(State.options)
+            TargetBody(props.uid, props.tid, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
+          }
         }
       }
   }

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -12,6 +12,7 @@ import explore.GraphQLSchemas.ObservationDB
 import explore.common.UserPreferencesQueries._
 import explore.components.graphql.LiveQueryRenderMod
 import explore.implicits._
+import explore.model.Constants
 import explore.model.TargetVisualOptions
 import explore.model.reusability._
 import explore.target.TargetQueries._
@@ -22,7 +23,6 @@ import lucuma.core.model.User
 import lucuma.ui.reusability._
 import monocle.macros.Lenses
 import react.common._
-import explore.model.Constants
 
 final case class TargetEditor(
   uid: User.Id,

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -18,18 +18,20 @@ import explore.implicits._
 import explore.model.Constants
 import explore.model.decoders._
 import explore.optics._
-import explore.undo.{ UndoableView, Undoer }
+import explore.undo.UndoableView
+import explore.undo.Undoer
+import lucuma.core.math.Coordinates
+import lucuma.core.math.Declination
+import lucuma.core.math.Epoch
+import lucuma.core.math.Parallax
+import lucuma.core.math.ProperMotion
+import lucuma.core.math.RadialVelocity
+import lucuma.core.math.RightAscension
 import lucuma.core.math.units.CentimetersPerSecond
-import lucuma.core.math.{
-  Coordinates,
-  Declination,
-  Epoch,
-  Parallax,
-  ProperMotion,
-  RadialVelocity,
-  RightAscension
-}
-import lucuma.core.model.{ CatalogId, Magnitude, SiderealTracking, Target }
+import lucuma.core.model.CatalogId
+import lucuma.core.model.Magnitude
+import lucuma.core.model.SiderealTracking
+import lucuma.core.model.Target
 import lucuma.ui.reusability._
 import monocle.Lens
 

--- a/targeteditor/src/main/scala/explore/targeteditor/Test.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/Test.scala
@@ -4,10 +4,11 @@
 package explore.targeteditor
 
 import eu.timepit.refined.auto._
+import explore.AppMain
+import explore._
 import explore.components.Tile
 import explore.components.state.IfLogged
 import explore.model._
-import explore.{ AppMain, _ }
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Target
 import lucuma.core.model.User

--- a/targeteditor/src/main/scala/explore/targeteditor/plotPeriod.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/plotPeriod.scala
@@ -4,9 +4,13 @@
 package explore.targeteditor
 
 import lucuma.core.enum.Site
-import lucuma.core.model.{ LocalObservingNight, ObservingNight, Semester }
+import lucuma.core.model.LocalObservingNight
+import lucuma.core.model.ObservingNight
+import lucuma.core.model.Semester
 
-import java.time.{ Duration, Instant, LocalDate }
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
 
 sealed trait PlotPeriod {
   def start(site: Site): Instant


### PR DESCRIPTION
This PR aims to set the target tile on the observation tab. It will now read the target (asterisms not supported) of an obs and display part of the target tab inside the tile

It also contains some explorations on how to make the target tab more responsive.