### PR TITLE
Reusable functions: Part 2

### DIFF
--- a/common/src/main/scala/explore/common/ConstraintSetObsQueries.scala
+++ b/common/src/main/scala/explore/common/ConstraintSetObsQueries.scala
@@ -17,6 +17,7 @@ import explore.model.Pointing
 import explore.model.reusability._
 import explore.schemas.ObservationDB
 import explore.schemas.ObservationDB.Types._
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.ConstraintSet
@@ -90,7 +91,7 @@ object ConstraintSetObsQueries {
     Reusability.derive
 
   val ConstraintSetObsLiveQuery =
-    ScalaFnComponent[View[ConstraintSetsWithObs] ~=> VdomNode](render =>
+    ScalaFnComponent[View[ConstraintSetsWithObs] ==> VdomNode](render =>
       AppCtx.using { implicit appCtx =>
         LiveQueryRenderMod[ObservationDB, ConstraintSetsObsQuery.Data, ConstraintSetsWithObs](
           ConstraintSetsObsQuery.query(),

--- a/common/src/main/scala/explore/common/ObsQueries.scala
+++ b/common/src/main/scala/explore/common/ObsQueries.scala
@@ -12,6 +12,7 @@ import explore.implicits._
 import explore.model.ObsSummaryWithPointingAndConstraints
 import explore.model.Pointing
 import explore.model.reusability._
+import explore.utils._
 import explore.schemas.ObservationDB
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -51,7 +52,7 @@ object ObsQueries {
   }
 
   val ObsLiveQuery =
-    ScalaFnComponent[View[ObservationList] ~=> VdomNode](render =>
+    ScalaFnComponent[View[ObservationList] ==> VdomNode](render =>
       AppCtx.using { implicit appCtx =>
         LiveQueryRenderMod[ObservationDB, ProgramObservationsQuery.Data, ObservationList](
           ProgramObservationsQuery.query(),

--- a/common/src/main/scala/explore/common/TargetObsQueries.scala
+++ b/common/src/main/scala/explore/common/TargetObsQueries.scala
@@ -14,6 +14,7 @@ import explore.model.PointingId
 import explore.model.reusability._
 import explore.optics._
 import explore.schemas.ObservationDB
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Asterism
@@ -107,7 +108,7 @@ object TargetObsQueries {
     Reusability.derive
 
   val TargetObsLiveQuery =
-    ScalaFnComponent[View[PointingsWithObs] ~=> VdomNode](render =>
+    ScalaFnComponent[View[PointingsWithObs] ==> VdomNode](render =>
       AppCtx.using { implicit appCtx =>
         LiveQueryRenderMod[ObservationDB, TargetsObsQuery.Data, PointingsWithObs](
           TargetsObsQuery.query(),

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
@@ -12,6 +12,7 @@ import cats.syntax.all._
 import clue.GraphQLSubscription
 import clue.WebSocketClient
 import crystal.react._
+import explore.utils._
 import fs2.concurrent.Queue
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -26,11 +27,10 @@ final case class LiveQueryRender[S, D, A](
   extract:             D => A,
   changeSubscriptions: NonEmptyList[IO[GraphQLSubscription[IO, _]]]
 )(
-  val valueRender:     A ~=> VdomNode,
-  val pendingRender:   Long ~=> VdomNode =
-    Reusable.always(_ => Icon(name = "spinner", loading = true, size = Large)),
-  val errorRender:     Throwable ~=> VdomNode =
-    Reusable.always(t => Message(error = true)(t.getMessage)),
+  val valueRender:     A ==> VdomNode,
+  val pendingRender:   Long ==> VdomNode =
+    Reuse.always(_ => Icon(name = "spinner", loading = true, size = Large)),
+  val errorRender:     Throwable ==> VdomNode = Reuse.always(t => Message(error = true)(t.getMessage)),
   val onNewData:       IO[Unit] = IO.unit
 )(implicit
   val F:               ConcurrentEffect[IO],

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
@@ -16,6 +16,7 @@ import crystal.Pot
 import crystal.ViewF
 import crystal.react._
 import explore._
+import explore.utils._
 import fs2.concurrent.Queue
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -33,11 +34,10 @@ final case class LiveQueryRenderMod[S, D, A](
   extract:             D => A,
   changeSubscriptions: NonEmptyList[IO[GraphQLSubscription[IO, _]]]
 )(
-  val valueRender:     View[A] ~=> VdomNode,
-  val pendingRender:   Long ~=> VdomNode =
-    Reusable.always(_ => Icon(name = "spinner", loading = true, size = Large)),
-  val errorRender:     Throwable ~=> VdomNode =
-    Reusable.always(t => Message(error = true)(t.getMessage)),
+  val valueRender:     View[A] ==> VdomNode,
+  val pendingRender:   Long ==> VdomNode =
+    Reuse.always(_ => Icon(name = "spinner", loading = true, size = Large)),
+  val errorRender:     Throwable ==> VdomNode = Reuse.always(t => Message(error = true)(t.getMessage)),
   val onNewData:       IO[Unit] = IO.unit
 )(implicit
   val F:               ConcurrentEffect[IO],

--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -14,6 +14,7 @@ import clue.PersistentClientStatus
 import clue.WebSocketClient
 import crystal.Pot
 import crystal.react.implicits._
+import explore.utils._
 import fs2.concurrent.Queue
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
@@ -25,9 +26,9 @@ import org.typelevel.log4cats.Logger
 
 object Render {
   trait Props[F[_], G[_], A] {
-    val valueRender: G[A] ~=> VdomNode
-    val pendingRender: Long ~=> VdomNode
-    val errorRender: Throwable ~=> VdomNode
+    val valueRender: G[A] ==> VdomNode
+    val pendingRender: Long ==> VdomNode
+    val errorRender: Throwable ==> VdomNode
     val onNewData: F[Unit]
 
     implicit val F: ConcurrentEffect[F]

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
@@ -10,6 +10,7 @@ import cats.syntax.all._
 import clue.GraphQLSubscription
 import crystal.react._
 import crystal.react.implicits._
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
@@ -22,11 +23,10 @@ final case class SubscriptionRender[D, A](
   subscribe:         IO[GraphQLSubscription[IO, D]],
   streamModifier:    fs2.Stream[IO, D] => fs2.Stream[IO, A] = identity[fs2.Stream[IO, D]] _
 )(
-  val valueRender:   A ~=> VdomNode,
-  val pendingRender: Long ~=> VdomNode =
-    Reusable.always(_ => Icon(name = "spinner", loading = true, size = Large)),
-  val errorRender:   Throwable ~=> VdomNode =
-    Reusable.always(t => Message(error = true)(t.getMessage)),
+  val valueRender:   A ==> VdomNode,
+  val pendingRender: Long ==> VdomNode =
+    Reuse.always(_ => Icon(name = "spinner", loading = true, size = Large)),
+  val errorRender:   Throwable ==> VdomNode = Reuse.always(t => Message(error = true)(t.getMessage)),
   val onNewData:     IO[Unit] = IO.unit
 )(implicit
   val F:             ConcurrentEffect[IO],

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -14,6 +14,7 @@ import crystal.ViewF
 import crystal.react._
 import crystal.react.implicits._
 import explore.View
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
@@ -29,11 +30,10 @@ final case class SubscriptionRenderMod[D, A](
   subscribe:         IO[GraphQLSubscription[IO, D]],
   streamModifier:    fs2.Stream[IO, D] => fs2.Stream[IO, A] = identity[fs2.Stream[IO, D]] _
 )(
-  val valueRender:   View[A] ~=> VdomNode,
-  val pendingRender: Long ~=> VdomNode =
-    Reusable.always(_ => Icon(name = "spinner", loading = true, size = Large)),
-  val errorRender:   Throwable ~=> VdomNode =
-    Reusable.always(t => Message(error = true)(t.getMessage)),
+  val valueRender:   View[A] ==> VdomNode,
+  val pendingRender: Long ==> VdomNode =
+    Reuse.always(_ => Icon(name = "spinner", loading = true, size = Large)),
+  val errorRender:   Throwable ==> VdomNode = Reuse.always(t => Message(error = true)(t.getMessage)),
   val onNewData:     IO[Unit] = IO.unit
 )(implicit
   val F:             ConcurrentEffect[IO],

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -45,6 +45,10 @@ package object utils {
           .orEmpty
     )
   }
+
+  implicit class AnyReuseOps[A](val a: A) extends AnyVal {
+    def reuse: Reuse.Applied[A] = Reuse(a)
+  }
 }
 
 package utils {

--- a/explore/src/main/scala/explore/constraints/ConstraintSetEditor.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintSetEditor.scala
@@ -18,6 +18,7 @@ import lucuma.ui.reusability._
 import react.common._
 
 import ConstraintsQueries._
+import explore.utils._
 
 final case class ConstraintSetEditor(csid: ConstraintSet.Id)
     extends ReactProps[ConstraintSetEditor](ConstraintSetEditor.component)
@@ -35,8 +36,6 @@ object ConstraintSetEditor {
       ConstraintsPanel(csid, csOpt.zoom(_.get)(f => _.map(f)))
     }
 
-  protected val reusableRender = Reusable.fn(renderFn _)
-
   val component =
     ScalaComponent
       .builder[Props]
@@ -46,7 +45,7 @@ object ConstraintSetEditor {
             ConstraintSetQuery.query(props.csid),
             _.constraintSet,
             NonEmptyList.of(ConstraintSetEditSubscription.subscribe[IO](props.csid))
-          )(reusableRender(props.csid))
+          )((renderFn _).reuse(props.csid))
         }
       }
       .configure(Reusability.shouldComponentUpdate)

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -21,6 +21,7 @@ import explore.model._
 import explore.model.enum.AppTab
 import explore.model.reusability._
 import explore.observationtree.ConstraintSetObsList
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
 import japgolly.scalajs.react.vdom.html_<^._
@@ -159,8 +160,6 @@ object ConstraintSetTabContents {
 
   protected implicit val innerWidthReuse = Reusability.double(2.0)
 
-  protected val reusableRender = Reusable.fn(renderFn _)
-
   protected val component =
     ScalaComponent
       .builder[Props]
@@ -175,7 +174,7 @@ object ConstraintSetTabContents {
       .render { $ =>
         implicit val ctx = $.props.ctx
         ConstraintSetObsLiveQuery(
-          reusableRender($.props)(ViewF.fromState[IO]($))(window.innerWidth)
+          (renderFn _).reuse($.props, ViewF.fromState[IO]($), window.innerWidth)
         )
       }
       .componentDidMount(readWidthPreference)

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -30,6 +30,7 @@ import explore.model.reusability._
 import explore.observationtree.ObsList
 import explore.schemas.ObservationDB
 import explore.targeteditor.TargetBody
+import explore.utils._
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -258,8 +259,6 @@ object ObsTabContents {
           )
         }
 
-      val reusableTargetRender = Reusable.fn(targetRenderFn _)
-
       val rightSideRGL =
         ResponsiveReactGridLayout(
           width = coreWidth,
@@ -305,7 +304,7 @@ object ObsTabContents {
                     TargetEditQuery.query(targetId),
                     _.target,
                     NonEmptyList.of(TargetEditSubscription.subscribe[IO](targetId))
-                  )(reusableTargetRender(targetId)).withKey(s"target-$targetId")
+                  )((targetRenderFn _).reuse(targetId)).withKey(s"target-$targetId")
                 }
                 .getOrElse(
                   <.div(ExploreStyles.HVCenter |+| ExploreStyles.EmptyTreeContent,
@@ -358,11 +357,9 @@ object ObsTabContents {
       }
     }
 
-    protected val reusableRender = Reusable.fn(renderFn _)
-
     def render(props: Props) = {
       implicit val ctx = props.ctx
-      ObsLiveQuery(reusableRender(props)(ViewF.fromState[IO]($)))
+      ObsLiveQuery((renderFn _).reuse(props, ViewF.fromState[IO]($)))
     }
   }
 

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -21,6 +21,7 @@ import explore.model.enum.AppTab
 import explore.model.reusability._
 import explore.observationtree.TargetObsList
 import explore.targeteditor.TargetEditor
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
 import japgolly.scalajs.react.vdom.html_<^._
@@ -170,8 +171,6 @@ object TargetTabContents {
     }
   }
 
-  protected val reusableRender = Reusable.fn(renderFn _)
-
   protected val component =
     ScalaComponent
       .builder[Props]
@@ -186,7 +185,7 @@ object TargetTabContents {
       )
       .render { $ =>
         implicit val ctx = $.props.ctx
-        TargetObsLiveQuery(reusableRender($.props)(ViewF.fromState($)))
+        TargetObsLiveQuery((renderFn _).reuse($.props, ViewF.fromState($)))
       }
       .componentDidMount(readWidthPreference)
       .configure(Reusability.shouldComponentUpdate)

--- a/explore/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -16,6 +16,7 @@ import explore.model.Constants
 import explore.model.TargetVisualOptions
 import explore.model.reusability._
 import explore.schemas.ObservationDB
+import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Target
@@ -58,8 +59,6 @@ object TargetEditor {
       )
     }
 
-  protected val reusableRender = Reusable.fn(renderFn _)
-
   protected class Backend($ : BackendScope[Props, State]) {
     def render(props: Props) = {
       implicit val ctx = props.ctx
@@ -67,7 +66,7 @@ object TargetEditor {
         TargetEditQuery.query(props.tid),
         _.target,
         NonEmptyList.of(TargetEditSubscription.subscribe[IO](props.tid))
-      )(reusableRender(props)(ViewF.fromState[IO]($)))
+      )((renderFn _).reuse(props, ViewF.fromState[IO]($)))
     }
   }
 


### PR DESCRIPTION
This is the PR that shows the difference when using both approaches.

Note that I had to make some adjustments to `Reuse` to allow for higher arity functions and because `TypeTag` is not available in Scala.js.

Basically, the differences are that when using our `Reuse`:
* We don't have to define a separate `val` with the `Reuse` instance (we can create it inline with `.reuse`).
* We can partially invoke the function with multiple parameters, instead of having to instantiate the curried parameters one by one.