### PR TITLE
Close the help when clicking on the main content

### DIFF
--- a/common/src/main/scala/explore/components/HelpIcon.scala
+++ b/common/src/main/scala/explore/components/HelpIcon.scala
@@ -32,7 +32,9 @@ object HelpIcon {
         AppCtx.using { implicit ctx =>
           val helpMsg = help.zoom(HelpContext.displayedHelp)
           <.span(
-            ^.onClick --> helpMsg.set(p.id.some).runAsyncCB,
+            ^.onClick ==> { (e: ReactMouseEvent) =>
+              e.stopPropagationCB *> e.preventDefaultCB *> helpMsg.set(p.id.some).runAsyncCB
+            },
             Icons.Info
               .link(true)
               .inverted(true)


### PR DESCRIPTION
This is a small improvement to the help system. Now you can click outside the help to close it