### PR TITLE
Magnitude list editor

### DIFF
--- a/common-graphql/src/main/resources/graphql/schemas/ObservationDB.graphql
+++ b/common-graphql/src/main/resources/graphql/schemas/ObservationDB.graphql
@@ -360,7 +360,7 @@ input CreateNonsiderealInput {
   name: NonEmptyString!
   key: EphemerisKeyType!
   des: String!
-  magnitudes: [MagnitudeInput!]
+  magnitudes: [MagnitudeCreateInput!]
 }
 
 # Observation creation parameters
@@ -387,7 +387,7 @@ input CreateSiderealInput {
   properMotion: ProperMotionInput
   radialVelocity: RadialVelocityInput
   parallax: ParallaxModelInput
-  magnitudes: [MagnitudeInput!]
+  magnitudes: [MagnitudeCreateInput!]
 }
 
 # Opaque object cursor
@@ -625,14 +625,8 @@ input EditObservationPointingInput {
 input EditSiderealInput {
   targetId: TargetId!
 
-  # Replace all magnitudes with the provided values
-  magnitudes: [MagnitudeInput!]
-
-  # Update any listed magnitudes leaving unmentioned values unchanged
-  modifyMagnitudes: [MagnitudeInput!]
-
-  # Removes any listed magnitude values
-  deleteMagnitudes: [MagnitudeBand!]
+  # Edit magnitudes
+  magnitudes: MagnitudeEditList
 
   # The existence field must be either specified or skipped altogether.  It cannot be unset with a null value.
   existence: Existence
@@ -1987,12 +1981,39 @@ enum MagnitudeBand {
   AP
 }
 
-# Magnitude description
-input MagnitudeInput {
-  value: BigDecimal!
+# Magnitude creation parameters
+input MagnitudeCreateInput {
   band: MagnitudeBand!
+  value: BigDecimal!
   error: BigDecimal
   system: MagnitudeSystem = VEGA
+}
+
+# Magnitude edit action (choose one option only)
+input MagnitudeEditAction {
+  add: MagnitudeCreateInput
+  delete: MagnitudeBand
+  edit: MagnitudeEditInput
+}
+
+# Magnitude editing parameters
+input MagnitudeEditInput {
+  band: MagnitudeBand!
+
+  # The value field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  value: BigDecimal
+
+  # The system field must be either specified or skipped altogether.  It cannot be unset with a null value.
+  system: MagnitudeSystem
+
+  # The error field may be unset by assigning a null value, or ignored by skipping it altogether
+  error: BigDecimal
+}
+
+# Magnitude list editing (choose one option only)
+input MagnitudeEditList {
+  replaceList: [MagnitudeCreateInput!]
+  editList: [MagnitudeEditAction!]
 }
 
 # Magnitude system
@@ -2676,7 +2697,7 @@ input QueryConfigurationAlternativeSearchInput {
   spectralDistribution: SpctralDistribution
 
   # Target magnitude/system/band.
-  magnitude: MagnitudeInput
+  magnitude: MagnitudeCreateInput
 
   # Target redshift.
   redshift: BigDecimal

--- a/common/src/main/scala/explore/common/TargetQueries.scala
+++ b/common/src/main/scala/explore/common/TargetQueries.scala
@@ -151,7 +151,7 @@ object TargetQueries {
         parallax(t.parallax)
   }
 
-  def updateMagnitudes(mags: List[Magnitude]): Endo[EditSiderealInput] =
+  def replaceMagnitudes(mags: List[Magnitude]): Endo[EditSiderealInput] =
     EditSiderealInput.magnitudes.set(
       MagnitudeEditList(replaceList = mags.map(_.toCreateInput).assign).assign
     )

--- a/common/src/main/scala/explore/common/TargetQueries.scala
+++ b/common/src/main/scala/explore/common/TargetQueries.scala
@@ -152,5 +152,7 @@ object TargetQueries {
   }
 
   def updateMagnitudes(mags: List[Magnitude]): Endo[EditSiderealInput] =
-    EditSiderealInput.magnitudes.set(mags.map(_.toInput).assign)
+    EditSiderealInput.magnitudes.set(
+      MagnitudeEditList(replaceList = mags.map(_.toCreateInput).assign).assign
+    )
 }

--- a/common/src/main/scala/explore/schemas/implicits.scala
+++ b/common/src/main/scala/explore/schemas/implicits.scala
@@ -8,16 +8,16 @@ import lucuma.core.model.Magnitude
 
 import java.math.MathContext
 
-import ObservationDB.Types.MagnitudeInput
+import ObservationDB.Types.MagnitudeCreateInput
 import UserPreferencesDB.Types.ExploreResizableWidthInsertInput
 
 object implicits {
   implicit class MagnitudeOps(m: Magnitude) {
-    def toInput: MagnitudeInput =
-      MagnitudeInput(m.value.toDoubleValue,
-                     m.band,
-                     m.error.map(_.toRational.toBigDecimal(MathContext.UNLIMITED)).orIgnore,
-                     m.system.assign
+    def toCreateInput: MagnitudeCreateInput =
+      MagnitudeCreateInput(m.band,
+                           m.value.toDoubleValue,
+                           m.error.map(_.toRational.toBigDecimal(MathContext.UNLIMITED)).orIgnore,
+                           m.system.assign
       )
   }
 

--- a/explore/src/main/scala/explore/observationtree/TargetObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/TargetObsList.scala
@@ -302,7 +302,7 @@ object TargetObsList {
           ).parTupled.flatMap {
             case (_, Right(Some(Target(_, Right(st), m)))) =>
               val update = TargetQueries.UpdateSiderealTracking(st) >>>
-                TargetQueries.updateMagnitudes(m.values.toList)
+                TargetQueries.replaceMagnitudes(m.values.toList)
               TargetQueriesGQL.TargetMutation.execute(update(EditSiderealInput(newTarget.id))).void
             case _                                         =>
               IO.unit

--- a/explore/src/main/scala/explore/targeteditor/TargetBody.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetBody.scala
@@ -87,7 +87,7 @@ object TargetBody {
           { args: (NonEmptyString, SiderealTracking, List[Magnitude]) =>
             EditSiderealInput.name.set(args._1.value.assign) >>>
               TargetQueries.UpdateSiderealTracking(args._2) >>>
-              TargetQueries.updateMagnitudes(args._3)
+              TargetQueries.replaceMagnitudes(args._3)
           }
         )
 
@@ -108,7 +108,7 @@ object TargetBody {
           )
 
         val magnitudesView =
-          undoViewSet(TargetResult.magnitudes, TargetQueries.updateMagnitudes)
+          undoViewSet(TargetResult.magnitudes, TargetQueries.replaceMagnitudes)
 
         val nameView = undoViewSet(
           TargetResult.name,


### PR DESCRIPTION
This accommodates the changes in https://github.com/gemini-hlsw/lucuma-tmp-api/pull/318. However, it only makes use of `replaceList` to replace the entire magnitudes list. This is equivalent to the previous editing method. A different PR may be created to utilize the more fine-grained editing afforded by `editList`.