### PR TITLE
Small improvements to the spectroscopy panel

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1396,7 +1396,7 @@ html {
 .explore-configuration-grid {
   padding: 0.5em;
   display: grid;
-  grid-template-columns: 350px 1fr;
+  grid-template-columns: 380px 1fr;
 }
 
 .explore-configuration-form {
@@ -1438,13 +1438,12 @@ html {
   }
 
   .field {
-    width: 5ch;
+    width: 8ch;
   }
 }
 
 .explore-configuration-capabilities {
   grid-column: span 2;
-  min-width: 100%;
 }
 
 .block.header.obs-tree-header {

--- a/common/src/main/webapp/less/variables-dark.less
+++ b/common/src/main/webapp/less/variables-dark.less
@@ -171,10 +171,16 @@
     1;
   --color-text-alt: hsla(var(--color-text-alt-hsla));
   // dark shades
-  --color-text-dark-10-hsla:
+  --color-text-dark-8-hsla:
     var(--color-text-base-h),
     var(--color-text-base-s),
     calc(var(--color-text-base-l) - 8%),
+    calc(var(--color-text-base-a) - 0.1);
+  --color-text-dark-8: hsla(var(--color-text-dark-8-hsla));
+  --color-text-dark-10-hsla:
+    var(--color-text-base-h),
+    var(--color-text-base-s),
+    calc(var(--color-text-base-l) - 10%),
     calc(var(--color-text-base-a) - 0.3);
   --color-text-dark-10: hsla(var(--color-text-dark-10-hsla));
   --gray-h: 210;
@@ -233,7 +239,7 @@
   --site-text-color: var(--text-color);
   --site-dark-text-color: var(--dark-text-color);
   --site-hovered-text-color: var(--text-alt);
-  --site-input-color: var(--input-color);
+  --site-input-color: var(--color-text-dark-8);
   --site-border-color: var(--gray);
   --site-solid-border-color: var(--color-background-light-50);
   --site-input-placeholder-focus-color: var(--color-text-light-45);
@@ -246,7 +252,7 @@
 
 .form-dark() {
   --input-color: var(--color-text-full);
-  --form-input-color: var(--color-text-dark-10);
+  --form-input-color: var(--site-input-color);
   --form-input-focus-color: var(--color-text-base);
   --form-input-background: var(--control-background-color);
   --form-input-focus-border-color: transparent;
@@ -324,6 +330,7 @@
 .dropdown-dark() {
   --dropdown-selection-background: var(--control-background-color);
   --dropdown-selection-visible-color: @gray-darker;
+  --dropdown-item-color: var(--site-input-color);
 }
 
 .checkbox-dark() {

--- a/common/src/main/webapp/theme/modules/dropdown.variables
+++ b/common/src/main/webapp/theme/modules/dropdown.variables
@@ -1,5 +1,5 @@
 @menuBackground: @gray-dark;
-@itemColor: @textColor;
+@itemColor: var(--dropdown-item-color);
 @hoveredItemColor: #fff;
 @hoveredItemBackground: @gray-darker;
 @activeItemColor: #fff;

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -10,6 +10,7 @@ import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import explore.AppCtx
 import explore.UnderConstruction
+import explore.components.HelpIcon
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.implicits._
@@ -67,7 +68,7 @@ object ConfigurationPanel {
               ExploreStyles.Grid,
               ExploreStyles.Compact,
               ExploreStyles.ConfigurationForm,
-              <.label("Mode"),
+              <.label("Mode", HelpIcon("configuration/simple/mode.md")),
               EnumViewSelect(id = "configuration-mode", value = mode),
               SpectroscopyConfigurationPanel(spectroscopy).when(isSpectroscopy)
             ),

--- a/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
@@ -7,6 +7,7 @@ import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
 import explore.AppCtx
+import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.SpectroscopyConfigurationOptions
@@ -20,7 +21,6 @@ import japgolly.scalajs.react.feature.ReactFragment
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.util.Display
 import lucuma.ui.forms.EnumViewOptionalSelect
-import lucuma.ui.forms.EnumViewSelect
 import lucuma.ui.forms.FormInputEV
 import lucuma.ui.optics.ChangeAuditor
 import lucuma.ui.optics.ValidFormatInput
@@ -50,13 +50,16 @@ object SpectroscopyConfigurationPanel {
           val signalToNoise            = p.options.zoom(SpectroscopyConfigurationOptions.signalToNoise)
           val signalToNoiseAt          = p.options.zoom(SpectroscopyConfigurationOptions.signalToNoiseAt)
           val wavelengthRange          = p.options.zoom(SpectroscopyConfigurationOptions.wavelengthRange)
-          val slitMode                 = p.options.zoom(SpectroscopyConfigurationOptions.slitMode)
+          val focalPlane               = p.options.zoom(SpectroscopyConfigurationOptions.focalPlane)
           val focalPlaneAngle          = p.options.zoom(SpectroscopyConfigurationOptions.focalPlaneAngle)
           val spectroscopyCapabilities =
             p.options.zoom(SpectroscopyConfigurationOptions.capabilities)
 
           ReactFragment(
-            <.label("Wavelength", ExploreStyles.SkipToNext),
+            <.label("Wavelength",
+                    HelpIcon("configuration/simple/wavelength.md"),
+                    ExploreStyles.SkipToNext
+            ),
             InputWithUnits(
               id = "configuration-wavelength",
               clazz = Css.Empty,
@@ -67,14 +70,20 @@ object SpectroscopyConfigurationPanel {
               changeAuditor = ChangeAuditor.fromFormat(formatWavelength).decimal(3).optional,
               disabled = false
             ),
-            <.label("λ / Δλ", ExploreStyles.SkipToNext),
+            <.label("λ / Δλ",
+                    HelpIcon("configuration/simple/spectral-resolution.md"),
+                    ExploreStyles.SkipToNext
+            ),
             FormInputEV(
               id = "configuration-resolution-power",
               value = resolutionPower,
               validFormat = ValidFormatInput.fromFormatOptional(formatPosInt),
               changeAuditor = ChangeAuditor.fromFormat(formatPosInt).optional
             ),
-            <.label("S / N", ExploreStyles.SkipToNext),
+            <.label("S / N",
+                    HelpIcon("configuration/simple/signal_to_noise.md"),
+                    ExploreStyles.SkipToNext
+            ),
             FormInputEV(id = "signal-to-noise",
                         value = signalToNoise,
                         validFormat = ValidFormatInput.fromFormatOptional(formatPosBigDecimal)
@@ -92,7 +101,10 @@ object SpectroscopyConfigurationPanel {
                 disabled = false
               )
             ),
-            <.label("λ Range", ExploreStyles.SkipToNext),
+            <.label("λ Range",
+                    HelpIcon("configuration/simple/frequency_range.md"),
+                    ExploreStyles.SkipToNext
+            ),
             InputWithUnits(
               id = "wavelength-range",
               clazz = Css.Empty,
@@ -103,8 +115,16 @@ object SpectroscopyConfigurationPanel {
               changeAuditor = ChangeAuditor.fromFormat(formatWavelength).decimal(3).optional,
               disabled = false
             ),
-            <.label("Focal Plane", ExploreStyles.SkipToNext),
-            EnumViewSelect(id = "focal-plane", upward = true, value = slitMode),
+            <.label("Focal Plane",
+                    HelpIcon("configuration/simple/focal_plane.md"),
+                    ExploreStyles.SkipToNext
+            ),
+            EnumViewOptionalSelect(id = "focal-plane",
+                                   placeholder = "Focal plane",
+                                   upward = true,
+                                   value = focalPlane,
+                                   clearable = true
+            ),
             <.div(
               ExploreStyles.SignalToNoiseAt,
               InputWithUnits(
@@ -117,7 +137,10 @@ object SpectroscopyConfigurationPanel {
                 disabled = false
               )
             ),
-            <.label("Capabilities", ExploreStyles.SkipToNext),
+            <.label("Capabilities",
+                    HelpIcon("configuration/simple/capabilities.md"),
+                    ExploreStyles.SkipToNext
+            ),
             EnumViewOptionalSelect(
               id = "spectroscopy-capabilities",
               clazz = ExploreStyles.ConfigurationCapabilities,

--- a/explore/src/main/scala/explore/tabs/TargetTile.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTile.scala
@@ -65,7 +65,7 @@ object TargetTile {
           )
         )
 
-    Tile(ObsTabTiles.TargetId, "Target")((renderTarget _).reusable(targetId))
+    Tile(ObsTabTiles.TargetId, "Target", canMinimize = true)((renderTarget _).reusable(targetId))
   }
 
 }

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbSpectroscopyConfigurationOptions.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbSpectroscopyConfigurationOptions.scala
@@ -34,7 +34,7 @@ trait ArbSpectroscopyConfigurationOptions {
       sn  <- arbitrary[Option[PosDouble]]
       sna <- arbitrary[Option[Wavelength]]
       wr  <- arbitrary[Option[Wavelength]]
-      sm  <- arbitrary[FocalPlaneOptions]
+      sm  <- arbitrary[Option[FocalPlaneOptions]]
       fa  <- arbitrary[Option[Angle]]
       sc  <- arbitrary[Option[SpectroscopyCapabilities]]
     } yield SpectroscopyConfigurationOptions(
@@ -57,7 +57,7 @@ trait ArbSpectroscopyConfigurationOptions {
         Option[BigDecimal],
         Option[Wavelength],
         Option[Wavelength],
-        FocalPlaneOptions,
+        Option[FocalPlaneOptions],
         Option[Angle],
         Option[SpectroscopyCapabilities]
       )
@@ -68,7 +68,7 @@ trait ArbSpectroscopyConfigurationOptions {
          cs.signalToNoise.map(_.value),
          cs.signalToNoiseAt,
          cs.wavelengthRange,
-         cs.slitMode,
+         cs.focalPlane,
          cs.focalPlaneAngle,
          cs.capabilities
         )

--- a/model/shared/src/main/scala/explore/model/SpectroscopyConfigurationOptions.scala
+++ b/model/shared/src/main/scala/explore/model/SpectroscopyConfigurationOptions.scala
@@ -4,14 +4,15 @@
 package explore.model
 
 import cats.Eq
-import eu.timepit.refined.types.numeric.PosBigDecimal
-import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.cats._
 import explore.model.enum.FocalPlaneOptions
 import explore.model.enum.SpectroscopyCapabilities
 import lucuma.core.math.Angle
 import lucuma.core.math.Wavelength
 import monocle.macros.Lenses
+
+import eu.timepit.refined.types.numeric.PosBigDecimal
+import eu.timepit.refined.types.numeric.PosInt
 
 @Lenses
 final case class SpectroscopyConfigurationOptions(
@@ -20,21 +21,13 @@ final case class SpectroscopyConfigurationOptions(
   signalToNoise:   Option[PosBigDecimal],
   signalToNoiseAt: Option[Wavelength],
   wavelengthRange: Option[Wavelength],
-  slitMode:        FocalPlaneOptions,
+  focalPlane:      Option[FocalPlaneOptions],
   focalPlaneAngle: Option[Angle],
   capabilities:    Option[SpectroscopyCapabilities]
 )
 
 object SpectroscopyConfigurationOptions {
-  val Default = SpectroscopyConfigurationOptions(None,
-                                                 None,
-                                                 None,
-                                                 None,
-                                                 None,
-                                                 FocalPlaneOptions.SingleSlit,
-                                                 None,
-                                                 None
-  )
+  val Default = SpectroscopyConfigurationOptions(None, None, None, None, None, None, None, None)
 
   implicit val eqSpectroscopyConfigurationOptions: Eq[SpectroscopyConfigurationOptions] = Eq.by(x =>
     (x.wavelength,
@@ -42,7 +35,7 @@ object SpectroscopyConfigurationOptions {
      x.signalToNoise,
      x.signalToNoiseAt,
      x.wavelengthRange,
-     x.slitMode,
+     x.focalPlane,
      x.focalPlaneAngle,
      x.capabilities
     )


### PR DESCRIPTION
This adds some fixes suggested by users to the spectroscopy panel:

* Add help icons
* Make the wavelength field for the slit wider
* Make the focal plane selector optional
* Make the target tile minimizable
* Some minor UI touches