### PR TITLE
Switch target form to have labels next to controls and a few small fixes

### DIFF
--- a/common/src/main/scala/explore/components/FormStaticData.scala
+++ b/common/src/main/scala/explore/components/FormStaticData.scala
@@ -18,7 +18,6 @@ final case class FormStaticData(
   id:        String,
   value:     TagMod,
   label:     String,
-  hideLabel: Boolean = false,
   modifiers: Seq[TagMod] = Seq.empty
 ) extends ReactProps[FormStaticData](FormStaticData.component) {
   def apply(mods: TagMod*): FormStaticData = copy(modifiers = modifiers ++ mods)
@@ -33,7 +32,6 @@ object FormStaticData {
       .render_P { props =>
         <.div(
           props.modifiers.toTagMod,
-          (ExploreStyles.HideLabel).when(props.hideLabel),
           ^.cls := "field",
           <.label(props.label, ^.htmlFor := props.id),
           <.div(^.cls := "ui input",

--- a/common/src/main/scala/explore/components/HelpIcon.scala
+++ b/common/src/main/scala/explore/components/HelpIcon.scala
@@ -17,31 +17,29 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import react.common._
 
-final case class HelpIcon(id: Help.Id) extends ReactProps[HelpIcon](HelpIcon.component)
+final case class HelpIcon(id: Help.Id)
 
 object HelpIcon {
   type Props = HelpIcon
 
   type HelpId = NonEmptyFiniteString[20]
 
-  val component = ScalaComponent
-    .builder[Props]
-    .stateless
-    .render_P { p =>
-      HelpCtx.usingView { help =>
-        AppCtx.using { implicit ctx =>
-          val helpMsg = help.zoom(HelpContext.displayedHelp)
-          <.span(
-            ^.onClick ==> { (e: ReactMouseEvent) =>
-              e.stopPropagationCB *> e.preventDefaultCB *> helpMsg.set(p.id.some).runAsyncCB
-            },
-            Icons.Info
-              .link(true)
-              .inverted(true)
-              .clazz(ExploreStyles.HelpIcon)
-          )
-        }
+  implicit def render(props: HelpIcon): VdomElement = component(props).vdomElement
+
+  val component = ScalaFnComponent[Props] { p =>
+    HelpCtx.usingView { help =>
+      AppCtx.using { implicit ctx =>
+        val helpMsg = help.zoom(HelpContext.displayedHelp)
+        <.span(
+          ^.onClick ==> { (e: ReactMouseEvent) =>
+            e.stopPropagationCB *> e.preventDefaultCB *> helpMsg.set(p.id.some).runAsyncCB
+          },
+          Icons.Info
+            .link(true)
+            .inverted(true)
+            .clazz(ExploreStyles.HelpIcon)
+        )
       }
     }
-    .build
+  }
 }

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -43,9 +43,6 @@ object ExploreStyles {
   def Grow(i:       Int Refined Interval.Closed[1, 4]): Css  = Css(s"explore-grow-$i")
   def ColumnSpan(i: Int Refined Interval.Closed[1, 16]): Css = Css(s"explore-column-span-$i")
 
-  // Hide a label while keeping it accessible to screen readers
-  val HideLabel: Css = Css("hide-label")
-
   // Change styles for a readonly input
   val StaticData: Css = Css("static-data")
 
@@ -167,13 +164,14 @@ object ExploreStyles {
   val EditWarning: Css = Css("edit-warning")
 
   // The Target tab contents
-  val TargetGrid: Css           = Css("target-grid")
-  val TargetAladinCell: Css     = Css("target-aladin-cell")
-  val TargetSkyplotCell: Css    = Css("target-skyplot-cell")
-  val TargetRaDecMinWidth: Css  = Css("target-ra-dec-min-width")
-  val SearchForm: Css           = Css("target-search-form")
-  val TargetPropertiesForm: Css = Css("target-properties-form")
-  val CatalogueForm: Css        = Css("catalogue-form")
+  val TargetGrid: Css          = Css("target-grid")
+  val TargetAladinCell: Css    = Css("target-aladin-cell")
+  val TargetSkyplotCell: Css   = Css("target-skyplot-cell")
+  val TargetRaDecMinWidth: Css = Css("target-ra-dec-min-width")
+  val TargetForm: Css          = Css("target-form")
+  val SearchForm: Css          = Css("target-search-form")
+  val TargetRVControls: Css    = Css("target-rv-controls")
+  val CatalogueForm: Css       = Css("catalogue-form")
 
   // The Constraints tab contents
   val ConstraintsGrid                = Css("constraints-grid")
@@ -232,8 +230,8 @@ object ExploreStyles {
   val StepTableHeader: Css = Css("step-table-header")
   val StepGuided: Css      = Css("step-guided")
 
-  val ConfigurationForm: Css         = Css("explore-configuration-form")
-  val ConfigurationGrid: Css         = Css("explore-configuration-grid")
+  val ExploreForm: Css               = Css("explore-form")
+  val ExploreFormGrid: Css           = Css("explore-form-grid")
   val ConfigurationCapabilities: Css = Css("explore-configuration-capabilities")
   val SkipToNext: Css                = Css("explore-skip-to-next")
   val SignalToNoiseAt: Css           = Css("explore-configuration-signal-to-noise-at")

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -822,7 +822,6 @@ tfoot {
 .target-form {
   grid-template-columns: [label] minmax(100px, 1fr) [field] 6fr;
   justify-items: stretch;
-
 }
 
 .target-search-form {

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -819,6 +819,23 @@ tfoot {
 @target-grid-responsive-cutoff: 992px;
 @mobile-responsive-cutoff: 670;
 
+.target-form {
+  grid-template-columns: [label] minmax(100px, 1fr) [field] 6fr;
+  justify-items: stretch;
+
+}
+
+.target-search-form {
+  grid-column: 1 / span 2;
+  display: grid;
+  grid-template-columns: [label] minmax(100px, 1fr) [field] 6fr;
+  grid-gap: 0.3em;
+
+  .field {
+    margin-bottom: 0 !important;
+  }
+}
+
 .target-grid {
   display: grid;
   grid-gap: 1em;
@@ -857,20 +874,19 @@ tfoot {
   }
 }
 
-.target-properties-form {
-  grid-template-columns: [field] 6fr [units] auto;
-  align-self: start;
-  justify-items: stretch;
+.target-rv-controls {
+  justify-self: stretch;
 }
 
 .catalogue-form {
   height: max-content; // keep it from expanding to fill cell
 }
 
-// for the ra and dec inputs and the flex container
-// that holds them
+// for the ra and dec inputs expand
 .target-ra-dec-min-width {
-  min-width: 3em;
+  .ui.input {
+    width: 100%;
+  }
 }
 
 .error-label-mixin() {
@@ -897,8 +913,6 @@ tfoot {
 .explore-units-label {
   margin-left: 0.25em;
   margin-bottom: 0.2em;
-  justify-self: end;
-  align-self: end;
 }
 
 .proposal-details-grid {
@@ -1405,13 +1419,13 @@ html {
   color: lightgreen;
 }
 
-.explore-configuration-grid {
+.explore-form-grid {
   padding: 0.5em;
   display: grid;
   grid-template-columns: 380px 1fr;
 }
 
-.explore-configuration-form {
+.explore-form {
   display: grid;
   justify-items: start;
   align-items: baseline;

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -98,11 +98,11 @@ object ConfigurationPanel {
       ReactFragment(
         props.renderInTitle(<.span(ExploreStyles.TitleStrip)(UndoButtons(state, undoCtx))),
         <.div(
-          ExploreStyles.ConfigurationGrid,
+          ExploreStyles.ExploreFormGrid,
           Form(size = Small)(
             ExploreStyles.Grid,
             ExploreStyles.Compact,
-            ExploreStyles.ConfigurationForm,
+            ExploreStyles.ExploreForm,
             <.label("Mode", HelpIcon("configuration/mode.md")),
             EnumViewSelect(id = "configuration-mode", value = mode),
             SpectroscopyConfigurationPanel(spectroscopy).when(isSpectroscopy),

--- a/explore/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/explore/src/main/scala/explore/targeteditor/RVInput.scala
@@ -99,48 +99,50 @@ object RVInput {
           case RVView.Z  =>
             FormInputEV(
               id = state.rvView.tag,
-              label = state.rvView.tag.value,
               value = props.value.zoom(rvToRedshiftGet)(rvToRedshiftMod),
               errorClazz = ExploreStyles.InputErrorTooltip,
               errorPointing = LabelPointing.Below,
               validFormat = ValidFormatInput.fromFormatOptional(formatZ, "Must be a number"),
               changeAuditor = ChangeAuditor.fromFormat(formatZ).decimal(9).optional,
-              clazz = ExploreStyles.Grow(1) |+| ExploreStyles.HideLabel,
+              clazz = ExploreStyles.Grow(1),
               disabled = props.disabled
             )
           case RVView.CZ =>
             FormInputEV(
               id = state.rvView.tag,
-              label = state.rvView.tag.value,
               value = props.value.zoom(rvToARVGet)(rvToARVMod),
               errorClazz = ExploreStyles.InputErrorTooltip,
               errorPointing = LabelPointing.Below,
               validFormat = ValidFormatInput.fromFormatOptional(formatCZ, "Must be a number"),
               changeAuditor = ChangeAuditor.fromFormat(formatCZ).decimal(10).optional,
-              clazz = ExploreStyles.Grow(1) |+| ExploreStyles.HideLabel,
+              clazz = ExploreStyles.Grow(1),
               disabled = props.disabled
             )
           case RVView.RV =>
             FormInputEV(
               id = state.rvView.tag,
-              label = state.rvView.tag.value,
               value = props.value,
               errorClazz = ExploreStyles.InputErrorTooltip,
               errorPointing = LabelPointing.Below,
               validFormat = ValidFormatInput.fromFormatOptional(formatRV, "Must be a number"),
               changeAuditor = ChangeAuditor.fromFormat(formatRV).decimal(3).optional,
-              clazz = ExploreStyles.Grow(1) |+| ExploreStyles.HideLabel,
+              clazz = ExploreStyles.Grow(1),
               disabled = props.disabled
             )
         }
+        val label  = state.rvView match {
+          case RVView.Z  =>
+            state.rvView.tag.value
+          case RVView.CZ =>
+            state.rvView.tag.value
+          case RVView.RV =>
+            state.rvView.tag.value
+        }
         React.Fragment(
+          <.label(label, ExploreStyles.SkipToNext),
           <.div(
-            ExploreStyles.FlexContainer |+| ExploreStyles.Grow(1),
-            EnumViewSelect[IO, RVView](id = "view",
-                                       value = rvView,
-                                       label = state.rvView.tag.value,
-                                       disabled = props.disabled
-            ),
+            ExploreStyles.FlexContainer |+| ExploreStyles.TargetRVControls,
+            EnumViewSelect[IO, RVView](id = "view", value = rvView, disabled = props.disabled),
             input
           ),
           state.units

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -28,7 +28,6 @@ import monocle.macros.Lenses
 import react.common._
 import react.semanticui.collections.form.Form.FormProps
 import react.semanticui.collections.form._
-import react.semanticui.elements.label.Label
 import react.semanticui.elements.label.LabelPointing
 import react.semanticui.sizes._
 
@@ -111,15 +110,12 @@ object SearchForm {
 
       val disabled   = props.searching.get.exists(_ === props.id)
 
-      Form(size = Small, onSubmitE = submitForm)(
-        ExploreStyles.Grid,
-        ExploreStyles.Compact,
-        ExploreStyles.SearchForm,
+      Form(size = Small, clazz = ExploreStyles.SearchForm, onSubmitE = submitForm)(
+        <.label("Name", HelpIcon("target/main/search-target.md"), ExploreStyles.SkipToNext),
         FormInputEV(
           id = "search",
           value = ViewF.fromState[IO]($).zoom(State.searchTerm),
           validFormat = ValidFormatInput.nonEmptyValidFormat,
-          label = Label("Name", HelpIcon("target/main/search-target.md")),
           error = state.searchError.orUndefined,
           loading = disabled,
           disabled = disabled,

--- a/explore/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -43,9 +43,7 @@ import lucuma.ui.optics.TruncatedRA
 import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.reusability._
 import react.common._
-import react.common.implicits._
 import react.semanticui.collections.form.Form
-import react.semanticui.elements.label.Label
 import react.semanticui.elements.label.LabelPointing
 import react.semanticui.sizes.Small
 
@@ -169,9 +167,10 @@ object TargetBody {
         React.Fragment(
           <.div(
             ExploreStyles.TargetGrid,
-            Form(as = <.div, size = Small)(
+            <.div(
               ExploreStyles.Grid,
               ExploreStyles.Compact,
+              ExploreStyles.TargetForm,
               // Keep the search field and the coords always together
               SearchForm(
                 props.id,
@@ -182,31 +181,27 @@ object TargetBody {
                 props.searching,
                 Reuse.currying(allView, nameView).in(searchAndSet _)
               ),
-              <.div(
-                ExploreStyles.FlexContainer,
-                ExploreStyles.TargetRaDecMinWidth,
-                FormInputEV(
-                  id = "ra",
-                  value = coordsRAView.zoomSplitEpi(TruncatedRA.rightAscension),
-                  validFormat = ValidFormatInput.truncatedRA,
-                  changeAuditor = ChangeAuditor.truncatedRA,
-                  label = Label("RA", HelpIcon("target/main/coordinates.md")),
-                  clazz = ExploreStyles.FlexGrow(1) |+| ExploreStyles.TargetRaDecMinWidth,
-                  errorPointing = LabelPointing.Below,
-                  errorClazz = ExploreStyles.InputErrorTooltip,
-                  disabled = disabled
-                ),
-                FormInputEV(
-                  id = "dec",
-                  value = coordsDecView.zoomSplitEpi(TruncatedDec.declination),
-                  validFormat = ValidFormatInput.truncatedDec,
-                  changeAuditor = ChangeAuditor.truncatedDec,
-                  label = Label("Dec", HelpIcon("target/main/coordinates.md")),
-                  clazz = ExploreStyles.FlexGrow(1) |+| ExploreStyles.TargetRaDecMinWidth,
-                  errorPointing = LabelPointing.Below,
-                  errorClazz = ExploreStyles.InputErrorTooltip,
-                  disabled = disabled
-                )
+              <.label("RA", HelpIcon("target/main/coordinates.md"), ExploreStyles.SkipToNext),
+              FormInputEV(
+                id = "ra",
+                value = coordsRAView.zoomSplitEpi(TruncatedRA.rightAscension),
+                validFormat = ValidFormatInput.truncatedRA,
+                changeAuditor = ChangeAuditor.truncatedRA,
+                clazz = ExploreStyles.TargetRaDecMinWidth,
+                errorPointing = LabelPointing.Below,
+                errorClazz = ExploreStyles.InputErrorTooltip,
+                disabled = disabled
+              ),
+              <.label("Dec", HelpIcon("target/main/coordinates.md"), ExploreStyles.SkipToNext),
+              FormInputEV(
+                id = "dec",
+                value = coordsDecView.zoomSplitEpi(TruncatedDec.declination),
+                validFormat = ValidFormatInput.truncatedDec,
+                changeAuditor = ChangeAuditor.truncatedDec,
+                clazz = ExploreStyles.TargetRaDecMinWidth,
+                errorPointing = LabelPointing.Below,
+                errorClazz = ExploreStyles.InputErrorTooltip,
+                disabled = disabled
               )
             ),
             AladinCell(
@@ -216,43 +211,43 @@ object TargetBody {
               props.options
             ),
             CataloguesForm(props.options).when(false),
-            Form(as = <.div, size = Small)(
+            Form(as = <.div, clazz = ExploreStyles.ExploreFormGrid, size = Small)(
               ExploreStyles.Grid,
               ExploreStyles.Compact,
-              ExploreStyles.TargetPropertiesForm,
+              ExploreStyles.ExploreForm,
+              <.label("Epoch", HelpIcon("target/main/epoch.md"), ExploreStyles.SkipToNext),
               InputWithUnits(
                 epochView,
                 ValidFormatInput.fromFormat(Epoch.fromStringNoScheme, "Invalid Epoch"),
                 ChangeAuditor.maxLength(8).decimal(3).deny("-").as[Epoch],
                 id = "epoch",
-                label = Label("Epoch", HelpIcon("target/main/epoch.md")),
                 units = "years",
                 disabled = disabled
               ),
+              <.label("µ RA", ExploreStyles.SkipToNext),
               InputWithUnits(
                 properMotionRAView,
                 ValidFormatInput.fromFormatOptional(pmRAFormat, "Must be a number"),
                 ChangeAuditor.fromFormat(pmRAFormat).decimal(3).optional,
                 id = "raPM",
-                label = "µ RA",
                 units = "mas/y",
                 disabled = disabled
               ),
+              <.label("µ Dec", ExploreStyles.SkipToNext),
               InputWithUnits(
                 properMotionDecView,
                 ValidFormatInput.fromFormatOptional(pmDecFormat, "Must be a number"),
                 ChangeAuditor.fromFormat(pmDecFormat).decimal(3).optional,
                 id = "raDec",
-                label = "µ Dec",
                 units = "mas/y",
                 disabled = disabled
               ),
+              <.label("Parallax", ExploreStyles.SkipToNext),
               InputWithUnits(
                 parallaxView,
                 ValidFormatInput.fromFormatOptional(pxFormat, "Must be a number"),
                 ChangeAuditor.fromFormat(pxFormat).decimal(3).optional,
                 id = "parallax",
-                label = "Parallax",
                 units = "mas",
                 disabled = disabled
               ),


### PR DESCRIPTION
This PR converts the target forms to have the labels next to the field

![image](https://user-images.githubusercontent.com/3615303/120856135-5e4a1880-c54d-11eb-9822-7aa5d43c3976.png)
