### PR TITLE
Show spectroscopy modes in the table

### DIFF
--- a/explore/src/main/scala/explore/config/ModesTable.scala
+++ b/explore/src/main/scala/explore/config/ModesTable.scala
@@ -4,10 +4,19 @@
 package explore.config
 
 import cats.syntax.all._
+import coulomb.Quantity
+import eu.timepit.refined.auto._
+import eu.timepit.refined.types.numeric.NonNegBigDecimal
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ui.ExploreStyles
 import explore.modes._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.enum.F2Disperser
+import lucuma.core.enum.GmosSouthDisperser
+import lucuma.core.enum.GnirsDisperser
+import lucuma.core.enum.GpiDisperser
+import lucuma.core.math.units.Micrometer
 import lucuma.core.util.Display
 import react.common._
 import react.common.implicits._
@@ -16,14 +25,15 @@ import reactST.reactTable._
 
 import scalajs.js.JSConverters._
 
-final case class ModesTable(
-  matrix: ModesMatrix
-) extends ReactProps[ModesTable](ModesTable.component)
+final case class SpectroscopyModesTable(
+  matrix: SpectroscopyModesMatrix
+) extends ReactProps[SpectroscopyModesTable](SpectroscopyModesTable.component)
 
-object ModesTable {
-  type Props = ModesTable
+object SpectroscopyModesTable {
+  type Props = SpectroscopyModesTable
+  type ColId = NonEmptyString
 
-  protected val ModesTableMaker = TableMaker[ModeRow]
+  protected val ModesTableMaker = TableMaker[SpectroscopyModeRow]
 
   import ModesTableMaker.syntax._
 
@@ -34,21 +44,70 @@ object ModesTable {
     case ModeDisperser.SomeDisperser(t) => t
   }
 
-  def column[V](id: String, accessor: ModeRow => V) =
+  def column[V](id: ColId, accessor: SpectroscopyModeRow => V) =
     ModesTableMaker
       .Column(id, accessor)
-      .setHeader(columnNames(id))
+      .setHeader(columnNames.getOrElse(id, id.value): String)
 
-  private val columnNames: Map[String, String] = Map("instrument" -> " ", "disperser" -> "")
+  val InstrumentColumnId: ColId = "instrument"
+  val ConfigColumnId: ColId     = "config"
+  val SlitWidthColumnId: ColId  = "slit_width"
+  val SlitLengthColumnId: ColId = "slit_length"
+  val DisperserColumnId: ColId  = "disperser"
+  val RangeColumnId: ColId      = "range"
+  val ResolutionColumnId: ColId = "resolution"
+
+  private val columnNames: Map[ColId, String] =
+    Map[NonEmptyString, String](
+      InstrumentColumnId -> "Instrument",
+      ConfigColumnId     -> "Config",
+      SlitWidthColumnId  -> "Slit Width",
+      SlitLengthColumnId -> "Slit Length",
+      DisperserColumnId  -> "Disperser",
+      RangeColumnId      -> "Range",
+      ResolutionColumnId -> "Res."
+    )
+
+  val formatSlitWidth: ModeSlitSize => String = ss =>
+    f"${ModeSlitSize.milliarcseconds.get(ss.size).setScale(3, BigDecimal.RoundingMode.UP)}%1.3f"
+
+  val formatSlitLength: ModeSlitSize => String = ss =>
+    f"${ModeSlitSize.milliarcseconds.get(ss.size).setScale(0, BigDecimal.RoundingMode.DOWN)}%1.0f"
+
+  def formatDisperser(disperser: InstrumentRow#Disperser): String = disperser match {
+    case f: GmosSouthDisperser => f.shortName
+    case f: F2Disperser        => f.shortName
+    case f: GpiDisperser       => f.shortName
+    case f: GnirsDisperser     => f.shortName
+    case r                     => r.toString
+  }
+
+  def formatWavelengthRange(r: Quantity[NonNegBigDecimal, Micrometer]): String =
+    f"${r.value.value.setScale(3, BigDecimal.RoundingMode.DOWN)}%1.0f"
 
   val columns =
     List(
-      column("instrument", ModeRow.instrument.get)
+      column(InstrumentColumnId, SpectroscopyModeRow.instrument.get)
         .setCell(_.value.shortName)
         .setWidth(30),
-      column("disperser", ModeRow.disperser.get)
-        .setCell(d => disperserDisplay.shortName(d.value))
-        .setWidth(30)
+      column(ConfigColumnId, SpectroscopyModeRow.config.get)
+        .setCell(_.value.value)
+        .setWidth(30),
+      column(SlitWidthColumnId, SpectroscopyModeRow.slitWidth.get)
+        .setCell(c => formatSlitWidth(c.value))
+        .setWidth(10),
+      column(SlitLengthColumnId, SpectroscopyModeRow.slitLength.get)
+        .setCell(c => formatSlitLength(c.value))
+        .setWidth(10),
+      column(DisperserColumnId, SpectroscopyModeRow.disperser.get)
+        .setCell(c => formatDisperser(c.value))
+        .setWidth(10),
+      column(RangeColumnId, SpectroscopyModeRow.range.get)
+        .setCell(c => formatWavelengthRange(c.value))
+        .setWidth(10),
+      column(ResolutionColumnId, SpectroscopyModeRow.resolution.get)
+        .setCell(c => c.value.toString)
+        .setWidth(10)
     )
 
   protected val component =
@@ -66,7 +125,7 @@ object ModesTable {
 
   protected final case class ModesTableProps(
     options: ModesTableMaker.OptionsType
-  ) extends ReactProps[ModesTable](ModesTable.component)
+  ) extends ReactProps[SpectroscopyModesTable](SpectroscopyModesTable.component)
 
   protected val tableComponent =
     ScalaFnComponent[ModesTableProps] { props =>
@@ -79,11 +138,10 @@ object ModesTable {
           table =
             Table(celled = true, selectable = true, striped = true, compact = TableCompact.Very)(),
           header = true,
-          headerCell = (col: ModesTableMaker.ColumnType) =>
+          headerCell = (_: ModesTableMaker.ColumnType) =>
             TableHeaderCell(clazz = ExploreStyles.Sticky |+| ExploreStyles.ModesHeader)(
               ^.textTransform.capitalize,
-              ^.whiteSpace.nowrap,
-              col.id.toString
+              ^.whiteSpace.nowrap
             )
         )(tableInstance)
       )

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -13,8 +13,12 @@ import explore.modes._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.F2Disperser
+import lucuma.core.enum.F2Filter
+import lucuma.core.enum.GmosNorthFilter
 import lucuma.core.enum.GmosSouthDisperser
+import lucuma.core.enum.GmosSouthFilter
 import lucuma.core.enum.GnirsDisperser
+import lucuma.core.enum.GnirsFilter
 import lucuma.core.enum.GpiDisperser
 import lucuma.core.enum.Instrument
 import lucuma.core.math.units.Micrometer
@@ -24,8 +28,9 @@ import react.common.implicits._
 import react.semanticui.collections.table._
 import reactST.reactTable._
 
-import scalajs.js.JSConverters._
 import java.text.DecimalFormat
+
+import scalajs.js.JSConverters._
 
 final case class SpectroscopyModesTable(
   matrix: SpectroscopyModesMatrix
@@ -39,7 +44,8 @@ object SpectroscopyModesTable {
 
   import ModesTableMaker.syntax._
 
-  val  swFormat = new DecimalFormat("0.###");
+  val decFormat = new DecimalFormat("0.###");
+
   protected val ModesTableComponent = new SUITable(ModesTableMaker)
 
   val disperserDisplay: Display[ModeDisperser] = Display.byShortName {
@@ -56,6 +62,7 @@ object SpectroscopyModesTable {
   val SlitWidthColumnId: ColId  = "slit_width"
   val SlitLengthColumnId: ColId = "slit_length"
   val DisperserColumnId: ColId  = "disperser"
+  val FilterColumnId: ColId     = "filter"
   val RangeColumnId: ColId      = "range"
   val ResolutionColumnId: ColId = "resolution"
 
@@ -65,12 +72,15 @@ object SpectroscopyModesTable {
       SlitWidthColumnId  -> "Slit Width",
       SlitLengthColumnId -> "Slit Length",
       DisperserColumnId  -> "Disperser",
+      FilterColumnId     -> "Filter",
       RangeColumnId      -> "Range",
       ResolutionColumnId -> "Res."
     )
 
   val formatSlitWidth: ModeSlitSize => String = ss =>
-    swFormat.format(ModeSlitSize.milliarcseconds.get(ss.size).setScale(3, BigDecimal.RoundingMode.UP))
+    decFormat.format(
+      ModeSlitSize.milliarcseconds.get(ss.size).setScale(3, BigDecimal.RoundingMode.UP)
+    )
 
   val formatSlitLength: ModeSlitSize => String = ss =>
     f"${ModeSlitSize.milliarcseconds.get(ss.size).setScale(0, BigDecimal.RoundingMode.DOWN)}%1.0f"
@@ -83,8 +93,17 @@ object SpectroscopyModesTable {
     case r                     => r.toString
   }
 
+  def formatFilter(filter: InstrumentRow#Filter): String = filter match {
+    case Some(f: GmosSouthFilter) => f.shortName
+    case Some(f: GmosNorthFilter) => f.shortName
+    case f: F2Filter              => f.shortName
+    case f: GnirsFilter           => f.shortName
+    case _: None.type             => "none"
+    case r                        => r.toString
+  }
+
   def formatWavelengthRange(r: Quantity[NonNegBigDecimal, Micrometer]): String =
-    swFormat.format(r.value.value.setScale(3, BigDecimal.RoundingMode.DOWN))
+    decFormat.format(r.value.value.setScale(3, BigDecimal.RoundingMode.DOWN))
 
   def formatInstrument(r: (Instrument, NonEmptyString)): String = r match {
     case (i @ Instrument.Gnirs, m) => s"${i.longName} $m"
@@ -104,6 +123,9 @@ object SpectroscopyModesTable {
         .setWidth(10),
       column(DisperserColumnId, SpectroscopyModeRow.disperser.get)
         .setCell(c => formatDisperser(c.value))
+        .setWidth(10),
+      column(FilterColumnId, SpectroscopyModeRow.filter.get)
+        .setCell(c => formatFilter(c.value))
         .setWidth(10),
       column(RangeColumnId, SpectroscopyModeRow.range.get)
         .setCell(c => formatWavelengthRange(c.value))

--- a/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
+++ b/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
@@ -39,7 +39,7 @@ GMOS-S,B600 IFU2,ifu,IFU2,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,,s
 GMOS-S,B600 IFU1 NS,ifu,IFU1 N&S,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,Nod&Shuffle,s
 GMOS-S,B600 IFU2 NS,ifu,IFU2 N&S,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,Nod&Shuffle,s
 GMOS-S,R150 NS1.0 GG455,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG455,0.46,1.03,0.717,0.57,316,no,Nod&Shuffle,s
-GMOS-S,R150 NS1.0 GG515,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
+GMOS-S,R150 NS1.0 OG515,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,OG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
 GMOS-S,R831 NS1.0 CaT,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R831,CaT,0.78,0.933,0.757,0.23,2198,no,Nod&Shuffle,s
 NIFS,Z + ZJ,ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,,n
 NIFS,J + ZJ,ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,,n
@@ -65,18 +65,18 @@ NIFS,"J + HK + 0.5"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coro
 NIFS,"H + JH + 0.5"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
 NIFS,"H + HK + 0.5"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
 NIFS,"K + HK + 0.5"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
-FLAMINGOS2,"R3K + J + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,J,1.175,1.333,1.254,0.158,2800,no,,s
-FLAMINGOS2,"R3K + H + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,H,1.486,1.775,1.6305,0.289,2800,no,,s
-FLAMINGOS2,"R3K + Ks + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,Ks,1.991,2.32,2.1555,0.329,2900,no,,s
-FLAMINGOS2,"R3K + Kb + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-blue,1.934,2.177,2.0555,0.243,2900,no,,s
-FLAMINGOS2,"R3K + Kr + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-red,2.181,2.446,2.3135,0.265,2900,no,,s
-FLAMINGOS2,"JH 0.36""","singleslit,multislit",2pixel,0.360,263,JH,JH,0.97,1.805,1.3875,0.835,900,no,,s
-FLAMINGOS2,"HK 0.36""","singleslit,multislit",2pixel,0.360,263,HK,HK,1.261,2.551,1.906,1.29,900,no,,s
-GPI,Y,ifu,Coronagraph,0.156,2.8,prism,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
-GPI,J,ifu,Coronagraph,0.184,2.8,prism,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
-GPI,H,ifu,Coronagraph,0.246,2.8,prism,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
-GPI,K1,ifu,Coronagraph,0.306,2.8,prism,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
-GPI,K2,ifu,Coronagraph,0.306,2.8,prism,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
+FLAMINGOS2,"R3K + J + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,J,1.175,1.333,1.254,0.158,2800,no,,s
+FLAMINGOS2,"R3K + H + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,H,1.486,1.775,1.6305,0.289,2800,no,,s
+FLAMINGOS2,"R3K + Ks + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,K-short,1.991,2.32,2.1555,0.329,2900,no,,s
+FLAMINGOS2,"R3K + Kb + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,K-blue,1.934,2.177,2.0555,0.243,2900,no,,s
+FLAMINGOS2,"R3K + Kr + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,K-red,2.181,2.446,2.3135,0.265,2900,no,,s
+FLAMINGOS2,"JH 0.36""","singleslit,multislit",2pixel,0.360,263,R1200JH,JH,0.97,1.805,1.3875,0.835,900,no,,s
+FLAMINGOS2,"HK 0.36""","singleslit,multislit",2pixel,0.360,263,R1200HK,HK,1.261,2.551,1.906,1.29,900,no,,s
+GPI,Y,ifu,Coronagraph,0.156,2.8,Prism,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
+GPI,J,ifu,Coronagraph,0.184,2.8,Prism,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
+GPI,H,ifu,Coronagraph,0.246,2.8,Prism,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
+GPI,K1,ifu,Coronagraph,0.306,2.8,Prism,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
+GPI,K2,ifu,Coronagraph,0.306,2.8,Prism,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
 SCORPIO,foo,singleslit,?,0.300,180,?,dichroic,0.37,2.35,1.36,1.98,4000,no,,s
 GNIRS,SC,singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
 GNIRS,SC,singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n

--- a/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
+++ b/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
@@ -1,0 +1,245 @@
+instrument,Config,Focal Plane,fpu,slit width,slit length,disperser,filter,wave min,wave max,wave optimal,wave range,resolution,AO,capabilities,site
+GMOS-S,"B1200 0.25""","singleslit,multislit",0.25arcsec,0.250,330,B1200,none,0.36,1.03,0.463,0.159,7488,no,,s
+GMOS-S,"B1200 0.50""","singleslit,multislit",0.50arcsec,0.500,330,B1200,none,0.36,1.03,0.463,0.159,3744,no,,s
+GMOS-S,"B1200 0.75""","singleslit,multislit",0.75arcsec,0.750,330,B1200,none,0.36,1.03,0.463,0.159,2496,no,,s
+GMOS-S,"B1200 1.0""","singleslit,multislit",1.00arcsec,1.000,330,B1200,none,0.36,1.03,0.463,0.159,1872,no,,s
+GMOS-S,"B1200 1.5""","singleslit,multislit",1.50arcsec,1.500,330,B1200,none,0.36,1.03,0.463,0.159,1248,no,,s
+GMOS-S,"B1200 2.0""","singleslit,multislit",2.00arcsec,2.000,330,B1200,none,0.36,1.03,0.463,0.159,936,no,,s
+GMOS-S,"B1200 5.0""","singleslit,multislit",5.00arcsec,5.000,330,B1200,none,0.36,1.03,0.463,0.159,374,no,,s
+GMOS-S,"B600 0.25""","singleslit,multislit",0.25arcsec,0.250,330,B600,none,0.36,1.03,0.461,0.307,3376,no,,s
+GMOS-S,"B600 0.50""","singleslit,multislit",0.50arcsec,0.500,330,B600,none,0.36,1.03,0.461,0.307,1688,no,,s
+GMOS-S,"B600 0.75""","singleslit,multislit",0.75arcsec,0.750,330,B600,none,0.36,1.03,0.461,0.307,1125,no,,s
+GMOS-S,"B600 1.0""","singleslit,multislit",1.00arcsec,1.000,330,B600,none,0.36,1.03,0.461,0.307,844,no,,s
+GMOS-S,"B600 1.5""","singleslit,multislit",1.50arcsec,1.500,330,B600,none,0.36,1.03,0.461,0.307,563,no,,s
+GMOS-S,"B600 2.0""","singleslit,multislit",2.00arcsec,2.000,330,B600,none,0.36,1.03,0.461,0.307,422,no,,s
+GMOS-S,"B600 5.0""","singleslit,multislit",5.00arcsec,5.000,330,B600,none,0.36,1.03,0.461,0.307,169,no,,s
+GMOS-S,"R831 0.25""","singleslit,multislit",0.25arcsec,0.250,330,R831,none,0.36,1.03,0.757,0.23,8792,no,,s
+GMOS-S,"R831 0.50""","singleslit,multislit",0.50arcsec,0.500,330,R831,none,0.36,1.03,0.757,0.23,4396,no,,s
+GMOS-S,"R831 0.75""","singleslit,multislit",0.75arcsec,0.750,330,R831,none,0.36,1.03,0.757,0.23,2931,no,,s
+GMOS-S,"R831 1.0""","singleslit,multislit",1.00arcsec,1.000,330,R831,none,0.36,1.03,0.757,0.23,2198,no,,s
+GMOS-S,"R831 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R831,none,0.36,1.03,0.757,0.23,1465,no,,s
+GMOS-S,"R831 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R831,none,0.36,1.03,0.757,0.23,1099,no,,s
+GMOS-S,"R831 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R831,none,0.36,1.03,0.757,0.23,440,no,,s
+GMOS-S,"R400 0.25""","singleslit,multislit",0.25arcsec,0.250,330,R400,none,0.36,1.03,0.764,0.462,3836,no,,s
+GMOS-S,"R400 0.50""","singleslit,multislit",0.50arcsec,0.500,330,R400,none,0.36,1.03,0.764,0.462,1918,no,,s
+GMOS-S,"R400 0.75""","singleslit,multislit",0.75arcsec,0.750,330,R400,none,0.36,1.03,0.764,0.462,1279,no,,s
+GMOS-S,"R400 1.0""","singleslit,multislit",1.00arcsec,1.000,330,R400,none,0.36,1.03,0.764,0.462,959,no,,s
+GMOS-S,"R400 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R400,none,0.36,1.03,0.764,0.462,639,no,,s
+GMOS-S,"R400 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R400,none,0.36,1.03,0.764,0.462,480,no,,s
+GMOS-S,"R400 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R400,none,0.36,1.03,0.764,0.462,192,no,,s
+GMOS-S,"R150 0.25""","singleslit,multislit",0.25arcsec,0.250,330,R150,none,0.36,1.03,0.717,1.19,1262,no,,s
+GMOS-S,"R150 0.50""","singleslit,multislit",0.50arcsec,0.500,330,R150,none,0.36,1.03,0.717,1.19,631,no,,s
+GMOS-S,"R150 0.75""","singleslit,multislit",0.75arcsec,0.750,330,R150,none,0.36,1.03,0.717,1.19,421,no,,s
+GMOS-S,"R150 1.0""","singleslit,multislit",1.00arcsec,1.000,330,R150,none,0.36,1.03,0.717,1.19,316,no,,s
+GMOS-S,"R150 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R150,none,0.36,1.03,0.717,1.19,210,no,,s
+GMOS-S,"R150 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R150,none,0.36,1.03,0.717,1.19,158,no,,s
+GMOS-S,"R150 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R150,none,0.36,1.03,0.717,1.19,63,no,,s
+GMOS-S,B600 IFU1,ifu,IFU1,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,,s
+GMOS-S,B600 IFU1 NS,ifu,IFU1 N&S,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,Nod&Shuffle,s
+GMOS-S,B600 IFU2,ifu,IFU2,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,,s
+GMOS-S,B600 IFU2 NS,ifu,IFU2 N&S,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,Nod&Shuffle,s
+GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG455,0.46,1.03,0.717,0.57,316,no,Nod&Shuffle,s
+GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
+GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R831,CaT,0.78,0.933,0.757,0.23,2198,no,Nod&Shuffle,s
+NIFS,Z + ZJ,ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,,n
+NIFS,J + ZJ,ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,,n
+NIFS,J + HK,ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,,n
+NIFS,H + JH,ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,,n
+NIFS,H + HK,ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,,n
+NIFS,K + HK,ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,,n
+NIFS,"Z + ZJ + 0.1"" OD",ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,coronagraph,n
+NIFS,"J + ZJ + 0.1"" OD",ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,coronagraph,n
+NIFS,"J + HK + 0.1"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coronagraph,n
+NIFS,"H + JH + 0.1"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
+NIFS,"H + HK + 0.1"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
+NIFS,"K + HK + 0.1"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
+NIFS,"Z + ZJ + 0.2"" OD",ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,coronagraph,n
+NIFS,"J + ZJ + 0.2"" OD",ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,coronagraph,n
+NIFS,"J + HK + 0.2"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coronagraph,n
+NIFS,"H + JH + 0.2"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
+NIFS,"H + HK + 0.2"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
+NIFS,"K + HK + 0.2"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
+NIFS,"Z + ZJ + 0.5"" OD",ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,coronagraph,n
+NIFS,"J + ZJ + 0.5"" OD",ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,coronagraph,n
+NIFS,"J + HK + 0.5"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coronagraph,n
+NIFS,"H + JH + 0.5"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
+NIFS,"H + HK + 0.5"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
+NIFS,"K + HK + 0.5"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
+FLAMINGOS2,"R3K + J + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,J,1.175,1.333,1.254,0.158,2800,no,,s
+FLAMINGOS2,"R3K + H + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,H,1.486,1.775,1.6305,0.289,2800,no,,s
+FLAMINGOS2,"R3K + Ks + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,Ks,1.991,2.32,2.1555,0.329,2900,no,,s
+FLAMINGOS2,"R3K + Kb + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-blue,1.934,2.177,2.0555,0.243,2900,no,,s
+FLAMINGOS2,"R3K + Kr + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-red,2.181,2.446,2.3135,0.265,2900,no,,s
+FLAMINGOS2,"JH 0.36""","singleslit,multislit",2pixel,0.360,263,JH,JH,0.97,1.805,1.3875,0.835,900,no,,s
+FLAMINGOS2,"HK 0.36""","singleslit,multislit",2pixel,0.360,263,HK,HK,1.261,2.551,1.906,1.29,900,no,,s
+GPI,foo,ifu,Coronagraph,0.156,2.8,GPI,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.184,2.8,GPI,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.246,2.8,GPI,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
+GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
+SCORPIO,foo,singleslit,?,0.300,180,?,dichroic,0.37,2.35,1.36,1.98,4000,no,,s
+GNIRS,"SCLS + X + 0.3""",singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
+GNIRS,"SCLS + J + 0.3""",singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
+GNIRS,"SCLS + H + 0.3""",singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
+GNIRS,"SCLS + K + 0.3""",singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
+GNIRS,"SCLS + L + 0.3""",singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
+GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
+GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
+GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
+GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
+GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
+GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
+GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
+GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
+GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
+GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
+GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
+GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
+GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
+GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
+GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
+GNIRS SCXD,foo,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
+GNIRS LCXD,foo,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n

--- a/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
+++ b/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
@@ -35,12 +35,12 @@ GMOS-S,"R150 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R150,none,0.36,1
 GMOS-S,"R150 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R150,none,0.36,1.03,0.717,1.19,158,no,,s
 GMOS-S,"R150 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R150,none,0.36,1.03,0.717,1.19,63,no,,s
 GMOS-S,B600 IFU1,ifu,IFU1,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,,s
-GMOS-S,B600 IFU1 NS,ifu,IFU1 N&S,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,Nod&Shuffle,s
 GMOS-S,B600 IFU2,ifu,IFU2,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,,s
+GMOS-S,B600 IFU1 NS,ifu,IFU1 N&S,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,Nod&Shuffle,s
 GMOS-S,B600 IFU2 NS,ifu,IFU2 N&S,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,Nod&Shuffle,s
-GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG455,0.46,1.03,0.717,0.57,316,no,Nod&Shuffle,s
-GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
-GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R831,CaT,0.78,0.933,0.757,0.23,2198,no,Nod&Shuffle,s
+GMOS-S,R150 NS1.0 GG455,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG455,0.46,1.03,0.717,0.57,316,no,Nod&Shuffle,s
+GMOS-S,R150 NS1.0 GG515,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
+GMOS-S,R831 NS1.0 CaT,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R831,CaT,0.78,0.933,0.757,0.23,2198,no,Nod&Shuffle,s
 NIFS,Z + ZJ,ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,,n
 NIFS,J + ZJ,ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,,n
 NIFS,J + HK,ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,,n
@@ -72,174 +72,174 @@ FLAMINGOS2,"R3K + Kb + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-blu
 FLAMINGOS2,"R3K + Kr + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-red,2.181,2.446,2.3135,0.265,2900,no,,s
 FLAMINGOS2,"JH 0.36""","singleslit,multislit",2pixel,0.360,263,JH,JH,0.97,1.805,1.3875,0.835,900,no,,s
 FLAMINGOS2,"HK 0.36""","singleslit,multislit",2pixel,0.360,263,HK,HK,1.261,2.551,1.906,1.29,900,no,,s
-GPI,foo,ifu,Coronagraph,0.156,2.8,GPI,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.184,2.8,GPI,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.246,2.8,GPI,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
+GPI,Y,ifu,Coronagraph,0.156,2.8,prism,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
+GPI,J,ifu,Coronagraph,0.184,2.8,prism,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
+GPI,H,ifu,Coronagraph,0.246,2.8,prism,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
+GPI,K1,ifu,Coronagraph,0.306,2.8,prism,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
+GPI,K2,ifu,Coronagraph,0.306,2.8,prism,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
 SCORPIO,foo,singleslit,?,0.300,180,?,dichroic,0.37,2.35,1.36,1.98,4000,no,,s
-GNIRS,"SCLS + X + 0.3""",singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
-GNIRS,"SCLS + J + 0.3""",singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
-GNIRS,"SCLS + H + 0.3""",singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
-GNIRS,"SCLS + K + 0.3""",singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
-GNIRS,"SCLS + L + 0.3""",singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
-GNIRS SCXD,foo,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
-GNIRS LCXD,foo,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n
+GNIRS,"SCLS 32 X 0.3""",singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
+GNIRS,"SCLS 32 J 0.3""",singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
+GNIRS,"SCLS 32 H 0.3""",singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
+GNIRS,"SCLS 32 K 0.3""",singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
+GNIRS,"SCLS 32 L 0.3""",singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
+GNIRS,"SCLS 32 X 0.45""",singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
+GNIRS,"SCLS 32 J 0.45""",singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
+GNIRS,"SCLS 32 H 0.45""",singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
+GNIRS,"SCLS 32 K 0.45""",singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
+GNIRS,"SCLS 32 L 0.45""",singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
+GNIRS,"SCLS 32 X 0.675""",singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
+GNIRS,"SCLS 32 J 0.675""",singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
+GNIRS,"SCLS 32 H 0.675""",singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
+GNIRS,"SCLS 32 K 0.675""",singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
+GNIRS,"SCLS 32 L 0.675""",singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
+GNIRS,"SCLS 32 X 1.0""",singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
+GNIRS,"SCLS 32 J 1.0""",singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
+GNIRS,"SCLS 32 H 1.0""",singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
+GNIRS,"SCLS 32 K 1.0""",singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
+GNIRS,"SCLS 32 L 1.0""",singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
+GNIRS,"SCLS 111 X 0.3""",singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
+GNIRS,"SCLS 111 J 0.3""",singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
+GNIRS,"SCLS 111 H 0.3""",singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
+GNIRS,"SCLS 111 K 0.3""",singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
+GNIRS,"SCLS 111 L 0.3""",singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
+GNIRS,"SCLS 111 M 0.3""",singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
+GNIRS,"SCLS 111 X 0.45""",singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
+GNIRS,"SCLS 111 J 0.45""",singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
+GNIRS,"SCLS 111 H 0.45""",singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
+GNIRS,"SCLS 111 K 0.45""",singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
+GNIRS,"SCLS 111 L 0.45""",singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
+GNIRS,"SCLS 111 M 0.45""",singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
+GNIRS,"SCLS 111 X 0.675""",singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
+GNIRS,"SCLS 111 J 0.675""",singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
+GNIRS,"SCLS 111 H 0.675""",singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
+GNIRS,"SCLS 111 K 0.675""",singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
+GNIRS,"SCLS 111 L 0.675""",singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
+GNIRS,"SCLS 111 M 0.675""",singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
+GNIRS,"SCLS 111 X 1.0""",singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
+GNIRS,"SCLS 111 J 1.0""",singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
+GNIRS,"SCLS 111 H 1.0""",singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
+GNIRS,"SCLS 111 K 1.0""",singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
+GNIRS,"SCLS 111 L 1.0""",singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
+GNIRS,"SCLS 111 M 1.0""",singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
+GNIRS,"LCLS 10 X 0.1""",singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
+GNIRS,"LCLS 10 J 0.1""",singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
+GNIRS,"LCLS 10 H 0.1""",singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
+GNIRS,"LCLS 10 K 0.1""",singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
+GNIRS,"LCLS 10 L 0.1""",singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
+GNIRS,"LCLS 10 X 0.15""",singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
+GNIRS,"LCLS 10 J 0.15""",singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
+GNIRS,"LCLS 10 H 0.15""",singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
+GNIRS,"LCLS 10 K 0.15""",singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
+GNIRS,"LCLS 10 L 0.15""",singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
+GNIRS,"LCLS 10 X 0.2""",singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
+GNIRS,"LCLS 10 J 0.2""",singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
+GNIRS,"LCLS 10 H 0.2""",singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
+GNIRS,"LCLS 10 K 0.2""",singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
+GNIRS,"LCLS 10 L 0.2""",singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
+GNIRS,"LCLS 10 X 0.3""",singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
+GNIRS,"LCLS 10 J 0.3""",singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
+GNIRS,"LCLS 10 H 0.3""",singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
+GNIRS,"LCLS 10 K 0.3""",singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
+GNIRS,"LCLS 10 L 0.3""",singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
+GNIRS,"LCLS 10 X 0.45""",singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
+GNIRS,"LCLS 10 J 0.45""",singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
+GNIRS,"LCLS 10 H 0.45""",singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
+GNIRS,"LCLS 10 K 0.45""",singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
+GNIRS,"LCLS 10 L 0.45""",singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
+GNIRS,"LCLS 10 X 0.675""",singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
+GNIRS,"LCLS 10 J 0.675""",singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
+GNIRS,"LCLS 10 H 0.675""",singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
+GNIRS,"LCLS 10 K 0.675""",singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
+GNIRS,"LCLS 10 L 0.675""",singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
+GNIRS,"LCLS 10 X 1.0""",singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
+GNIRS,"LCLS 10 J 1.0""",singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
+GNIRS,"LCLS 10 H 1.0""",singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
+GNIRS,"LCLS 10 K 1.0""",singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
+GNIRS,"LCLS 10 L 1.0""",singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
+GNIRS,"LCLS 32 X 0.1""",singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
+GNIRS,"LCLS 32 J 0.1""",singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
+GNIRS,"LCLS 32 H 0.1""",singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
+GNIRS,"LCLS 32 K 0.1""",singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
+GNIRS,"LCLS 32 L 0.1""",singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
+GNIRS,"LCLS 32 M 0.1""",singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
+GNIRS,"LCLS 32 X 0.15""",singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
+GNIRS,"LCLS 32 J 0.15""",singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
+GNIRS,"LCLS 32 H 0.15""",singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
+GNIRS,"LCLS 32 K 0.15""",singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
+GNIRS,"LCLS 32 L 0.15""",singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
+GNIRS,"LCLS 32 M 0.15""",singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
+GNIRS,"LCLS 32 X 0.2""",singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
+GNIRS,"LCLS 32 J 0.2""",singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
+GNIRS,"LCLS 32 H 0.2""",singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
+GNIRS,"LCLS 32 K 0.2""",singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
+GNIRS,"LCLS 32 L 0.2""",singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
+GNIRS,"LCLS 32 M 0.2""",singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
+GNIRS,"LCLS 32 X 0.3""",singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
+GNIRS,"LCLS 32 J 0.3""",singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
+GNIRS,"LCLS 32 H 0.3""",singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
+GNIRS,"LCLS 32 K 0.3""",singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
+GNIRS,"LCLS 32 L 0.3""",singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
+GNIRS,"LCLS 32 M 0.3""",singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
+GNIRS,"LCLS 32 X 0.45""",singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
+GNIRS,"LCLS 32 J 0.45""",singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
+GNIRS,"LCLS 32 H 0.45""",singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
+GNIRS,"LCLS 32 K 0.45""",singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
+GNIRS,"LCLS 32 L 0.45""",singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
+GNIRS,"LCLS 32 M 0.45""",singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
+GNIRS,"LCLS 32 X 0.675""",singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
+GNIRS,"LCLS 32 J 0.675""",singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
+GNIRS,"LCLS 32 H 0.675""",singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
+GNIRS,"LCLS 32 K 0.675""",singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
+GNIRS,"LCLS 32 L 0.675""",singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
+GNIRS,"LCLS 32 M 0.675""",singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
+GNIRS,"LCLS 32 X 1.0""",singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
+GNIRS,"LCLS 32 J 1.0""",singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
+GNIRS,"LCLS 32 H 1.0""",singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
+GNIRS,"LCLS 32 K 1.0""",singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
+GNIRS,"LCLS 32 L 1.0""",singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
+GNIRS,"LCLS 32 M 1.0""",singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
+GNIRS,"LCLS 111 X 0.1""",singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
+GNIRS,"LCLS 111 J 0.1""",singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
+GNIRS,"LCLS 111 H 0.1""",singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
+GNIRS,"LCLS 111 K 0.1""",singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
+GNIRS,"LCLS 111 L 0.1""",singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
+GNIRS,"LCLS 111 M 0.1""",singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
+GNIRS,"LCLS 111 X 0.15""",singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
+GNIRS,"LCLS 111 J 0.15""",singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
+GNIRS,"LCLS 111 H 0.15""",singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
+GNIRS,"LCLS 111 K 0.15""",singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
+GNIRS,"LCLS 111 L 0.15""",singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
+GNIRS,"LCLS 111 M 0.15""",singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
+GNIRS,"LCLS 111 X 0.2""",singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
+GNIRS,"LCLS 111 J 0.2""",singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
+GNIRS,"LCLS 111 H 0.2""",singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
+GNIRS,"LCLS 111 K 0.2""",singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
+GNIRS,"LCLS 111 L 0.2""",singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
+GNIRS,"LCLS 111 M 0.2""",singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
+GNIRS,"LCLS 111 X 0.3""",singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
+GNIRS,"LCLS 111 J 0.3""",singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
+GNIRS,"LCLS 111 H 0.3""",singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
+GNIRS,"LCLS 111 K 0.3""",singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
+GNIRS,"LCLS 111 L 0.3""",singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
+GNIRS,"LCLS 111 M 0.3""",singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
+GNIRS,"LCLS 111 X 0.45""",singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
+GNIRS,"LCLS 111 J 0.45""",singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
+GNIRS,"LCLS 111 H 0.45""",singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
+GNIRS,"LCLS 111 K 0.45""",singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
+GNIRS,"LCLS 111 L 0.45""",singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
+GNIRS,"LCLS 111 M 0.45""",singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
+GNIRS,"LCLS 111 X 0.675""",singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
+GNIRS,"LCLS 111 J 0.675""",singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
+GNIRS,"LCLS 111 H 0.675""",singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
+GNIRS,"LCLS 111 K 0.675""",singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
+GNIRS,"LCLS 111 L 0.675""",singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
+GNIRS,"LCLS 111 M 0.675""",singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
+GNIRS,"LCLS 111 X 1.0""",singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
+GNIRS,"LCLS 111 J 1.0""",singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
+GNIRS,"LCLS 111 H 1.0""",singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
+GNIRS,"LCLS 111 K 1.0""",singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
+GNIRS,"LCLS 111 L 1.0""",singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
+GNIRS,"LCLS 111 M 1.0""",singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
+GNIRS,SCXD,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
+GNIRS,LCXD,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n

--- a/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
+++ b/explore/src/main/webapp/instrument_spectroscopy_matrix.csv
@@ -78,168 +78,168 @@ GPI,H,ifu,Coronagraph,0.246,2.8,prism,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
 GPI,K1,ifu,Coronagraph,0.306,2.8,prism,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
 GPI,K2,ifu,Coronagraph,0.306,2.8,prism,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
 SCORPIO,foo,singleslit,?,0.300,180,?,dichroic,0.37,2.35,1.36,1.98,4000,no,,s
-GNIRS,"SCLS 32 X 0.3""",singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
-GNIRS,"SCLS 32 J 0.3""",singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
-GNIRS,"SCLS 32 H 0.3""",singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
-GNIRS,"SCLS 32 K 0.3""",singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
-GNIRS,"SCLS 32 L 0.3""",singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
-GNIRS,"SCLS 32 X 0.45""",singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
-GNIRS,"SCLS 32 J 0.45""",singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
-GNIRS,"SCLS 32 H 0.45""",singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
-GNIRS,"SCLS 32 K 0.45""",singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
-GNIRS,"SCLS 32 L 0.45""",singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
-GNIRS,"SCLS 32 X 0.675""",singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
-GNIRS,"SCLS 32 J 0.675""",singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
-GNIRS,"SCLS 32 H 0.675""",singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
-GNIRS,"SCLS 32 K 0.675""",singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
-GNIRS,"SCLS 32 L 0.675""",singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
-GNIRS,"SCLS 32 X 1.0""",singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
-GNIRS,"SCLS 32 J 1.0""",singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
-GNIRS,"SCLS 32 H 1.0""",singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
-GNIRS,"SCLS 32 K 1.0""",singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
-GNIRS,"SCLS 32 L 1.0""",singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
-GNIRS,"SCLS 111 X 0.3""",singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
-GNIRS,"SCLS 111 J 0.3""",singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
-GNIRS,"SCLS 111 H 0.3""",singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
-GNIRS,"SCLS 111 K 0.3""",singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
-GNIRS,"SCLS 111 L 0.3""",singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
-GNIRS,"SCLS 111 M 0.3""",singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
-GNIRS,"SCLS 111 X 0.45""",singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
-GNIRS,"SCLS 111 J 0.45""",singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
-GNIRS,"SCLS 111 H 0.45""",singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
-GNIRS,"SCLS 111 K 0.45""",singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
-GNIRS,"SCLS 111 L 0.45""",singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
-GNIRS,"SCLS 111 M 0.45""",singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
-GNIRS,"SCLS 111 X 0.675""",singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
-GNIRS,"SCLS 111 J 0.675""",singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
-GNIRS,"SCLS 111 H 0.675""",singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
-GNIRS,"SCLS 111 K 0.675""",singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
-GNIRS,"SCLS 111 L 0.675""",singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
-GNIRS,"SCLS 111 M 0.675""",singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
-GNIRS,"SCLS 111 X 1.0""",singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
-GNIRS,"SCLS 111 J 1.0""",singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
-GNIRS,"SCLS 111 H 1.0""",singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
-GNIRS,"SCLS 111 K 1.0""",singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
-GNIRS,"SCLS 111 L 1.0""",singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
-GNIRS,"SCLS 111 M 1.0""",singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
-GNIRS,"LCLS 10 X 0.1""",singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
-GNIRS,"LCLS 10 J 0.1""",singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
-GNIRS,"LCLS 10 H 0.1""",singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
-GNIRS,"LCLS 10 K 0.1""",singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
-GNIRS,"LCLS 10 L 0.1""",singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
-GNIRS,"LCLS 10 X 0.15""",singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
-GNIRS,"LCLS 10 J 0.15""",singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
-GNIRS,"LCLS 10 H 0.15""",singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
-GNIRS,"LCLS 10 K 0.15""",singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
-GNIRS,"LCLS 10 L 0.15""",singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
-GNIRS,"LCLS 10 X 0.2""",singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
-GNIRS,"LCLS 10 J 0.2""",singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
-GNIRS,"LCLS 10 H 0.2""",singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
-GNIRS,"LCLS 10 K 0.2""",singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
-GNIRS,"LCLS 10 L 0.2""",singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
-GNIRS,"LCLS 10 X 0.3""",singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
-GNIRS,"LCLS 10 J 0.3""",singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
-GNIRS,"LCLS 10 H 0.3""",singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
-GNIRS,"LCLS 10 K 0.3""",singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
-GNIRS,"LCLS 10 L 0.3""",singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
-GNIRS,"LCLS 10 X 0.45""",singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
-GNIRS,"LCLS 10 J 0.45""",singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
-GNIRS,"LCLS 10 H 0.45""",singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
-GNIRS,"LCLS 10 K 0.45""",singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
-GNIRS,"LCLS 10 L 0.45""",singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
-GNIRS,"LCLS 10 X 0.675""",singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
-GNIRS,"LCLS 10 J 0.675""",singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
-GNIRS,"LCLS 10 H 0.675""",singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
-GNIRS,"LCLS 10 K 0.675""",singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
-GNIRS,"LCLS 10 L 0.675""",singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
-GNIRS,"LCLS 10 X 1.0""",singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
-GNIRS,"LCLS 10 J 1.0""",singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
-GNIRS,"LCLS 10 H 1.0""",singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
-GNIRS,"LCLS 10 K 1.0""",singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
-GNIRS,"LCLS 10 L 1.0""",singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
-GNIRS,"LCLS 32 X 0.1""",singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
-GNIRS,"LCLS 32 J 0.1""",singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
-GNIRS,"LCLS 32 H 0.1""",singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
-GNIRS,"LCLS 32 K 0.1""",singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
-GNIRS,"LCLS 32 L 0.1""",singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
-GNIRS,"LCLS 32 M 0.1""",singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
-GNIRS,"LCLS 32 X 0.15""",singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
-GNIRS,"LCLS 32 J 0.15""",singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
-GNIRS,"LCLS 32 H 0.15""",singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
-GNIRS,"LCLS 32 K 0.15""",singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
-GNIRS,"LCLS 32 L 0.15""",singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
-GNIRS,"LCLS 32 M 0.15""",singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
-GNIRS,"LCLS 32 X 0.2""",singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
-GNIRS,"LCLS 32 J 0.2""",singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
-GNIRS,"LCLS 32 H 0.2""",singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
-GNIRS,"LCLS 32 K 0.2""",singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
-GNIRS,"LCLS 32 L 0.2""",singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
-GNIRS,"LCLS 32 M 0.2""",singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
-GNIRS,"LCLS 32 X 0.3""",singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
-GNIRS,"LCLS 32 J 0.3""",singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
-GNIRS,"LCLS 32 H 0.3""",singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
-GNIRS,"LCLS 32 K 0.3""",singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
-GNIRS,"LCLS 32 L 0.3""",singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
-GNIRS,"LCLS 32 M 0.3""",singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
-GNIRS,"LCLS 32 X 0.45""",singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
-GNIRS,"LCLS 32 J 0.45""",singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
-GNIRS,"LCLS 32 H 0.45""",singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
-GNIRS,"LCLS 32 K 0.45""",singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
-GNIRS,"LCLS 32 L 0.45""",singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
-GNIRS,"LCLS 32 M 0.45""",singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
-GNIRS,"LCLS 32 X 0.675""",singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
-GNIRS,"LCLS 32 J 0.675""",singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
-GNIRS,"LCLS 32 H 0.675""",singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
-GNIRS,"LCLS 32 K 0.675""",singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
-GNIRS,"LCLS 32 L 0.675""",singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
-GNIRS,"LCLS 32 M 0.675""",singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
-GNIRS,"LCLS 32 X 1.0""",singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
-GNIRS,"LCLS 32 J 1.0""",singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
-GNIRS,"LCLS 32 H 1.0""",singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
-GNIRS,"LCLS 32 K 1.0""",singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
-GNIRS,"LCLS 32 L 1.0""",singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
-GNIRS,"LCLS 32 M 1.0""",singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
-GNIRS,"LCLS 111 X 0.1""",singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
-GNIRS,"LCLS 111 J 0.1""",singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
-GNIRS,"LCLS 111 H 0.1""",singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
-GNIRS,"LCLS 111 K 0.1""",singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
-GNIRS,"LCLS 111 L 0.1""",singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
-GNIRS,"LCLS 111 M 0.1""",singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
-GNIRS,"LCLS 111 X 0.15""",singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
-GNIRS,"LCLS 111 J 0.15""",singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
-GNIRS,"LCLS 111 H 0.15""",singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
-GNIRS,"LCLS 111 K 0.15""",singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
-GNIRS,"LCLS 111 L 0.15""",singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
-GNIRS,"LCLS 111 M 0.15""",singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
-GNIRS,"LCLS 111 X 0.2""",singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
-GNIRS,"LCLS 111 J 0.2""",singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
-GNIRS,"LCLS 111 H 0.2""",singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
-GNIRS,"LCLS 111 K 0.2""",singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
-GNIRS,"LCLS 111 L 0.2""",singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
-GNIRS,"LCLS 111 M 0.2""",singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
-GNIRS,"LCLS 111 X 0.3""",singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
-GNIRS,"LCLS 111 J 0.3""",singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
-GNIRS,"LCLS 111 H 0.3""",singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
-GNIRS,"LCLS 111 K 0.3""",singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
-GNIRS,"LCLS 111 L 0.3""",singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
-GNIRS,"LCLS 111 M 0.3""",singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
-GNIRS,"LCLS 111 X 0.45""",singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
-GNIRS,"LCLS 111 J 0.45""",singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
-GNIRS,"LCLS 111 H 0.45""",singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
-GNIRS,"LCLS 111 K 0.45""",singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
-GNIRS,"LCLS 111 L 0.45""",singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
-GNIRS,"LCLS 111 M 0.45""",singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
-GNIRS,"LCLS 111 X 0.675""",singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
-GNIRS,"LCLS 111 J 0.675""",singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
-GNIRS,"LCLS 111 H 0.675""",singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
-GNIRS,"LCLS 111 K 0.675""",singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
-GNIRS,"LCLS 111 L 0.675""",singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
-GNIRS,"LCLS 111 M 0.675""",singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
-GNIRS,"LCLS 111 X 1.0""",singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
-GNIRS,"LCLS 111 J 1.0""",singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
-GNIRS,"LCLS 111 H 1.0""",singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
-GNIRS,"LCLS 111 K 1.0""",singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
-GNIRS,"LCLS 111 L 1.0""",singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
-GNIRS,"LCLS 111 M 1.0""",singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
-GNIRS,SCXD,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
-GNIRS,LCXD,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
+GNIRS,SC,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
+GNIRS,LC,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n

--- a/model-tests/jvm/src/test/resources/instrument_spectroscopy_matrix.csv
+++ b/model-tests/jvm/src/test/resources/instrument_spectroscopy_matrix.csv
@@ -35,12 +35,12 @@ GMOS-S,"R150 1.5""","singleslit,multislit",1.50arcsec,1.500,330,R150,none,0.36,1
 GMOS-S,"R150 2.0""","singleslit,multislit",2.00arcsec,2.000,330,R150,none,0.36,1.03,0.717,1.19,158,no,,s
 GMOS-S,"R150 5.0""","singleslit,multislit",5.00arcsec,5.000,330,R150,none,0.36,1.03,0.717,1.19,63,no,,s
 GMOS-S,B600 IFU1,ifu,IFU1,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,,s
-GMOS-S,B600 IFU1 NS,ifu,IFU1 N&S,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,Nod&Shuffle,s
 GMOS-S,B600 IFU2,ifu,IFU2,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,,s
+GMOS-S,B600 IFU1 NS,ifu,IFU1 N&S,3.000,5,B600,none,0.36,1.03,0.461,0.307,2722,no,Nod&Shuffle,s
 GMOS-S,B600 IFU2 NS,ifu,IFU2 N&S,5.000,7,B600,g,0.398,0.552,0.461,0.154,2722,no,Nod&Shuffle,s
-GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG455,0.46,1.03,0.717,0.57,316,no,Nod&Shuffle,s
-GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
-GMOS-S,foo,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R831,CaT,0.78,0.933,0.757,0.23,2198,no,Nod&Shuffle,s
+GMOS-S,R150 NS1.0 GG455,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,GG455,0.46,1.03,0.717,0.57,316,no,Nod&Shuffle,s
+GMOS-S,R150 NS1.0 OG515,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R150,OG515,0.52,1.03,0.717,0.51,316,no,Nod&Shuffle,s
+GMOS-S,R831 NS1.0 CaT,"singleslit,multislit",N&S 1.0arcsec,1.000,330,R831,CaT,0.78,0.933,0.757,0.23,2198,no,Nod&Shuffle,s
 NIFS,Z + ZJ,ifu,none,3.000,3,Z,ZJ,1.11,1.265,1.1875,0.21,4990,yes,,n
 NIFS,J + ZJ,ifu,none,3.000,3,J,ZJ,1.11,1.44,1.275,0.18,6040,yes,,n
 NIFS,J + HK,ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,,n
@@ -65,181 +65,181 @@ NIFS,"J + HK + 0.5"" OD",ifu,none,3.000,3,J,HK,1.57,1.45,1.51,0.18,6040,yes,coro
 NIFS,"H + JH + 0.5"" OD",ifu,none,3.000,3,H,JH,1.325,1.96,1.6425,0.31,5290,yes,coronagraph,n
 NIFS,"H + HK + 0.5"" OD",ifu,none,3.000,3,H,HK,1.635,1.975,1.805,0.31,5290,yes,coronagraph,n
 NIFS,"K + HK + 0.5"" OD",ifu,none,3.000,3,K,HK,1.775,2.615,2.195,0.41,5290,yes,coronagraph,n
-FLAMINGOS2,"R3K + J + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,J,1.175,1.333,1.254,0.158,2800,no,,s
-FLAMINGOS2,"R3K + H + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,H,1.486,1.775,1.6305,0.289,2800,no,,s
-FLAMINGOS2,"R3K + Ks + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,Ks,1.991,2.32,2.1555,0.329,2900,no,,s
-FLAMINGOS2,"R3K + Kb + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-blue,1.934,2.177,2.0555,0.243,2900,no,,s
-FLAMINGOS2,"R3K + Kr + 0.36""","singleslit,multislit",2pixel,0.360,263,R3K,K-red,2.181,2.446,2.3135,0.265,2900,no,,s
-FLAMINGOS2,"JH 0.36""","singleslit,multislit",2pixel,0.360,263,JH,JH,0.97,1.805,1.3875,0.835,900,no,,s
-FLAMINGOS2,"HK 0.36""","singleslit,multislit",2pixel,0.360,263,HK,HK,1.261,2.551,1.906,1.29,900,no,,s
-GPI,foo,ifu,Coronagraph,0.156,2.8,GPI,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.184,2.8,GPI,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.246,2.8,GPI,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
-GPI,foo,ifu,Coronagraph,0.306,2.8,GPI,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
+FLAMINGOS2,"R3K + J + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,J,1.175,1.333,1.254,0.158,2800,no,,s
+FLAMINGOS2,"R3K + H + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,H,1.486,1.775,1.6305,0.289,2800,no,,s
+FLAMINGOS2,"R3K + Ks + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,K-short,1.991,2.32,2.1555,0.329,2900,no,,s
+FLAMINGOS2,"R3K + Kb + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,K-blue,1.934,2.177,2.0555,0.243,2900,no,,s
+FLAMINGOS2,"R3K + Kr + 0.36""","singleslit,multislit",2pixel,0.360,263,R3000,K-red,2.181,2.446,2.3135,0.265,2900,no,,s
+FLAMINGOS2,"JH 0.36""","singleslit,multislit",2pixel,0.360,263,R1200JH,JH,0.97,1.805,1.3875,0.835,900,no,,s
+FLAMINGOS2,"HK 0.36""","singleslit,multislit",2pixel,0.360,263,R1200HK,HK,1.261,2.551,1.906,1.29,900,no,,s
+GPI,Y,ifu,Coronagraph,0.156,2.8,Prism,Y,0.95,1.14,1.045,0.19,35,yes,coronagraph,s
+GPI,J,ifu,Coronagraph,0.184,2.8,Prism,J,1.12,1.35,1.235,0.23,36,yes,coronagraph,s
+GPI,H,ifu,Coronagraph,0.246,2.8,Prism,H,1.5,1.8,1.65,0.30,46,yes,coronagraph,s
+GPI,K1,ifu,Coronagraph,0.306,2.8,Prism,K1,1.9,2.19,2.045,0.29,66,yes,coronagraph,s
+GPI,K2,ifu,Coronagraph,0.306,2.8,Prism,K2,2.13,2.4,2.265,0.27,79,yes,coronagraph,s
 SCORPIO,foo,singleslit,?,0.300,180,?,dichroic,0.37,2.35,1.36,1.98,4000,no,,s
-GNIRS,"SCLS + X + 0.3""",singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
-GNIRS,"SCLS + J + 0.3""",singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
-GNIRS,"SCLS + H + 0.3""",singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
-GNIRS,"SCLS + K + 0.3""",singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
-GNIRS,"SCLS + L + 0.3""",singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
-GNIRS SCLS,foo,singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
-GNIRS SCLS,foo,singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
-GNIRS SCLS,foo,singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
-GNIRS SCLS,foo,singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
-GNIRS SCLS,foo,singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
-GNIRS LCLS,foo,singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
-GNIRS LCLS,foo,singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
-GNIRS LCLS,foo,singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
-GNIRS LCLS,foo,singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
-GNIRS LCLS,foo,singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
-GNIRS LCLS,foo,singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
-GNIRS LCLS,foo,singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
-GNIRS LCLS,foo,singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
-GNIRS LCLS,foo,singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
-GNIRS LCLS,foo,singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
-GNIRS SCXD,foo,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
-GNIRS LCXD,foo,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,X,1.03,1.17,1.1,0.331,1700,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,J,1.17,1.37,1.27,0.397,1600,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,H,1.49,1.8,1.645,0.496,1700,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,K,1.91,2.49,2.2,0.661,1700,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,32,L,2.8,4.2,3.5,0.992,1800,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,X,1.03,1.17,1.1,0.331,1133,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,J,1.17,1.37,1.27,0.397,1067,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,H,1.49,1.8,1.645,0.496,1133,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,K,1.91,2.49,2.2,0.661,1133,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,32,L,2.8,4.2,3.5,0.992,1200,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,X,1.03,1.17,1.1,0.331,756,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,J,1.17,1.37,1.27,0.397,711,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,H,1.49,1.8,1.645,0.496,756,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,K,1.91,2.49,2.2,0.661,756,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,32,L,2.8,4.2,3.5,0.992,800,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,X,1.03,1.17,1.1,0.331,510,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,J,1.17,1.37,1.27,0.397,480,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,H,1.49,1.8,1.645,0.496,510,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,K,1.91,2.49,2.2,0.661,510,no,,n
+GNIRS,SC,singleslit,1.0,1.000,99,32,L,2.8,4.2,3.5,0.992,540,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,X,1.03,1.17,1.1,0.094,6600,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,J,1.17,1.37,1.27,0.113,7200,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,H,1.49,1.8,1.645,0.142,5900,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,K,1.91,2.49,2.2,0.189,5900,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,L,2.8,4.2,3.5,0.28,6400,no,,n
+GNIRS,SC,singleslit,0.3,0.300,99,111,M,4.4,6,4.8,0.575,4300,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,X,1.03,1.17,1.1,0.094,4400,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,J,1.17,1.37,1.27,0.113,4800,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,H,1.49,1.8,1.645,0.142,3933,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,K,1.91,2.49,2.2,0.189,3933,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,L,2.8,4.2,3.5,0.28,4267,no,,n
+GNIRS,SC,singleslit,0.45,0.450,99,111,M,4.4,6,4.8,0.575,2867,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,X,1.03,1.17,1.1,0.094,2933,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,J,1.17,1.37,1.27,0.113,3200,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,H,1.49,1.8,1.645,0.142,2622,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,K,1.91,2.49,2.2,0.189,2622,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,L,2.8,4.2,3.5,0.28,2844,no,,n
+GNIRS,SC,singleslit,0.675,0.675,99,111,M,4.4,6,4.8,0.575,1911,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,X,1.03,1.17,1.1,0.094,1980,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,J,1.17,1.37,1.27,0.113,2160,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,H,1.49,1.8,1.645,0.142,1770,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,K,1.91,2.49,2.2,0.189,1770,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,L,2.8,4.2,3.5,0.28,1920,no,,n
+GNIRS,SC,singleslit,1.00,1.000,99,111,M,4.4,6,4.8,0.575,1290,no,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,X,1.03,1.17,1.1,0.332,2100,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,J,1.17,1.37,1.27,0.398,1600,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,H,1.49,1.8,1.645,0.497,1700,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,K,1.91,2.49,2.2,0.663,1700,yes,,n
+GNIRS,LC,singleslit,0.10,0.100,49,10,L,2.8,4.2,3.5,0.995,1800,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,X,1.03,1.17,1.1,0.332,1400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,J,1.17,1.37,1.27,0.398,1067,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,H,1.49,1.8,1.645,0.497,1133,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,K,1.91,2.49,2.2,0.663,1133,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,10,L,2.8,4.2,3.5,0.995,1200,no,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,X,1.03,1.17,1.1,0.332,1050,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,J,1.17,1.37,1.27,0.398,800,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,H,1.49,1.8,1.645,0.497,850,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,K,1.91,2.49,2.2,0.663,850,yes,,n
+GNIRS,LC,singleslit,0.20,0.200,49,10,L,2.8,4.2,3.5,0.995,900,no,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,X,1.03,1.17,1.1,0.332,700,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,J,1.17,1.37,1.27,0.398,533,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,H,1.49,1.8,1.645,0.497,567,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,K,1.91,2.49,2.2,0.663,567,yes,,n
+GNIRS,LC,singleslit,0.30,0.300,49,10,L,2.8,4.2,3.5,0.995,600,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,X,1.03,1.17,1.1,0.332,467,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,J,1.17,1.37,1.27,0.398,356,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,H,1.49,1.8,1.645,0.497,378,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,K,1.91,2.49,2.2,0.663,378,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,10,L,2.8,4.2,3.5,0.995,400,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,X,1.03,1.17,1.1,0.332,311,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,J,1.17,1.37,1.27,0.398,237,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,H,1.49,1.8,1.645,0.497,252,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,K,1.91,2.49,2.2,0.663,252,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,10,L,2.8,4.2,3.5,0.995,267,no,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,X,1.03,1.17,1.1,0.332,210,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,J,1.17,1.37,1.27,0.398,160,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,H,1.49,1.8,1.645,0.497,170,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,K,1.91,2.49,2.2,0.663,170,yes,,n
+GNIRS,LC,singleslit,1.00,1.000,49,10,L,2.8,4.2,3.5,0.995,180,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,X,1.03,1.17,1.1,0.11,5100,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,J,1.17,1.37,1.27,0.132,4800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,H,1.49,1.8,1.645,0.166,5100,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,K,1.91,2.49,2.2,0.221,5100,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,L,2.8,4.2,3.5,0.332,5400,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,32,M,2.8,4.2,3.5,0.66,3700,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,X,1.03,1.17,1.1,0.11,3400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,J,1.17,1.37,1.27,0.132,3200,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,H,1.49,1.8,1.645,0.166,3400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,K,1.91,2.49,2.2,0.221,3400,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,L,2.8,4.2,3.5,0.332,3600,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,32,M,2.8,4.2,3.5,0.66,2467,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,X,1.03,1.17,1.1,0.11,2550,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,J,1.17,1.37,1.27,0.132,2400,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,H,1.49,1.8,1.645,0.166,2550,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,K,1.91,2.49,2.2,0.221,2550,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,L,2.8,4.2,3.5,0.332,2700,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,32,M,2.8,4.2,3.5,0.66,1850,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,X,1.03,1.17,1.1,0.11,1700,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,J,1.17,1.37,1.27,0.132,1600,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,H,1.49,1.8,1.645,0.166,1700,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,K,1.91,2.49,2.2,0.221,1700,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,L,2.8,4.2,3.5,0.332,1800,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,32,M,2.8,4.2,3.5,0.66,1233,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,X,1.03,1.17,1.1,0.11,1133,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,J,1.17,1.37,1.27,0.132,1067,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,H,1.49,1.8,1.645,0.166,1133,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,K,1.91,2.49,2.2,0.221,1133,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,L,2.8,4.2,3.5,0.332,1200,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,32,M,2.8,4.2,3.5,0.66,822,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,X,1.03,1.17,1.1,0.11,756,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,J,1.17,1.37,1.27,0.132,711,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,H,1.49,1.8,1.645,0.166,756,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,K,1.91,2.49,2.2,0.221,756,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,L,2.8,4.2,3.5,0.332,800,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,32,M,2.8,4.2,3.5,0.66,548,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,X,1.03,1.17,1.1,0.11,510,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,J,1.17,1.37,1.27,0.132,480,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,H,1.49,1.8,1.645,0.166,510,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,K,1.91,2.49,2.2,0.221,510,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,L,2.8,4.2,3.5,0.332,540,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,32,M,2.8,4.2,3.5,0.66,370,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,X,1.03,1.17,1.1,0.0316,17800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,J,1.17,1.37,1.27,0.038,17000,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,H,1.49,1.8,1.645,0.0475,17800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,K,1.91,2.49,2.2,0.0633,17800,yes,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,L,2.8,4.2,3.5,0.0944,19000,no,,n
+GNIRS,LC,singleslit,0.1,0.100,49,111,M,2.8,4.2,3.5,0.192,12800,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,X,1.03,1.17,1.1,0.0316,11867,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,J,1.17,1.37,1.27,0.038,11333,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,H,1.49,1.8,1.645,0.0475,11867,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,K,1.91,2.49,2.2,0.0633,11867,yes,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,L,2.8,4.2,3.5,0.0944,12667,no,,n
+GNIRS,LC,singleslit,0.15,0.150,49,111,M,2.8,4.2,3.5,0.192,8533,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,X,1.03,1.17,1.1,0.0316,8900,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,J,1.17,1.37,1.27,0.038,8500,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,H,1.49,1.8,1.645,0.0475,8900,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,K,1.91,2.49,2.2,0.0633,8900,yes,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,L,2.8,4.2,3.5,0.0944,9500,no,,n
+GNIRS,LC,singleslit,0.2,0.200,49,111,M,2.8,4.2,3.5,0.192,6400,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,X,1.03,1.17,1.1,0.0316,5933,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,J,1.17,1.37,1.27,0.038,5667,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,H,1.49,1.8,1.645,0.0475,5933,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,K,1.91,2.49,2.2,0.0633,5933,yes,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,L,2.8,4.2,3.5,0.0944,6333,no,,n
+GNIRS,LC,singleslit,0.3,0.300,49,111,M,2.8,4.2,3.5,0.192,4267,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,X,1.03,1.17,1.1,0.0316,3956,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,J,1.17,1.37,1.27,0.038,3778,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,H,1.49,1.8,1.645,0.0475,3956,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,K,1.91,2.49,2.2,0.0633,3956,yes,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,L,2.8,4.2,3.5,0.0944,4222,no,,n
+GNIRS,LC,singleslit,0.45,0.450,49,111,M,2.8,4.2,3.5,0.192,2844,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,X,1.03,1.17,1.1,0.0316,2637,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,J,1.17,1.37,1.27,0.038,2519,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,H,1.49,1.8,1.645,0.0475,2637,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,K,1.91,2.49,2.2,0.0633,2637,yes,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,L,2.8,4.2,3.5,0.0944,2815,no,,n
+GNIRS,LC,singleslit,0.675,0.675,49,111,M,2.8,4.2,3.5,0.192,1896,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,X,1.03,1.17,1.1,0.0316,1780,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,J,1.17,1.37,1.27,0.038,1700,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,H,1.49,1.8,1.645,0.0475,1780,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,K,1.91,2.49,2.2,0.0633,1780,yes,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,L,2.8,4.2,3.5,0.0944,1900,no,,n
+GNIRS,LC,singleslit,1.0,1.000,49,111,M,2.8,4.2,3.5,0.192,1280,no,,n
+GNIRS,SC,singleslit,0.3,0.300,7,32,XD,0.85,2.5,1.675,2.5,1700,no,,n
+GNIRS,LC,singleslit,0.1,0.100,5,32,XD,0.85,2.5,1.675,2.5,5000,yes,,n

--- a/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
+++ b/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
@@ -8,14 +8,14 @@ import cats.syntax.all._
 import fs2._
 import fs2.data.csv._
 
-trait SpectroscopyModesMatrixPlatform extends ModesMatrixDecoders {
-  def loadMatrix[F[_]: Concurrent](s: Stream[F, String]): F[List[ModeRow]] =
+trait SpectroscopyModesMatrixPlatform extends SpectroscopyModesMatrixDecoders {
+  def loadMatrix[F[_]: Concurrent](s: Stream[F, String]): F[List[SpectroscopyModeRow]] =
     s
-      .through(decodeUsingHeaders[ModeRow]())
+      .through(decodeUsingHeaders[SpectroscopyModeRow]())
       .compile
       .toList
 
-  def apply[F[_]: Concurrent](s: Stream[F, String]): F[ModesMatrix] =
-    loadMatrix(s).map(ModesMatrix(_))
+  def apply[F[_]: Concurrent](s: Stream[F, String]): F[SpectroscopyModesMatrix] =
+    loadMatrix(s).map(SpectroscopyModesMatrix(_))
 
 }

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -14,9 +14,15 @@ import eu.timepit.refined.types.string._
 import explore.model.enum.SpectroscopyCapabilities
 import fs2.data.csv._
 import lucuma.core.enum.F2Disperser
+import lucuma.core.enum.F2Filter
+import lucuma.core.enum.GmosNorthDisperser
+import lucuma.core.enum.GmosNorthFilter
 import lucuma.core.enum.GmosSouthDisperser
+import lucuma.core.enum.GmosSouthFilter
 import lucuma.core.enum.GnirsDisperser
+import lucuma.core.enum.GnirsFilter
 import lucuma.core.enum.GpiDisperser
+import lucuma.core.enum.GpiFilter
 import lucuma.core.enum.ImageQuality
 import lucuma.core.enum.Instrument
 import lucuma.core.math.Angle
@@ -45,65 +51,110 @@ trait InstrumentRow {
 
   type Disperser
   val disperser: Disperser
+
+  type Filter
+  val filter: Filter
 }
 
 object InstrumentRow {
-  def apply[FPU0](
+
+  def decodeEnum[A: Enumerated, B](
+    id:       B,
+    criteria: (B, A) => Boolean
+  ): Either[DecoderError, A] =
+    Enumerated[A].all.find(criteria(id, _)).toRight(new DecoderError(s"Unknown enum $id"))
+
+  def decodeOptionalEnum[A: Enumerated](
+    filter:   String,
+    criteria: (String, A) => Boolean
+  ): Either[DecoderError, Option[A]] =
+    if (filter.isEmpty || filter.toLowerCase === "none") none.asRight
+    else decodeEnum[A, String](filter, criteria).map(_.some)
+
+  def decodeGmosSouthFilter(filter: NonEmptyString): Either[DecoderError, Option[GmosSouthFilter]] =
+    decodeOptionalEnum[GmosSouthFilter](filter.value, (i, f) => !f.obsolete && i === f.shortName)
+
+  def decodeGmosSouthDisperser(disperser: String): Either[DecoderError, GmosSouthDisperser] =
+    decodeEnum[GmosSouthDisperser, String](disperser, (i, f) => !f.obsolete && i === f.shortName)
+
+  def decodeGmosNorthFilter(filter: NonEmptyString): Either[DecoderError, Option[GmosNorthFilter]] =
+    decodeOptionalEnum[GmosNorthFilter](filter.value, (i, f) => !f.obsolete && i === f.shortName)
+
+  def decodeGmosNorthDisperser(disperser: String): Either[DecoderError, GmosNorthDisperser] =
+    decodeEnum[GmosNorthDisperser, String](disperser, (i, f) => !f.obsolete && i === f.shortName)
+
+  def decodeF2Filter(filter: NonEmptyString): Either[DecoderError, F2Filter] =
+    decodeEnum[F2Filter, String](filter.value, (i, f) => !f.obsolete && i === f.shortName)
+
+  def decodeF2Disperser(disperser: String): Either[DecoderError, F2Disperser] =
+    decodeEnum[F2Disperser, String](disperser, _ === _.shortName)
+
+  def decodeGpiFilter(filter: NonEmptyString): Either[DecoderError, GpiFilter] =
+    decodeEnum[GpiFilter, String](filter.value, (i, f) => !f.obsolete && i === f.shortName)
+
+  def decodeGpiDisperser(disperser: String): Either[DecoderError, GpiDisperser] =
+    decodeEnum[GpiDisperser, String](disperser, _ === _.shortName)
+
+  def decodeGnirsFilter(filter: NonEmptyString): Either[DecoderError, GnirsFilter] =
+    decodeEnum[GnirsFilter, String](filter.value, _ === _.shortName)
+
+  def decodeGnirsDisperser(disperser: String): Either[DecoderError, GnirsDisperser] =
+    decodeEnum[GnirsDisperser, String](disperser, _ === _.shortName)
+
+  def decode(
     instrument0: Instrument,
-    disperser0:  String
+    disperser0:  String,
+    filter0:     NonEmptyString
   ): Either[DecoderError, InstrumentRow] =
     instrument0 match {
+      case i @ Instrument.GmosNorth  =>
+        (decodeGmosNorthDisperser(disperser0), decodeGmosNorthFilter(filter0)).mapN { case (d, f) =>
+          new InstrumentRow {
+            val instrument = i
+            type Disperser = GmosNorthDisperser
+            val disperser = d
+            type Filter = Option[GmosNorthFilter]
+            val filter = f
+          }
+        }
       case i @ Instrument.GmosSouth  =>
-        (disperser0 match {
-          case "B1200" => GmosSouthDisperser.B1200_G5321.asRight
-          case "B600"  => GmosSouthDisperser.B600_G5323.asRight
-          case "R831"  => GmosSouthDisperser.R831_G5322.asRight
-          case "R400"  => GmosSouthDisperser.R400_G5325.asRight
-          case "R150"  => GmosSouthDisperser.R150_G5326.asRight
-          case x       => new DecoderError(s"Unknown disperser $x").asLeft
-        }).map { d =>
+        (decodeGmosSouthDisperser(disperser0), decodeGmosSouthFilter(filter0)).mapN { case (d, f) =>
           new InstrumentRow {
             val instrument = i
             type Disperser = GmosSouthDisperser
             val disperser = d
+            type Filter = Option[GmosSouthFilter]
+            val filter = f
           }
         }
       case i @ Instrument.Flamingos2 =>
-        (disperser0 match {
-          case "R3K" => F2Disperser.R3000.asRight
-          case "JH"  => F2Disperser.R1200JH.asRight
-          case "HK"  => F2Disperser.R1200HK.asRight
-          case x     => new DecoderError(s"Unknown disperser $x").asLeft
-        }).map { d =>
+        (decodeF2Disperser(disperser0), decodeF2Filter(filter0)).mapN { case (d, f) =>
           new InstrumentRow {
             val instrument = i
             type Disperser = F2Disperser
             val disperser = d
+            type Filter = F2Filter
+            val filter = f
           }
         }
       case i @ Instrument.Gpi        =>
-        (disperser0.toLowerCase match {
-          case "prism"     => GpiDisperser.PRISM.asRight
-          case "wollaston" => GpiDisperser.WOLLASTON.asRight
-          case x           => new DecoderError(s"Unknown disperser $x").asLeft
-        }).map { d =>
+        (decodeGpiDisperser(disperser0), decodeGpiFilter(filter0)).mapN { case (d, f) =>
           new InstrumentRow {
             val instrument = i
             type Disperser = GpiDisperser
             val disperser = d
+            type Filter = GpiFilter
+            val filter = f
           }
         }
       case i @ Instrument.Gnirs      =>
-        (disperser0.toLowerCase match {
-          case "10"  => GnirsDisperser.D10.asRight
-          case "32"  => GnirsDisperser.D32.asRight
-          case "111" => GnirsDisperser.D111.asRight
-          case x     => new DecoderError(s"Unknown disperser $x").asLeft
-        }).map { d =>
+        (decodeGnirsDisperser(disperser0), decodeGnirsFilter(filter0)).mapN { case (d, f) =>
           new InstrumentRow {
             val instrument = i
             type Disperser = GnirsDisperser
             val disperser = d
+            type Filter = GnirsFilter
+            val filter = f
           }
         }
       case i                         =>
@@ -111,6 +162,8 @@ object InstrumentRow {
           val instrument = i
           type Disperser = String
           val disperser = disperser0
+          type Filter = String
+          val filter = filter0.value
         }.asRight
     }
 
@@ -120,12 +173,14 @@ object InstrumentRow {
   def disperser: Getter[InstrumentRow, InstrumentRow#Disperser] =
     Getter[InstrumentRow, InstrumentRow#Disperser](_.disperser)
 
+  def filter: Getter[InstrumentRow, InstrumentRow#Filter] =
+    Getter[InstrumentRow, InstrumentRow#Filter](_.filter)
+
 }
 
 case class SpectroscopyModeRow(
   instrument:        InstrumentRow,
   config:            NonEmptyString,
-  filterTag:         Option[NonEmptyString], // TODO Find a better type to represent any filter
   focalPlane:        NonEmptyList[FocalPlane],
   capabilities:      Option[SpectroscopyCapabilities],
   ao:                ModeAO,
@@ -138,6 +193,12 @@ case class SpectroscopyModeRow(
   slitWidth:         ModeSlitSize
 ) {
   def calculatedRange: Quantity[NonNegBigDecimal, Micrometer] = wavelengthRange
+
+  val hasFilter: Boolean = instrument.filter match {
+    case _: None.type => false
+    case _            => true
+  }
+
 }
 
 object SpectroscopyModeRow {
@@ -161,6 +222,9 @@ object SpectroscopyModeRow {
 
   def disperser: Getter[SpectroscopyModeRow, InstrumentRow#Disperser] =
     instrumentRow.composeGetter(InstrumentRow.disperser)
+
+  def filter: Getter[SpectroscopyModeRow, InstrumentRow#Filter] =
+    instrumentRow.composeGetter(InstrumentRow.filter)
 
   def range: Getter[SpectroscopyModeRow, Quantity[NonNegBigDecimal, Micrometer]] =
     Getter(_.calculatedRange)
@@ -207,12 +271,9 @@ trait SpectroscopyModesMatrixDecoders extends Decoders {
     def apply(row: CsvRow[String]): DecoderResult[SpectroscopyModeRow] =
       for {
         di  <- row.as[String]("disperser")
-        i   <- row.as[Instrument]("instrument").flatMap(InstrumentRow(_, di))
+        fi  <- row.as[NonEmptyString]("filter")
+        i   <- row.as[Instrument]("instrument").flatMap(InstrumentRow.decode(_, di, fi))
         s   <- row.as[NonEmptyString]("Config")
-        fi  <- row.as[NonEmptyString]("filter").map {
-                 case n if n.value.toLowerCase === "none" => none
-                 case f                                   => f.some
-               }
         f   <- row.as[NonEmptyList[FocalPlane]]("Focal Plane")
         c   <- row.as[Option[SpectroscopyCapabilities]]("capabilities")
         a   <- row.as[ModeAO]("AO")
@@ -223,7 +284,7 @@ trait SpectroscopyModesMatrixDecoders extends Decoders {
         r   <- row.as[PosBigDecimal]("resolution")
         sl  <- row.as[ModeSlitSize]("slit length")
         sw  <- row.as[ModeSlitSize]("slit width")
-      } yield SpectroscopyModeRow(i, s, fi, f, c, a, min, max, wo, wr, r, sl, sw)
+      } yield SpectroscopyModeRow(i, s, f, c, a, min, max, wo, wr, r, sl, sw)
   }
 }
 
@@ -274,7 +335,7 @@ final case class SpectroscopyModesMatrix(matrix: List[SpectroscopyModeRow]) {
       val filterScore: Rational     =
         (wavelength, FilterLimit)
           .mapN { (w, l) =>
-            if (w >= l && r.filterTag.isDefined) ScoreBump else Rational.zero
+            if (w >= l && r.hasFilter) ScoreBump else Rational.zero
           }
           .getOrElse(Rational.zero)
       // Wavelength matche

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -150,6 +150,9 @@ object SpectroscopyModeRow {
   val config: Lens[SpectroscopyModeRow, NonEmptyString] =
     GenLens[SpectroscopyModeRow](_.config)
 
+  val instrumentAndConfig: Getter[SpectroscopyModeRow, (Instrument, NonEmptyString)] =
+    instrument.zip(config.asGetter)
+
   val slitWidth: Lens[SpectroscopyModeRow, ModeSlitSize] =
     GenLens[SpectroscopyModeRow](_.slitWidth)
 

--- a/model/shared/src/main/scala/explore/modes/package.scala
+++ b/model/shared/src/main/scala/explore/modes/package.scala
@@ -12,7 +12,10 @@ import fs2.data.csv._
 import lucuma.core.enum.Instrument
 import lucuma.core.math.Angle
 import lucuma.core.math.Wavelength
+import lucuma.core.optics.Wedge
 import lucuma.core.util.Enumerated
+import monocle.Lens
+import monocle.macros.GenLens
 
 package modes {
 
@@ -20,8 +23,18 @@ package modes {
     override def toString: String = s"${w.micrometer.value.toDouble} μm"
   }
 
-  case class ModeSlitSize(sw: Angle) {
-    override def toString: String = s"${Angle.milliarcseconds.get(sw) / 1000.0} arcsec"
+  case class ModeSlitSize(size: Angle) {
+    override def toString: String = s"${Angle.milliarcseconds.get(size) / 1000.0} arcsec"
+  }
+
+  object ModeSlitSize {
+    val size: Lens[ModeSlitSize, Angle] = GenLens[ModeSlitSize](_.size)
+
+    val milliarcseconds: Wedge[Angle, BigDecimal] =
+      Angle.milliarcseconds
+        .imapB(_.underlying.movePointRight(3).intValue,
+               n => new java.math.BigDecimal(n).movePointLeft(3)
+        )
   }
 
   sealed trait ModeAO extends Product with Serializable


### PR DESCRIPTION
This shows the modes for spectroscopy in the config tables. Some notes:

* There is no  filtering nor sorting yet
* The UI is not finished and feedback is welcome
* I'm trying an encoding with Dependent types to avoid existentials and seems to be working fine, again feedback is welcome