### PR TITLE
Remove user defined name

### DIFF
--- a/common/src/main/resources/less/style.less
+++ b/common/src/main/resources/less/style.less
@@ -593,6 +593,19 @@ tfoot {
   color: var(--obs-badge-color);
 }
 
+.obs-badge-target-and-id {
+  display: flex;
+  width: 100%;
+}
+
+.obs-badge-id {
+  margin-left: auto;
+  margin-right: 1em;
+  font-style: italic;
+  font-weight: normal;
+  opacity: 0.5;
+}
+
 .selected-obs-item .card.obs-badge {
   background-color: var(--obs-selected-badge-background);
 }

--- a/common/src/main/scala/explore/common/ConstraintSetObsQueries.scala
+++ b/common/src/main/scala/explore/common/ConstraintSetObsQueries.scala
@@ -77,9 +77,11 @@ object ConstraintSetObsQueries {
               type: __typename
               ... on Target {
                 target_id: id
+                target_name: name
               }
               ... on Asterism {
                 asterism_id: id
+                asterism_name: name
               }
             }
             constraintSet {
@@ -136,9 +138,11 @@ object ConstraintSetObsQueries {
                 type: __typename
                 ... on Target {
                   target_id: id
+                  target_name: name
                 }
                 ... on Asterism {
                   asterism_id: id
+                  asterism_name: name
                 }
               }
               constraintSet {

--- a/common/src/main/scala/explore/common/ObsQueries.scala
+++ b/common/src/main/scala/explore/common/ObsQueries.scala
@@ -31,14 +31,15 @@ object ObsQueries {
         observations(programId: "p-2", first: 2147483647) {
           nodes {
             id
-            name
             observationTarget {
               type: __typename
               ... on Target {
                 target_id: id
+                target_name: name
               }
               ... on Asterism {
                 asterism_id: id
+                asterism_name: name
               }
             }
             constraintSet {
@@ -75,14 +76,15 @@ object ObsQueries {
           observations(programId: "p-2", first: 2147483647) {
             nodes {
               id
-              name
               observationTarget {
                 type: __typename
                 ... on Target {
                   target_id: id
+                  target_name: name
                 }
                 ... on Asterism {
                   asterism_id: id
+                  asterism_name: name
                 }
               }
               constraintSet {

--- a/common/src/main/scala/explore/common/TargetObsQueries.scala
+++ b/common/src/main/scala/explore/common/TargetObsQueries.scala
@@ -96,9 +96,11 @@ object TargetObsQueries {
               type: __typename
               ... on Target {
                 target_id: id
+                target_name: name
               }
               ... on Asterism {
                 asterism_id: id
+                asterism_name: name
               }
             }
             constraintSet {
@@ -168,9 +170,11 @@ object TargetObsQueries {
                 type: __typename
                 ... on Target {
                   target_id: id
+                  target_name: name
                 }
                 ... on Asterism {
                   asterism_id: id
+                  asterism_name: name
                 }
               }
               constraintSet {

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -104,6 +104,8 @@ object ExploreStyles {
   val ObsTreeItem: Css             = Css("obs-tree-item")
   val TreeToolbar: Css             = Css("tree-toolbar")
   val ObsBadge: Css                = Css("obs-badge")
+  val ObsBadgeId: Css              = Css("obs-badge-id")
+  val ObsBadgeTargetAndId: Css     = Css("obs-badge-target-and-id")
   val SelectedObsItem: Css         = Css("selected-obs-item")
   val ObsItem: Css                 = Css("obs-item")
   val TrashIcon: Css               = Css("trash-icon")

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -21,6 +21,7 @@ import react.common.implicits._
 import react.semanticui.elements.button.Button
 import react.semanticui.sizes._
 import react.semanticui.views.card._
+import lucuma.core.util.Gid
 
 final case class ObsBadge(
   obs:      ObsSummary,
@@ -50,6 +51,7 @@ object ObsBadge {
   }
 
   import Layout._
+  val idIso = Gid[Observation.Id].isoPosLong
 
   protected val component =
     ScalaComponent
@@ -76,7 +78,16 @@ object ObsBadge {
                   ExploreStyles.ObservationCardHeader,
                   props.layout match {
                     case NameAndConf | NameAndConfAndConstraints =>
-                      obs.name.fold("--------")(_.value)
+                      val targetName: String = obs.pointingName match {
+                        case Some(Right(n)) => n.value
+                        case Some(Left(n))  => n.map(_.value).getOrElse("<Asterism>")
+                        case None           => "<No target>"
+                      }
+                      <.div(
+                        ExploreStyles.ObsBadgeTargetAndId,
+                        <.div(targetName),
+                        <.div(ExploreStyles.ObsBadgeId, s"[${idIso.get(obs.id).value.toHexString}]")
+                      )
                     case ConfAndConstraints                      => obs.conf
                   },
                   props.deleteCB.whenDefined(_ => deleteButton)

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -214,8 +214,7 @@ object ObsTabContents {
           }.flatten
 
           val targetId = obsSummaryOpt.collect {
-            case ObsSummary(_, _, _, _, _, _, Some(Right(tid))) =>
-              tid
+            case ObsSummary(_, _, _, _, _, Some(Right(tid)), _) => tid
           }
 
           val backButton = TileButton(
@@ -292,8 +291,13 @@ object ObsTabContents {
                           )
                         }
 
-                      }.withKey(s"target-$targetId")
+                      }.withKey(s"target-$targetId"): VdomNode
                     }
+                    .getOrElse(
+                      <.div(ExploreStyles.HVCenter |+| ExploreStyles.EmptyTreeContent,
+                            <.div("No target assigned")
+                      )
+                    )
                 )
               )
             )

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -3,9 +3,11 @@
 
 package explore
 
+import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.model.Asterism
 import lucuma.core.model.Target
 
 package object model {
-  type PointingId = Either[Asterism.Id, Target.Id]
+  type PointingId   = Either[Asterism.Id, Target.Id]
+  type PointingName = Either[Option[NonEmptyString], NonEmptyString]
 }


### PR DESCRIPTION
This PR removes the user defined name of observations and instead shows the target/asterism name and the obs id

It will be discussed if we should replace the obs id with a different type of index

![image](https://user-images.githubusercontent.com/3615303/113639660-a9c47100-9647-11eb-94e5-135d8e4e8432.png)
