### PR TITLE
Prevent target FOV user preference being set to zero

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -78,14 +78,16 @@ object AladinCell extends ModelOptics {
     val coordinatesSetter =
       ((coords: Coordinates) => $.setStateL(State.current)(coords)).reuseAlways
 
-    def fovSetter(props: Props, fov: Fov): Callback = {
-      implicit val ctx = props.ctx
-      $.setStateL(State.fov)(fov) >>
-        UserTargetPreferencesUpsert
-          .updateFov[IO](props.uid, props.tid, fov.x)
-          .runAsyncAndForgetCB
-          .debounce(1.seconds)
-    }
+    def fovSetter(props: Props, fov: Fov): Callback =
+      if (fov.x.toMicroarcseconds === 0L) Callback.empty
+      else {
+        implicit val ctx = props.ctx
+        $.setStateL(State.fov)(fov) >>
+          UserTargetPreferencesUpsert
+            .updateFov[IO](props.uid, props.tid, fov.x)
+            .runAsyncAndForgetCB
+            .debounce(1.seconds)
+      }
 
     def render(props: Props, state: State) =
       React.Fragment(


### PR DESCRIPTION
This prevents a drastic changing of the FOV for the aladin component to full zoom out. If the user switches between targets too quickly, the callback from the aladin component to set the user preferences was being called with a zero from the target that was being navigated away from. The user preference was set to 0 and the next time the user viewed that target it would be zoomed full out.

There is still a React warning being printed to the console in this case, but I'm not sure which component is causing it:

> react_devtools_backend.js:4049 Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.

Note that there is a subtler case of the zoom being changed, as documented in ch-729, that varies for different targets.