### PR TITLE
Don't run linter on dependabot PRs.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   run-linters:
     name: Run linters
     runs-on: ubuntu-latest
-    if: startsWith(github.repository, 'gemini')
+    if: (startsWith(github.repository, 'gemini') && github.actor != 'dependabot')
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
Dependabot PRs run on `push` and `pull_request` no longer have access to `secrets` (see https://github.com/dependabot/dependabot-core/issues/3253#issuecomment-797125425).

This makes the lint action fail with a 403 on dependabot PRs.

We could switch to running on `pull_request_target`, but I think we don't actually need the linter on dependabot PRs, which is what this PR is about.