### PR TITLE
Render in tiles' titles.

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -13,6 +13,7 @@ object ExploreStyles {
   val Tile: Css            = Css("explore-tile")
   val TileTitle: Css       = Css("explore-tile-title")
   val TileTitleMenu: Css   = Css("explore-tile-title-menu")
+  val TileTitleInfo: Css   = Css("explore-tile-title-info")
   val TileBackButton: Css  = Css("tile-back-button")
   val TileBody: Css        = Css("explore-tile-body")
   val TileButton: Css      = Css("explore-tile-button")
@@ -216,4 +217,6 @@ object ExploreStyles {
   val HelpTitleLabel: Css   = Css("explore-help-title-label")
   val HelpBody: Css         = Css("explore-help-body")
   val HelpMarkdownBody: Css = Css("markdown-body")
+
+  val TitleUndoButtons: Css = Css("title-undo-buttons")
 }

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -247,6 +247,10 @@ tfoot {
   }
 }
 
+.explore-tile-title-info {
+  width: 100%;
+}
+
 .ui.menu.explore-tile-title-menu {
   margin-top: 0;
   cursor: pointer;
@@ -1356,4 +1360,8 @@ html {
     text-shadow: none;
     color: black;
   }
+}
+
+.title-undo-buttons {
+  float: right;
 }

--- a/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -13,6 +13,7 @@ import eu.timepit.refined.types.string.NonEmptyString
 import explore.AppCtx
 import explore.common.ConstraintsQueries._
 import explore.components.HelpIcon
+import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.components.undo.UndoRegion
@@ -47,7 +48,8 @@ import react.semanticui.elements.label.LabelPointing
 
 final case class ConstraintsPanel(
   id:            ConstraintSet.Id,
-  constraintSet: View[ConstraintSetModel]
+  constraintSet: View[ConstraintSetModel],
+  renderInTitle: Tile.RenderInTitle
 ) extends ReactProps[ConstraintsPanel](ConstraintsPanel.component)
 
 object ConstraintsPanel {
@@ -281,7 +283,9 @@ object ConstraintsPanel {
               <.div(ExploreStyles.UnitsLabel, "hours")
             ).when(state.get.rangeType === HourAngle)
           ),
-          UndoButtons(constraintSet.get, undoCtx)
+          props.renderInTitle(
+            <.span(ExploreStyles.TitleUndoButtons, UndoButtons(constraintSet.get, undoCtx))
+          )
         )
       }
 

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -69,6 +69,12 @@ object ConstraintSetTabContents {
     ) >>= $.setStateLIn[IO](TwoPanelState.treeWidth)).runAsyncCB
   }
 
+  protected def renderEditor(
+    csIdOpt:       Option[ConstraintSet.Id],
+    renderInTitle: Tile.RenderInTitle
+  ): VdomNode =
+    csIdOpt.map(csId => ConstraintSetEditor(csId, renderInTitle).withKey(csId.show))
+
   protected def renderFn(
     props:                 Props,
     state:                 View[State],
@@ -119,9 +125,7 @@ object ConstraintSetTabContents {
     val coreWidth  = props.size.width.getOrElse(0) - treeWidth
     val coreHeight = props.size.height.getOrElse(0)
 
-    val rightSide = Tile("Constraints", backButton.some)(
-      csIdOpt.map(csId => ConstraintSetEditor(csId).withKey(csId.show))
-    )
+    val rightSide = Tile("Constraints", backButton.some)((renderEditor _).reusable(csIdOpt))
 
     if (innerWidth <= Constants.TwoPanelCutoff) {
       <.div(

--- a/explore/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -15,6 +15,7 @@ import explore.common.SimbadSearch
 import explore.common.TargetQueries
 import explore.common.TargetQueries._
 import explore.components.HelpIcon
+import explore.components.Tile
 import explore.components.WIP
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
@@ -56,11 +57,12 @@ final case class SearchCallback(
 }
 
 final case class TargetBody(
-  uid:       User.Id,
-  id:        Target.Id,
-  target:    View[TargetResult],
-  searching: View[Set[Target.Id]],
-  options:   View[TargetVisualOptions]
+  uid:           User.Id,
+  id:            Target.Id,
+  target:        View[TargetResult],
+  searching:     View[Set[Target.Id]],
+  options:       View[TargetVisualOptions],
+  renderInTitle: Tile.RenderInTitle
 ) extends ReactProps[TargetBody](TargetBody.component) {
   val baseCoordinates: Coordinates =
     target.zoom(TargetQueries.baseCoordinates).get
@@ -256,7 +258,11 @@ object TargetBody {
               RVInput(radialVelocityView, disabled)
             ),
             MagnitudeForm(target.id, magnitudesView, disabled = disabled),
-            UndoButtons(target, undoCtx, disabled = disabled),
+            props.renderInTitle(
+              <.span(ExploreStyles.TitleUndoButtons,
+                     UndoButtons(target, undoCtx, disabled = disabled)
+              )
+            ),
             <.div(
               ExploreStyles.TargetSkyplotCell,
               WIP(

--- a/explore/src/main/scala/explore/targeteditor/TargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetEditor.scala
@@ -10,6 +10,7 @@ import crystal.react.implicits._
 import explore.common.TargetQueriesGQL._
 import explore.common.UserPreferencesQueries._
 import explore.common.UserPreferencesQueriesGQL._
+import explore.components.Tile
 import explore.components.graphql.LiveQueryRenderMod
 import explore.implicits._
 import explore.model.Constants
@@ -27,7 +28,8 @@ import react.common._
 final case class TargetEditor(
   uid:              User.Id,
   tid:              Target.Id,
-  searching:        View[Set[Target.Id]]
+  searching:        View[Set[Target.Id]],
+  renderInTitle:    Tile.RenderInTitle
 )(implicit val ctx: AppContextIO)
     extends ReactProps[TargetEditor](TargetEditor.component)
 
@@ -54,7 +56,8 @@ object TargetEditor {
                  props.tid,
                  targetOpt.zoom(_.get)(f => _.map(f)),
                  props.searching,
-                 state.zoom(State.options)
+                 state.zoom(State.options),
+                 props.renderInTitle
       )
     }
 


### PR DESCRIPTION
By using React's portals, tiles contents can now render things into the tile's title.

`Tile` now accepts a `render` function `Tile.RenderInTitle ~=> VdomNode` instead of children. The contents renderer therefore now receive a `Tile.RenderInTitle` which is just a `VdomNode ~=> VdomNode` that when called, will create a portal into a `<.span` in the title.

Undo buttons have been migrated to use this mechanism. 