### PR TITLE
Several UI improvements.

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -613,7 +613,6 @@ tfoot {
   background-color: rgba(0, 0, 0, 0);
 }
 
-
 .vertical.segment.unselected-obs-tree-group:hover {
   background-color: var(--explore-group-hover);
 
@@ -629,6 +628,10 @@ tfoot {
   user-select: none;
   margin-top: 2px;
   margin-bottom: 0;
+
+  :not(.obs-count) {
+    text-transform: uppercase;
+  }
 }
 
 .vertical.segment.obs-tree-group {
@@ -647,7 +650,7 @@ tfoot {
   color: var(--negative-icon-color);
 }
 
-.target-label-title {
+.obs-group-title {
   flex-grow: 2;
   white-space: nowrap;
   overflow: hidden;

--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -545,6 +545,18 @@ tfoot {
   border: solid 1px var(--under-tab-border-color);
 }
 
+.obs-unassigned {
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+
+  &.dragging-over {
+    .obs-tree-header {
+      background-color: rgba(0, 0, 0, 0); // transparent
+    }
+  }
+}
+
 .obs-item {
   margin: 0;
   padding: 0;
@@ -596,6 +608,11 @@ tfoot {
 .vertical.segment.selected-obs-tree-group {
   background-color: var(--tile-background);
 }
+
+.dragging-over .vertical.segment.selected-obs-tree-group {
+  background-color: rgba(0, 0, 0, 0);
+}
+
 
 .vertical.segment.unselected-obs-tree-group:hover {
   background-color: var(--explore-group-hover);
@@ -652,9 +669,7 @@ tfoot {
 }
 
 .dragging-over {
-  .vertical.segment {
-    background-color: var(--explore-group-dragging) !important;
-  }
+  background-color: var(--explore-group-dragging) !important;
 }
 
 .sky-plot {

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -65,7 +65,7 @@ object ExploreStyles {
   val TabSelector: Css      = Css("bottom-tab-selector")
   val BlendedButton: Css    = Css("blended-button")
   val JustifyRight: Css     = Css("justify-right")
-  val TargetLabelTitle: Css = Css("target-label-title")
+  val ObsGroupTitle: Css    = Css("obs-group-title")
   val DeleteButton: Css     = Css("delete-button")
 
   val ResizeHandle: Css         = Css("resize-handle")

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -93,6 +93,7 @@ object ExploreStyles {
   val ObsTree: Css                 = Css("obs-tree")
   val ObsTreeWrapper: Css          = Css("obs-tree-wrapper")
   val ObsScrollTree: Css           = Css("obs-scroll-tree")
+  val ObsUnassigned: Css           = Css("obs-unassigned")
   val ObsTreeGroup: Css            = Css("obs-tree-group")
   val ObsTreeHeader: Css           = Css("obs-tree-header")
   val ObsTreeSection: Css          = Css("obs-tree-section")

--- a/common/src/main/scala/react/reflex/ReflexContainer.scala
+++ b/common/src/main/scala/react/reflex/ReflexContainer.scala
@@ -5,11 +5,24 @@ package react.reflex
 
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.raw.JsNumber
+import japgolly.scalajs.react.vdom.TagMod
 import react.common._
 
 import scala.scalajs.js.annotation.JSImport
 
 import scalajs.js
+
+final case class ReflexContainer(
+  orientation:            js.UndefOr[Orientation] = js.undefined,
+  maxRecDepth:            js.UndefOr[JsNumber] = js.undefined,
+  windowResizeAware:      js.UndefOr[Boolean] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[ReflexContainer.Props, ReflexContainer] {
+  override protected def cprops    = ReflexContainer.props(this)
+  override protected val component = ReflexContainer.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
 
 object ReflexContainer {
 
@@ -26,33 +39,22 @@ object ReflexContainer {
     var style: js.UndefOr[js.Object]
   }
 
-  object Props {
-    def apply(
-      orientation:       js.UndefOr[Orientation] = js.undefined,
-      maxRecDepth:       js.UndefOr[JsNumber] = js.undefined,
-      windowResizeAware: js.UndefOr[Boolean] = js.undefined,
-      clazz:             js.UndefOr[Css] = js.undefined,
-      style:             js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-    ): Props = {
-      val p = (new js.Object).asInstanceOf[Props]
-      orientation.foreach(v => p.orientation = v.toJs)
-      maxRecDepth.foreach(v => p.maxRecDepth = v)
-      windowResizeAware.foreach(v => p.windowResizeAware = v)
-      clazz.foreach(v => p.className = v.htmlClass)
-      style.foreach(v => p.style = v)
-      p
-    }
-  }
+  protected def props(p: ReflexContainer): Props =
+    rawprops(p.orientation, p.maxRecDepth, p.windowResizeAware, p.clazz)
 
-  private val component = JsComponent[Props, Children.Varargs, Null](RawComponent)
-
-  def apply(
+  protected def rawprops(
     orientation:       js.UndefOr[Orientation] = js.undefined,
     maxRecDepth:       js.UndefOr[JsNumber] = js.undefined,
     windowResizeAware: js.UndefOr[Boolean] = js.undefined,
-    clazz:             js.UndefOr[Css] = js.undefined,
-    style:             js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-  )(children:          CtorType.ChildArg*) = component(
-    Props(orientation, maxRecDepth, windowResizeAware, clazz, style)
-  )(children: _*)
+    clazz:             js.UndefOr[Css] = js.undefined
+  ): Props = {
+    val p = (new js.Object).asInstanceOf[Props]
+    orientation.foreach(v => p.orientation = v.toJs)
+    maxRecDepth.foreach(v => p.maxRecDepth = v)
+    windowResizeAware.foreach(v => p.windowResizeAware = v)
+    clazz.foreach(v => p.className = v.htmlClass)
+    p
+  }
+
+  private val component = JsComponent[Props, Children.Varargs, Null](RawComponent)
 }

--- a/common/src/main/scala/react/reflex/ReflexElement.scala
+++ b/common/src/main/scala/react/reflex/ReflexElement.scala
@@ -5,11 +5,34 @@ package react.reflex
 
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.raw.JsNumber
+import japgolly.scalajs.react.vdom.TagMod
 import react.common._
 
 import scala.scalajs.js.annotation.JSImport
 
 import scalajs.js
+
+final case class ReflexElement(
+  propagateDimensions:     js.UndefOr[Boolean] = js.undefined,
+  propagateDimensionsRate: js.UndefOr[JsNumber] = js.undefined,
+  resizeHeight:            js.UndefOr[Boolean] = js.undefined,
+  resizeWidth:             js.UndefOr[Boolean] = js.undefined,
+  size:                    js.UndefOr[JsNumber] = js.undefined,
+  minSize:                 js.UndefOr[JsNumber] = js.undefined,
+  maxSize:                 js.UndefOr[JsNumber] = js.undefined,
+  flex:                    js.UndefOr[JsNumber] = js.undefined,
+  direction:               js.UndefOr[Direction] = js.undefined,
+  onStartResize:           js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  onStopResize:            js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  onResize:                js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  clazz:                   js.UndefOr[Css] = js.undefined,
+  withHandle:              js.UndefOr[Boolean] = js.undefined,
+  override val modifiers:  Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[ReflexElement.Props, ReflexElement] {
+  override protected def cprops    = ReflexElement.props(this)
+  override protected val component = ReflexElement.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
 
 object ReflexElement {
 
@@ -33,47 +56,28 @@ object ReflexElement {
     var onResize: js.UndefOr[js.Function1[ResizeEvent, Unit]]
     var className: js.UndefOr[String]
     var style: js.UndefOr[js.Object]
+    var withHandle: js.UndefOr[Boolean]
   }
 
-  object Props {
-    def apply(
-      propagateDimensions:     js.UndefOr[Boolean] = js.undefined,
-      propagateDimensionsRate: js.UndefOr[JsNumber] = js.undefined,
-      resizeHeight:            js.UndefOr[Boolean] = js.undefined,
-      resizeWidth:             js.UndefOr[Boolean] = js.undefined,
-      size:                    js.UndefOr[JsNumber] = js.undefined,
-      minSize:                 js.UndefOr[JsNumber] = js.undefined,
-      maxSize:                 js.UndefOr[JsNumber] = js.undefined,
-      flex:                    js.UndefOr[JsNumber] = js.undefined,
-      direction:               js.UndefOr[Direction] = js.undefined,
-      onStartResize:           js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      onStopResize:            js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      onResize:                js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      clazz:                   js.UndefOr[Css] = js.undefined,
-      style:                   js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-    ): Props = {
-      val p = (new js.Object).asInstanceOf[Props]
-      propagateDimensions.foreach(v => p.propagateDimensions = v)
-      propagateDimensionsRate.foreach(v => p.propagateDimensionsRate = v)
-      resizeHeight.foreach(v => p.resizeHeight = v)
-      resizeWidth.foreach(v => p.resizeWidth = v)
-      size.foreach(v => p.size = v)
-      minSize.foreach(v => p.minSize = v)
-      maxSize.foreach(v => p.maxSize = v)
-      flex.foreach(v => p.flex = v)
-      direction.foreach(v => p.direction = v.toJs)
-      onStartResize.toJs.foreach(v => p.onStartResize = v)
-      onStopResize.toJs.foreach(v => p.onStopResize = v)
-      onResize.toJs.foreach(v => p.onResize = v)
-      clazz.foreach(v => p.className = v.htmlClass)
-      style.foreach(v => p.style = v)
-      p
-    }
-  }
+  protected def props(p: ReflexElement): Props =
+    rawprops(
+      p.propagateDimensions,
+      p.propagateDimensionsRate,
+      p.resizeHeight,
+      p.resizeWidth,
+      p.size,
+      p.minSize,
+      p.maxSize,
+      p.flex,
+      p.direction,
+      p.onStartResize,
+      p.onStopResize,
+      p.onResize,
+      p.clazz,
+      p.withHandle
+    )
 
-  private val component = JsComponent[Props, Children.Varargs, Null](RawComponent)
-
-  def apply(
+  protected def rawprops(
     propagateDimensions:     js.UndefOr[Boolean] = js.undefined,
     propagateDimensionsRate: js.UndefOr[JsNumber] = js.undefined,
     resizeHeight:            js.UndefOr[Boolean] = js.undefined,
@@ -87,23 +91,26 @@ object ReflexElement {
     onStopResize:            js.UndefOr[ResizeEvent => Callback] = js.undefined,
     onResize:                js.UndefOr[ResizeEvent => Callback] = js.undefined,
     clazz:                   js.UndefOr[Css] = js.undefined,
-    style:                   js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-  )(children:                CtorType.ChildArg*) = component(
-    Props(
-      propagateDimensions,
-      propagateDimensionsRate,
-      resizeHeight,
-      resizeWidth,
-      size,
-      minSize,
-      maxSize,
-      flex,
-      direction,
-      onStartResize,
-      onStopResize,
-      onResize,
-      clazz,
-      style
-    )
-  )(children: _*)
+    withHandle:              js.UndefOr[Boolean] = js.undefined
+  ): Props = {
+    val p = (new js.Object).asInstanceOf[Props]
+    propagateDimensions.foreach(v => p.propagateDimensions = v)
+    propagateDimensionsRate.foreach(v => p.propagateDimensionsRate = v)
+    resizeHeight.foreach(v => p.resizeHeight = v)
+    resizeWidth.foreach(v => p.resizeWidth = v)
+    size.foreach(v => p.size = v)
+    minSize.foreach(v => p.minSize = v)
+    maxSize.foreach(v => p.maxSize = v)
+    flex.foreach(v => p.flex = v)
+    direction.foreach(v => p.direction = v.toJs)
+    onStartResize.toJs.foreach(v => p.onStartResize = v)
+    onStopResize.toJs.foreach(v => p.onStopResize = v)
+    onResize.toJs.foreach(v => p.onResize = v)
+    clazz.foreach(v => p.className = v.htmlClass)
+    withHandle.foreach(v => p.withHandle = v)
+    p
+  }
+
+  private val component = JsComponent[Props, Children.Varargs, Null](RawComponent)
+
 }

--- a/common/src/main/scala/react/reflex/ReflexHandle.scala
+++ b/common/src/main/scala/react/reflex/ReflexHandle.scala
@@ -4,11 +4,29 @@
 package react.reflex
 
 import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.TagMod
 import react.common._
 
 import scala.scalajs.js.annotation.JSImport
 
 import scalajs.js
+
+// ReflexHandle must either:
+// 1) Be the first direct child of a ReactElement; or otherwise:
+// 2) Be wrapped within a ReflexWithHandle, and the provided parameter be passed on opaquely.
+final case class ReflexHandle(
+  propagate:              js.UndefOr[Boolean] = js.undefined,
+  onStartResize:          js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  onStopResize:           js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  onResize:               js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  provided:               js.UndefOr[HandleProps] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPAC[ReflexHandle.Props, ReflexHandle] {
+  override protected def cprops    = ReflexHandle.props(this)
+  override protected val component = ReflexHandle.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
 
 object ReflexHandle {
 
@@ -16,45 +34,40 @@ object ReflexHandle {
   @JSImport("react-reflex", "ReflexHandle")
   private object RawComponent extends js.Object
 
-  type Props = ReflexSplitter.Props
+  @js.native
+  trait Props extends ReflexSplitter.Props with HandleProps
 
-  object Props {
-    def apply(
-      propagate:     js.UndefOr[Boolean] = js.undefined,
-      onStartResize: js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      onStopResize:  js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      onResize:      js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      clazz:         js.UndefOr[Css] = js.undefined,
-      style:         js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-    ): Props = {
-      val p = (new js.Object).asInstanceOf[Props]
-      propagate.foreach(v => p.propagate = v)
-      onStartResize.toJs.foreach(v => p.onStartResize = v)
-      onStopResize.toJs.foreach(v => p.onStopResize = v)
-      onResize.toJs.foreach(v => p.onResize = v)
-      clazz.foreach(v => p.className = v.htmlClass)
-      style.foreach(v => p.style = v)
-      p
-    }
-  }
+  protected def props(p: ReflexHandle): Props =
+    rawprops(p.propagate, p.onStartResize, p.onStopResize, p.onResize, p.provided, p.clazz)
 
-  private val component = JsComponent[Props, Children.Varargs, Null](RawComponent)
-
-  def apply(
+  protected def rawprops(
     propagate:     js.UndefOr[Boolean] = js.undefined,
     onStartResize: js.UndefOr[ResizeEvent => Callback] = js.undefined,
     onStopResize:  js.UndefOr[ResizeEvent => Callback] = js.undefined,
     onResize:      js.UndefOr[ResizeEvent => Callback] = js.undefined,
-    clazz:         js.UndefOr[Css] = js.undefined,
-    style:         js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-  )(children:      CtorType.ChildArg*) = component(
-    Props(
-      propagate,
-      onStartResize,
-      onStopResize,
-      onResize,
-      clazz,
-      style
-    )
-  )(children: _*)
+    provided:      js.UndefOr[HandleProps] = js.undefined,
+    clazz:         js.UndefOr[Css] = js.undefined
+  ): Props = {
+    val p = (new js.Object).asInstanceOf[Props]
+    propagate.foreach(v => p.propagate = v)
+    onStartResize.toJs.foreach(v => p.onStartResize = v)
+    onStopResize.toJs.foreach(v => p.onStopResize = v)
+    onResize.toJs.foreach(v => p.onResize = v)
+    provided.foreach { v =>
+      import cats.syntax.all._
+      (v.index.toOption, v.events.toOption).tupled match {
+        case None                  =>
+          throw new Exception(
+            "ReflexHandle received provided property without injected properties. Did you specify \"withHandle = true\" on enclosing ReflexElement?"
+          )
+        case Some((index, events)) =>
+          p.index = index
+          p.events = events
+      }
+    }
+    clazz.foreach(v => p.className = v.htmlClass)
+    p
+  }
+
+  private val component = JsComponent[Props, Children.Varargs, Null](RawComponent)
 }

--- a/common/src/main/scala/react/reflex/ReflexSplitter.scala
+++ b/common/src/main/scala/react/reflex/ReflexSplitter.scala
@@ -4,11 +4,25 @@
 package react.reflex
 
 import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.TagMod
 import react.common._
 
 import scala.scalajs.js.annotation.JSImport
 
 import scalajs.js
+
+final case class ReflexSplitter(
+  propagate:              js.UndefOr[Boolean] = js.undefined,
+  onStartResize:          js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  onStopResize:           js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  onResize:               js.UndefOr[ResizeEvent => Callback] = js.undefined,
+  clazz:                  js.UndefOr[Css] = js.undefined,
+  override val modifiers: Seq[TagMod] = Seq.empty
+) extends GenericComponentPA[ReflexSplitter.Props, ReflexSplitter] {
+  override protected def cprops    = ReflexSplitter.props(this)
+  override protected val component = ReflexSplitter.component
+  override def addModifiers(modifiers: Seq[TagMod]) = copy(modifiers = this.modifiers ++ modifiers)
+}
 
 object ReflexSplitter {
 
@@ -26,43 +40,24 @@ object ReflexSplitter {
     var style: js.UndefOr[js.Object]
   }
 
-  object Props {
-    def apply(
-      propagate:     js.UndefOr[Boolean] = js.undefined,
-      onStartResize: js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      onStopResize:  js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      onResize:      js.UndefOr[ResizeEvent => Callback] = js.undefined,
-      clazz:         js.UndefOr[Css] = js.undefined,
-      style:         js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-    ): Props = {
-      val p = (new js.Object).asInstanceOf[Props]
-      propagate.foreach(v => p.propagate = v)
-      onStartResize.toJs.foreach(v => p.onStartResize = v)
-      onStopResize.toJs.foreach(v => p.onStopResize = v)
-      onResize.toJs.foreach(v => p.onResize = v)
-      clazz.foreach(v => p.className = v.htmlClass)
-      style.foreach(v => p.style = v)
-      p
-    }
-  }
+  protected def props(p: ReflexSplitter): Props =
+    rawprops(p.propagate, p.onStartResize, p.onStopResize, p.onResize, p.clazz)
 
-  private val component = JsComponent[Props, Children.None, Null](RawComponent)
-
-  def apply(
+  protected def rawprops(
     propagate:     js.UndefOr[Boolean] = js.undefined,
     onStartResize: js.UndefOr[ResizeEvent => Callback] = js.undefined,
     onStopResize:  js.UndefOr[ResizeEvent => Callback] = js.undefined,
     onResize:      js.UndefOr[ResizeEvent => Callback] = js.undefined,
-    clazz:         js.UndefOr[Css] = js.undefined,
-    style:         js.UndefOr[js.Object] = js.undefined // TODO Use GenericComponentPA mechanism
-  ) = component(
-    Props(
-      propagate,
-      onStartResize,
-      onStopResize,
-      onResize,
-      clazz,
-      style
-    )
-  )
+    clazz:         js.UndefOr[Css] = js.undefined
+  ): Props = {
+    val p = (new js.Object).asInstanceOf[Props]
+    propagate.foreach(v => p.propagate = v)
+    onStartResize.toJs.foreach(v => p.onStartResize = v)
+    onStopResize.toJs.foreach(v => p.onStopResize = v)
+    onResize.toJs.foreach(v => p.onResize = v)
+    clazz.foreach(v => p.className = v.htmlClass)
+    p
+  }
+
+  private val component = JsComponent[Props, Children.None, Null](RawComponent)
 }

--- a/common/src/main/scala/react/reflex/ReflexWithHandle.scala
+++ b/common/src/main/scala/react/reflex/ReflexWithHandle.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.reflex
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+
+import scalajs.js
+
+trait ReflexEvents extends js.Object
+
+object ReflexWithHandle {
+  // Yes, this is a hack. We use it because react-reflex expects a ReactHandle to be the
+  // direct first child of a ReactElement. This makes it impossible to make the ReactHandle
+  // part of, say, a react-beautiful-dnd Droppable, which would have to go between the
+  // ReactElement and the ReactHandle. Since ReactElement injects properties into its
+  // ReactHandle child, things break down if there's anything in between.
+  //
+  // We are therefore using:
+  // 1) An undocumented feature of react-reflex. If a boolean property "withHandle" is passed
+  // to ReactElement, it will inject into its children the properties that ReactHandle needs.
+  // (These properties are modeled in ReflexHandle.HandleProps).
+  // 2) We create a Scala component that will take ReflexHandle.HandleProps + a render function,
+  // to which it will provide the ReflexHandle.HandleProps. The render function can then pass this
+  // to a ReactHandle within.
+  // 3) Since the Scala component needs to capture the unboxed properties that ReactElement will
+  // inject, we turn it into a JS component to avoid boxing, and we build a facade for it.
+  // From our code, therefore, it is used as a JS component.
+  //
+  // For future reference, here is a permalink to where react-reflex injects properties for handle:
+  // - https://github.com/leefsmp/Re-Flex/blob/850e1153ae3bddd3b0b1143b9fdb72a185027fd9/src/lib/ReflexElement.js#L198
+
+  @js.native
+  trait JsProps extends HandleProps with Props
+
+  private val component = ScalaComponent
+    .builder[JsProps]
+    .render_P(p => p.render(p))
+    .build
+
+  private val jsComponent = component.toJsComponent.raw
+
+  @js.native
+  trait Props extends js.Object {
+    var render: HandleProps => VdomNode
+  }
+
+  private val jsComponentFacade = JsFnComponent[Props, Children.None](jsComponent)
+
+  private def props(render: HandleProps => VdomNode): Props = {
+    val p = (new js.Object).asInstanceOf[Props]
+    p.render = render
+    p
+  }
+
+  def apply(render: HandleProps => VdomNode) = jsComponentFacade(props(render))
+
+}

--- a/common/src/main/scala/react/reflex/types.scala
+++ b/common/src/main/scala/react/reflex/types.scala
@@ -16,6 +16,12 @@ trait ResizeEvent extends js.Object {
   val component: JsComponent.RawMounted[ReflexElement.Props, js.Object]
 }
 
+@js.native
+protected[reflex] trait HandleProps extends js.Object {
+  var index: js.UndefOr[Int]
+  var events: js.UndefOr[ReflexEvents]
+}
+
 sealed trait Orientation extends Product with Serializable
 
 object Orientation {

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import crystal.react.implicits._
 import explore.AppCtx
 import explore.Icons
+import explore.UnderConstruction
 import explore.common.UserPreferencesQueries._
 import explore.components.Tile
 import explore.components.TileButton
@@ -132,8 +133,9 @@ object TargetTabContents {
 
             val rightSide =
               Tile(s"Target", backButton.some)(
-                (props.userId.get, targetIdOpt).mapN { case (uid, tid) =>
-                  TargetEditor(uid, tid, props.searching).withKey(tid.show)
+                (props.userId.get, targetIdOpt).tupled match {
+                  case Some((uid, tid)) => TargetEditor(uid, tid, props.searching).withKey(tid.show)
+                  case None             => UnderConstruction()
                 }
               )
 

--- a/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
@@ -7,6 +7,9 @@ import cats.effect.IO
 import cats.syntax.all._
 import clue.TransactionalClient
 import crystal.react.implicits._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.PosLong
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.AppCtx
 import explore.GraphQLSchemas.ObservationDB
 import explore.Icons
@@ -23,9 +26,6 @@ import explore.optics.GetAdjust
 import explore.optics._
 import explore.undo.KIListMod
 import explore.undo.Undoer
-import eu.timepit.refined.auto._
-import eu.timepit.refined.types.numeric.PosLong
-import eu.timepit.refined.types.string.NonEmptyString
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -393,7 +393,7 @@ object ConstraintSetObsList {
                               csHeader,
                               TagMod.when(props.expandedIds.get.contains(csId))(
                                 csObs.zipWithIndex.toTagMod(
-                                  (props.renderObsBadgeItem _).tupled
+                                  (props.renderObsBadgeItem(selectable = true) _).tupled
                                 )
                               ),
                               <.span(provided.placeholder)
@@ -407,36 +407,44 @@ object ConstraintSetObsList {
               // end of constraint set tree
               ReflexSplitter(propagate = true),
               // start of unassigned observations list
-              ReflexElement(size = 36, minSize = 36, clazz = ExploreStyles.ObsTreeSection)(
-                ReflexHandle()(
-                  Header(block = true,
-                         clazz = ExploreStyles.ObsTreeHeader |+| ExploreStyles.ObsTreeGroupHeader
-                  )(
-                    <.span(ExploreStyles.TargetLabelTitle)("UNASSIGNED OBSERVATIONS"),
-                    <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
-                  )
-                ),
-                Droppable(UnassignedObsId) { case (provided, snapshot) =>
-                  <.div(
-                    provided.innerRef,
-                    provided.droppableProps,
-                    props.getListStyle(snapshot.isDraggingOver)
-                  )(
-                    <.div(ExploreStyles.ObsTree)(
-                      <.div(ExploreStyles.ObsScrollTree) {
-                        Segment(
-                          vertical = true,
-                          clazz = ExploreStyles.ObsTreeGroup
+              ReflexElement(size = 36,
+                            minSize = 36,
+                            clazz = ExploreStyles.ObsTreeSection,
+                            withHandle = true
+              )(
+                ReflexWithHandle(reflexProvided =>
+                  Droppable(UnassignedObsId) { case (provided, snapshot) =>
+                    <.div(
+                      ExploreStyles.ObsUnassigned,
+                      provided.innerRef,
+                      provided.droppableProps,
+                      props.getListStyle(snapshot.isDraggingOver)
+                    )(
+                      ReflexHandle(provided = reflexProvided)(
+                        Header(block = true,
+                               clazz =
+                                 ExploreStyles.ObsTreeHeader |+| ExploreStyles.ObsTreeGroupHeader
                         )(
-                          unassignedObs.zipWithIndex.toTagMod(
-                            (props.renderObsBadgeItem _).tupled
-                          ),
-                          provided.placeholder
+                          <.span(ExploreStyles.TargetLabelTitle)("UNASSIGNED OBSERVATIONS"),
+                          <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
                         )
-                      }
+                      ),
+                      <.div(ExploreStyles.ObsTree)(
+                        <.div(ExploreStyles.ObsScrollTree) {
+                          Segment(
+                            vertical = true,
+                            clazz = ExploreStyles.ObsTreeGroup
+                          )(
+                            unassignedObs.zipWithIndex.toTagMod(
+                              (props.renderObsBadgeItem(selectable = false) _).tupled
+                            ),
+                            provided.placeholder
+                          )
+                        }
+                      )
                     )
-                  )
-                }
+                  }
+                )
               )
               // end of unassigned observations list
             )

--- a/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
@@ -306,7 +306,7 @@ object ConstraintSetObsList {
             ReflexContainer()(
               // Start constraint sets tree
               ReflexElement(minSize = 36, clazz = ExploreStyles.ObsTreeSection)(
-                Header(block = true, clazz = ExploreStyles.ObsTreeHeader)("CONSTRAINTS"),
+                Header(block = true, clazz = ExploreStyles.ObsTreeHeader)("Constraints"),
                 <.div(ExploreStyles.ObsTree)(
                   <.div(ExploreStyles.ObsScrollTree)(
                     constraintSetsWithIdx.toTagMod { case (constraintSet, csIdx) =>
@@ -339,8 +339,7 @@ object ConstraintSetObsList {
                       Droppable(csId.toString, renderClone = renderClone) {
                         case (provided, snapshot) =>
                           val csHeader = <.span(ExploreStyles.ObsTreeGroupHeader)(
-                            // TODO: Give it its own style?
-                            <.span(ExploreStyles.TargetLabelTitle)(
+                            <.span(ExploreStyles.ObsGroupTitle)(
                               opIcon,
                               constraintSet.name.value
                             ),
@@ -425,7 +424,7 @@ object ConstraintSetObsList {
                                clazz =
                                  ExploreStyles.ObsTreeHeader |+| ExploreStyles.ObsTreeGroupHeader
                         )(
-                          <.span(ExploreStyles.TargetLabelTitle)("UNASSIGNED OBSERVATIONS"),
+                          <.span(ExploreStyles.ObsGroupTitle)("Unassigned observations"),
                           <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
                         )
                       ),

--- a/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsQueries.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ConstraintSetObsQueries.scala
@@ -9,12 +9,13 @@ import clue.GraphQLOperation
 import clue.data.Input
 import clue.macros.GraphQL
 import explore.AppCtx
-import explore.GraphQLSchemas._
 import explore.GraphQLSchemas.ObservationDB.Types._
+import explore.GraphQLSchemas._
 import explore.components.graphql.LiveQueryRenderMod
 import explore.data.KeyedIndexedList
 import explore.implicits._
-import explore.model.{ ConstraintsSummary, ObsSummary }
+import explore.model.ConstraintsSummary
+import explore.model.ObsSummary
 import explore.model.reusability._
 import japgolly.scalajs.react.Reusability
 import japgolly.scalajs.react.vdom.html_<^._

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -184,7 +184,7 @@ object TargetObsList {
     ): (DropResult, ResponderProvided) => IO[Unit] =
       (result, _) =>
         $.propsIn[IO] >>= { props =>
-          println(scalajs.js.JSON.stringify(result))
+          // println(scalajs.js.JSON.stringify(result))
           // We can drag:
           //  - An observation from a target or an asterism to another target or asterism.
           //  - A target into an asterism.
@@ -682,7 +682,7 @@ object TargetObsList {
                                 TagMod
                                   .when(expandedTargetIds.get.contains(targetId))(
                                     targetObs.zipWithIndex.toTagMod(
-                                      (props.renderObsBadgeItem _).tupled
+                                      (props.renderObsBadgeItem(selectable = true) _).tupled
                                     )
                                   ),
                                 provided.placeholder
@@ -812,7 +812,7 @@ object TargetObsList {
                                       )
                                   ).when(asterismTargets.nonEmpty),
                                   asterismObs.zipWithIndex.toTagMod(
-                                    (props.renderObsBadgeItem _).tupled
+                                    (props.renderObsBadgeItem(selectable = true) _).tupled
                                   )
                                 )
                               ),
@@ -824,40 +824,46 @@ object TargetObsList {
                     )
                   )
                 ): VdomNode).some.filter(_ => asterisms.nonEmpty),
-                // ): VdomElement).when_(asterisms.nonEmpty),
                 (ReflexSplitter(propagate = true): VdomNode).some,
-                // End Asterism Tree - Start Unassigned Observations List
-                (ReflexElement(size = 36, minSize = 36, clazz = ExploreStyles.ObsTreeSection)(
-                  ReflexHandle()(
-                    Header(block = true,
-                           clazz = ExploreStyles.ObsTreeHeader |+| ExploreStyles.ObsTreeGroupHeader
-                    )(
-                      <.span(ExploreStyles.TargetLabelTitle)("UNASSIGNED OBSERVATIONS"),
-                      <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
-                    )
-                  ),
-                  Droppable(UnassignedObsId) { case (provided, snapshot) =>
-                    <.div(
-                      provided.innerRef,
-                      provided.droppableProps,
-                      props.getListStyle(snapshot.isDraggingOver)
-                    )(
-                      <.div(ExploreStyles.ObsTree)(
-                        <.div(ExploreStyles.ObsScrollTree) {
-
-                          Segment(
-                            vertical = true,
-                            clazz = ExploreStyles.ObsTreeGroup
+                (ReflexElement(size = 36,
+                               minSize = 36,
+                               clazz = ExploreStyles.ObsTreeSection,
+                               withHandle = true
+                )(
+                  ReflexWithHandle(reflexProvided =>
+                    // End Asterism Tree - Start Unassigned Observations List
+                    Droppable(UnassignedObsId) { case (provided, snapshot) =>
+                      <.div(ExploreStyles.ObsUnassigned,
+                            provided.innerRef,
+                            provided.droppableProps,
+                            props.getListStyle(snapshot.isDraggingOver)
+                      )(
+                        ReflexHandle(provided = reflexProvided)(
+                          Header(
+                            block = true,
+                            clazz = ExploreStyles.ObsTreeHeader |+| ExploreStyles.ObsTreeGroupHeader
                           )(
-                            unassignedObs.zipWithIndex.toTagMod(
-                              (props.renderObsBadgeItem _).tupled
-                            ),
-                            provided.placeholder
+                            <.span(ExploreStyles.TargetLabelTitle)("UNASSIGNED OBSERVATIONS"),
+                            <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
                           )
-                        }
+                        ),
+                        <.div(ExploreStyles.ObsTree)(
+                          <.div(ExploreStyles.ObsScrollTree) {
+
+                            Segment(
+                              vertical = true,
+                              clazz = ExploreStyles.ObsTreeGroup
+                            )(
+                              unassignedObs.zipWithIndex.toTagMod(
+                                (props.renderObsBadgeItem(selectable = false) _).tupled
+                              ),
+                              provided.placeholder
+                            )
+                          }
+                        )
                       )
-                    )
-                  }
+                    }
+                  )
                 ): VdomNode).some
                 // End Unassigned Observations List
               ).flatten: _*

--- a/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/observationtree/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -569,7 +569,7 @@ object TargetObsList {
               List[Option[VdomNode]](
                 // Start Target Tree
                 (ReflexElement(minSize = 36, clazz = ExploreStyles.ObsTreeSection)(
-                  Header(block = true, clazz = ExploreStyles.ObsTreeHeader)("TARGETS"),
+                  Header(block = true, clazz = ExploreStyles.ObsTreeHeader)("Targets"),
                   <.div(ExploreStyles.ObsTree)(
                     <.div(ExploreStyles.ObsScrollTree)(
                       targetsWithIdx.toTagMod { case (target, targetIdx) =>
@@ -613,7 +613,7 @@ object TargetObsList {
 
                             val targetHeader =
                               <.span(ExploreStyles.ObsTreeGroupHeader)(
-                                <.span(ExploreStyles.TargetLabelTitle)(
+                                <.span(ExploreStyles.ObsGroupTitle)(
                                   opIcon,
                                   target.name.value
                                 ),
@@ -696,7 +696,7 @@ object TargetObsList {
                 (ReflexSplitter(propagate = true): VdomNode).some.filter(_ => asterisms.nonEmpty),
                 (ReflexElement(minSize = 36, clazz = ExploreStyles.ObsTreeSection)(
                   ReflexHandle()(
-                    Header(block = true, clazz = ExploreStyles.ObsTreeHeader)("ASTERISMS")
+                    Header(block = true, clazz = ExploreStyles.ObsTreeHeader)("Asterisms")
                   ),
                   <.div(ExploreStyles.ObsTree)(
                     <.div(ExploreStyles.ObsScrollTree)(
@@ -762,7 +762,7 @@ object TargetObsList {
                                 <.span(
                                   opIcon,
                                   asterism.name.value,
-                                  ExploreStyles.TargetLabelTitle
+                                  ExploreStyles.ObsGroupTitle
                                 ),
                                 Button(
                                   size = Small,
@@ -791,9 +791,7 @@ object TargetObsList {
                                         Segment(basic = true,
                                                 clazz = ExploreStyles.ObsTreeGroupHeader
                                         )(
-                                          <.span(ExploreStyles.TargetLabelTitle)(
-                                            target.name.value
-                                          ),
+                                          <.span(ExploreStyles.ObsGroupTitle)(target.name.value),
                                           Button(
                                             size = Small,
                                             compact = true,
@@ -843,7 +841,7 @@ object TargetObsList {
                             block = true,
                             clazz = ExploreStyles.ObsTreeHeader |+| ExploreStyles.ObsTreeGroupHeader
                           )(
-                            <.span(ExploreStyles.TargetLabelTitle)("UNASSIGNED OBSERVATIONS"),
+                            <.span(ExploreStyles.ObsGroupTitle)("Unassigned Observations"),
                             <.span(ExploreStyles.ObsCount, s"${unassignedObs.length} Obs")
                           )
                         ),

--- a/observationtree/src/main/scala/explore/observationtree/ViewCommon.scala
+++ b/observationtree/src/main/scala/explore/observationtree/ViewCommon.scala
@@ -28,16 +28,18 @@ trait ViewCommon {
       selected = focused.get.exists(_ === FocusedObs(obs.id))
     )
 
-  def renderObsBadgeItem(obs: ObsSummary, idx: Int)(implicit logger: Logger[IO]): TagMod =
+  def renderObsBadgeItem(selectable: Boolean)(obs: ObsSummary, idx: Int)(implicit
+    logger:                          Logger[IO]
+  ): TagMod =
     <.div(ExploreStyles.ObsTreeItem)(
       Draggable(obs.id.toString, idx) { case (provided, snapshot, _) =>
         <.div(
           provided.innerRef,
           provided.draggableProps,
           getDraggedStyle(provided.draggableStyle, snapshot),
-          ^.onClick ==> { e: ReactEvent =>
+          (^.onClick ==> { e: ReactEvent =>
             e.stopPropagationCB >> focused.set(FocusedObs(obs.id).some).runAsyncCB
-          }
+          }).when(selectable)
         )(<.span(provided.dragHandleProps)(renderObsBadge(obs)))
       }
     )


### PR DESCRIPTION
* `react-reflex` facade now allows passing `scalajs-react` style attributes for styling, using the mechanism provided by `react-common`.
* `react-reflex` facade allows defining `ReactHandler` that are not direct children of a `ReactElement`.
* "Unassigned observations" header is now painted when dragging over it. Useful to drag onto it when the section is collapsed (Targets or Constraints View).
* Selected target/asterism/constraints are now painted when dragging over them. Before this, the selected color took precedence.
* Clicking on unassigned observations no longer selects them, since there is nothing to show in this case when in Targets or Constraints View.
