### PR TITLE
Don't report errors when stopping subscriptions.

### DIFF
--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -186,7 +186,7 @@ object Render {
         $.state
           .map(state =>
             (state.cancelConnectionTracker >>
-              state.subscriptions.map(_.stop()).sequence.void).runAsyncCB
+              state.subscriptions.map(_.stop().handleError(_ => ())).sequence.void).runAsyncCB
           )
           .getOrEmpty
       }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -11,7 +11,7 @@ object Settings {
     val catsRetry         = "2.1.0"
     val circe             = "0.13.0"
     val circeGolden       = "0.3.0"
-    val clue              = "0.12.2"
+    val clue              = "0.13.0"
     val crystal           = "0.11.0"
     val discipline        = "1.1.4"
     val disciplineMUnit   = "1.0.7"


### PR DESCRIPTION
Also, use new clue with better handling of connection recycling (and less error messages).