### PR TITLE
Redo the algorithm to select the spectroscopy list of modes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ val FUILess              = "2.8.7"
 val kindProjectorVersion = "0.13.0"
 
 ThisBuild / Test / bspEnabled := false
+ThisBuild / ScalafixConfig / bspEnabled := false
 
 addCommandAlias(
   "quickTest",

--- a/model-tests/jvm/src/test/resources/instrument_spectroscopy_matrix.csv
+++ b/model-tests/jvm/src/test/resources/instrument_spectroscopy_matrix.csv
@@ -1,0 +1,245 @@
+instrument,Config,Focal Plane,fpu,slit width,slit length,disperser,filter,wave min,wave max,wave optimal,wave range,resolution,AO,capabilities,site
+GMOS-S,"B1200 0.25""","singleslit,multislit",0.25arcsec,0.250,330,B1200,none,0.36,1.03,0.463,0.159,7488,no,,s
+GMOS-S,"B1200 0.50""","singleslit,multislit",0.50arcsec,0.500,330,B1200,none,0.36,1.03,0.463,0.159,3744,no,,s
+GMOS-S,"B1200 0.75""","singleslit,multislit",0.75arcsec,0.750,330,B1200,none,0.36,1.03,0.463,0.159,2496,no,,s
+GMOS-S,"B1200 1.0""","singleslit,multislit",1.00arcsec,1.000,330,B1200,none,0.36,1.03,0.463,0.159,1872,no,,s
+GMOS-S,"B1200 1.5""","singleslit,multislit",1.50arcsec,1.500,330,B1200,none,0.36,1.03,0.463,0.159,1248,no,,s
+GMOS-S,"B1200 2.0""","singleslit,multislit",2.00arcsec,2.000,330,B1200,none,0.36,1.03,0.463,0.159,936,no,,s
+GMOS-S,"B1200 5.0""","singleslit,multislit",5.00arcsec,5.000,330,B1200,none,0.36,1.03,0.463,0.159,374,no,,s
+GMOS-S,"B600 0.25""","singleslit,multislit",0.25arcsec,0.250,330,B600,none,0.36,1.03,0.461,0.307,3376,no,,s
+GMOS-S,"B600 0.50""","singleslit,multislit",0.50arcsec,0.500,330,B600,none,0.36,1.03,0.461,0.307,1688,no,,s
+GMOS-S,"B600 0.75""","singleslit,multislit",0.75arcsec,0.750,330,B600,none,0.36,1.03,0.461,0.307,1125,no,,s
+GMOS-S,"B600 1.0""","singleslit,multislit",1.00arcsec,1.000,330,B600,none,0.36,1.03,0.461,0.307,844,no,,s
+GMOS-S,"B600 1.5""","singleslit,multislit",1.50arcsec,1.500,330,B600,none,0.36,1.03,0.461,0.307,563,no,,s
+GMOS-S,"B600 2.0""","singleslit,multislit",2.00arcsec,2.000,330,B600,none,0.36,1.03,0.461,0.307,422,no,,s
+GMOS-S,"B600 5.0""","singleslit,multislit",5.00arcsec,5.000,330,B600,none,0.36,1.03,0.461,0.307,169,no,,s
+GMOS-S,"R831 0.25""","singleslit,multislit",0.25arcsec,0.250,330,R831,none,0.36,1.03,0.757,0.23,8792,no,,s
+GMOS-S,"R831 0.50""","singleslit,multislit",0.50arcsec,0.500,330,R831,none,0.36,1.03,0.757,0.23,4396,no,,s
+GMOS-S,"R831 0.75""","singleslit,multislit",0.75arcsec,0.750,330,R831,none,0.36,1.03,0.757,0.23,2931,no,,s
+GMOS-S,"R831 1.0""","singleslit,multislit",1.00arcsec,1.000,330,R831,none,0.36,1.03,0.757,0.23,2198,no,,s
+GMOS-S,"R831 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R831,none,0.36,1.03,0.757,0.23,1465,no,,s
+GMOS-S,"R831 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R831,none,0.36,1.03,0.757,0.23,1099,no,,s
+GMOS-S,"R831 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R831,none,0.36,1.03,0.757,0.23,440,no,,s
+GMOS-S,"R400 0.25""","singleslit,multislit",0.25arcsec,0.250,330,R400,none,0.36,1.03,0.764,0.462,3836,no,,s
+GMOS-S,"R400 0.50""","singleslit,multislit",0.50arcsec,0.500,330,R400,none,0.36,1.03,0.764,0.462,1918,no,,s
+GMOS-S,"R400 0.75""","singleslit,multislit",0.75arcsec,0.750,330,R400,none,0.36,1.03,0.764,0.462,1279,no,,s
+GMOS-S,"R400 1.0""","singleslit,multislit",1.00arcsec,1.000,330,R400,none,0.36,1.03,0.764,0.462,959,no,,s
+GMOS-S,"R400 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R400,none,0.36,1.03,0.764,0.462,639,no,,s
+GMOS-S,"R400 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R400,none,0.36,1.03,0.764,0.462,480,no,,s
+GMOS-S,"R400 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R400,none,0.36,1.03,0.764,0.462,192,no,,s
+GMOS-S,"R150 0.25""","singleslit,multislit",0.25arcsec,0.250,330,R150,none,0.36,1.03,0.717,1.19,1262,no,,s
+GMOS-S,"R150 0.50""","singleslit,multislit",0.50arcsec,0.500,330,R150,none,0.36,1.03,0.717,1.19,631,no,,s
+GMOS-S,"R150 0.75""","singleslit,multislit",0.75arcsec,0.750,330,R150,none,0.36,1.03,0.717,1.19,421,no,,s
+GMOS-S,"R150 1.0""","singleslit,multislit",1.00arcsec,1.000,330,R150,none,0.36,1.03,0.717,1.19,316,no,,s
+GMOS-S,"R150 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R150,none,0.36,1.03,0.717,1.19,210,no,,s
+GMOS-S,"R150 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R150,none,0.36,1.03,0.717,1.19,158,no,,s
+GMOS-S,"R150 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R150,none,0.36,1.03,0.717,1.19,63,no,,s
+GMOS-S,B600 IFU1,ifu,IFU1,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,,s
+GMOS-S,B600 IFU1 NS,ifu,IFU1 N&S,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,Nod&Shuffle,s
+GMOS-S,B600 IFU2,ifu,IFU2,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,,s
+GMOS-S,B600 IFU2 NS,ifu,IFU2 N&S,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,Nod&Shuffle,s
+GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG455,0.46,1.03,0.717,0.57,316,no,Nod&Shuffle,s
+GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
+GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R831,CaT,0.78,0.933,0.757,0.23,2198,no,Nod&Shuffle,s
+NIFS,Z + ZJ,ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,,n
+NIFS,J + ZJ,ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,,n
+NIFS,J + HK,ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,,n
+NIFS,H + JH,ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,,n
+NIFS,H + HK,ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,,n
+NIFS,K + HK,ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,,n
+NIFS,"Z + ZJ + 0.1"" OD",ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,coronagraph,n
+NIFS,"J + ZJ + 0.1"" OD",ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,coronagraph,n
+NIFS,"J + HK + 0.1"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coronagraph,n
+NIFS,"H + JH + 0.1"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
+NIFS,"H + HK + 0.1"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
+NIFS,"K + HK + 0.1"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
+NIFS,"Z + ZJ + 0.2"" OD",ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,coronagraph,n
+NIFS,"J + ZJ + 0.2"" OD",ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,coronagraph,n
+NIFS,"J + HK + 0.2"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coronagraph,n
+NIFS,"H + JH + 0.2"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
+NIFS,"H + HK + 0.2"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
+NIFS,"K + HK + 0.2"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
+NIFS,"Z + ZJ + 0.5"" OD",ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,coronagraph,n
+NIFS,"J + ZJ + 0.5"" OD",ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,coronagraph,n
+NIFS,"J + HK + 0.5"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coronagraph,n
+NIFS,"H + JH + 0.5"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
+NIFS,"H + HK + 0.5"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
+NIFS,"K + HK + 0.5"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
+FLAMINGOS2,"R3K + J + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,J,1.175,1.333,1.254,0.158,2800,no,,s
+FLAMINGOS2,"R3K + H + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,H,1.486,1.775,1.6305,0.289,2800,no,,s
+FLAMINGOS2,"R3K + Ks + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,Ks,1.991,2.32,2.1555,0.329,2900,no,,s
+FLAMINGOS2,"R3K + Kb + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-blue,1.934,2.177,2.0555,0.243,2900,no,,s
+FLAMINGOS2,"R3K + Kr + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-red,2.181,2.446,2.3135,0.265,2900,no,,s
+FLAMINGOS2,"JH 0.36""","singleslit,multislit",2pixel,0.360,263,JH,JH,0.97,1.805,1.3875,0.835,900,no,,s
+FLAMINGOS2,"HK 0.36""","singleslit,multislit",2pixel,0.360,263,HK,HK,1.261,2.551,1.906,1.29,900,no,,s
+GPI,foo,ifu,Coronagraph,0.156,2.8,GPI,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.184,2.8,GPI,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.246,2.8,GPI,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
+SCORPIO,foo,singleslit,?,0.300,180,?,dichroic,0.37,2.35,1.36,1.98,4000,no,,s
+GNIRS,"SCLS + X + 0.3""",singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
+GNIRS,"SCLS + J + 0.3""",singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
+GNIRS,"SCLS + H + 0.3""",singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
+GNIRS,"SCLS + K + 0.3""",singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
+GNIRS,"SCLS + L + 0.3""",singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
+GNIRS SCXD,foo,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
+GNIRS LCXD,foo,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n

--- a/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
+++ b/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.modes
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import fs2._
+import fs2.data.csv._
+
+trait SpectroscopyModesMatrixPlatform extends ModesMatrixDecoders {
+  def loadMatrix[F[_]: Concurrent](s: Stream[F, String]): F[List[ModeRow]] =
+    s
+      .through(decodeUsingHeaders[ModeRow]())
+      .compile
+      .toList
+
+  def apply[F[_]: Concurrent](s: Stream[F, String]): F[ModesMatrix] =
+    loadMatrix(s).map(ModesMatrix(_))
+
+}

--- a/model/jvm/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
+++ b/model/jvm/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
@@ -1,0 +1,26 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.modes
+
+import cats.effect.Async
+import cats.syntax.all._
+import fs2.data.csv._
+import fs2.io.file._
+import fs2.text
+
+import java.nio.file.Path
+
+trait SpectroscopyModesMatrixPlatform extends SpectroscopyModesMatrixDecoders {
+
+  def loadMatrix[F[_]: Async](path: Path): F[List[SpectroscopyModeRow]] =
+    Files[F]
+      .readAll(path, 1024)
+      .through(text.utf8Decode)
+      .through(decodeUsingHeaders[SpectroscopyModeRow]())
+      .compile
+      .toList
+
+  def apply[F[_]: Async](path: Path): F[SpectroscopyModesMatrix] =
+    loadMatrix(path).map(SpectroscopyModesMatrix(_))
+}

--- a/model/shared/src/main/scala/explore/modes/SpectrosocpyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectrosocpyModesMatrix.scala
@@ -1,0 +1,191 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.modes
+
+import cats.data.NonEmptyList
+import cats.implicits._
+import coulomb._
+import eu.timepit.refined._
+import eu.timepit.refined.cats._
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.types.numeric._
+import eu.timepit.refined.types.string._
+import explore.model.enum.SpectroscopyCapabilities
+import fs2.data.csv._
+import lucuma.core.enum.ImageQuality
+import lucuma.core.enum.Instrument
+import lucuma.core.math.Angle
+import lucuma.core.math.Wavelength
+import lucuma.core.math.units.Micrometer
+import lucuma.core.util.Enumerated
+import monocle.Lens
+import monocle.macros.GenLens
+import spire.math.Rational
+
+sealed trait FocalPlane extends Product with Serializable
+
+object FocalPlane {
+  case object SingleSlit   extends FocalPlane
+  case object MultipleSlit extends FocalPlane
+  case object IFU          extends FocalPlane
+
+  /** @group Typeclass Instances */
+  implicit val FocalPlaneEnumerated: Enumerated[FocalPlane] =
+    Enumerated.of(SingleSlit, MultipleSlit, IFU)
+}
+
+case class SpectroscopyModeRow(
+  instrument:        Instrument,
+  config:            NonEmptyString,
+  filterTag:         Option[NonEmptyString], // TODO Find a better type to represent any filter
+  focalPlane:        NonEmptyList[FocalPlane],
+  capabilities:      Option[SpectroscopyCapabilities],
+  ao:                ModeAO,
+  minWavelength:     ModeWavelength,
+  maxWavelength:     ModeWavelength,
+  optimalWavelength: ModeWavelength,
+  wavelengthRange:   Quantity[NonNegBigDecimal, Micrometer],
+  resolution:        PosBigDecimal,
+  slitLength:        ModeSlitSize,
+  slitWidth:         ModeSlitSize
+)
+
+object SpectroscopyModeRow {
+  val instrument: Lens[SpectroscopyModeRow, Instrument] = GenLens[SpectroscopyModeRow](_.instrument)
+}
+
+trait SpectroscopyModesMatrixDecoders extends Decoders {
+  implicit val nonEmptyStringDecoder: CellDecoder[NonEmptyString] =
+    CellDecoder.stringDecoder
+      .emap { x =>
+        refineV[NonEmpty](x).leftMap(s => new DecoderError(s))
+      }
+
+  implicit val focalPlaneDecoder: CellDecoder[NonEmptyList[FocalPlane]] =
+    CellDecoder.stringDecoder
+      .emap { r =>
+        r.toLowerCase
+          .replace("\\s", "")
+          .trim
+          .split(",")
+          .toList
+          .collect {
+            case "singleslit" => FocalPlane.SingleSlit
+            case "multislit"  => FocalPlane.MultipleSlit
+            case "ifu"        => FocalPlane.IFU
+          } match {
+          case h :: t => NonEmptyList.of(h, t: _*).asRight
+          case Nil    => new DecoderError(s"Unknown focal plane $r").asLeft
+        }
+      }
+
+  implicit val capabilitiesDecoder: CellDecoder[Option[SpectroscopyCapabilities]] =
+    CellDecoder.stringDecoder
+      .map {
+        case "Nod&Shuffle" => SpectroscopyCapabilities.NodAndShuffle.some
+        case "coronagraph" => SpectroscopyCapabilities.Corongraphy.some
+        case _             => none
+      }
+
+  implicit object SpectroscopySpectroscopyModeRowDecoder
+      extends CsvRowDecoder[SpectroscopyModeRow, String] {
+    def apply(row: CsvRow[String]): DecoderResult[SpectroscopyModeRow] =
+      for {
+        i   <- row.as[Instrument]("instrument")
+        s   <- row.as[NonEmptyString]("Config")
+        fi  <- row.as[NonEmptyString]("filter").map {
+                 case n if n.value.toLowerCase === "none" => none
+                 case f                                   => f.some
+               }
+        f   <- row.as[NonEmptyList[FocalPlane]]("Focal Plane")
+        c   <- row.as[Option[SpectroscopyCapabilities]]("capabilities")
+        a   <- row.as[ModeAO]("AO")
+        min <- row.as[ModeWavelength]("wave min")
+        max <- row.as[ModeWavelength]("wave max")
+        wo  <- row.as[ModeWavelength]("wave optimal")
+        wr  <- row.as[NonNegBigDecimal]("wave range").map(_.withUnit[Micrometer])
+        r   <- row.as[PosBigDecimal]("resolution")
+        sl  <- row.as[ModeSlitSize]("slit length")
+        sw  <- row.as[ModeSlitSize]("slit width")
+      } yield SpectroscopyModeRow(i, s, fi, f, c, a, min, max, wo, wr, r, sl, sw)
+  }
+}
+
+final case class SpectroscopyModesMatrix(matrix: List[SpectroscopyModeRow]) {
+  val ScoreBump   = Rational(1, 2)
+  val FilterLimit = Wavelength.fromNanometers(650)
+
+  def filtered(
+    focalPlane:   Option[FocalPlane],
+    capabilities: Option[SpectroscopyCapabilities],
+    iq:           Option[ImageQuality],
+    wavelength:   Option[Wavelength],
+    resolution:   Option[PosBigDecimal],
+    range:        Option[Quantity[NonNegBigDecimal, Micrometer]],
+    slitWidth:    Option[Angle]
+  ): List[SpectroscopyModeRow] = {
+    // Criteria to filter the modes
+    val filter: SpectroscopyModeRow => Boolean = r => {
+      focalPlane.forall(f => r.focalPlane.exists(_ === f)) &&
+        r.capabilities === capabilities &&
+        iq.forall(i => r.ao =!= ModeAO.AO || (i.toArcSeconds <= 0.2)) &&
+        wavelength.forall(w => w >= r.minWavelength.w && w <= r.maxWavelength.w) &&
+        resolution.forall(_ <= r.resolution) &&
+        range.forall(_ <= r.wavelengthRange) &&
+        slitWidth.forall(_.toMicroarcseconds <= r.slitLength.sw.toMicroarcseconds)
+    }
+
+    // Calculates a score for each mode for sorting purposes. It is down in Rational space, we may change it to double as we don't really need high precission for this
+    val score: SpectroscopyModeRow => Rational = { r =>
+      // Difference in wavelength
+      val deltaWave: Rational       =
+        wavelength
+          .map(w => (r.optimalWavelength.w.nanometer - w.nanometer).value.abs)
+          .getOrElse(Rational.zero)
+      // Difference in slit width
+      val deltaSlitWidth            =
+        iq.foldMap(i => (r.slitWidth.sw.toMicroarcseconds / 1000000.0 - i.toArcSeconds).abs)
+      // Difference in resolution
+      val deltaRes: BigDecimal      =
+        resolution.foldMap(re => (re.value - r.resolution.value).abs)
+      // give a bumpp to non-AO modes (but don't discard them)
+      val aoScore: Rational         =
+        if (iq.forall(i => r.ao =!= ModeAO.AO || (i.toArcSeconds <= 0.2))) ScoreBump
+        else Rational.zero
+      // If wavelength > 0.65mu, then prefer settings with a filter to avoid 2nd order contamination
+      val filterScore: Rational     =
+        (wavelength, FilterLimit)
+          .mapN { (w, l) =>
+            if (w >= l && r.filterTag.isDefined) ScoreBump else Rational.zero
+          }
+          .getOrElse(Rational.zero)
+      // Wavelength matche
+      val wavelengthScore: Rational = wavelength
+        .map(w => (w.nanometer.value / (w.nanometer.value + deltaWave)))
+        .getOrElse(Rational.zero)
+      // Resolution match
+      val resolutionScore: Rational = resolution
+        .map(r => Rational(r.value / (r.value + deltaRes)))
+        .getOrElse(Rational.zero)
+      // Slit width match to the seeing (the IFU always matches)
+      val slitWidthScore            =
+        if (r.focalPlane.forall(_ === FocalPlane.IFU)) Rational.one
+        else
+          iq.map(i => Rational(i.toArcSeconds / (i.toArcSeconds + deltaSlitWidth)))
+            .getOrElse(Rational.zero)
+      aoScore + wavelengthScore + filterScore + resolutionScore + slitWidthScore
+    }
+
+    matrix
+      .filter(filter)  // Only include matches
+      .fproduct(score) // Give it a score
+      .sortBy(_._2)    // Sort by score
+      .map(_._1)
+      .reverse
+  }
+}
+
+object SpectroscopyModesMatrix extends SpectroscopyModesMatrixPlatform {
+  val empty: SpectroscopyModesMatrix = SpectroscopyModesMatrix(Nil)
+}

--- a/model/shared/src/main/scala/explore/modes/package.scala
+++ b/model/shared/src/main/scala/explore/modes/package.scala
@@ -1,0 +1,102 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore
+
+import cats.syntax.all._
+import eu.timepit.refined._
+import eu.timepit.refined.numeric.NonNegative
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.types.numeric._
+import fs2.data.csv._
+import lucuma.core.enum.Instrument
+import lucuma.core.math.Angle
+import lucuma.core.math.Wavelength
+import lucuma.core.util.Enumerated
+
+package modes {
+
+  case class ModeWavelength(w: Wavelength) {
+    override def toString: String = s"${w.micrometer.value.toDouble} μm"
+  }
+
+  case class ModeSlitSize(sw: Angle) {
+    override def toString: String = s"${Angle.milliarcseconds.get(sw) / 1000.0} arcsec"
+  }
+
+  sealed trait ModeAO extends Product with Serializable
+
+  object ModeAO {
+    case object NoAO extends ModeAO
+    case object AO   extends ModeAO
+
+    /** @group Typeclass Instances */
+    implicit val ModeAOEnumerated: Enumerated[ModeAO] =
+      Enumerated.of(NoAO, AO)
+  }
+
+  trait Decoders {
+    implicit val posIntDecoder: CellDecoder[PosInt] =
+      CellDecoder.intDecoder
+        .emap { x =>
+          refineV[Positive](x).leftMap(s => new DecoderError(s))
+        }
+
+    implicit val nonNegativeIntDecoder: CellDecoder[NonNegInt] =
+      CellDecoder.intDecoder
+        .emap { x =>
+          refineV[NonNegative](x).leftMap(s => new DecoderError(s))
+        }
+
+    implicit val instDecoder: CellDecoder[Instrument] =
+      CellDecoder.stringDecoder
+        .emap {
+          case "FLAMINGOS2" => Instrument.Flamingos2.asRight
+          case "GSAOI"      => Instrument.Gsaoi.asRight
+          case "GMOS-S"     => Instrument.GmosSouth.asRight
+          case "GMOS-N"     => Instrument.GmosNorth.asRight
+          case "GPI"        => Instrument.Gpi.asRight
+          case "NIFS"       => Instrument.Nifs.asRight
+          case "SCORPIO"    => Instrument.Scorpio.asRight
+          case "GNIRS"      => Instrument.Gnirs.asRight
+          case s"GNIRS $_"  => Instrument.Gnirs.asRight
+          case x            => new DecoderError(s"Unknown instrument $x").asLeft
+        }
+
+    implicit val modeAODecoder: CellDecoder[ModeAO] =
+      CellDecoder.stringDecoder
+        .map {
+          case "yes" => ModeAO.AO
+          case _     => ModeAO.NoAO
+        }
+
+    val micrometerDecoder: CellDecoder[Wavelength] =
+      CellDecoder.bigDecimalDecoder.emap(x =>
+        Wavelength.fromPicometers
+          .getOption((x * 1000000).intValue)
+          .toRight(new DecoderError(s"Invalid wavelength value $x"))
+      )
+
+    implicit val wavelength: CellDecoder[ModeWavelength] =
+      micrometerDecoder.map(ModeWavelength.apply)
+
+    implicit val posBigDecimalDecoder: CellDecoder[PosBigDecimal] =
+      CellDecoder.bigDecimalDecoder
+        .emap { x =>
+          refineV[Positive](x).leftMap(s => new DecoderError(s))
+        }
+
+    implicit val nonNegativeBigDecimalDecoder: CellDecoder[NonNegBigDecimal] =
+      CellDecoder.bigDecimalDecoder
+        .emap { x =>
+          refineV[NonNegative](x).leftMap(s => new DecoderError(s))
+        }
+
+    val arcsecDecoder: CellDecoder[Angle] =
+      CellDecoder.bigDecimalDecoder.map(x => Angle.milliarcseconds.reverseGet((x * 1000).intValue))
+
+    implicit val swDecoder: CellDecoder[ModeSlitSize] =
+      arcsecDecoder.map(ModeSlitSize.apply)
+
+  }
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -20,7 +20,7 @@ object Settings {
     val geminiLocales     = "0.6.0"
     val log4Cats          = "2.1.1"
     val log4CatsLogLevel  = "0.3.0"
-    val lucumaCore        = "0.9.1"
+    val lucumaCore        = "0.10.1"
     val lucumaCatalog     = "0.4.1"
     val lucumaUI          = "0.15.0"
     val lucumaSSO         = "0.0.9"


### PR DESCRIPTION
The algorithm to select spectroscopy modes has been updated to reflect the current UI. This will supersede the previous modes matrix once the imaging mode is done