### PR TITLE
Unify styles between observation and target trees

### DIFF
--- a/observationtree/src/main/scala/explore/observationtree/ObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ObsList.scala
@@ -4,6 +4,7 @@
 package explore.observationtree
 
 import cats.Applicative
+import cats.ApplicativeError
 import cats.effect.IO
 import cats.syntax.all._
 import clue.TransactionalClient
@@ -41,7 +42,6 @@ import react.semanticui.sizes._
 import scala.util.Random
 
 import ObsQueries._
-import cats.ApplicativeError
 
 final case class ObsList(
   observations: View[ObservationList],

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -246,9 +246,9 @@ object TargetObsList {
           .mod(targetWithIndexSetter.set(targetWithIndex)) >>
           // 2) Send mutation & adjust focus
           targetWithIndex.fold(
-            focused.set(nextToFoucs.map(f => Focused.FocusedTarget(f.id))) *> removeTarget(targetId)
+            focused.set(nextToFoucs.map(f => Focused.FocusedTarget(f.id))) >> removeTarget(targetId)
           ) { case (target, _) =>
-            insertTarget(target) *> focused.set(FocusedTarget(targetId).some)
+            insertTarget(target) >> focused.set(FocusedTarget(targetId).some)
           }
 
     private def targetMod(
@@ -355,9 +355,9 @@ object TargetObsList {
         .mod(asterismWithIndexSetter.set(asterismWithIndex)) >>
         // 2) Send mutation & adjust focus
         asterismWithIndex.fold(
-          focused.set(nextToFoucs.map(f => FocusedAsterism(f.id))) *> removeAsterism(asterismId)
+          focused.set(nextToFoucs.map(f => FocusedAsterism(f.id))) >> removeAsterism(asterismId)
         ) { case (asterism, _) =>
-          insertAsterism(asterism) *> focused.set(FocusedAsterism(asterismId).some)
+          insertAsterism(asterism) >> focused.set(FocusedAsterism(asterismId).some)
         }
     }
 
@@ -625,7 +625,7 @@ object TargetObsList {
                             compact = true,
                             clazz = ExploreStyles.DeleteButton |+| ExploreStyles.JustifyRight,
                             onClickE = (e: ReactMouseEvent, _: ButtonProps) =>
-                              e.stopPropagationCB *>
+                              e.stopPropagationCB >>
                                 deleteTarget(targetId, undoCtx.setter, focusOnDelete).runAsyncCB
                           )(
                             Icons.Trash

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
@@ -10,7 +10,6 @@ import clue.GraphQLOperation
 import clue.macros.GraphQL
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.AppCtx
-import explore.GraphQLSchemas.ObservationDB.Types._
 import explore.GraphQLSchemas._
 import explore.components.graphql.LiveQueryRenderMod
 import explore.data.KeyedIndexedList
@@ -310,49 +309,6 @@ object TargetObsQueries {
       }    
     """
   }
-
-  def moveObs(obsId: Observation.Id, to: ObjectId): IO[Unit] =
-    AppCtx.withCtx { implicit appCtx =>
-      (to match {
-        case Left(targetId)    => ShareTargetWithObs.execute(targetId, obsId)
-        case Right(asterismId) => ShareAsterismWithObs.execute(asterismId, obsId)
-      }).void
-    }
-
-  def updateObs(input: EditObservationInput): IO[Unit] =
-    AppCtx.withCtx(implicit appCtx => UpdateObservationMutation.execute(input).void)
-
-  def insertTarget(target: TargetIdName): IO[Unit] =
-    AppCtx.flatMap(implicit ctx =>
-      AddTarget
-        .execute(target.id, target.name.value)
-        .handleErrorWith { _ =>
-          UndeleteTarget.execute(target.id)
-        }
-        .void
-    )
-
-  def removeTarget(id: Target.Id): IO[Unit] =
-    AppCtx.flatMap(implicit ctx => RemoveTarget.execute(id).void)
-
-  def insertAsterism(asterism: AsterismIdName): IO[Unit] =
-    AppCtx.flatMap(implicit ctx =>
-      AddAsterism
-        .execute(asterism.id, asterism.name.value)
-        .void
-        .handleErrorWith { _ =>
-          UndeleteAsterism.execute(asterism.id).void
-        }
-    )
-
-  def removeAsterism(id: Asterism.Id): IO[Unit] =
-    AppCtx.flatMap(implicit ctx => RemoveAsterism.execute(id).void)
-
-  def shareTargetWithAsterism(targetId: Target.Id, asterismId: Asterism.Id): IO[Unit] =
-    AppCtx.flatMap(implicit ctx => ShareTargetWithAsterisms.execute(targetId, asterismId).void)
-
-  def unshareTargetWithAsterism(targetId: Target.Id, asterismId: Asterism.Id): IO[Unit] =
-    AppCtx.flatMap(implicit ctx => UnshareTargetWithAsterisms.execute(targetId, asterismId).void)
 
   implicit val targetIdNameReusability: Reusability[TargetIdName]                 =
     Reusability.by(x => (x.id, x.name))


### PR DESCRIPTION
This is just a refactor. It brings the query executions from the `*Queries` object into the component, and passes the GraphQL client implicitly to the invoker methods instead of calling `AppCtx` in each of them. Also, handler methods now return `IO[Unit]` instead of `Callback` and `randomInt` is now called within `IO`.