### PR TITLE
Use firebase for review apps and staging.

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,13 @@
+{
+  "projects": {
+    "default": "explore-gemini"
+  },
+  "targets": {
+    "explore-gemini": {
+      "hosting": {
+        "staging": ["explore-gemini"],
+        "production": ["explore-gemini-prod"]
+      }
+    }
+  }
+}

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -48,3 +48,22 @@ jobs:
         run: yarn bundlemon
         env:
           BUNDLEMON_PROJECT_ID: 614a60c0e759f5000834cacc
+
+      - name: Deploy review app to Firebase
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_EXPLORE_GEMINI }}'
+          projectId: explore-gemini
+          target: 'staging'
+
+      - name: Deploy staging app to Firebase
+        if: github.event_name == 'push'
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_EXPLORE_GEMINI }}'
+          projectId: explore-gemini
+          target: 'staging'
+          channelId: live

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ common/src/main/publicdev/
 server.cert
 server.key
 stats.html
+
+# Firebase
+.firebase/

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,34 @@
+{
+  "hosting": [
+    {
+      "target": "staging",
+      "public": "heroku/static",
+      "ignore": ["/*.conf.json"],
+      "rewrites": [
+        {
+          "source": "/conf.json",
+          "destination": "/staging.conf.json"
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
+      "target": "production",
+      "public": "heroku/static",
+      "ignore": ["/*.conf.json"],
+      "rewrites": [
+        {
+          "source": "/conf.json",
+          "destination": "/production.conf.json"
+        },
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Since we actually run our builds in GitHub, there's nothing really tying us to Heroku. Therefore, I'm exploring other hosting options. I played a bit with Netlify and Firebase, and I decided to go for the latter. (We could also explore other options, like AWS's Amplify).

Reasons for these are:
 - Options for serving static assets from Heroku are limited.
 - The buildpack for serving static assets hasn't been maintained in a year.
 - It doesn't support brotli compression.
 - Cold-serving Explore from Heroku takes between ~3s (rarely) to ~6s (and sometimes more). Serving from Firebase consistently takes ~1.8s. (From Netlify takes ~3s).
 - We can have review apps for all PRs in Firebase (which this PR does).
 
Things we lose by moving away from Heroku:
- Nice workflow UI.
- Promoting from staging to production without rebuilding. There may be ways to achieve this. We could investigate implementing a cloud function that copies resource from one app to the other. 

I don't consider these big losses compared to the gains.

