### PR TITLE
Several fixes [ch-1017] [ch-1015]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ val FUILess              = "2.8.7"
 val kindProjectorVersion = "0.13.0"
 
 ThisBuild / Test / bspEnabled := false
-ThisBuild / ScalafixConfig / bspEnabled := false
+ThisBuild / ScalafixConfig / bspEnabled.withRank(KeyRanks.Invisible) := false
 
 addCommandAlias(
   "quickTest",
@@ -231,12 +231,12 @@ lazy val esModule = Seq(
 
 val lintCSS = TaskKey[Unit]("lintCSS", "Lint CSS files")
 lintCSS := {
-  if(("npm run lint-dark" #&& "npm run lint-light" !) != 0)
+  if (("npm run lint-dark" #&& "npm run lint-light" !) != 0)
     throw new Exception("Error in CSS format")
 }
 
 val fixCSS = TaskKey[Unit]("fixCSS", "Fix CSS files")
 fixCSS := {
-  if(("npm run fix-dark" #&& "npm run fix-light" !) != 0)
+  if (("npm run fix-dark" #&& "npm run fix-light" !) != 0)
     throw new Exception("Error in CSS fix")
 }

--- a/common/src/main/scala/reactST/reactTable/SUITableVirtuoso.scala
+++ b/common/src/main/scala/reactST/reactTable/SUITableVirtuoso.scala
@@ -183,11 +183,14 @@ class SUITableVirtuoso[
       }
 
       val bodyElement: TableBody = props.body.copy(as = <.div)(tableInstance.getTableBodyProps())(
-        GroupedVirtuoso[Row[D]](
-          data = tableInstance.rows,
-          itemContent = renderRow,
-          groupContent = headerElement.map(header => (_: Int) => header.vdomElement).orUndefined
-        )(ExploreStyles.TBody)
+        TagMod.when(tableInstance.rows.nonEmpty)(
+          GroupedVirtuoso[Row[D]](
+            data = tableInstance.rows,
+            itemContent = renderRow,
+            groupContent = headerElement.map(header => (_: Int) => header.vdomElement).orUndefined
+          )(ExploreStyles.TBody)
+        ),
+        TagMod.when(tableInstance.rows.isEmpty)("No matching modes")
       )
 
       def standardFooter(footerTag: TableFooter) =

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
     val reactAtlasKitTree = "0.4.1"
     val reactClipboard    = "1.5.0"
     val reactCommon       = "0.13.0"
-    val reactDatepicker   = "0.3.0"
+    val reactDatepicker   = "0.3.1"
     val reactGridLayout   = "0.14.0"
     val reactHighcharts   = "0.4.1"
     val reactHotkeys      = "0.3.2"


### PR DESCRIPTION
* In Observation View, when no modes match the requirements Explore no longer breaks.
* In Target View, date in night elevation plot now matches the selected date (no more 1 month offset).
* In Target View, semester plots now show visibility time above 30 degrees (instead of 0).
* In Target View, semester plots now render a data point every 3 days (instead of 1), which increases threefold the rendering speed.