### PR TITLE
Unfocus when navigating to deleted element.

### DIFF
--- a/common/src/main/scala/explore/utils/ReactTableHelpers.scala
+++ b/common/src/main/scala/explore/utils/ReactTableHelpers.scala
@@ -18,7 +18,6 @@ import monocle.Lens
 import react.common.style.Css
 import react.semanticui.elements.button.Button
 import reactST.reactTable.mod.{ ^ => _, _ }
-
 import scalajs.js
 
 object ReactTableHelpers {

--- a/explore/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ConstraintSetObsList.scala
@@ -487,6 +487,18 @@ object ConstraintSetObsList {
         val constraintSetsWithObs = $.props.constraintSetsWithObs.get
         val expandedIds           = $.props.expandedIds
 
+        // Unfocus if focused element is not in list.
+        val unfocus =
+          $.props.focused.get.map { focused =>
+            $.props.focused
+              .set(none)
+              .whenA(focused match {
+                case FocusedConstraintSet(csid) =>
+                  !constraintSetsWithObs.constraintSets.contains(csid)
+                case _                          => true // If focused on something else, unfocus too.
+              })
+          }.orEmpty
+
         // expand constraint set with focused observation
         val expandConstraintSets = $.props.focused.get
           .collect { case FocusedObs(obsId) =>
@@ -503,7 +515,7 @@ object ConstraintSetObsList {
             .map(missingIds => expandedIds.mod(_ -- missingIds.toSortedSet))
             .orEmpty
 
-        (expandConstraintSets >> removeConstraintSets).runAsyncCB
+        (unfocus >> expandConstraintSets >> removeConstraintSets).runAsyncCB
       }
       .configure(Reusability.shouldComponentUpdate)
       .build


### PR DESCRIPTION
I'm not entirely sure if this logic goes in the tree. It seems like the best place given the circumstances: namely, all the information is there at the right time (after the tree data is retrieved).

Otherwise, we have to create an intermediate wrapper for each view.