### PR TITLE
Actions in ObsList

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -654,7 +654,7 @@ tfoot {
   margin: 0 0;
   background-color: var(--obs-badge-background);
   border: solid 1px var(--site-border-color);
-  font-size: inherit;
+  font-size: smaller;
 }
 
 .card.obs-badge:last-child {

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -39,7 +39,7 @@ final case class ObsBadge(
   selected:          Boolean = false,
   setStatusCB:       Option[ObsStatus ==> SyncIO[Unit]] = None,
   setActiveStatusCB: Option[ObsActiveStatus ==> SyncIO[Unit]] = None,
-  deleteCB:          Option[Observation.Id ==> SyncIO[Unit]] = None
+  deleteCB:          Option[Reuse[SyncIO[Unit]]] = None
 ) extends ReactProps[ObsBadge](ObsBadge.component)
 
 object ObsBadge {
@@ -77,9 +77,9 @@ object ObsBadge {
             clazz = ExploreStyles.DeleteButton |+| ExploreStyles.ObsDeleteButton,
             icon = true,
             onClickE = (e: ReactMouseEvent, _: Button.ButtonProps) =>
-              e.preventDefaultCB *> e.stopPropagationCB *> props.deleteCB
-                .map(cb => cb.value(props.obs.id).toCB)
-                .getOrEmpty
+              e.preventDefaultCB *>
+                e.stopPropagationCB *>
+                props.deleteCB.map(_.value: Callback).getOrEmpty
           )(
             Icons.Trash
           )

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -4,7 +4,7 @@
 package explore.observationtree
 
 import cats.Applicative
-import cats.ApplicativeError
+import cats.effect.Async
 import cats.effect.IO
 import cats.effect.SyncIO
 import cats.syntax.all._
@@ -27,7 +27,6 @@ import explore.model.ObsSummaryWithPointingAndConstraints
 import explore.model.enum.AppTab
 import explore.model.reusability._
 import explore.observationtree.ObsBadge
-import explore.optics.GetAdjust
 import explore.schemas.ObservationDB
 import explore.schemas.ObservationDB.Types._
 import explore.undo.Action
@@ -69,34 +68,15 @@ object ObsList {
       ObsSummaryWithPointingAndConstraints.id
     )
 
-  protected class Backend($ : BackendScope[Props, Unit]) {
-    def createObservation[F[_]](obsId: Observation.Id)(implicit
-      F:                               ApplicativeError[F, Throwable],
-      c:                               TransactionalClient[F, ObservationDB]
-    ): F[Unit] =
-      ProgramCreateObservation
-        .execute[F](
-          CreateObservationInput(programId = "p-2", observationId = obsId.assign)
-        )
-        .void
+  object Actions {
 
-    def deleteObservation[F[_]: Applicative](id: Observation.Id)(implicit
-      c:                                         TransactionalClient[F, ObservationDB]
-    ): F[Unit] =
-      ProgramDeleteObservation.execute[F](id).void
-
-    def undeleteObservation[F[_]: Applicative](id: Observation.Id)(implicit
-      c:                                           TransactionalClient[F, ObservationDB]
-    ): F[Unit] =
-      ProgramUndeleteObservation.execute[F](id).void
-
-    protected def obsWithId(obsId: Observation.Id) =
+    private def obsWithId(obsId: Observation.Id) =
       obsListMod.withKey(obsId).composeOptionLens(first)
 
-    protected def obsStatus[F[_]: Applicative](obsId: Observation.Id)(implicit
-      c:                                              TransactionalClient[F, ObservationDB]
+    def obsStatus[F[_]: Applicative](obsId: Observation.Id)(implicit
+      c:                                    TransactionalClient[F, ObservationDB]
     ) = Action[F](
-      obsWithId(obsId).composeOptionLens(ObsSummaryWithPointingAndConstraints.status)
+      access = obsWithId(obsId).composeOptionLens(ObsSummaryWithPointingAndConstraints.status)
     )((_, status) =>
       UpdateObservationMutation
         .execute[F](
@@ -105,10 +85,10 @@ object ObsList {
         .void
     )
 
-    protected def obsActiveStatus[F[_]: Applicative](obsId: Observation.Id)(implicit
-      c:                                                    TransactionalClient[F, ObservationDB]
+    def obsActiveStatus[F[_]: Applicative](obsId: Observation.Id)(implicit
+      c:                                          TransactionalClient[F, ObservationDB]
     ) = Action[F](
-      obsWithId(obsId).composeOptionLens(ObsSummaryWithPointingAndConstraints.activeStatus)
+      access = obsWithId(obsId).composeOptionLens(ObsSummaryWithPointingAndConstraints.activeStatus)
     )((_, activeStatus) =>
       UpdateObservationMutation
         .execute[F](
@@ -117,40 +97,41 @@ object ObsList {
         .void
     )
 
-    private def obsMod(
-      undoCtx: UndoCtx[ObservationList],
+    def obsExistence[F[_]: Async](obsId: Observation.Id, focused: View[Option[Focused]])(implicit
+      c:                                 TransactionalClient[F, ObservationDB]
+    ) =
+      Action[F](
+        access = obsListMod.withKey(obsId)
+      )(
+        onSet = (_, elemWithIndexOpt) =>
+          elemWithIndexOpt.fold {
+            ProgramDeleteObservation.execute[F](obsId).void
+          } { case (obs, _) =>
+            ProgramCreateObservation
+              .execute[F](CreateObservationInput(programId = "p-2", observationId = obs.id.assign))
+              .void >>
+              focused.set(Focused.FocusedObs(obs.id).some).to[F]
+          },
+        onRestore = (_, elemWithIndexOpt) =>
+          elemWithIndexOpt.fold {
+            ProgramDeleteObservation.execute[F](obsId).void
+          } { case (obs, _) =>
+            ProgramUndeleteObservation.execute[F](obs.id).void >>
+              focused.set(Focused.FocusedObs(obs.id).some).to[F]
+          }
+      )
+  }
+
+  protected class Backend {
+    protected def insertObs(
+      pos:     Int,
       focused: View[Option[Focused]],
-      obsId:   Observation.Id
+      undoCtx: UndoCtx[ObservationList]
     )(implicit
       c:       TransactionalClient[IO, ObservationDB]
-    ): obsListMod.Operation => SyncIO[Unit] = {
-      val obsWithId: GetAdjust[ObservationList, obsListMod.ElemWithIndexOpt] =
-        obsListMod.withKey(obsId)
-
-      undoCtx
-        .mod[obsListMod.ElemWithIndexOpt](
-          obsWithId.getter.get,
-          obsWithId.adjuster.set,
-          onSet = (_: obsListMod.ElemWithIndexOpt).fold {
-            deleteObservation[IO](obsId)
-          } { case (obs, _) =>
-            createObservation[IO](obs.id) >>
-              focused.set(Focused.FocusedObs(obs.id).some).to[IO]
-          },
-          onRestore = (_: obsListMod.ElemWithIndexOpt).fold {
-            deleteObservation[IO](obsId)
-          } { case (obs, _) =>
-            undeleteObservation[IO](obs.id) >>
-              focused.set(Focused.FocusedObs(obs.id).some).to[IO]
-          }
-        )
-    }
-
-    protected def newObs(undoCtx: UndoCtx[ObservationList])(implicit
-      c:                          TransactionalClient[IO, ObservationDB]
-    ): IO[Unit] = {
+    ): SyncIO[Unit] = {
       // Temporary measure until we have id pools.
-      val newObs = IO(Random.nextInt(0xfff)).map(int =>
+      val newObs = SyncIO(Random.nextInt(0xfff)).map(int =>
         ObsSummaryWithPointingAndConstraints(
           Observation.Id(PosLong.unsafeFrom(int.abs.toLong + 1)),
           pointing = none,
@@ -161,11 +142,10 @@ object ObsList {
         )
       )
 
-      $.propsIn[IO] >>= { props =>
-        newObs >>= { obs =>
-          val mod = obsMod(undoCtx, props.focused, obs.id)
-          mod(obsListMod.upsert(obs, props.observations.get.length)).to[IO]
-        }
+      newObs.flatMap { obs =>
+        Actions
+          .obsExistence[IO](obs.id, focused)
+          .mod(undoCtx)(obsListMod.upsert(obs, pos))
       }
     }
 
@@ -174,18 +154,13 @@ object ObsList {
         val undoCtx      = UndoContext(props.undoStacks, props.observations)
         val observations = props.observations.get.toList
 
-        def deleteObs(obsId: Observation.Id): SyncIO[Unit] = {
-          val mod = obsMod(undoCtx, props.focused, obsId)
-          mod(obsListMod.delete)
-        }
-
         <.div(ExploreStyles.ObsTreeWrapper)(
           <.div(ExploreStyles.TreeToolbar)(
             Button(size = Mini,
                    compact = true,
                    icon = Icons.New,
                    content = "Obs",
-                   onClick = newObs(undoCtx).runAsyncCB
+                   onClick = insertObs(observations.length, props.focused, undoCtx)
             ),
             UndoButtons(undoCtx, size = Mini)
           ),
@@ -210,11 +185,17 @@ object ObsList {
                   ObsBadge(
                     obs,
                     selected = selected,
-                    setStatusCB = (obsStatus[IO](obs.id)
+                    setStatusCB = (Actions
+                      .obsStatus[IO](obs.id)
                       .set(undoCtx) _).compose((_: ObsStatus).some).reuseAlways.some,
-                    setActiveStatusCB = (obsActiveStatus[IO](obs.id)
+                    setActiveStatusCB = (Actions
+                      .obsActiveStatus[IO](obs.id)
                       .set(undoCtx) _).compose((_: ObsActiveStatus).some).reuseAlways.some,
-                    deleteCB = (deleteObs _).reuseAlways.some
+                    deleteCB = Actions
+                      .obsExistence[IO](obs.id, props.focused)
+                      .mod(undoCtx)(obsListMod.delete)
+                      .reuseAlways
+                      .some
                   )
                 )
               }

--- a/explore/src/main/scala/explore/observationtree/ObsListActions.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsListActions.scala
@@ -1,0 +1,81 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.observationtree
+
+import cats.Applicative
+import cats.effect.Async
+import cats.syntax.all._
+import clue.TransactionalClient
+import clue.data.syntax._
+import crystal.react.implicits._
+import explore.common.ObsQueriesGQL._
+import explore.implicits._
+import explore.model.Focused
+import explore.model.ObsSummaryWithPointingAndConstraints
+import explore.schemas.ObservationDB
+import explore.schemas.ObservationDB.Types._
+import explore.undo.Action
+import explore.undo.KIListMod
+import lucuma.core.model.Observation
+import monocle.function.Field1.first
+
+object ObsListActions {
+  protected val obsListMod =
+    KIListMod[ObsSummaryWithPointingAndConstraints, Observation.Id](
+      ObsSummaryWithPointingAndConstraints.id
+    )
+
+  private def obsWithId(obsId: Observation.Id) =
+    obsListMod.withKey(obsId).composeOptionLens(first)
+
+  def obsStatus[F[_]: Applicative](obsId: Observation.Id)(implicit
+    c:                                    TransactionalClient[F, ObservationDB]
+  ) = Action[F](
+    access = obsWithId(obsId).composeOptionLens(ObsSummaryWithPointingAndConstraints.status)
+  )(onSet =
+    (_, status) =>
+      UpdateObservationMutation
+        .execute[F](
+          EditObservationInput(observationId = obsId, status = status.orIgnore)
+        )
+        .void
+  )
+
+  def obsActiveStatus[F[_]: Applicative](obsId: Observation.Id)(implicit
+    c:                                          TransactionalClient[F, ObservationDB]
+  ) = Action[F](
+    access = obsWithId(obsId).composeOptionLens(ObsSummaryWithPointingAndConstraints.activeStatus)
+  )(onSet =
+    (_, activeStatus) =>
+      UpdateObservationMutation
+        .execute[F](
+          EditObservationInput(observationId = obsId, activeStatus = activeStatus.orIgnore)
+        )
+        .void
+  )
+
+  def obsExistence[F[_]: Async](obsId: Observation.Id, focused: View[Option[Focused]])(implicit
+    c:                                 TransactionalClient[F, ObservationDB]
+  ) =
+    Action[F](
+      access = obsListMod.withKey(obsId)
+    )(
+      onSet = (_, elemWithIndexOpt) =>
+        elemWithIndexOpt.fold {
+          ProgramDeleteObservation.execute[F](obsId).void
+        } { case (obs, _) =>
+          ProgramCreateObservation
+            .execute[F](CreateObservationInput(programId = "p-2", observationId = obs.id.assign))
+            .void >>
+            focused.set(Focused.FocusedObs(obs.id).some).to[F]
+        },
+      onRestore = (_, elemWithIndexOpt) =>
+        elemWithIndexOpt.fold {
+          ProgramDeleteObservation.execute[F](obsId).void
+        } { case (obs, _) =>
+          ProgramUndeleteObservation.execute[F](obs.id).void >>
+            focused.set(Focused.FocusedObs(obs.id).some).to[F]
+        }
+    )
+}

--- a/model/shared/src/main/scala/explore/undo/Action.scala
+++ b/model/shared/src/main/scala/explore/undo/Action.scala
@@ -39,11 +39,11 @@ object Action {
     ): AppliedGetSet[G, M, A] =
       new AppliedGetSet[G, M, A](getter, setter)
 
-    def apply[M, A](lens: Lens[M, A]): AppliedGetSet[G, M, A] =
-      new AppliedGetSet[G, M, A](lens.get, lens.set)
+    def apply[M, A](access: Lens[M, A]): AppliedGetSet[G, M, A] =
+      new AppliedGetSet[G, M, A](access.get, access.set)
 
-    def apply[M, A](getAdjust: GetAdjust[M, A]): AppliedGetSet[G, M, A] =
-      new AppliedGetSet[G, M, A](getAdjust.get, getAdjust.set)
+    def apply[M, A](access: GetAdjust[M, A]): AppliedGetSet[G, M, A] =
+      new AppliedGetSet[G, M, A](access.get, access.set)
   }
 
   class AppliedGetSet[G[_], M, A](val getter: M => A, val setter: A => M => M) {

--- a/model/shared/src/main/scala/explore/undo/KIListMod.scala
+++ b/model/shared/src/main/scala/explore/undo/KIListMod.scala
@@ -8,7 +8,7 @@ import monocle.Getter
 import monocle.Iso
 import monocle.Lens
 
-class KIListMod[A, K](protected val keyLens: Lens[A, K])
+case class KIListMod[A, K](protected val keyLens: Lens[A, K])
     extends IndexedCollMod[KeyedIndexedList, Int, A, cats.Id, K] {
 
   override protected val valueLens: Lens[A, A] = Iso.id.asLens


### PR DESCRIPTION
Refactor `ObsList` to use undoer's `Action` in the hopes of making code more legible/maintainable.

An `Action` is just a wrapper for:
* An `access` (which is just a `getter` and a `setter`, and can be provided in the form of separate functions, a `Lens`, `GetAdjust`, or other optics in the future).
* An `onSet` effect.
* An optional `onRestore` effect (if omitted, `onSet` will be used upon restore).

This is all the information an `UndoContext` needs to perform an undoable action (and undo/redo it). Maybe there's a better name than `Action` for this. Suggestions welcome.

I'd like to know if you find the resulting code easier to read/write than the original one.