### PR TITLE
Fix issue when un-assigning observations

### DIFF
--- a/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
@@ -282,14 +282,14 @@ object ConstraintSetObsList {
                         <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
                       )
                     ),
-                    <.div(ExploreStyles.ObsTree)(
-                      <.div(ExploreStyles.ObsScrollTree) {
-                        Droppable(UnassignedObsId) { case (provided, snapshot) =>
-                          <.div(
-                            provided.innerRef,
-                            provided.droppableProps,
-                            props.getListStyle(snapshot.isDraggingOver)
-                          )(
+                    Droppable(UnassignedObsId) { case (provided, snapshot) =>
+                      <.div(
+                        provided.innerRef,
+                        provided.droppableProps,
+                        props.getListStyle(snapshot.isDraggingOver)
+                      )(
+                        <.div(ExploreStyles.ObsTree)(
+                          <.div(ExploreStyles.ObsScrollTree) {
                             Segment(
                               vertical = true,
                               clazz = ExploreStyles.ObsTreeGroup
@@ -299,10 +299,10 @@ object ConstraintSetObsList {
                               ),
                               provided.placeholder
                             )
-                          )
-                        }
-                      }
-                    )
+                          }
+                        )
+                      )
+                    }
                   ): VdomNode
                   // end of unassigned observations list
                 )

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -836,14 +836,15 @@ object TargetObsList {
                       <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
                     )
                   ),
-                  <.div(ExploreStyles.ObsTree)(
-                    <.div(ExploreStyles.ObsScrollTree) {
-                      Droppable(UnassignedObsId) { case (provided, snapshot) =>
-                        <.div(
-                          provided.innerRef,
-                          provided.droppableProps,
-                          props.getListStyle(snapshot.isDraggingOver)
-                        )(
+                  Droppable(UnassignedObsId) { case (provided, snapshot) =>
+                    <.div(
+                      provided.innerRef,
+                      provided.droppableProps,
+                      props.getListStyle(snapshot.isDraggingOver)
+                    )(
+                      <.div(ExploreStyles.ObsTree)(
+                        <.div(ExploreStyles.ObsScrollTree) {
+
                           Segment(
                             vertical = true,
                             clazz = ExploreStyles.ObsTreeGroup
@@ -853,10 +854,10 @@ object TargetObsList {
                             ),
                             provided.placeholder
                           )
-                        )
-                      }
-                    }
-                  )
+                        }
+                      )
+                    )
+                  }
                 ): VdomNode).some
                 // End Unassigned Observations List
               ).flatten: _*


### PR DESCRIPTION
On the targets and constraints tabs, it was not possible to drag an observation to the "Unassigned" area if there were no other unassigned observations.