### PR TITLE
Request names when creating targets and asterisms.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -321,7 +321,6 @@ lazy val commonJsLibSettings = lucumaScalaJsSettings ++ commonLibSettings ++ Seq
   libraryDependencies ++=
     ScalaJSReact.value ++
       ReactSemanticUI.value ++
-      Chimney.value ++
       ClueScalaJS.value ++
       LucumaUI.value ++
       Log4Cats.value ++

--- a/build.sbt
+++ b/build.sbt
@@ -122,6 +122,7 @@ lazy val common = project
     libraryDependencies ++=
       LucumaSSO.value ++
         LucumaBC.value ++
+        LucumaCatalog.value ++
         ReactGridLayout.value ++
         ReactClipboard.value ++
         ReactCommon.value ++
@@ -150,7 +151,6 @@ lazy val targeteditor = project
   .settings(
     libraryDependencies ++=
       GeminiLocales.value ++
-        LucumaCatalog.value ++
         ReactAladin.value ++
         ReactDatepicker.value ++
         ReactHighcharts.value

--- a/common/src/main/scala/explore/common/SimbadSearch.scala
+++ b/common/src/main/scala/explore/common/SimbadSearch.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package explore.targeteditor
+package explore.common
 
 import cats.data.Validated
 import cats.effect._

--- a/common/src/main/scala/explore/common/TargetQueries.scala
+++ b/common/src/main/scala/explore/common/TargetQueries.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package explore.target
+package explore.common
 
 import cats.Endo
 import cats.effect.IO

--- a/common/src/main/scala/explore/utils/Reuse.scala
+++ b/common/src/main/scala/explore/utils/Reuse.scala
@@ -67,13 +67,25 @@ trait Reuse[A] {
 
   protected val reuseBy: B // We need to store it to combine into tuples when currying.
 
-  protected val typeTag: TypeTag[B]
+  protected implicit val typeTag: TypeTag[B]
 
-  protected val reusability: Reusability[B] // Turn into "(B, B) => Boolean" (will work in JVM)
+  // Turn into "(B, B) => Boolean" (will work in JVM)
+  protected implicit val reusability: Reusability[B]
 
-  def andBy[C](c: C)(implicit typeTagC: TypeTag[C], reuseC: Reusability[C]): Reuse[A] = ???
+  // How to combine the TypeTags and Reusability?
+  // def andBy[C](c: C)(implicit typeTagBC: TypeTag[(B, C)], reuseBC: Reusability[(B, C)]): Reuse[A] =
+  //   new Reuse[A] {
+  //     type B = (Reuse.this.B, C)
+  //     val value                                          = Reuse.this.value
+  //     implicit protected val typeTag: TypeTag[B]         = typeTagBC
+  //     implicit protected val reusability: Reusability[B] = reuseBC
+  //   }
 
-  def orBy[C](c: C)(implicit typeTagC: TypeTag[C], reuseC: Reusability[C]): Reuse[A] = ???
+  // def orBy[C](c: C)(implicit typeTagC: TypeTag[C], reuseC: Reusability[C]): Reuse[A] = ???
+
+  // // Combine inputs and reusability.
+  // def flatMap[C](f: A => Reuse[C]): Reuse[C] =
+  //   f(value()).andBy(reuseBy)
 }
 
 object Reuse {

--- a/common/src/main/scala/explore/utils/Reuse.scala
+++ b/common/src/main/scala/explore/utils/Reuse.scala
@@ -7,39 +7,93 @@ import japgolly.scalajs.react.Reusability
 
 import scala.reflect.runtime.universe._
 
-/*
- * This is a fledgling idea for a mechanism to provide Reusability for functions.
- * It's not used yet, will develop in future PR.
- */
+trait ReuseSyntax {
+  implicit class AnyReuseOps[A]( /*val*/ a: A) { //extends AnyVal {
+    def always: Reuse[A] = Reuse.always(a)
+
+    def never: Reuse[A] = Reuse.never(a)
+
+    def curry: Reuse.Curried1[A] = Reuse.curry(a)
+  }
+
+  implicit class Fn1ReuseOps[R, B]( /*val*/ fn: R => B) { //extends AnyVal {
+    def curry(
+      r:        R
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[B] = Reuse.curry(r)(fn)
+  }
+
+  implicit class Fn2ReuseOps[R, S, B]( /*val*/ fn: (R, S) => B) { //extends AnyVal {
+    def curry(
+      r:        R
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[S => B] = Reuse.curry(r)(fn)
+  }
+
+  implicit class Fn3ReuseOps[R, S, T, B]( /*val*/ fn: (R, S, T) => B) { //extends AnyVal {
+    def curry(
+      r:        R
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[(S, T) => B] = Reuse.curry(r)(fn)
+
+    def curry(
+      r:        R,
+      s:        S
+    )(implicit
+      typeTagR: TypeTag[(R, S)],
+      reuseR:   Reusability[(R, S)]
+    ): Reuse[T => B] = Reuse.curry(r, s)(fn)
+  }
+
+  implicit class Tuple2ReuseOps[R, S]( /*val*/ t: (R, S)) { //extends AnyVal {
+    def curry: Reuse.Curried2[R, S] = Reuse.curry(t._1, t._2)
+  }
+}
+
+object ReuseSyntax extends ReuseSyntax
+
+// TODO Convert into Reusable ?? Is it possible?
+
 trait Reuse[A] {
   type B
 
-  val value: A
+  val value: () => A
 
-  protected val reuseBy: B
+  protected val reuseBy: B // We need to store it to combine into tuples when currying.
 
   protected val typeTag: TypeTag[B]
 
-  protected val reusability: Reusability[B]
+  protected val reusability: Reusability[B] // Turn into "(B, B) => Boolean" (will work in JVM)
+
+  def andBy[C](c: C)(implicit typeTagC: TypeTag[C], reuseC: Reusability[C]): Reuse[A] = ???
+
+  def orBy[C](c: C)(implicit typeTagC: TypeTag[C], reuseC: Reusability[C]): Reuse[A] = ???
 }
 
 object Reuse {
-  implicit def toA[A](reuseFn: Reuse[A]): A = reuseFn.value
+  implicit def toA[A](reuseFn: Reuse[A]): A = reuseFn.value()
 
   implicit def reusability[A]: Reusability[Reuse[A]] =
     Reusability.apply((reuseA, reuseB) =>
       if (reuseA.typeTag == reuseB.typeTag)
-        reuseA.reusability.test(reuseA.reuseBy, reuseB.reuseBy.asInstanceOf[reuseA.B])
+        reuseA.reusability.test(reuseA.reuseBy, reuseB.reuseBy.asInstanceOf[reuseA.B]) &&
+        reuseB.reusability.test(reuseA.reuseBy.asInstanceOf[reuseB.B], reuseB.reuseBy)
       else false
     )
 
   def by[A, R](
     reuseByR: R
-  )(valueA:   A)(implicit typeTagR: TypeTag[R], reuseR: Reusability[R]): Reuse[A] =
+  )(valueA:   => A)(implicit typeTagR: TypeTag[R], reuseR: Reusability[R]): Reuse[A] =
     new Reuse[A] {
       type B = R
 
-      val value = valueA
+      val value = () => valueA
 
       protected val reuseBy = reuseByR
 
@@ -48,14 +102,130 @@ object Reuse {
       protected val reusability = reuseR
     }
 
-  def apply[A](value: A): Applied[A] = Applied(value)
+  def always[A](a: A): Reuse[A] = by(())(a)(implicitly[TypeTag[Unit]], Reusability.always)
 
-  case class Applied[A](valueA: A) {
+  def never[A](a: A): Reuse[A] = by(())(a)(implicitly[TypeTag[Unit]], Reusability.never)
+
+  def apply[A](value: => A): Applied[A] = new Applied(value)
+
+  class Applied[A](valueA: => A) {
+    val value: A = valueA // TODO Propagate laziness
+
     def by[R](reuseByR: R)(implicit typeTagR: TypeTag[R], reuseR: Reusability[R]): Reuse[A] =
       Reuse.by(reuseByR)(valueA)
+
+    def always: Reuse[A] = Reuse.by(())(valueA)
   }
 
-  // TODO Convert into Reusable ??
+  implicit class AppliedFn1Ops[A, R, S, B](aa: Applied[A])(implicit ev: A =:= ((R, S) => B)) {
+    // Curry (R, S) => B into (fixed R) + (S => B)
+    def apply(
+      r:        R
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[S => B] =
+      Reuse.by(r)(s => ev(aa.value)(r, s))
+  }
+
+  implicit class AppliedFn2Ops[A, R, S, T, B](aa: Applied[A])(implicit ev: A =:= ((R, S, T) => B)) {
+    // Curry (R, S, T) => B into (fixed R) + ((S, T) => B)
+    def apply(
+      r:        R
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[(S, T) => B] =
+      Reuse.by(r)((s, t) => ev(aa.value)(r, s, t))
+
+    // Curry (R, S, T) => B into (fixed (R, S)) + (T => B)
+    def apply(
+      r:         R,
+      s:         S
+    )(implicit
+      typeTagRS: TypeTag[(R, S)],
+      reuseR:    Reusability[(R, S)]
+    ): Reuse[T => B] =
+      Reuse.by((r, s))(t => ev(aa.value)(r, s, t))
+  }
+
+  implicit class ReuseFn1Ops[A, R, B](ra: Reuse[A])(implicit ev: A =:= (R => B)) {
+    // We can't use "apply" here since it's ambiguous with "toA" which unwraps the function and applies it.
+
+    // Curry (R, S) => B into (fixed R) + (S => B)
+    def curry(
+      r:        R
+    )(implicit
+      typeTagR: TypeTag[(ra.B, R)],
+      reuseR:   Reusability[R]
+    ): Reuse[B] = {
+      implicit val rB = ra.reusability
+      Reuse.by((ra.reuseBy, r))(ev(ra.value())(r))
+    }
+  }
+
+  implicit class ReuseFn2Ops[A, R, S, B](ra: Reuse[A])(implicit ev: A =:= ((R, S) => B)) {
+    // We can't use "apply" here since it's ambiguous with "toA" which unwraps the function and applies it.
+
+    // Curry (R, S) => B into (fixed R) + (S => B)
+    def curry(
+      r:        R
+    )(implicit
+      typeTagR: TypeTag[(ra.B, R)],
+      reuseR:   Reusability[R]
+    ): Reuse[S => B] = {
+      implicit val rB = ra.reusability
+      Reuse.by((ra.reuseBy, r))(s => ev(ra.value())(r, s))
+    }
+  }
+
+  def curry[R](r: R): Curried1[R] = new Curried1(r)
+
+  def curry[R, S](r: R, s: S): Curried2[R, S] = new Curried2(r, s)
+
+  class Curried1[R](val r: R) {
+    def curry[S](s: S): Curried2[R, S] = new Curried2(r, s)
+  }
+
+  implicit class Curried1Ops[R](curried: Curried1[R]) {
+    // Curry (R, S) => B into (fixed R) +  B
+    def apply[B](
+      fn:       R => B
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[B] =
+      Reuse.by(curried.r)(fn(curried.r))
+
+    // Curry (R, S) => B into (fixed R) + (S => B)
+    def apply[S, B](
+      fn:       (R, S) => B
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[S => B] =
+      Reuse.by(curried.r)(s => fn(curried.r, s))
+
+    // Curry (R, S, T) => B into (fixed R) + ((S, T) => B)
+    def apply[S, T, B](
+      fn:       (R, S, T) => B
+    )(implicit
+      typeTagR: TypeTag[R],
+      reuseR:   Reusability[R]
+    ): Reuse[(S, T) => B] =
+      Reuse.by(curried.r)((s, t) => fn(curried.r, s, t))
+  }
+
+  class Curried2[R, S](val r: R, val s: S) {
+    def apply[A, T, B](
+      valueA:   => A
+    )(implicit
+      ev:       A =:= ((R, S, T) => B),
+      typeTagR: TypeTag[(R, S)],
+      reuseR:   Reusability[(R, S)]
+    ): Reuse[T => B] =
+      Reuse.by((r, s))(t => ev(valueA)(r, s, t))
+  }
 
   object Examples {
     val propsUnits: String = "meters"
@@ -73,5 +243,46 @@ object Reuse {
     val example4 = Reuse(decorate _).by(propsUnits)
 
     val example5 = Reuse.by(propsUnits)(decorate _)
+
+    // Currying
+
+    def format(units: String, q: Double): String = s"$q $units"
+
+    val cexample1                           = Reuse(format _)("meters")
+    val cexample1a: Reuse[Double => String] = cexample1
+
+    def format2(units: String, prefix: String, q: Double): String =
+      s"$prefix $q $units"
+
+    val cexample2 = Reuse(format2 _)("meters")
+
+    val cexample3 = Reuse(format2 _)("meters", "Length:")
+
+    val cexample4 = Reuse(format2 _)("meters").curry("Length:")
+
+    val cexample5a = Reuse(format2 _)("meters")
+    val cexample5  = cexample5a.curry("Length:")
+
+    val cexample6 = Reuse.curry("meters")(format _)
+
+    val cexample7 = Reuse.curry("meters", "Length:")(format2 _)
+
+    import ReuseSyntax._
+
+    val cexample8 = (format _).curry("meters")
+
+    val cexample9 = (format2 _).curry("meters").curry("Length:")
+
+    val cexample10 = (format2 _).curry("meters", "Length:")
+
+    val cexample11 = "meters".curry(format _)
+
+    val cexample12 = "meters".curry(format2 _).curry("Length:")
+
+    val cexample13 = ("meters", "Length:").curry(format2 _)
+
+    implicit val reuseDouble = Reusability.double(0.1)
+
+    val cexample14 = ("meters", "Length:").curry(format2 _).curry(10.0)
   }
 }

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -17,7 +17,8 @@ import java.time.Instant
 import scala.scalajs.js
 
 package object utils {
-  type ==>[A, B] = Reuse[A => B]
+  type ReuseFn[A, B] = Reuse[A => B]
+  type ==>[A, B]     = ReuseFn[A, B]
 
   def setupScheme[F[_]: Sync](theme: Theme): F[Unit] =
     Sync[F].delay {

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -39,17 +39,23 @@ object Routing {
     }
 
   private def targetTab(model: View[RootModel]): VdomElement =
-    withSize(size =>
-      TargetTabContents(model.zoom(RootModel.userId),
-                        model.zoom(RootModel.focused),
-                        model.zoom(RootModel.targetViewExpandedIds),
-                        size
+    withSize { size =>
+      TargetTabContents(
+        model.zoom(RootModel.userId),
+        model.zoom(RootModel.focused),
+        model.zoom(RootModel.searchingTarget),
+        model.zoom(RootModel.targetViewExpandedIds),
+        size
       )
-    )
+    }
 
   private def obsTab(model: View[RootModel]): VdomElement =
     withSize(size =>
-      ObsTabContents(model.zoom(RootModel.userId), model.zoom(RootModel.focused), size)
+      ObsTabContents(model.zoom(RootModel.userId),
+                     model.zoom(RootModel.focused),
+                     model.zoom(RootModel.searchingTarget),
+                     size
+      )
     )
 
   val config: RouterWithPropsConfig[Page, View[RootModel]] =
@@ -101,7 +107,7 @@ object Routing {
             case _                  => Callback.empty
           }
           .renderWithP(layout)
-          .logToConsole
+      // .logToConsole
 
       // Only link and run this in dev mode. Works since calling `verify` trigger verification immediately.
       if (LinkingInfo.developmentMode) {

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -13,6 +13,7 @@ import eu.timepit.refined.types.numeric.NonNegInt
 import explore.AppCtx
 import explore.GraphQLSchemas.ObservationDB
 import explore.Icons
+import explore.common.TargetQueries._
 import explore.common.UserPreferencesQueries._
 import explore.components.Tile
 import explore.components.TileButton
@@ -28,7 +29,6 @@ import explore.model.layout.unsafe._
 import explore.model.reusability._
 import explore.observationtree.ObsList
 import explore.observationtree.ObsQueries._
-import explore.target.TargetQueries._
 import explore.targeteditor.TargetBody
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
@@ -52,9 +52,10 @@ import react.semanticui.sizes._
 import scala.concurrent.duration._
 
 final case class ObsTabContents(
-  userId:  ViewOpt[User.Id],
-  focused: View[Option[Focused]],
-  size:    ResizeDetector.Dimensions
+  userId:    ViewOpt[User.Id],
+  focused:   View[Option[Focused]],
+  searching: View[Set[Target.Id]],
+  size:      ResizeDetector.Dimensions
 ) extends ReactProps[ObsTabContents](ObsTabContents.component) {
   def isObsSelected: Boolean = focused.get.isDefined
 }
@@ -287,7 +288,12 @@ object ObsTabContents {
                       ) { targetOpt =>
                         (props.userId.get, targetOpt.get).mapN { case (uid, _) =>
                           val stateView = ViewF.fromState[IO]($).zoom(State.options)
-                          TargetBody(uid, targetId, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
+                          TargetBody(uid,
+                                     targetId,
+                                     targetOpt.zoom(_.get)(f => _.map(f)),
+                                     props.searching,
+                                     stateView
+                          )
                         }
 
                       }.withKey(s"target-$targetId")

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -23,6 +23,7 @@ import explore.targeteditor.TargetEditor
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.ui.reusability._
 import lucuma.ui.utils._
@@ -41,6 +42,7 @@ import scala.concurrent.duration._
 final case class TargetTabContents(
   userId:                ViewOpt[User.Id],
   focused:               View[Option[Focused]],
+  searching:             View[Set[Target.Id]],
   targetViewExpandedIds: View[TargetViewExpandedIds],
   size:                  ResizeDetector.Dimensions
 ) extends ReactProps[TargetTabContents](TargetTabContents.component) {
@@ -98,7 +100,8 @@ object TargetTabContents {
               TargetObsList(
                 objectsWithObs,
                 props.focused,
-                props.targetViewExpandedIds
+                props.targetViewExpandedIds,
+                props.searching
               )
             )
 
@@ -128,7 +131,7 @@ object TargetTabContents {
             val rightSide =
               Tile(s"Target", backButton.some)(
                 (props.userId.get, targetIdOpt).mapN { case (uid, tid) =>
-                  TargetEditor(uid, tid).withKey(tid.show)
+                  TargetEditor(uid, tid, props.searching).withKey(tid.show)
                 }
               )
 

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -119,7 +119,7 @@ object TargetTabContents {
               case FocusedObs(obsId)       =>
                 objectsWithObs.get.observations
                   .getElement(obsId)
-                  .flatMap(_.aimId.flatMap(_.toOption))
+                  .flatMap(_.pointingId.flatMap(_.toOption))
             }.flatten
 
             val coreWidth  = props.size.width.getOrElse(0) - treeWidth

--- a/model/shared/src/main/scala/explore/model/AimType.scala
+++ b/model/shared/src/main/scala/explore/model/AimType.scala
@@ -9,18 +9,18 @@ import io.circe.DecodingFailure
 import io.circe.Encoder
 
 // We can't use Enumerated since it encodes/decodes as SCREAMING_SNAKE.
-sealed abstract class AimType(val typeName: String) { self =>
+sealed abstract class PointingType(val typeName: String) { self =>
   // Using self.type allows us to use eg: Target.asJosn without need of widening.
-  implicit val aimTypeEncoder: Encoder[self.type] =
+  implicit val pointingTypeEncoder: Encoder[self.type] =
     Encoder.encodeString.contramap[self.type](_.typeName)
 }
 
-object AimType {
-  case object Target   extends AimType("Target")
-  case object Asterism extends AimType("Asterism")
+object PointingType {
+  case object Target   extends PointingType("Target")
+  case object Asterism extends PointingType("Asterism")
 
-  implicit val aimTypeDecoder: Decoder[AimType] =
-    Decoder.instance[AimType] { c =>
+  implicit val pointingTypeDecoder: Decoder[PointingType] =
+    Decoder.instance[PointingType] { c =>
       c.as[String]
         .flatMap(_ match {
           case Target.typeName   => Target.asRight

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -28,16 +28,16 @@ final case class ObsSummary(
   conf:        String = "GMOS-N R831 1x300",
   constraints: String = "<0.7\" <0.3 mag Bright",
   duration:    Duration = Duration.of(93, ChronoUnit.MINUTES),
-  aimId:       Option[AimId]
+  pointingId:  Option[PointingId]
 )
 
 object ObsSummary {
-  implicit val eqObsSummary: Eq[ObsSummary] = Eq.by(x => (x.id, x.name, x.aimId))
+  implicit val eqObsSummary: Eq[ObsSummary] = Eq.by(x => (x.id, x.name, x.pointingId))
 
   implicit val obsSummaryEncoder: Encoder[ObsSummary] = new Encoder[ObsSummary] {
     final def apply(c: ObsSummary): Json = {
       val common = JsonObject(("id", c.id.asJson), ("name", c.name.asJson))
-      (c.aimId match {
+      (c.pointingId match {
         case None    => common
         case Some(t) =>
           common.add(
@@ -54,9 +54,9 @@ object ObsSummary {
 
   }
 
-  implicit val obsTargetDecoder: Decoder[AimId] =
-    new Decoder[AimId] {
-      final def apply(c: HCursor): Decoder.Result[AimId] =
+  implicit val obsTargetDecoder: Decoder[PointingId] =
+    new Decoder[PointingId] {
+      final def apply(c: HCursor): Decoder.Result[PointingId] =
         c.downField("type").as[AimType].flatMap {
           case AimType.Target   => c.downField("target_id").as[Target.Id].map(_.asRight)
           case AimType.Asterism => c.downField("asterism_id").as[Asterism.Id].map(_.asLeft)
@@ -66,9 +66,9 @@ object ObsSummary {
   implicit val obsSummaryDecoder: Decoder[ObsSummary] = new Decoder[ObsSummary] {
     final def apply(c: HCursor): Decoder.Result[ObsSummary] =
       for {
-        id    <- c.downField("id").as[Observation.Id]
-        name  <- c.downField("name").as[Option[String]]
-        aimId <- c.downField("observationTarget").as[Option[AimId]]
-      } yield ObsSummary(id, name, aimId = aimId)
+        id         <- c.downField("id").as[Observation.Id]
+        name       <- c.downField("name").as[Option[String]]
+        pointingId <- c.downField("observationTarget").as[Option[PointingId]]
+      } yield ObsSummary(id, name, pointingId = pointingId)
   }
 }

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -44,9 +44,9 @@ object ObsSummary {
             "observationTarget",
             t match {
               case Right(tid) =>
-                Json.obj("type" -> AimType.Target.asJson, "target_id" -> tid.asJson)
+                Json.obj("type" -> PointingType.Target.asJson, "target_id" -> tid.asJson)
               case Left(aid)  =>
-                Json.obj("type" -> AimType.Asterism.asJson, "asterism_id" -> aid.asJson)
+                Json.obj("type" -> PointingType.Asterism.asJson, "asterism_id" -> aid.asJson)
             }
           )
       }).asJson
@@ -57,9 +57,9 @@ object ObsSummary {
   implicit val obsTargetDecoder: Decoder[PointingId] =
     new Decoder[PointingId] {
       final def apply(c: HCursor): Decoder.Result[PointingId] =
-        c.downField("type").as[AimType].flatMap {
-          case AimType.Target   => c.downField("target_id").as[Target.Id].map(_.asRight)
-          case AimType.Asterism => c.downField("asterism_id").as[Asterism.Id].map(_.asLeft)
+        c.downField("type").as[PointingType].flatMap {
+          case PointingType.Target   => c.downField("target_id").as[Target.Id].map(_.asRight)
+          case PointingType.Asterism => c.downField("asterism_id").as[Asterism.Id].map(_.asLeft)
         }
     }
 

--- a/model/shared/src/main/scala/explore/model/RootModel.scala
+++ b/model/shared/src/main/scala/explore/model/RootModel.scala
@@ -12,10 +12,13 @@ import lucuma.core.data.EnumZipper
 import lucuma.core.model.GuestUser
 import lucuma.core.model.ServiceUser
 import lucuma.core.model.StandardUser
+import lucuma.core.model.Target
 import lucuma.core.model.User
 import monocle.Lens
 import monocle.macros.Lenses
 import monocle.std.option
+
+import scala.collection.immutable.HashSet
 
 @Lenses
 case class RootModel(
@@ -23,6 +26,7 @@ case class RootModel(
   tabs:                  EnumZipper[AppTab],
   focused:               Option[Focused] = none,
   targetViewExpandedIds: TargetViewExpandedIds = TargetViewExpandedIds(),
+  searchingTarget:       Set[Target.Id] = HashSet.empty,
   userSelectionMessage:  Option[NonEmptyString] = none
 )
 
@@ -43,5 +47,13 @@ object RootModel {
       .composeLens(userUserId)
 
   implicit val eqRootModel: Eq[RootModel] =
-    Eq.by(m => (m.vault, m.tabs, m.focused, m.targetViewExpandedIds, m.userSelectionMessage))
+    Eq.by(m =>
+      (m.vault,
+       m.tabs,
+       m.focused,
+       m.targetViewExpandedIds,
+       m.searchingTarget,
+       m.userSelectionMessage
+      )
+    )
 }

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -7,5 +7,5 @@ import lucuma.core.model.Asterism
 import lucuma.core.model.Target
 
 package object model {
-  type AimId = Either[Asterism.Id, Target.Id]
+  type PointingId = Either[Asterism.Id, Target.Id]
 }

--- a/model/shared/src/test/scala/explore/model/arb/ArbObsSummary.scala
+++ b/model/shared/src/test/scala/explore/model/arb/ArbObsSummary.scala
@@ -8,7 +8,7 @@ import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
-import explore.model.AimId
+import explore.model.PointingId
 import explore.model.ObsSummary
 import lucuma.core.model.Observation
 import lucuma.core.util.arb.ArbGid._
@@ -19,12 +19,14 @@ trait ArbObsSummary {
     for {
       id  <- arbitrary[Observation.Id]
       nm  <- arbitrary[Option[String]]
-      aim <- arbitrary[Option[AimId]]
-    } yield ObsSummary(id = id, name = nm, aimId = aim)
+      aim <- arbitrary[Option[PointingId]]
+    } yield ObsSummary(id = id, name = nm, pointingId = aim)
   }
 
   implicit val obsSummaryCogen: Cogen[ObsSummary] =
-    Cogen[(Observation.Id, Option[String], Option[AimId])].contramap(c => (c.id, c.name, c.aimId))
+    Cogen[(Observation.Id, Option[String], Option[PointingId])].contramap(c =>
+      (c.id, c.name, c.pointingId)
+    )
 
 }
 

--- a/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
+++ b/observationtree/src/main/scala/explore/observationtree/AndOrTest.scala
@@ -96,7 +96,7 @@ object AndOrTest {
         obs = ObsSummary(
           id = Observation.Id.parse(s"o-${obs.id.toString.filter(_.isDigit).take(4)}").get,
           name = obs.target.name.value.some,
-          aimId = None
+          pointingId = None
         ),
         layout = ObsBadge.Layout.NameAndConf,
         selected = false

--- a/observationtree/src/main/scala/explore/observationtree/ObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ObsList.scala
@@ -128,7 +128,10 @@ object ObsList {
     ): IO[Unit] = {
       // Temporary measure until we have id pools.
       val newObs = IO(Random.nextInt()).map(int =>
-        ObsSummary(Observation.Id(PosLong.unsafeFrom(int.abs.toLong + 1)), name.some, aimId = none)
+        ObsSummary(Observation.Id(PosLong.unsafeFrom(int.abs.toLong + 1)),
+                   name.some,
+                   pointingId = none
+        )
       )
 
       $.propsIn[IO] >>= { props =>

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsQueries.scala
@@ -18,7 +18,6 @@ import explore.model.ObsSummary
 import explore.model.reusability._
 import io.circe.Decoder
 import io.circe.HCursor
-import io.scalaland.chimney.dsl._
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Asterism
@@ -130,11 +129,7 @@ object TargetObsQueries {
       }
 
       object Asterisms {
-        object Nodes {
-          object Targets {
-            type Nodes = TargetIdName
-          }
-        }
+        type Nodes = AsterismIdName
       }
 
       object Observations {
@@ -145,20 +140,9 @@ object TargetObsQueries {
         name.flatMap(n => NonEmptyString.from(n).toOption).getOrElse(Constants.UnnamedAsterism)
 
       val asTargetsWithObs: Getter[Data, TargetsAndAsterismsWithObs] = data => {
-
-        val asterisms = data.asterisms.nodes.map {
-          _.into[AsterismIdName]
-            .withFieldComputed(_.name, a => asterismName(a.name))
-            .withFieldComputed(
-              _.targets,
-              a => KeyedIndexedList.fromList(a.targets.nodes, TargetIdName.id.get)
-            )
-            .transform
-        }
-
         TargetsAndAsterismsWithObs(
           KeyedIndexedList.fromList(data.targets.nodes, TargetIdName.id.get),
-          KeyedIndexedList.fromList(asterisms, AsterismIdName.id.get),
+          KeyedIndexedList.fromList(data.asterisms.nodes, AsterismIdName.id.get),
           KeyedIndexedList.fromList(data.observations.nodes, ObsSummary.id.get)
         )
       }

--- a/observationtree/src/main/scala/explore/observationtree/Test.scala
+++ b/observationtree/src/main/scala/explore/observationtree/Test.scala
@@ -25,7 +25,8 @@ object Test extends AppMain {
           TargetObsList(
             targetsWithObs,
             view.zoom(RootModel.focused),
-            view.zoom(RootModel.targetViewExpandedIds)
+            view.zoom(RootModel.targetViewExpandedIds),
+            view.zoom(RootModel.searchingTarget)
           )
         )
       )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -9,7 +9,6 @@ object Settings {
     val cats              = "2.4.2"
     val catsEffect        = "2.3.3"
     val catsRetry         = "2.1.0"
-    val chimney           = "0.6.1"
     val circe             = "0.13.0"
     val circeGolden       = "0.3.0"
     val clue              = "0.11.1"
@@ -66,12 +65,6 @@ object Settings {
       deps(
         "com.github.cb372" %%% "cats-retry"
       )(catsRetry)
-    )
-
-    val Chimney = Def.setting(
-      deps(
-        "io.scalaland" %%% "chimney"
-      )(chimney)
     )
 
     val Circe = Def.setting(

--- a/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/RVInput.scala
@@ -31,8 +31,8 @@ import react.common.implicits._
 import react.semanticui.elements.label.LabelPointing
 
 final case class RVInput(
-  value:    ViewF[IO, Option[RadialVelocity]],
-  disabled: ViewF[IO, Boolean]
+  value:    View[Option[RadialVelocity]],
+  disabled: Boolean
 ) extends ReactProps[RVInput](RVInput.component)
 
 object RVInput {
@@ -73,7 +73,7 @@ object RVInput {
     }
   }
 
-  implicit def propsReuse: Reusability[Props] = Reusability.by(x => (x.value, x.disabled))
+  implicit def propsReuse: Reusability[Props] = Reusability.derive
   implicit def stateReuse: Reusability[State] = Reusability.derive
 
   private val rvToRedshiftGet: Option[RadialVelocity] => Option[Redshift] =
@@ -106,7 +106,7 @@ object RVInput {
               validFormat = ValidFormatInput.fromFormatOptional(formatZ, "Must be a number"),
               changeAuditor = ChangeAuditor.fromFormat(formatZ).decimal(9).optional,
               clazz = ExploreStyles.Grow(1) |+| ExploreStyles.HideLabel,
-              disabled = props.disabled.get
+              disabled = props.disabled
             )
           case RVView.CZ =>
             FormInputEV(
@@ -118,7 +118,7 @@ object RVInput {
               validFormat = ValidFormatInput.fromFormatOptional(formatCZ, "Must be a number"),
               changeAuditor = ChangeAuditor.fromFormat(formatCZ).decimal(10).optional,
               clazz = ExploreStyles.Grow(1) |+| ExploreStyles.HideLabel,
-              disabled = props.disabled.get
+              disabled = props.disabled
             )
           case RVView.RV =>
             FormInputEV(
@@ -130,7 +130,7 @@ object RVInput {
               validFormat = ValidFormatInput.fromFormatOptional(formatRV, "Must be a number"),
               changeAuditor = ChangeAuditor.fromFormat(formatRV).decimal(3).optional,
               clazz = ExploreStyles.Grow(1) |+| ExploreStyles.HideLabel,
-              disabled = props.disabled.get
+              disabled = props.disabled
             )
         }
         React.Fragment(
@@ -139,7 +139,7 @@ object RVInput {
             EnumViewSelect[IO, RVView](id = "view",
                                        value = rvView,
                                        label = state.rvView.tag.value,
-                                       disabled = props.disabled.get
+                                       disabled = props.disabled
             ),
             input
           ),

--- a/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -9,13 +9,13 @@ import crystal.ViewF
 import crystal.react.implicits._
 import explore.AppCtx
 import explore.GraphQLSchemas.ObservationDB
+import explore.common.TargetQueries._
 import explore.common.UserPreferencesQueries._
 import explore.components.graphql.LiveQueryRenderMod
 import explore.implicits._
 import explore.model.Constants
 import explore.model.TargetVisualOptions
 import explore.model.reusability._
-import explore.target.TargetQueries._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Target
@@ -25,8 +25,9 @@ import monocle.macros.Lenses
 import react.common._
 
 final case class TargetEditor(
-  uid: User.Id,
-  tid: Target.Id
+  uid:       User.Id,
+  tid:       Target.Id,
+  searching: View[Set[Target.Id]]
 ) extends ReactProps[TargetEditor](TargetEditor.component)
 
 object TargetEditor {
@@ -55,7 +56,12 @@ object TargetEditor {
         ) { targetOpt =>
           targetOpt.get.map { _ =>
             val stateView = ViewF.fromState[IO]($).zoom(State.options)
-            TargetBody(props.uid, props.tid, targetOpt.zoom(_.get)(f => _.map(f)), stateView)
+            TargetBody(props.uid,
+                       props.tid,
+                       targetOpt.zoom(_.get)(f => _.map(f)),
+                       props.searching,
+                       stateView
+            )
           }
         }
       }

--- a/targeteditor/src/main/scala/explore/targeteditor/Test.scala
+++ b/targeteditor/src/main/scala/explore/targeteditor/Test.scala
@@ -26,7 +26,7 @@ object Test extends AppMain {
       <.div(^.height := "100vh",
             ^.width := "100%",
             Tile("Target")(
-              TargetEditor(uid, id)
+              TargetEditor(uid, id, view.zoom(RootModel.searchingTarget))
             )
       )
     )


### PR DESCRIPTION
When a target is created, a catalog search is triggered.

I had to move some code from the `targeteditor` module into `common`, so that it's callable from the target tree.

Also, there's some (WIP) code to attempt to have reusable functions, similar to what `Reusable` provides but with different ergonomics (reusable values can be specified manually).