### PR TITLE
Fix moon so it appears behind dropdown

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -931,7 +931,6 @@ tfoot {
   position: absolute;
   top: 5px;
   right: 1rem;
-  z-index: 10;
 }
 
 .connection-ok {

--- a/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
+++ b/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
@@ -309,6 +309,7 @@ object SkyPlotNight {
       ).bimap(MoonCalc.approxPhase, _.lunarIlluminatedFraction.toDouble)
 
       <.span(
+        Chart(options).withKey(props.toString),
         <.div(ExploreStyles.MoonPhase)(
           <.span(
             MoonPhase(phase = moonPhase,
@@ -318,8 +319,7 @@ object SkyPlotNight {
             ),
             <.small("%1.0f%%".format(moonIllum * 100))
           )
-        ),
-        Chart(options).withKey(props.toString)
+        )
       )
     }
   }


### PR DESCRIPTION
In narrow windows, the moon would appear in front of the magnitude dropdown.
<img width="126" alt="image" src="https://user-images.githubusercontent.com/6035943/132775657-ea018363-931a-4e9c-9e00-47ed43ff6f2f.png">

By placing the moon after the sky plot in the DOM, I was able to remove the z-index on the moon that was causing the problem.
<img width="126" alt="image" src="https://user-images.githubusercontent.com/6035943/132775614-b178482d-3f83-4d0d-bed9-308f0feb5225.png">
