### PR TITLE
ConstraintsSummary as trait.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,11 @@ addCommandAlias(
   "; scalafix OrganizeImports; scalafmtAll"
 )
 
+addCommandAlias(
+  "fix",
+  "; headerCreateAll; fixImports; scalafmtAll"
+)
+
 inThisBuild(
   Seq(
     homepage := Some(url("https://github.com/gemini-hlsw/explore")),

--- a/common-graphql/src/main/scala/explore/common/ConstraintSetObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/ConstraintSetObsQueriesGQL.scala
@@ -7,7 +7,6 @@ import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import explore.model.ConstraintsSummary
 import explore.schemas.ObservationDB
-// gql: import explore.model.reusability._
 // gql: import io.circe.refined._
 // gql: import lucuma.ui.reusability._
 
@@ -43,7 +42,6 @@ object ConstraintSetObsQueriesGQL {
             }
             constraintSet {
               id
-              name
               imageQuality
               cloudExtinction
               skyBackground
@@ -56,12 +54,12 @@ object ConstraintSetObsQueriesGQL {
 
     object Data {
       object ConstraintSets {
-        type Nodes = ConstraintsSummary
+        trait Nodes extends ConstraintsSummary
       }
 
       object Observations {
         object Nodes {
-          type ConstraintSet = ConstraintsSummary
+          trait ConstraintSet extends ConstraintsSummary
         }
       }
     }

--- a/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
@@ -7,7 +7,6 @@ import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import explore.model.ConstraintsSummary
 import explore.schemas.ObservationDB
-// gql: import explore.model.reusability._
 // gql: import io.circe.refined._
 // gql: import lucuma.ui.reusability._
 
@@ -33,7 +32,6 @@ object ObsQueriesGQL {
             }
             constraintSet {
               id
-              name
               imageQuality
               cloudExtinction
               skyBackground
@@ -47,7 +45,7 @@ object ObsQueriesGQL {
     object Data {
       object Observations {
         object Nodes {
-          type ConstraintSet = ConstraintsSummary
+          trait ConstraintSet extends ConstraintsSummary
         }
       }
     }

--- a/common-graphql/src/main/scala/explore/common/TargetObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/TargetObsQueriesGQL.scala
@@ -7,7 +7,6 @@ import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import explore.model.ConstraintsSummary
 import explore.schemas.ObservationDB
-// gql: import explore.model.reusability._
 // gql: import io.circe.refined._
 // gql: import lucuma.ui.reusability._
 
@@ -51,7 +50,6 @@ object TargetObsQueriesGQL {
             }
             constraintSet {
               id
-              name
               imageQuality
               cloudExtinction
               skyBackground
@@ -65,7 +63,7 @@ object TargetObsQueriesGQL {
     object Data {
       object Observations {
         object Nodes {
-          type ConstraintSet = ConstraintsSummary
+          trait ConstraintSet extends ConstraintsSummary
         }
       }
     }

--- a/common/src/test/scala/explore/common/arb/ArbTargetObsQueries.scala
+++ b/common/src/test/scala/explore/common/arb/ArbTargetObsQueries.scala
@@ -15,11 +15,14 @@ import lucuma.core.model.Target
 import lucuma.core.model.Asterism
 import explore.common.TargetObsQueries._
 import lucuma.core.model.Observation
-import explore.model.ConstraintsSummary
 import explore.model.arb.ArbConstraintsSummary
+import explore.common.TargetObsQueriesGQL
 
 trait ArbTargetObsQueries {
   import ArbConstraintsSummary._
+
+  type ConstraintSet = TargetObsQueriesGQL.TargetsObsQuery.Data.Observations.Nodes.ConstraintSet
+  val ConstraintSet = TargetObsQueriesGQL.TargetsObsQuery.Data.Observations.Nodes.ConstraintSet
 
   implicit val arbObsResultPointing =
     Arbitrary[ObsResult.Pointing] {
@@ -28,19 +31,21 @@ trait ArbTargetObsQueries {
       )
     }
 
-  implicit val cogenbsResultPointing: Cogen[ObsResult.Pointing] =
+  implicit val cogenObsResultPointing: Cogen[ObsResult.Pointing] =
     Cogen[Either[Asterism.Id, Target.Id]]
       .contramap {
         case ObsResult.Pointing.Target(id)   => id.asRight
         case ObsResult.Pointing.Asterism(id) => id.asLeft
       }
 
+  implicit val arbConstraintSet = buildConstraintsSummaryArb(ConstraintSet.apply)
+
   implicit val arbObsResult =
     Arbitrary[ObsResult] {
       for {
         id            <- arbitrary[Observation.Id]
         pointing      <- arbitrary[Option[ObsResult.Pointing]]
-        constraintSet <- arbitrary[Option[ConstraintsSummary]]
+        constraintSet <- arbitrary[Option[ConstraintSet]]
       } yield ObsResult(id, pointing, constraintSet)
     }
 }

--- a/model/shared/src/main/scala/explore/model/ConstraintsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ConstraintsSummary.scala
@@ -4,47 +4,24 @@
 package explore.model
 
 import cats._
-import eu.timepit.refined.cats._
-import eu.timepit.refined.types.string.NonEmptyString
-import io.circe.Decoder
-import io.circe.Encoder
-import io.circe.generic.semiauto._
-import io.circe.refined._
 import lucuma.core.enum.CloudExtinction
 import lucuma.core.enum.ImageQuality
 import lucuma.core.enum.SkyBackground
 import lucuma.core.enum.WaterVapor
 import lucuma.core.model.ConstraintSet
-import monocle.macros.Lenses
 
-@Lenses
-final case class ConstraintsSummary(
-  name:            NonEmptyString,
-  id:              ConstraintSet.Id,
-  imageQuality:    ImageQuality,
-  cloudExtinction: CloudExtinction,
-  skyBackground:   SkyBackground,
-  waterVapor:      WaterVapor
-) {
+trait ConstraintsSummary {
+  val id: ConstraintSet.Id
+  val imageQuality: ImageQuality
+  val cloudExtinction: CloudExtinction
+  val skyBackground: SkyBackground
+  val waterVapor: WaterVapor
+
   def summaryString: String =
     s"${imageQuality.label} ${cloudExtinction.label} ${skyBackground.label} ${waterVapor.label}"
 }
 
 object ConstraintsSummary {
-  def default(name: NonEmptyString, id: ConstraintSet.Id): ConstraintsSummary =
-    ConstraintsSummary(
-      id = id,
-      name = name,
-      imageQuality = ImageQuality.PointEight,
-      cloudExtinction = CloudExtinction.PointThree,
-      skyBackground = SkyBackground.Gray,
-      waterVapor = WaterVapor.Wet
-    )
-
-  implicit val constraintSummaryDecoder: Decoder[ConstraintsSummary] = deriveDecoder
-  implicit val constraintSummaryEncoder: Encoder[ConstraintsSummary] = deriveEncoder
-
-  implicit val eqConstraintSummary: Eq[ConstraintsSummary] = Eq.by(cs =>
-    (cs.name, cs.id, cs.imageQuality, cs.cloudExtinction, cs.skyBackground, cs.waterVapor)
-  )
+  implicit val eqConstraintSummary: Eq[ConstraintsSummary] =
+    Eq.by(cs => (cs.id, cs.imageQuality, cs.cloudExtinction, cs.skyBackground, cs.waterVapor))
 }


### PR DESCRIPTION
This PR aligns the use of `ConstraintSummary` with `ObsSummary`, in which we don't decode results directly into our model classes, converting or extending instead. This gives us more flexibility in building queries. We also avoid the need to provide decoders.