### PR TITLE
Potential fix for linting errors on forks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
           sed '/^[[:blank:]]*[\\.\\}\\@]/d;/^[[:blank:]]*\..*/d;/^[[:blank:]]*$/d;/\/\/.*/d' common/src/main/webapp/less/variables-dark.less > common/src/main/webapp/less/vars.css
           cat common/src/main/webapp/less/vars.css
       - name: Run linters in dark mode
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
         uses: wearerequired/lint-action@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,6 +40,7 @@ jobs:
           cat common/src/main/webapp/less/vars.css
       - name: Run linters in light mode
         uses: wearerequired/lint-action@v1
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.repository_owner }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Enable your linters herename: Lint


### PR DESCRIPTION
Dependabot PRs are erroring due to limitations of the linting action on forks. This is a potential fix that will disable these for fork PRs