### PR TITLE
Run terser after build

### DIFF
--- a/.github/workflows/heroku.yml
+++ b/.github/workflows/heroku.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Vite - Build
         run: |
           npm install
-          npx vite build
+          node build
         env:
           NODE_OPTIONS: --max_old_space_size=6144
       - name: Heroku - Deploy

--- a/build.js
+++ b/build.js
@@ -1,0 +1,48 @@
+const path = require("path")
+const fs = require("fs")
+const process = require("process")
+const size = require('human-format');
+const config = require("./vite.config.js")
+const { build } = require('vite')
+const { minify } = require("terser");
+const humanFormat = require("human-format");
+
+const outDir = path.resolve(__dirname, "heroku/static")
+const terserOptions =  {
+  sourceMap: false,
+  nameCache: {},
+  format: {
+    comments: false,
+  },
+  mangle: {
+    properties: {
+      debug: false,
+      keep_quoted: "strict",
+      reserved: ['$classData', 'main', 'toString', 'constructor', 'length', 'call', 'apply', 'NaN', 'Infinity', 'undefined'],
+      regex: /^(\$m_|loadHelp|.*__f\d?_|.*__O|.*L\S+_)/,
+    }
+  }
+}
+
+var i = 1
+function runTerserOn(fileName, length) {
+  process.stdout.write(`Minifying ${i++}/${length}: ${fileName}...`)
+  const absolute = path.join(outDir, fileName)
+  const original = fs.readFileSync(absolute, "utf8")
+  minify(original, terserOptions).then( minified => {
+    fs.writeFileSync(absolute, minified.code, "utf8")
+    const fromSize = original.length
+    const toSize = minified.code.length
+    const ratio = (toSize / fromSize) * 100
+    process.stdout.write(` ${humanFormat.bytes(fromSize, { prefix: 'Ki' })}  --> ${humanFormat.bytes(toSize, { prefix: 'Ki' })} (${ratio.toFixed(2)}%)\n`)
+  })
+}
+
+;(async () => {
+  const rollupOutput = await build(config)
+  const jsChunks = rollupOutput.output.map(chunk => chunk.fileName).filter(fileName => fileName.endsWith(".js"))
+
+  for (const fileName of jsChunks) {
+    await runTerserOn(fileName, jsChunks.length)
+  }
+})()

--- a/package-lock.json
+++ b/package-lock.json
@@ -965,6 +965,12 @@
         "node-releases": "^1.1.71"
       }
     },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -2019,6 +2025,12 @@
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
       }
+    },
+    "human-format": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/human-format/-/human-format-0.11.0.tgz",
+      "integrity": "sha512-g4UtoBnhfitCjkGjjiOlY8tkmArIcrstBa5adihxSJwSde1A7iQzvrNLB5ceX89FHXzYi9yTi04t3m82J/XIag==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -5611,6 +5623,24 @@
       "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
       "dev": true
     },
+    "source-map-support": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.20.tgz",
+      "integrity": "sha512-n1lZZ8Ve4ksRqizaBQgxXDgKwttHDhyfQjA6YZZn8+AroHbsIz+JjwxQDxbp+7y5OYCI8t1Yk7etjD9CRd2hIw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "space-separated-tokens": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
@@ -5974,6 +6004,31 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
+    },
+    "terser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.8.0.tgz",
+      "integrity": "sha512-f0JH+6yMpneYcRJN314lZrSwu9eKkUFEHLN/kNy8ceh8gaRiLgFPJqrB9HsXjhEGdv4e/ekjTOFxIlL6xlma8A==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "source-map": "~0.7.2",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@vitejs/plugin-react-refresh": "^1.3.6",
     "assert": "^2.0.0",
     "chokidar": "3.5.1",
+    "human-format": "0.11.0",
     "less": "3.9.0",
     "less-watch-compiler": "1.16.2",
     "process": "^0.11.10",
@@ -57,6 +58,7 @@
     "stylelint-color-format": "^1.1.0",
     "stylelint-config-standard": "^22.0.0",
     "stylelint-value-no-unknown-custom-properties": "^3.0.0",
+    "terser": "5.8.0",
     "vite": "2.5.0",
     "vite-plugin-fonts": "^0.2.2"
   },
@@ -65,7 +67,7 @@
     "fix-dark": "sed '/^[\\.\\}\\@]/d;/^[[:blank:]]*\\..*/d;/\\/\\/.*/d' common/src/main/webapp/less/variables-dark.less > vars.css;trap \"rm vars.css\" EXIT;npx stylelint --fix common/src/main/webapp/less",
     "lint-light": "sed '/^[\\.\\}\\@]/d;/^[[:blank:]]*\\..*/d;/\\/\\/.*/d' common/src/main/webapp/less/variables-light.less > vars.css;trap \"rm vars.css\" EXIT;npx stylelint common/src/main/webapp/less",
     "fix-light": "sed '/^[\\.\\}\\@]/d;/^[[:blank:]]*\\..*/d;/\\/\\/.*/d' common/src/main/webapp/less/variables-light.less > vars.css;trap \"rm vars.css\" EXIT;npx stylelint --fix common/src/main/webapp/less",
-    "build": "vite build",
+    "build": "--unhandled-rejections=strict build.js",
     "serve": "vite preview"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,10 @@
-import reactRefresh from "@vitejs/plugin-react-refresh";
-import { visualizer } from 'rollup-plugin-visualizer';
-import path from "path";
-import fs from "fs";
-import ViteFonts from "vite-plugin-fonts";
+const reactRefresh = require('@vitejs/plugin-react-refresh')
+const { visualizer } = require('rollup-plugin-visualizer')
+const path = require("path")
+const fs = require("fs")
+const ViteFonts = require("vite-plugin-fonts")
 
-const fontImport = ViteFonts({
+const fontImport = ViteFonts.Plugin({
   google: {
     families: [
       {
@@ -16,7 +16,7 @@ const fontImport = ViteFonts({
 });
 
 // https://vitejs.dev/config/
-export default ({ command, mode }) => {
+module.exports = ({ command, mode }) => {
   const scalaClassesDir = path.resolve(__dirname, "explore/target/scala-2.13");
   const isProduction = mode == "production";
   const sjs =
@@ -116,11 +116,18 @@ export default ({ command, mode }) => {
       },
     },
     build: {
-      rollupOptions: {
-        plugins: rollupPlugins
-      },
+      emptyOutDir: true,
+      chunkSizeWarningLimit: 20000,
       terserOptions: {
         sourceMap: false,
+        compress: {
+          passes: 2,
+          toplevel: true,
+          ecma: 2015
+        }
+      },
+      rollupOptions: {
+        plugins: rollupPlugins
       },
       outDir: path.resolve(__dirname, "heroku/static"),
     },


### PR DESCRIPTION
This PR switches to run `vite` programatically. This allows us to run things on `vite`'s output. In this case, we are running `terser` with our own handling of the `nameCache` for property mangling, since `vite` doesn't seem to handle it properly.

Strangely, the best results are obtained when running `terser` both within `vite` (without property mangling, just compressing) and afterwards (with property mangling).

For example, Explore's main chunk (`index.js`) results with:
- No terser: ~32.5 Mb.
- Terser only after vite: ~19.5 Mb.
- Terser only in vite: ~16.3 Mb.
- Terser both in and after vite: ~10.5MB.

Supersedes #1033