### PR TITLE
Rename Display to Visible

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -11,7 +11,7 @@ import explore.View
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.TargetVisualOptions
-import explore.model.enum.Display
+import explore.model.enum.Visible
 import explore.model.reusability._
 import japgolly.scalajs.react.MonocleReact._
 import japgolly.scalajs.react._
@@ -97,7 +97,7 @@ object AladinContainer {
         )
         .toCallback
 
-    def toggleVisibility(g: Element, selector: String, option: Display): Unit =
+    def toggleVisibility(g: Element, selector: String, option: Visible): Unit =
       g.querySelectorAll(selector).foreach {
         case e: Element =>
           option.fold(

--- a/explore/src/main/scala/explore/targeteditor/CataloguesForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/CataloguesForm.scala
@@ -10,7 +10,7 @@ import explore.View
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.TargetVisualOptions
-import explore.model.enum.Display
+import explore.model.enum.Visible
 import explore.model.reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -48,10 +48,10 @@ object CataloguesForm {
 
   val angleItems = angleItemsMap.values
 
-  val fovL     = TargetVisualOptions.fov ^<-> Display.boolReverseIso
-  val guidingL = TargetVisualOptions.guiding ^<-> Display.boolReverseIso
-  val probeL   = TargetVisualOptions.probe ^<-> Display.boolReverseIso
-  val offsetsL = TargetVisualOptions.offsets ^<-> Display.boolReverseIso
+  val fovL     = TargetVisualOptions.fov ^<-> Visible.boolReverseIso
+  val guidingL = TargetVisualOptions.guiding ^<-> Visible.boolReverseIso
+  val probeL   = TargetVisualOptions.probe ^<-> Visible.boolReverseIso
+  val offsetsL = TargetVisualOptions.offsets ^<-> Visible.boolReverseIso
 
   val component =
     ScalaComponent

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetVisualOptions.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetVisualOptions.scala
@@ -4,7 +4,7 @@
 package explore.model.arb
 
 import explore.model.TargetVisualOptions
-import explore.model.enum.Display
+import explore.model.enum.Visible
 import lucuma.core.util.arb.ArbEnumerated._
 import lucuma.core.math.Angle
 import lucuma.core.math.arb.ArbAngle._
@@ -17,17 +17,17 @@ trait ArbTargetVisualOptions {
 
   implicit val targetVisualOptionsArb = Arbitrary[TargetVisualOptions] {
     for {
-      f  <- arbitrary[Display]
+      f  <- arbitrary[Visible]
       fa <- arbitrary[Angle]
-      o  <- arbitrary[Display]
-      g  <- arbitrary[Display]
-      p  <- arbitrary[Display]
+      o  <- arbitrary[Visible]
+      g  <- arbitrary[Visible]
+      p  <- arbitrary[Visible]
       a  <- arbitrary[Angle]
     } yield TargetVisualOptions(f, fa, o, g, p, a)
   }
 
   implicit val targetVisualOptionsCogen: Cogen[TargetVisualOptions] =
-    Cogen[(Display, Display, Display, Display, Angle)].contramap(c =>
+    Cogen[(Visible, Visible, Visible, Visible, Angle)].contramap(c =>
       (c.fov, c.offsets, c.guiding, c.probe, c.posAngle)
     )
 }

--- a/model/shared/src/main/scala/explore/model/TargetVisualOptions.scala
+++ b/model/shared/src/main/scala/explore/model/TargetVisualOptions.scala
@@ -4,28 +4,28 @@
 package explore.model
 
 import cats._
-import explore.model.enum.Display
+import explore.model.enum.Visible
 import lucuma.core.math.Angle
 import lucuma.core.math.syntax.int._
 import monocle.macros.Lenses
 
 @Lenses
 final case class TargetVisualOptions(
-  fov:      Display,
+  fov:      Visible,
   fovAngle: Angle,
-  offsets:  Display,
-  guiding:  Display,
-  probe:    Display,
+  offsets:  Visible,
+  guiding:  Visible,
+  probe:    Visible,
   posAngle: Angle // This belongs to the observation model
 )
 
 object TargetVisualOptions {
   val Default =
-    TargetVisualOptions(Display.Hidden,
+    TargetVisualOptions(Visible.Hidden,
                         Constants.InitialFov,
-                        Display.Hidden,
-                        Display.Hidden,
-                        Display.Hidden,
+                        Visible.Hidden,
+                        Visible.Hidden,
+                        Visible.Hidden,
                         145.deg
     )
 

--- a/model/shared/src/main/scala/explore/model/enum/Visible.scala
+++ b/model/shared/src/main/scala/explore/model/enum/Visible.scala
@@ -10,32 +10,32 @@ import monocle.Iso
 /**
  * Enum to indicate visibility of an item, roughly equivalent to css display
  */
-sealed trait Display extends Product with Serializable {
+sealed trait Visible extends Product with Serializable {
   def fold[A](hidden: => A, inline: => A): A =
     this match {
-      case Display.Hidden => hidden
-      case Display.Inline => inline
+      case Visible.Hidden => hidden
+      case Visible.Inline => inline
     }
 
   def visible: Boolean = fold(false, true)
 }
 
-object Display {
-  case object Hidden extends Display
-  case object Inline extends Display
+object Visible {
+  case object Hidden extends Visible
+  case object Inline extends Visible
 
-  val boolIso: Iso[Boolean, Display] = Iso[Boolean, Display] { b =>
+  val boolIso: Iso[Boolean, Visible] = Iso[Boolean, Visible] { b =>
     if (b) Inline else Hidden
   } {
     case Hidden => false
     case Inline => true
   }
 
-  val boolReverseIso: Iso[Display, Boolean] = boolIso.reverse
+  val boolReverseIso: Iso[Visible, Boolean] = boolIso.reverse
 
   val all = NonEmptyList.of(Hidden, Inline)
 
   /** @group Typeclass Instances */
-  implicit val DisplayEnumerated: Enumerated[Display] =
+  implicit val DisplayEnumerated: Enumerated[Visible] =
     Enumerated.of(all.head, all.tail: _*)
 }


### PR DESCRIPTION
We already have an enum `Display` in lucuma core, we should rather rename this one