### PR TITLE
Experiment with dynamic modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ common/src/main/publicdev/
 # vite
 server.cert
 server.key
+stats.html

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -21,6 +21,7 @@ import react.semanticui.modules.sidebar.SidebarDirection
 import react.semanticui.modules.sidebar.SidebarPushable
 import react.semanticui.modules.sidebar.SidebarPusher
 import react.semanticui.modules.sidebar.SidebarWidth
+import scala.scalajs.js
 
 final case class ExploreLayout(c: RouterCtl[Page], r: ResolutionWithProps[Page, View[RootModel]])(
   val view:                       View[RootModel]
@@ -51,7 +52,11 @@ object ExploreLayout {
           )(
             helpView.get
               .map { h =>
-                HelpBody(helpCtx.get, h): VdomNode
+                // Lazy load the React component for help
+                val prom = js.dynamicImport {
+                  new HelpLoader().loadHelp(helpCtx.get, h)
+                }
+                React.Suspense(<.div("Loading"), AsyncCallback.fromJsPromise(prom))
               }
               .when(helpView.get.isDefined)
           ),

--- a/explore/src/main/scala/explore/HelpBody.scala
+++ b/explore/src/main/scala/explore/HelpBody.scala
@@ -46,6 +46,13 @@ final case class HelpBody(base: HelpContext, helpId: Help.Id)(implicit val ctx: 
     .addParam("message", s"Update $helpId")
 }
 
+// This is a sort of facade to get dynamic loading boundaries right
+// You'd be tempted to put this inside HelpBody but it will make it load HelpBody as part of the main bundle
+class HelpLoader {
+  def loadHelp(helpCtx: HelpContext, h: Help.Id)(implicit ctx: AppContextIO): VdomElement =
+    HelpBody(helpCtx, h)
+}
+
 object HelpBody {
   type Props = HelpBody
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -831,6 +831,17 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -1370,6 +1381,12 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true
     },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
     "get-intrinsic": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
@@ -1747,6 +1764,12 @@
       "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
       "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
+    "is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1818,6 +1841,15 @@
       "dev": true,
       "requires": {
         "url-regex": "^5.0.0"
+      }
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
       }
     },
     "isexe": {
@@ -2549,6 +2581,16 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
       }
     },
     "opencollective-postinstall": {
@@ -3308,6 +3350,12 @@
         "uuid": "^3.3.2"
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
     "require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3356,6 +3404,26 @@
       "dev": true,
       "requires": {
         "fsevents": "~2.3.1"
+      }
+    },
+    "rollup-plugin-visualizer": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.4.1.tgz",
+      "integrity": "sha512-mwrUIfOamkCw3dCtLvgnn/H0rvNSDA1RAe0sO9uHBpmdf86j/xOX/2yeCrVh2Ia/gCGLG846JB00MW0chq8CHQ==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.1.22",
+        "open": "^7.4.2",
+        "source-map": "^0.7.3",
+        "yargs": "^16.2.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
       }
     },
     "run-parallel": {
@@ -4187,6 +4255,43 @@
         "isexe": "^2.0.0"
       }
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -4209,6 +4314,12 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -4220,6 +4331,21 @@
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
       "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
     },
     "yargs-parser": {
       "version": "20.2.7",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chokidar": "3.5.1",
     "less": "3.9.0",
     "less-watch-compiler": "1.14.6",
+    "rollup-plugin-visualizer": "^5.4.1",
     "sass": "^1.32.8",
     "stylelint": "^13.8.0",
     "stylelint-color-format": "^1.1.0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 import reactRefresh from "@vitejs/plugin-react-refresh";
-// import pluginRewriteConf from "./rewriteconf";
+import { visualizer } from 'rollup-plugin-visualizer';
 import path from "path";
 import fs from "fs";
 import ViteFonts from "vite-plugin-fonts";
@@ -42,6 +42,7 @@ export default ({ command, mode }) => {
     root: "explore/src/main/webapp",
     publicDir: publicDir,
     resolve: {
+      dedupe: ["react-is"],
       alias: [
         {
           find: "@sjs",
@@ -93,13 +94,15 @@ export default ({ command, mode }) => {
       proxy: {
         "conf.json": {
           rewrite: (path) => {
-            console.log(path);
             path.replace(/^\/conf.json$/, "/conf/development.conf.json");
           },
         },
       },
     },
     build: {
+      rollupOptions: {
+        plugins: [visualizer()],
+      },
       terserOptions: {
         sourceMap: false,
       },


### PR DESCRIPTION
I've been tempted to test dynamic module loading for a while and this is my first attempt.
The help system is not used right away and in many cases won't be used. It would be better to load the code and dependencies on demand.

With the changes in this PR we'll create 2 js files, the main containing explore and another with the help windown and its dependencies (ReactMarkdown, et.al.)

Only when you open the help the files are loaded from then net and executed

I noted there maybe some duplication on code we could use to further reduce size.