### PR TITLE
Adapt ElevationRange editor to new View logic

### DIFF
--- a/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -236,7 +236,7 @@ object ConstraintsPanel {
                 changeAuditor = ChangeAuditor.accept.decimal(1),
                 clazz = ExploreStyles.ElevationRangeEntry
               ),
-              <.label("Min"),
+              <.label("Max"),
               FormInputEV(
                 id = "maxam",
                 value = airMassView

--- a/model/shared/src/main/scala/explore/model/ElevationRange.scala
+++ b/model/shared/src/main/scala/explore/model/ElevationRange.scala
@@ -40,7 +40,7 @@ private object ElevationRangeType {
 sealed trait ElevationRange extends Product with Serializable
 
 object ElevationRange {
-  val airmass: Prism[ElevationRange, AirMassRange] =
+  val airMass: Prism[ElevationRange, AirMassRange] =
     GenPrism[ElevationRange, AirMassRange]
 
   val hourAngle: Prism[ElevationRange, HourAngleRange] =


### PR DESCRIPTION
We discovered that the interaction of `getDerivedStateFromProps` and the new logic of `ViewF.withOnMod` could yield surprising results.

This is an attempt to rewrite the ElevationRange editor by making the derived state read-only and always modifying the original data directly. This removes the need to use `withOnMod`.