### PR TITLE
Update aladin-lite to work in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -290,9 +290,9 @@
       }
     },
     "@cquiroz/aladin-lite": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@cquiroz/aladin-lite/-/aladin-lite-0.4.0.tgz",
-      "integrity": "sha512-s7SSehon7KVpb+9uvyv1+uA9Ue6/RzYw/k5dvpyTuRzXdcD1O/OIq3yL2N+pUA7fBu7SeVYEkz+rH2tzh3ZQ7w==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@cquiroz/aladin-lite/-/aladin-lite-0.5.1.tgz",
+      "integrity": "sha512-1ZooMQ4xAQk/83TIuItLYEjy83iAKVN1Hq71Occ62vLs68B8HV6VnhFwD7mlZrUwpdjHDmkRwKD7yIObYr0oCA==",
       "requires": {
         "jquery": "^1.12.4",
         "raf": "^3.4.1",
@@ -352,9 +352,9 @@
       "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
     },
     "@fortawesome/fontawesome-pro": {
-      "version": "5.15.3",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/5.15.3/fontawesome-pro-5.15.3.tgz",
-      "integrity": "sha512-JAf7zDYGVtcJIqnWAzZ8KRqSHQ2+KnJi4K916Zxti4ONfaVw87jaUoxtfxtNsc3kgTmCmbwgPsi2nOA/1fEnzQ=="
+      "version": "5.15.4",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-pro/-/5.15.4/fontawesome-pro-5.15.4.tgz",
+      "integrity": "sha512-ApOqpDdKgA79xfLZH3B5PucZxj+TZyQUSrZ4bKkbJCR+zjmveQ4/gp/uXc5bNNhsdtJUy16BYJ/lAVydca2Y5Q=="
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "1.2.35",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   },
   "dependencies": {
     "@atlaskit/tree": "8.4.0",
-    "@cquiroz/aladin-lite": "0.4.0",
-    "@fortawesome/fontawesome-pro": "^5.15.3",
+    "@cquiroz/aladin-lite": "0.5.1",
+    "@fortawesome/fontawesome-pro": "^5.15.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/pro-duotone-svg-icons": "^5.15.3",
     "@fortawesome/pro-light-svg-icons": "^5.15.3",


### PR DESCRIPTION
Aladin was updated to use es-modules but we had babel transpiling aladin to emulate es for older browsers. This is in contradiction to how vite assembles the modules. 
The solution was to set babel to emit non emulated es-modules and this seems to work now in production