### PR TITLE
Some more format options.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -20,6 +20,11 @@ align.openParenCallSite = true
 spaces.inImportCurlyBraces = true
 
 verticalMultiline.atDefnSite = true
+verticalMultiline.newlineAfterOpenParen = true
+verticalMultiline.excludeDanglingParens=[]
+
+newlines.implicitParamListModifierForce = [after]
+newlines.avoidInResultType = false
 
 continuationIndent.defnSite = 2
 

--- a/common/src/main/scala/explore/common/SSOClient.scala
+++ b/common/src/main/scala/explore/common/SSOClient.scala
@@ -37,7 +37,8 @@ object SSOClient {
 
 case class SSOClient[F[_]: ConcurrentEffect: Timer: Logger](
   config:     SSOConfig,
-  fromFuture: SSOClient.FromFuture[F, Response[Either[String, String]]]) {
+  fromFuture: SSOClient.FromFuture[F, Response[Either[String, String]]]
+) {
   // Does a client side redirect to the sso site
   val redirectToLogin: F[Unit] =
     Sync[F].delay {

--- a/common/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/common/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -106,7 +106,8 @@ object UserPreferencesQueries {
       userId:       Option[User.Id],
       area:         ResizableSection,
       defaultValue: Int
-    )(implicit cl:  GraphQLClient[F, UserPreferencesDB]
+    )(implicit
+      cl:           GraphQLClient[F, UserPreferencesDB]
     ): F[Int] =
       (for {
         uid <- OptionT.fromOption[F](userId)
@@ -167,7 +168,8 @@ object UserPreferencesQueries {
       layoutSection: GridLayoutSection,
       resizableArea: ResizableSection,
       defaultValue:  (Int, LayoutsMap)
-    )(implicit cl:   GraphQLClient[F, UserPreferencesDB]
+    )(implicit
+      cl:            GraphQLClient[F, UserPreferencesDB]
     ): F[(Int, LayoutsMap)] =
       (for {
         uid <- OptionT.fromOption[F](userId)
@@ -249,10 +251,11 @@ object UserPreferencesQueries {
     // This is coded to return a default in case
     // there is no data or errors
     def queryWithDefault[F[_]: MonadError[*[_], Throwable]](
-      uid:         User.Id,
-      tid:         Target.Id,
-      defaultFov:  Angle
-    )(implicit cl: GraphQLClient[F, UserPreferencesDB]
+      uid:        User.Id,
+      tid:        Target.Id,
+      defaultFov: Angle
+    )(implicit
+      cl:         GraphQLClient[F, UserPreferencesDB]
     ): F[Angle] =
       (for {
         r <-

--- a/common/src/main/scala/explore/components/FormStaticData.scala
+++ b/common/src/main/scala/explore/components/FormStaticData.scala
@@ -19,8 +19,8 @@ final case class FormStaticData(
   value:     TagMod,
   label:     String,
   hideLabel: Boolean = false,
-  modifiers: Seq[TagMod] = Seq.empty)
-    extends ReactProps[FormStaticData](FormStaticData.component) {
+  modifiers: Seq[TagMod] = Seq.empty
+) extends ReactProps[FormStaticData](FormStaticData.component) {
   def apply(mods: TagMod*): FormStaticData = copy(modifiers = modifiers ++ mods)
 }
 

--- a/common/src/main/scala/explore/components/ObsBadge.scala
+++ b/common/src/main/scala/explore/components/ObsBadge.scala
@@ -16,8 +16,8 @@ import react.semanticui.views.card._
 final case class ObsBadge(
   obs:      ObsSummary,
   layout:   ObsBadge.Layout,
-  selected: Boolean = false)
-    extends ReactProps[ObsBadge](ObsBadge.component)
+  selected: Boolean = false
+) extends ReactProps[ObsBadge](ObsBadge.component)
 object ObsBadge {
   type Props = ObsBadge
 

--- a/common/src/main/scala/explore/components/ResponsiveComponent.scala
+++ b/common/src/main/scala/explore/components/ResponsiveComponent.scala
@@ -13,8 +13,8 @@ import react.resizeDetector.ResizeDetector
 final case class ResponsiveComponent(
   widthBreakpoints:  List[(Int, Css)],
   heightBreakpoints: List[(Int, Css)] = Nil,
-  clazz:             Css = Css.Empty)
-    extends ReactPropsWithChildren[ResponsiveComponent](ResponsiveComponent.component)
+  clazz:             Css = Css.Empty
+) extends ReactPropsWithChildren[ResponsiveComponent](ResponsiveComponent.component)
 
 object ResponsiveComponent {
   type Props = ResponsiveComponent

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -24,8 +24,8 @@ final case class Tile(
   canMinimize:       Boolean = false,
   canMaximize:       Boolean = false,
   state:             TileSizeState = TileSizeState.Normal,
-  sizeStateCallback: TileSizeState => Callback = _ => Callback.empty)
-    extends ReactPropsWithChildren[Tile](Tile.component) {
+  sizeStateCallback: TileSizeState => Callback = _ => Callback.empty
+) extends ReactPropsWithChildren[Tile](Tile.component) {
   def showMaximize: Boolean = canMaximize && state === TileSizeState.Minimized
   def showMinimize: Boolean = canMinimize && state === TileSizeState.Normal
 }

--- a/common/src/main/scala/explore/components/UserSelectionForm.scala
+++ b/common/src/main/scala/explore/components/UserSelectionForm.scala
@@ -28,8 +28,8 @@ import react.semanticui.sizes._
 
 final case class UserSelectionForm(
   vault:   View[Option[UserVault]],
-  message: View[Option[NonEmptyString]])
-    extends ReactProps[UserSelectionForm](UserSelectionForm.component) {
+  message: View[Option[NonEmptyString]]
+) extends ReactProps[UserSelectionForm](UserSelectionForm.component) {
   def guest: Callback = AppCtx.flatMap(_.sso.guest.flatMap(v => vault.set(v.some))).runAsyncCB
   def login: Callback = AppCtx.flatMap(_.sso.redirectToLogin).runAsyncCB
 

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
@@ -25,7 +25,8 @@ final case class LiveQueryRender[S, D, A](
   query:               IO[D],
   extract:             D => A,
   changeSubscriptions: NonEmptyList[IO[GraphQLSubscription[IO, _]]]
-)(val valueRender:     A => VdomNode,
+)(
+  val valueRender:     A => VdomNode,
   val pendingRender:   Long => VdomNode = (_ => Icon(name = "spinner", loading = true, size = Large)),
   val errorRender:     Throwable => VdomNode = (t => Message(error = true)(t.getMessage)),
   val onNewData:       IO[Unit] = IO.unit
@@ -33,8 +34,8 @@ final case class LiveQueryRender[S, D, A](
   val F:               ConcurrentEffect[IO],
   val logger:          Logger[IO],
   val reuse:           Reusability[A],
-  val client:          GraphQLWebSocketClient[IO, S])
-    extends ReactProps(LiveQueryRender.component)
+  val client:          GraphQLWebSocketClient[IO, S]
+) extends ReactProps(LiveQueryRender.component)
     with LiveQueryRender.Props[IO, S, D, A]
 
 object LiveQueryRender {
@@ -44,8 +45,8 @@ object LiveQueryRender {
     queue:                   Queue[F, A],
     subscriptions:           NonEmptyList[GraphQLSubscription[F, _]],
     cancelConnectionTracker: CancelToken[F],
-    renderer:                StreamRenderer.Component[A])
-      extends Render.LiveQuery.State[F, Id, S, D, A]
+    renderer:                StreamRenderer.Component[A]
+  ) extends Render.LiveQuery.State[F, Id, S, D, A]
 
   // Reusability should be controlled by enclosing components and reuse parameter. We allow rerender every time it's requested.
   implicit def propsReuse[F[_], S, D, A]: Reusability[Props[F, S, D, A]] = Reusability.never

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
@@ -32,7 +32,8 @@ final case class LiveQueryRenderMod[S, D, A](
   query:               IO[D],
   extract:             D => A,
   changeSubscriptions: NonEmptyList[IO[GraphQLSubscription[IO, _]]]
-)(val valueRender:     View[A] => VdomNode,
+)(
+  val valueRender:     View[A] => VdomNode,
   val pendingRender:   Long => VdomNode = (_ => Icon(name = "spinner", loading = true, size = Large)),
   val errorRender:     Throwable => VdomNode = (t => Message(error = true)(t.getMessage)),
   val onNewData:       IO[Unit] = IO.unit
@@ -42,8 +43,8 @@ final case class LiveQueryRenderMod[S, D, A](
   val cs:              ContextShift[IO],
   val logger:          Logger[IO],
   val reuse:           Reusability[A],
-  val client:          GraphQLWebSocketClient[IO, S])
-    extends ReactProps(LiveQueryRenderMod.component)
+  val client:          GraphQLWebSocketClient[IO, S]
+) extends ReactProps(LiveQueryRenderMod.component)
     with LiveQueryRenderMod.Props[IO, S, D, A]
 
 object LiveQueryRenderMod {
@@ -56,8 +57,8 @@ object LiveQueryRenderMod {
     queue:                   Queue[F, A],
     subscriptions:           NonEmptyList[GraphQLSubscription[F, _]],
     cancelConnectionTracker: CancelToken[F],
-    renderer:                StreamRendererMod.Component[F, A])
-      extends Render.LiveQuery.State[F, ViewF[F, *], S, D, A]
+    renderer:                StreamRendererMod.Component[F, A]
+  ) extends Render.LiveQuery.State[F, ViewF[F, *], S, D, A]
 
   // Reusability should be controlled by enclosing components and reuse parameter. We allow rerender every time it's requested.
   implicit def propsReuse[F[_], S, D, A]: Reusability[Props[F, S, D, A]]                 = Reusability.never

--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -106,7 +106,8 @@ object Render {
         buildRenderer: (fs2.Stream[F, A], P) => StreamRendererComponent[G, A],
         buildState:    (Queue[F, A], NonEmptyList[GraphQLSubscription[F, _]], CancelToken[F],
           StreamRendererComponent[G, A]) => ST
-      )($             : ComponentDidMount[P, Option[ST], Unit]
+      )(
+        $             : ComponentDidMount[P, Option[ST], Unit]
       ): Callback = {
         implicit val F      = $.props.F
         implicit val logger = $.props.logger

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
@@ -21,15 +21,16 @@ import react.semanticui.sizes._
 final case class SubscriptionRender[D, A](
   subscribe:         IO[GraphQLSubscription[IO, D]],
   streamModifier:    fs2.Stream[IO, D] => fs2.Stream[IO, A] = identity[fs2.Stream[IO, D]] _
-)(val valueRender:   A => VdomNode,
+)(
+  val valueRender:   A => VdomNode,
   val pendingRender: Long => VdomNode = (_ => Icon(name = "spinner", loading = true, size = Large)),
   val errorRender:   Throwable => VdomNode = (t => Message(error = true)(t.getMessage)),
   val onNewData:     IO[Unit] = IO.unit
 )(implicit
   val F:             ConcurrentEffect[IO],
   val logger:        Logger[IO],
-  val reuse:         Reusability[A])
-    extends ReactProps(SubscriptionRender.component)
+  val reuse:         Reusability[A]
+) extends ReactProps(SubscriptionRender.component)
     with SubscriptionRender.Props[IO, D, A]
 
 object SubscriptionRender {
@@ -37,8 +38,8 @@ object SubscriptionRender {
 
   final case class State[F[_], D, A](
     subscription: GraphQLSubscription[F, D],
-    renderer:     StreamRenderer.Component[A])
-      extends Render.Subscription.State[F, Id, D, A]
+    renderer:     StreamRenderer.Component[A]
+  ) extends Render.Subscription.State[F, Id, D, A]
 
   // Reusability should be controlled by enclosing components and reuse parameter. We allow rerender every time it's requested.
   implicit def propsReuse[F[_], D, A]: Reusability[Props[F, D, A]] = Reusability.never

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -28,7 +28,8 @@ import scala.language.postfixOps
 final case class SubscriptionRenderMod[D, A](
   subscribe:         IO[GraphQLSubscription[IO, D]],
   streamModifier:    fs2.Stream[IO, D] => fs2.Stream[IO, A] = identity[fs2.Stream[IO, D]] _
-)(val valueRender:   View[A] => VdomNode,
+)(
+  val valueRender:   View[A] => VdomNode,
   val pendingRender: Long => VdomNode = (_ => Icon(name = "spinner", loading = true, size = Large)),
   val errorRender:   Throwable => VdomNode = (t => Message(error = true)(t.getMessage)),
   val onNewData:     IO[Unit] = IO.unit
@@ -37,8 +38,8 @@ final case class SubscriptionRenderMod[D, A](
   val timer:         Timer[IO],
   val cs:            ContextShift[IO],
   val logger:        Logger[IO],
-  val reuse:         Reusability[A])
-    extends ReactProps(SubscriptionRenderMod.component)
+  val reuse:         Reusability[A]
+) extends ReactProps(SubscriptionRenderMod.component)
     with SubscriptionRenderMod.Props[IO, D, A]
 
 object SubscriptionRenderMod {
@@ -49,8 +50,8 @@ object SubscriptionRenderMod {
 
   protected final case class State[F[_], D, A](
     subscription: GraphQLSubscription[F, D],
-    renderer:     StreamRendererMod.Component[F, A])
-      extends Render.Subscription.State[F, ViewF[F, *], D, A]
+    renderer:     StreamRendererMod.Component[F, A]
+  ) extends Render.Subscription.State[F, ViewF[F, *], D, A]
 
   // Reusability should be controlled by enclosing components and reuse parameter. We allow rerender every time it's requested.
   implicit protected def propsReuse[F[_], D, A]: Reusability[Props[F, D, A]] =

--- a/common/src/main/scala/explore/components/state/LogoutTracker.scala
+++ b/common/src/main/scala/explore/components/state/LogoutTracker.scala
@@ -19,8 +19,9 @@ import react.common.ReactProps
 final case class LogoutTracker(
   setVault:   Option[UserVault] => IO[Unit],
   setMessage: NonEmptyString => IO[Unit]
-)(val render: IO[Unit] => VdomNode)
-    extends ReactProps[LogoutTracker](LogoutTracker.component)
+)(
+  val render: IO[Unit] => VdomNode
+) extends ReactProps[LogoutTracker](LogoutTracker.component)
 
 object LogoutTracker {
   type Props = LogoutTracker

--- a/common/src/main/scala/explore/components/state/SSOManager.scala
+++ b/common/src/main/scala/explore/components/state/SSOManager.scala
@@ -23,8 +23,8 @@ import java.time.Instant
 final case class SSOManager(
   expiration: Instant,
   setVault:   Option[UserVault] => IO[Unit],
-  setMessage: NonEmptyString => IO[Unit])
-    extends ReactProps[SSOManager](SSOManager.component)
+  setMessage: NonEmptyString => IO[Unit]
+) extends ReactProps[SSOManager](SSOManager.component)
 
 object SSOManager {
   type Props = SSOManager

--- a/common/src/main/scala/explore/components/undo/UndoButtons.scala
+++ b/common/src/main/scala/explore/components/undo/UndoButtons.scala
@@ -21,8 +21,8 @@ final case class UndoButtons[F[_], A](
   iconSize:   SemanticSize = Small,
   disabled:   Boolean = false
 )(implicit
-  val effect: Effect[F])
-    extends ReactProps[UndoButtons[Any, Any]](UndoButtons.component)
+  val effect: Effect[F]
+) extends ReactProps[UndoButtons[Any, Any]](UndoButtons.component)
 
 object UndoButtons {
   type Props[F[_], A] = UndoButtons[F, A]

--- a/common/src/main/scala/explore/components/undo/UndoRegion.scala
+++ b/common/src/main/scala/explore/components/undo/UndoRegion.scala
@@ -13,8 +13,8 @@ import monocle.macros.Lenses
 import react.common.ReactProps
 
 final case class UndoRegion[M](
-  renderer: Undoer.Context[IO, M] => VdomNode)
-    extends ReactProps(UndoRegion.component)
+  renderer: Undoer.Context[IO, M] => VdomNode
+) extends ReactProps(UndoRegion.component)
     with UndoRegion.Props[IO, M]
 
 object UndoRegion {
@@ -25,7 +25,8 @@ object UndoRegion {
   @Lenses
   protected final case class State[F[_], M](
     undoStack: Undoer.Stack[F, M] = List.empty,
-    redoStack: Undoer.Stack[F, M] = List.empty)
+    redoStack: Undoer.Stack[F, M] = List.empty
+  )
 
   // Reusability should be controlled by enclosing components and reuse parameter. We allow rerender every time it's requested.
   implicit protected def propsReuse[F[_], M]: Reusability[Props[F, M]] =

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -21,7 +21,8 @@ import sttp.client3.Response
 
 case class Clients[F[_]: ConcurrentEffect: Logger](
   odb:           GraphQLWebSocketClient[F, ObservationDB],
-  preferencesDB: GraphQLWebSocketClient[F, UserPreferencesDB]) {
+  preferencesDB: GraphQLWebSocketClient[F, UserPreferencesDB]
+) {
   lazy val PreferencesDBConnectionStatus: StreamRenderer.Component[StreamingClientStatus] =
     StreamRenderer.build(preferencesDB.statusStream)
 
@@ -53,7 +54,8 @@ case class AppContext[F[_]](
   val F:       Applicative[F],
   val cs:      ContextShift[F],
   val timer:   Timer[F],
-  val logger:  Logger[F])
+  val logger:  Logger[F]
+)
 
 object AppContext {
   def from[F[_]: ConcurrentEffect: ContextShift: Timer: Logger: Backend: WebSocketBackend](

--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -38,7 +38,8 @@ object ReactTableHelpers {
     changeAuditor: ChangeAuditor[B] = ChangeAuditor.accept[B],
     disabled:      Boolean = false,
     modifiers:     Seq[TagMod] = Seq.empty
-  )(implicit eq:   Eq[B]
+  )(implicit
+    eq:            Eq[B]
   ) =
     ScalaComponent
       .builder[View[A]]
@@ -66,12 +67,14 @@ object ReactTableHelpers {
    * @return The component.
    */
   def editableEnumViewColumn[A, B](
-    lens:          Lens[A, B]
-  )(disabled:      Boolean = false,
-    excludeFn:     Option[View[A] => Set[B]] = None,
-    modifiers:     Seq[TagMod] = Seq.empty
-  )(implicit enum: Enumerated[B],
-    display:       Display[B]
+    lens:      Lens[A, B]
+  )(
+    disabled:  Boolean = false,
+    excludeFn: Option[View[A] => Set[B]] = None,
+    modifiers: Seq[TagMod] = Seq.empty
+  )(implicit
+    enum:      Enumerated[B],
+    display:   Display[B]
   ) =
     ScalaComponent
       .builder[View[A]]

--- a/common/src/main/scala/react/resizeDetector/ResizeDetector.scala
+++ b/common/src/main/scala/react/resizeDetector/ResizeDetector.scala
@@ -165,7 +165,8 @@ object ResizeDetector {
     refreshRate:     js.UndefOr[Int] = js.undefined,
     refreshOptions:  js.UndefOr[RefreshOptions] = js.undefined,
     observerOptions: js.UndefOr[ObserverOptions] = js.undefined
-  )(children:        Render
+  )(
+    children:        Render
   ) = component(
     Props(children,
           onResize,

--- a/constraints/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/constraints/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -27,8 +27,8 @@ import react.semanticui.widths._
 
 final case class ConstraintsPanel(
   id:          Constraints.Id,
-  constraints: View[Constraints])
-    extends ReactProps[ConstraintsPanel](ConstraintsPanel.component)
+  constraints: View[Constraints]
+) extends ReactProps[ConstraintsPanel](ConstraintsPanel.component)
 
 object ConstraintsPanel {
   type Props = ConstraintsPanel

--- a/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
+++ b/constraints/src/main/scala/explore/constraints/ConstraintsQueries.scala
@@ -59,11 +59,13 @@ object ConstraintsQueries {
   case class UndoViewZoom(
     id:     Constraints.Id,
     view:   View[Constraints],
-    setter: Undoer.Setter[IO, Constraints]) {
+    setter: Undoer.Setter[IO, Constraints]
+  ) {
     def apply[A](
-      lens:        Lens[Constraints, A],
-      fields:      A => ConstraintsSetInput
-    )(implicit cs: ContextShift[IO]
+      lens:   Lens[Constraints, A],
+      fields: A => ConstraintsSetInput
+    )(implicit
+      cs:     ContextShift[IO]
     ): View[A] =
       ViewF[IO, A](
         lens.get(view.get),
@@ -99,7 +101,8 @@ object ConstraintsQueries {
 
   def ConstraintsSubscription(
     id:     Constraints.Id
-  )(render: View[Constraints] => VdomNode
+  )(
+    render: View[Constraints] => VdomNode
   ): SubscriptionRenderMod[Subscription.Data, Constraints] =
     ???
   // AppCtx.withCtx { implicit appCtx =>

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -15,8 +15,9 @@ import react.common._
 final case class ExploreLayout(
   c:        RouterCtl[Page],
   r:        ResolutionWithProps[Page, View[RootModel]]
-)(val view: View[RootModel])
-    extends ReactProps[ExploreLayout](ExploreLayout.component)
+)(
+  val view: View[RootModel]
+) extends ReactProps[ExploreLayout](ExploreLayout.component)
 
 object ExploreLayout {
   type Props = ExploreLayout

--- a/explore/src/main/scala/explore/SideTabs.scala
+++ b/explore/src/main/scala/explore/SideTabs.scala
@@ -23,8 +23,8 @@ import react.semanticui.elements.label.Label.LabelProps
 import react.semanticui.sizes._
 
 final case class SideTabs(
-  tabs: View[EnumZipper[AppTab]])
-    extends ReactProps[SideTabs](SideTabs.component)
+  tabs: View[EnumZipper[AppTab]]
+) extends ReactProps[SideTabs](SideTabs.component)
 
 object SideTabs {
   type Props = SideTabs

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -34,8 +34,8 @@ import react.semanticui.views.item.Item
 
 final case class TopBar(
   user:   User,
-  logout: IO[Unit])
-    extends ReactProps[TopBar](TopBar.component)
+  logout: IO[Unit]
+) extends ReactProps[TopBar](TopBar.component)
 
 object TopBar {
   type Props = TopBar

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -54,8 +54,8 @@ import scala.concurrent.duration._
 final case class ObsTabContents(
   userId:  ViewOpt[User.Id],
   focused: View[Option[Focused]],
-  size:    ResizeDetector.Dimensions)
-    extends ReactProps[ObsTabContents](ObsTabContents.component) {
+  size:    ResizeDetector.Dimensions
+) extends ReactProps[ObsTabContents](ObsTabContents.component) {
   def isObsSelected: Boolean = focused.get.isDefined
 }
 
@@ -119,7 +119,8 @@ object ObsTabContents {
   final case class State(
     panels:  TwoPanelState,
     layouts: LayoutsMap,
-    options: TargetVisualOptions) {
+    options: TargetVisualOptions
+  ) {
     def updateLayouts(newLayouts: LayoutsMap): State =
       copy(layouts = mergeMap(layouts, newLayouts))
   }

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -43,8 +43,8 @@ final case class TargetTabContents(
   userId:                ViewOpt[User.Id],
   focused:               View[Option[Focused]],
   targetViewExpandedIds: View[TargetViewExpandedIds],
-  size:                  ResizeDetector.Dimensions)
-    extends ReactProps[TargetTabContents](TargetTabContents.component) {
+  size:                  ResizeDetector.Dimensions
+) extends ReactProps[TargetTabContents](TargetTabContents.component) {
   def isTargetSelected: Boolean = focused.get.isDefined
 }
 

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -14,7 +14,8 @@ import KeyedIndexedTree._
 case class KeyedIndexedTree[K: Eq, A] private (
   private val byKey:  Map[K, Node[IndexedElem[K, A]]],
   private val tree:   Tree[IndexedElem[K, A]]
-)(private val getKey: A => K // Having in another param set keeps this out of equality
+)(
+  private val getKey: A => K // Having in another param set keeps this out of equality
 ) {
 
   def toTree: Tree[A] = tree.map(_.elem)
@@ -36,7 +37,8 @@ case class KeyedIndexedTree[K: Eq, A] private (
   private def removeInTree(key: K): Tree[IndexedElem[K, A]] = {
     def removeInChildren(
       idx:       Index[K]
-    )(children:  List[Node[IndexedElem[K, A]]],
+    )(
+      children:  List[Node[IndexedElem[K, A]]],
       parentKey: Option[K] = None
     ): List[Node[IndexedElem[K, A]]] =
       if (parentKey === idx.parentKey)

--- a/model/shared/src/main/scala/explore/model/AppConfig.scala
+++ b/model/shared/src/main/scala/explore/model/AppConfig.scala
@@ -19,7 +19,8 @@ case class SSOConfig(
   uri:                        Uri,
   readTimeoutSeconds:         Long = 10,
   refreshTimeoutDeltaSeconds: Long = 10, // time before expiration to renew
-  refreshIntervalFactor:      Long = 1) {
+  refreshIntervalFactor:      Long = 1
+) {
   val readTimeout: FiniteDuration         = FiniteDuration(readTimeoutSeconds, TimeUnit.SECONDS)
   val refreshTimeoutDelta: FiniteDuration =
     FiniteDuration(refreshTimeoutDeltaSeconds, TimeUnit.SECONDS)
@@ -37,7 +38,8 @@ case class AppConfig(
   environment:      ExecutionEnvironment,
   preferencesDBURI: Uri,
   odbURI:           Uri,
-  sso:              SSOConfig)
+  sso:              SSOConfig
+)
 
 object AppConfig {
   implicit val eqAppConfig: Eq[AppConfig]     = Eq.fromUniversalEquals

--- a/model/shared/src/main/scala/explore/model/Constraints.scala
+++ b/model/shared/src/main/scala/explore/model/Constraints.scala
@@ -16,7 +16,8 @@ final case class Constraints(
   cc:   CloudCover,
   iq:   ImageQuality,
   sb:   SkyBackground,
-  wv:   WaterVapor) {
+  wv:   WaterVapor
+) {
   override def toString: String =
     s"""$productPrefix(UUID.fromString("$id")
        |"$name"

--- a/model/shared/src/main/scala/explore/model/ExploreObservation.scala
+++ b/model/shared/src/main/scala/explore/model/ExploreObservation.scala
@@ -17,7 +17,8 @@ final case class ExploreObservation(
   status:      ObsStatus,
   conf:        String,
   constraints: Constraints,
-  duration:    Duration)
+  duration:    Duration
+)
 
 object ExploreObservation {
   type Id = UUID

--- a/model/shared/src/main/scala/explore/model/ExploreSiderealTarget.scala
+++ b/model/shared/src/main/scala/explore/model/ExploreSiderealTarget.scala
@@ -25,7 +25,8 @@ import java.util.UUID
 final case class SiderealTarget(
   id:    SiderealTarget.Id,
   name:  NonEmptyString,
-  track: SiderealTracking)
+  track: SiderealTracking
+)
 
 object SiderealTarget {
   type Id = UUID
@@ -52,7 +53,8 @@ object SiderealTarget {
 final case class ExploreSiderealTarget(
   searchTerm: String,
   target:     Option[SiderealTarget],
-  options:    TargetVisualOptions)
+  options:    TargetVisualOptions
+)
 
 object ExploreSiderealTarget {
   implicit val siderealTargetEq: Eq[ExploreSiderealTarget] =

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -28,7 +28,8 @@ final case class ObsSummary(
   conf:              String = "GMOS-N R831 1x300",
   constraints:       String = "<0.7\" <0.3 mag Bright",
   duration:          Duration = Duration.of(93, ChronoUnit.MINUTES),
-  observationTarget: Option[Either[Asterism.Id, Target.Id]])
+  observationTarget: Option[Either[Asterism.Id, Target.Id]]
+)
 
 object ObsSummary {
   implicit val eqObsSummary: Eq[ObsSummary] = Eq.by(x => (x.id, x.name, x.observationTarget))

--- a/model/shared/src/main/scala/explore/model/ProposalDetails.scala
+++ b/model/shared/src/main/scala/explore/model/ProposalDetails.scala
@@ -30,7 +30,8 @@ final case class ProposalDetails(
   requestTime1:  NonNegHour,
   requestTime2:  NonNegHour,
   minimumPct1:   IntPercent,
-  minimumPct2:   IntPercent)
+  minimumPct2:   IntPercent
+)
 
 object ProposalDetails {
   implicit val equalProposalDetails: Eq[ProposalDetails] = Eq.fromUniversalEquals

--- a/model/shared/src/main/scala/explore/model/RootModel.scala
+++ b/model/shared/src/main/scala/explore/model/RootModel.scala
@@ -23,7 +23,8 @@ case class RootModel(
   tabs:                  EnumZipper[AppTab],
   focused:               Option[Focused] = none,
   targetViewExpandedIds: TargetViewExpandedIds = TargetViewExpandedIds(),
-  userSelectionMessage:  Option[NonEmptyString] = none)
+  userSelectionMessage:  Option[NonEmptyString] = none
+)
 
 object RootModel {
   val userUserId = Lens[User, User.Id](_.id)(s =>

--- a/model/shared/src/main/scala/explore/model/enum/AppTab.scala
+++ b/model/shared/src/main/scala/explore/model/enum/AppTab.scala
@@ -17,8 +17,8 @@ import lucuma.core.util.Enumerated
  */
 sealed abstract class AppTab(
   val title:       String,
-  val buttonGroup: Int)
-    extends Product
+  val buttonGroup: Int
+) extends Product
     with Serializable
 
 object AppTab {

--- a/model/shared/src/main/scala/explore/model/expandedIds.scala
+++ b/model/shared/src/main/scala/explore/model/expandedIds.scala
@@ -14,7 +14,8 @@ import scala.collection.immutable.SortedSet
 @Lenses
 case class TargetViewExpandedIds(
   targetIds:   SortedSet[Target.Id] = SortedSet.empty,
-  asterismIds: SortedSet[Asterism.Id] = SortedSet.empty)
+  asterismIds: SortedSet[Asterism.Id] = SortedSet.empty
+)
 
 object TargetViewExpandedIds {
   implicit val eqTargetViewExpandedIds: Eq[TargetViewExpandedIds] =

--- a/model/shared/src/main/scala/explore/undo/IndexedCollMod.scala
+++ b/model/shared/src/main/scala/explore/undo/IndexedCollMod.scala
@@ -17,7 +17,8 @@ trait IndexedCollMod[
   Idx,
   A,
   N[_],
-  K] { // N = Type of internal Node containing A. Can be Id for just A.
+  K
+] { // N = Type of internal Node containing A. Can be Id for just A.
   protected val keyLens: Lens[A, K]
 
   protected val valueLens: Lens[N[A], A]

--- a/model/shared/src/main/scala/explore/undo/UndoableView.scala
+++ b/model/shared/src/main/scala/explore/undo/UndoableView.scala
@@ -23,7 +23,8 @@ import monocle.Lens
  */
 case class UndoableView[F[_]: Async: ContextShift, T](
   view:   ViewF[F, T],
-  setter: Undoer.Setter[F, T]) {
+  setter: Undoer.Setter[F, T]
+) {
   def apply[A](get: T => A, mod: (A => A) => T => T, onChange: A => F[Unit]): ViewF[F, A] = {
     val zoomed = view.zoom(get)(mod)
     ViewF(

--- a/model/shared/src/main/scala/explore/undo/Undoer.scala
+++ b/model/shared/src/main/scala/explore/undo/Undoer.scala
@@ -17,21 +17,24 @@ object Undoer {
     undo:      Undo[F, M],
     redo:      Redo[F, M],
     undoEmpty: Boolean,
-    redoEmpty: Boolean)
+    redoEmpty: Boolean
+  )
 
   trait Setter[F[_], M] {
     def set[A](
       m:        M,
       getter:   M => A,
       onChange: A => F[Unit]
-    )(v:        A
+    )(
+      v:        A
     ): F[Unit]
 
     def mod[A](
       m:        M,
       getter:   M => A,
       onChange: A => F[Unit]
-    )(f:        A => A
+    )(
+      f:        A => A
     ): F[Unit] =
       set(m, getter, onChange)(f(getter(m)))
   }
@@ -89,7 +92,8 @@ abstract class Undoer[F[_]: Sync, M] {
       m:        M,
       getter:   M => A,
       onChange: A => F[Unit]
-    )(v:        A
+    )(
+      v:        A
     ): F[Unit] =
       for {
         _ <- pushUndo(Restorer[F, M, A](m, getter, onChange))
@@ -102,7 +106,8 @@ abstract class Undoer[F[_]: Sync, M] {
   private def restore(
     popFrom: F[Option[Restorer[F, M]]],
     pushTo:  Restorer[F, M] => F[Unit]
-  )(m:       M
+  )(
+    m:       M
   ): F[Unit] =
     popFrom.flatMap(
       _.map(restorer => restorer.restore(m).flatMap(pushTo)).orUnit

--- a/model/shared/src/test/scala/explore/undo/TestUndoable.scala
+++ b/model/shared/src/test/scala/explore/undo/TestUndoable.scala
@@ -14,7 +14,8 @@ import monocle.macros.Lenses
 @Lenses
 case class TestStacks[F[_], A](
   undoStack: Undoer.Stack[F, A] = List.empty,
-  redoStack: Undoer.Stack[F, A] = List.empty)
+  redoStack: Undoer.Stack[F, A] = List.empty
+)
 
 class TestUndoer[F[_]: Sync, M](stacks: Ref[F, TestStacks[F, M]]) extends Undoer[F, M] {
   type Stacks = TestStacks[F, M]

--- a/observationtree/src/main/scala/explore/observationtree/ObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ObsList.scala
@@ -23,8 +23,8 @@ import react.semanticui.sizes._
 
 final case class ObsList(
   observations: View[List[ObsSummary]],
-  focused:      View[Option[Focused]])
-    extends ReactProps[ObsList](ObsList.component)
+  focused:      View[Option[Focused]]
+) extends ReactProps[ObsList](ObsList.component)
 
 object ObsList {
   type Props = ObsList

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -55,8 +55,8 @@ import TargetObsQueries._
 final case class TargetObsList(
   objectsWithObs: View[TargetsAndAsterismsWithObs],
   focused:        View[Option[Focused]],
-  expandedIds:    View[TargetViewExpandedIds])
-    extends ReactProps[TargetObsList](TargetObsList.component)
+  expandedIds:    View[TargetViewExpandedIds]
+) extends ReactProps[TargetObsList](TargetObsList.component)
 
 object TargetObsList {
   type Props = TargetObsList

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
@@ -36,7 +36,8 @@ object TargetObsQueries {
   case class AsterismIdName(
     id:      Asterism.Id,
     targets: TargetList,
-    name:    NonEmptyString = Constants.UnnamedAsterism)
+    name:    NonEmptyString = Constants.UnnamedAsterism
+  )
 
   type ObjectId = Either[Target.Id, Asterism.Id]
 

--- a/observationtree/src/main/scala/explore/observationtree/TreeComp.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TreeComp.scala
@@ -30,8 +30,8 @@ final case class TreeComp[K, A](
   keyToItemId:   K => AtlasTree.ItemId,
   keyFromItemId: AtlasTree.ItemId => K,
   treeMod:       KITreeMod[IO, A, K],
-  render:        AtlasTree.RenderItemParams[A] => VdomNode)
-    extends ReactProps[TreeComp[Any, Any]](TreeComp.component)
+  render:        AtlasTree.RenderItemParams[A] => VdomNode
+) extends ReactProps[TreeComp[Any, Any]](TreeComp.component)
 
 object TreeComp {
   type Props[K, A] = TreeComp[K, A]
@@ -73,7 +73,8 @@ object TreeComp {
   @Lenses
   final case class State[K, A](
     tree:             KeyedIndexedTree[K, A],
-    collapsedItemIds: Set[AtlasTree.ItemId] = Set.empty)
+    collapsedItemIds: Set[AtlasTree.ItemId] = Set.empty
+  )
 
   class Backend[K, A]($ : BackendScope[Props[K, A], State[K, A]]) {
 
@@ -91,7 +92,8 @@ object TreeComp {
       tree:        KeyedIndexedTree[K, A],
       modState:    ModState[IO, KeyedIndexedTree[K, A]],
       setter:      Undoer.Setter[IO, KeyedIndexedTree[K, A]]
-    )(source:      AtlasTree.Position,
+    )(
+      source:      AtlasTree.Position,
       destination: Option[AtlasTree.Position]
     ): Callback =
       $.props >>= { props =>

--- a/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
+++ b/proposal/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
@@ -30,8 +30,8 @@ final case class PartnerSplitsEditor(
   show:    Boolean,
   splits:  View[List[PartnerSplit]],
   closeMe: Callback,
-  onSave:  List[PartnerSplit] => Callback)
-    extends ReactProps[PartnerSplitsEditor](PartnerSplitsEditor.component)
+  onSave:  List[PartnerSplit] => Callback
+) extends ReactProps[PartnerSplitsEditor](PartnerSplitsEditor.component)
 
 object PartnerSplitsEditor {
   type Props = PartnerSplitsEditor

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -38,8 +38,8 @@ final case class AladinCell(
   uid:     User.Id,
   tid:     Target.Id,
   target:  View[Coordinates],
-  options: View[TargetVisualOptions])
-    extends ReactProps[AladinCell](AladinCell.component) {
+  options: View[TargetVisualOptions]
+) extends ReactProps[AladinCell](AladinCell.component) {
   val aladinCoords: Coordinates = target.get
 }
 

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -33,8 +33,8 @@ final case class AladinContainer(
   target:                 View[Coordinates],
   options:                TargetVisualOptions,
   updateMouseCoordinates: Coordinates => Callback,
-  updateFov:              Fov => Callback)
-    extends ReactProps[AladinContainer](AladinContainer.component) {
+  updateFov:              Fov => Callback
+) extends ReactProps[AladinContainer](AladinContainer.component) {
   val aladinCoords: Coordinates = target.get
   val aladinCoordsStr: String   = Coordinates.fromHmsDms.reverseGet(aladinCoords)
 }

--- a/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -20,8 +20,8 @@ import scala.math.rint
 
 final case class AladinToolbar(
   fov:     Fov,
-  current: Coordinates)
-    extends ReactProps[AladinToolbar](AladinToolbar.component)
+  current: Coordinates
+) extends ReactProps[AladinToolbar](AladinToolbar.component)
 
 object AladinToolbar {
   type Props = AladinToolbar

--- a/targeteditor/src/main/scala/explore/targeteditor/CataloguesForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/CataloguesForm.scala
@@ -24,9 +24,10 @@ import react.semanticui.sizes._
 import scala.collection.SortedMap
 
 final case class CataloguesForm(
-  options:          View[TargetVisualOptions]
-)(implicit val ctx: AppContextIO)
-    extends ReactProps[CataloguesForm](CataloguesForm.component)
+  options: View[TargetVisualOptions]
+)(implicit
+  val ctx: AppContextIO
+) extends ReactProps[CataloguesForm](CataloguesForm.component)
 
 object CataloguesForm {
   type Props = CataloguesForm

--- a/targeteditor/src/main/scala/explore/targeteditor/InputWithUnits.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/InputWithUnits.scala
@@ -21,17 +21,18 @@ import react.common._
 import react.semanticui.elements.label.LabelPointing
 
 final case class InputWithUnits[F[_]: Effect, A](
-  value:           ViewF[F, A],
-  validFormat:     ValidFormatInput[A],
-  changeAuditor:   ChangeAuditor[A],
-  id:              NonEmptyString,
-  label:           String,
-  units:           String,
-  disabled:        Boolean,
-  columnSpam:      Int Refined Interval.Closed[1, 16] = 2
-)(implicit val ev: ExternalValue[ViewF[F, *]],
-  val eq:          Eq[A])
-    extends ReactProps[InputWithUnits[Any, Any]](InputWithUnits.component) {}
+  value:         ViewF[F, A],
+  validFormat:   ValidFormatInput[A],
+  changeAuditor: ChangeAuditor[A],
+  id:            NonEmptyString,
+  label:         String,
+  units:         String,
+  disabled:      Boolean,
+  columnSpam:    Int Refined Interval.Closed[1, 16] = 2
+)(implicit
+  val ev:        ExternalValue[ViewF[F, *]],
+  val eq:        Eq[A]
+) extends ReactProps[InputWithUnits[Any, Any]](InputWithUnits.component) {}
 
 object InputWithUnits {
   type Props[F[_], A] = InputWithUnits[F, A]

--- a/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -46,8 +46,8 @@ import scalajs.js.JSConverters._
 final case class MagnitudeForm(
   targetId:   Target.Id,
   magnitudes: View[List[Magnitude]],
-  disabled:   Boolean)
-    extends ReactProps[MagnitudeForm](MagnitudeForm.component)
+  disabled:   Boolean
+) extends ReactProps[MagnitudeForm](MagnitudeForm.component)
 
 object MagnitudeForm {
   type Props = MagnitudeForm

--- a/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
@@ -32,8 +32,8 @@ import react.semanticui.elements.label.LabelPointing
 
 final case class RVInput(
   value:    ViewF[IO, Option[RadialVelocity]],
-  disabled: ViewF[IO, Boolean])
-    extends ReactProps[RVInput](RVInput.component)
+  disabled: ViewF[IO, Boolean]
+) extends ReactProps[RVInput](RVInput.component)
 
 object RVInput {
   type Props = RVInput

--- a/targeteditor/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -32,8 +32,8 @@ import scalajs.js.JSConverters._
 final case class SearchForm(
   name:        View[NonEmptyString],
   searching:   View[Boolean],
-  searchAndGo: SearchCallback => Callback)
-    extends ReactProps[SearchForm](SearchForm.component) {
+  searchAndGo: SearchCallback => Callback
+) extends ReactProps[SearchForm](SearchForm.component) {
   def submit(
     searchTerm: String,
     before:     Callback,
@@ -54,7 +54,8 @@ object SearchForm {
   final case class State(
     initialName:   NonEmptyString,
     searchEnabled: Boolean,
-    searchError:   Option[NonEmptyString])
+    searchError:   Option[NonEmptyString]
+  )
 
   implicit val stateReuse                     = Reusability.derive[State]
   implicit val propsReuse: Reusability[Props] = Reusability.by(x => (x.name, x.searching))

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyPlot.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyPlot.scala
@@ -42,8 +42,8 @@ final case class SkyPlot(
   coords: Coordinates,
   date:   LocalDate,
   zoneId: ZoneId,
-  height: Int)
-    extends ReactProps[SkyPlot](SkyPlot.component)
+  height: Int
+) extends ReactProps[SkyPlot](SkyPlot.component)
 
 object SkyPlot {
   type Props = SkyPlot
@@ -63,12 +63,14 @@ object SkyPlot {
     targetAltitude:   List[Chart.Data],
     skyBrightness:    List[Chart.Data],
     parallacticAngle: List[Chart.Data],
-    moonAltitude:     List[Chart.Data])
+    moonAltitude:     List[Chart.Data]
+  )
 
   sealed abstract class ElevationSeries(
     val name:  String,
     val yAxis: Int,
-    val data:  SeriesData => List[Chart.Data])
+    val data:  SeriesData => List[Chart.Data]
+  )
   object ElevationSeries extends Enumerated[ElevationSeries] {
     case object Elevation        extends ElevationSeries("Elevation", 0, _.targetAltitude)
     case object ParallacticAngle extends ElevationSeries("Parallactic Angle", 1, _.parallacticAngle)

--- a/targeteditor/src/main/scala/explore/targeteditor/SkyPlotSection.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/SkyPlotSection.scala
@@ -24,8 +24,8 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 final case class SkyPlotSection(
-  coords: Coordinates)
-    extends ReactProps[SkyPlotSection](SkyPlotSection.component)
+  coords: Coordinates
+) extends ReactProps[SkyPlotSection](SkyPlotSection.component)
 
 object SkyPlotSection {
   type Props = SkyPlotSection

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -48,7 +48,8 @@ import react.semanticui.sizes.Small
 final case class SearchCallback(
   searchTerm: NonEmptyString,
   onComplete: Option[Target] => Callback,
-  onError:    Throwable => Callback) {
+  onError:    Throwable => Callback
+) {
   def run: Callback = Callback.empty
 }
 
@@ -56,8 +57,8 @@ final case class TargetBody(
   uid:     User.Id,
   id:      Target.Id,
   target:  View[TargetResult],
-  options: View[TargetVisualOptions])
-    extends ReactProps[TargetBody](TargetBody.component) {
+  options: View[TargetVisualOptions]
+) extends ReactProps[TargetBody](TargetBody.component) {
   val baseCoordinates: Coordinates =
     target.zoom(TargetQueries.baseCoordinates).get
 }

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -26,8 +26,8 @@ import react.common._
 
 final case class TargetEditor(
   uid: User.Id,
-  tid: Target.Id)
-    extends ReactProps[TargetEditor](TargetEditor.component)
+  tid: Target.Id
+) extends ReactProps[TargetEditor](TargetEditor.component)
 
 object TargetEditor {
   type Props = TargetEditor

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetQueries.scala
@@ -164,10 +164,12 @@ object TargetQueries {
   }
 
   case class UndoView(
-    id:           Target.Id,
-    view:         View[TargetResult],
-    setter:       Undoer.Setter[IO, TargetResult]
-  )(implicit ctx: AppContextIO) {
+    id:     Target.Id,
+    view:   View[TargetResult],
+    setter: Undoer.Setter[IO, TargetResult]
+  )(implicit
+    ctx:    AppContextIO
+  ) {
     private val undoableView = UndoableView(view, setter)
 
     def apply[A](

--- a/targeteditor/src/main/scala/reactmoon/MoonPhase.scala
+++ b/targeteditor/src/main/scala/reactmoon/MoonPhase.scala
@@ -15,8 +15,8 @@ final case class MoonPhase(
   lightColor: js.UndefOr[String] = js.undefined,
   darkColor:  js.UndefOr[String] = js.undefined,
   border:     js.UndefOr[String] = js.undefined,
-  rotation:   js.UndefOr[String] = js.undefined)
-    extends GenericFnComponentP[MoonPhase.MoonPhaseProps] {
+  rotation:   js.UndefOr[String] = js.undefined
+) extends GenericFnComponentP[MoonPhase.MoonPhaseProps] {
   override protected def cprops                        = MoonPhase.props(this)
   @inline def render: Render[MoonPhase.MoonPhaseProps] = MoonPhase.component(cprops)
 }


### PR DESCRIPTION
I haven't found a way to keep `(parameter)` in one line when it's a secondary single-parameter group, and I'm not thrilled about them being split.

However, I find this formatting easier to read with the dangling parens.

What do you think?