### PR TITLE
Generate BuildInfo only once

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,9 +108,9 @@ lazy val common = project
       scalaVersion,
       sbtVersion,
       git.gitHeadCommit,
-      "herokuSourceVersion" -> sys.env.get("SOURCE_VERSION")
+      "herokuSourceVersion" -> sys.env.get("SOURCE_VERSION"),
+      "buildDateTime"       -> System.currentTimeMillis()
     ),
-    buildInfoOptions += BuildInfoOption.BuildTime,
     buildInfoPackage := "explore",
     Compile / sourceGenerators += Def.taskDyn {
       val root    = (ThisBuild / baseDirectory).value.toURI.toString

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -29,7 +29,7 @@ package object utils {
     }
 
   def version(environment: ExecutionEnvironment): NonEmptyString = {
-    val instant = Instant.ofEpochMilli(BuildInfo.builtAtMillis)
+    val instant = Instant.ofEpochMilli(BuildInfo.buildDateTime)
     NonEmptyString.unsafeFrom(
       (environment match {
         case Development => versionDateTimeFormatter.format(instant)


### PR DESCRIPTION
This may seem trivial but when doing SmallestModules vite detects an extra changed module on each compilation

```
/Users/cquiroz/Projects/explore/explore/target/scala-2.13/explore-fastopt/explore.BuildInfo$.js
```
