### PR TITLE
Change constraints undo/redo so only keeps stack for most recent "thing"

### DIFF
--- a/common/src/main/scala/explore/model/ConstraintsUndoStacks.scala
+++ b/common/src/main/scala/explore/model/ConstraintsUndoStacks.scala
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.syntax.all._
+import explore.common.ConstraintGroupQueries.ConstraintGroupList
+import explore.undo.UndoStacks
+import lucuma.core.model.Observation
+
+import scala.collection.immutable.SortedSet
+
+sealed trait ConstraintsUndoStacks[F[_]] {
+  import ConstraintsUndoStacks._
+
+  def listStacks: UndoStacks[F, ConstraintGroupList] = this match {
+    case ConstraintGroupUndoStacks(_, _) => UndoStacks.empty[F, ConstraintGroupList]
+    case ConstraintListUndoStacks(us)    => us
+  }
+
+  def groupStacks(obsIds: SortedSet[Observation.Id]): UndoStacks[F, ConstraintSet] = this match {
+    case ConstraintGroupUndoStacks(ids, undoStacks) if ids === obsIds => undoStacks
+    case _                                                            => UndoStacks.empty[F, ConstraintSet]
+  }
+}
+
+object ConstraintsUndoStacks {
+  case class ConstraintGroupUndoStacks[F[_]](
+    ids:        SortedSet[Observation.Id],
+    undoStacks: UndoStacks[F, ConstraintSet]
+  ) extends ConstraintsUndoStacks[F]
+
+  case class ConstraintListUndoStacks[F[_]](undoStacks: UndoStacks[F, ConstraintGroupList])
+      extends ConstraintsUndoStacks[F]
+
+  def empty[F[_]] = ConstraintListUndoStacks(UndoStacks.empty[F, ConstraintGroupList])
+
+  implicit def eqConstraintsUndoStacks[F[_1]]: Eq[ConstraintsUndoStacks[F]] = Eq.instance {
+    case (ConstraintListUndoStacks(l1), ConstraintListUndoStacks(l2))           => l1 === l2
+    case (ConstraintGroupUndoStacks(i1, s1), ConstraintGroupUndoStacks(i2, s2)) =>
+      i1 === i2 && s1 === s2
+    case _                                                                      => false
+  }
+}

--- a/common/src/main/scala/explore/model/ModelUndoStacks.scala
+++ b/common/src/main/scala/explore/model/ModelUndoStacks.scala
@@ -4,7 +4,6 @@
 package explore.model
 
 import cats.Eq
-import explore.common.ConstraintGroupQueries.ConstraintGroupList
 import explore.common.ObsQueries.ObservationList
 import explore.common.ObsQueries.ScienceData
 import explore.common.TargetObsQueries.PointingsWithObs
@@ -14,40 +13,23 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Target
 import monocle.Focus
 
-import scala.collection.immutable.SortedSet
-
 case class ModelUndoStacks[F[_]](
-  forObsList:           UndoStacks[F, ObservationList] = UndoStacks.empty[F, ObservationList],
-  forTargetList:        UndoStacks[F, PointingsWithObs] = UndoStacks.empty[F, PointingsWithObs],
-  forTarget:            Map[Target.Id, UndoStacks[F, TargetResult]] =
+  forObsList:     UndoStacks[F, ObservationList] = UndoStacks.empty[F, ObservationList],
+  forTargetList:  UndoStacks[F, PointingsWithObs] = UndoStacks.empty[F, PointingsWithObs],
+  forTarget:      Map[Target.Id, UndoStacks[F, TargetResult]] =
     Map.empty[Target.Id, UndoStacks[F, TargetResult]],
-  forConstraintList:    UndoStacks[F, ConstraintGroupList] = UndoStacks.empty[F, ConstraintGroupList],
-  forConstraintSet:     Map[Observation.Id, UndoStacks[F, ConstraintSet]] =
-    Map.empty[Observation.Id, UndoStacks[F, ConstraintSet]],
-  forBulkConstraintSet: Map[SortedSet[Observation.Id], UndoStacks[F, ConstraintSet]] =
-    Map.empty[SortedSet[Observation.Id], UndoStacks[F, ConstraintSet]],
-  forScienceData:       Map[Observation.Id, UndoStacks[F, ScienceData]] =
+  forConstraints: ConstraintsUndoStacks[F] = ConstraintsUndoStacks.empty[F],
+  forScienceData: Map[Observation.Id, UndoStacks[F, ScienceData]] =
     Map.empty[Observation.Id, UndoStacks[F, ScienceData]]
 )
 
 object ModelUndoStacks {
-  def forObsList[F[_]]           = Focus[ModelUndoStacks[F]](_.forObsList)
-  def forTargetList[F[_]]        = Focus[ModelUndoStacks[F]](_.forTargetList)
-  def forTarget[F[_]]            = Focus[ModelUndoStacks[F]](_.forTarget)
-  def forConstraintList[F[_]]    = Focus[ModelUndoStacks[F]](_.forConstraintList)
-  def forConstraintSet[F[_]]     = Focus[ModelUndoStacks[F]](_.forConstraintSet)
-  def forBulkConstraintSet[F[_]] = Focus[ModelUndoStacks[F]](_.forBulkConstraintSet)
-  def forScienceData[F[_]]       = Focus[ModelUndoStacks[F]](_.forScienceData)
+  def forObsList[F[_]]     = Focus[ModelUndoStacks[F]](_.forObsList)
+  def forTargetList[F[_]]  = Focus[ModelUndoStacks[F]](_.forTargetList)
+  def forTarget[F[_]]      = Focus[ModelUndoStacks[F]](_.forTarget)
+  def forConstraints[F[_]] = Focus[ModelUndoStacks[F]](_.forConstraints)
+  def forScienceData[F[_]] = Focus[ModelUndoStacks[F]](_.forScienceData)
 
   implicit def eqModelUndoStacks[F[_]]: Eq[ModelUndoStacks[F]] =
-    Eq.by(u =>
-      (u.forObsList,
-       u.forTargetList,
-       u.forTarget,
-       u.forConstraintList,
-       u.forConstraintSet,
-       u.forBulkConstraintSet,
-       u.forScienceData
-      )
-    )
+    Eq.by(u => (u.forObsList, u.forTargetList, u.forTarget, u.forConstraints, u.forScienceData))
 }

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -50,15 +50,17 @@ object reusability {
   implicit def undoSetterReuse[F[_], G[_], M: Reusability]: Reusability[UndoSetter[F, G, M]] =
     Reusability.by(_.model)
 
-  implicit def undoStacksMapReuse[F[_], K, M]: Reusability[Map[K, UndoStacks[F, M]]] =
+  implicit def undoStacksMapReuse[F[_], K, M]: Reusability[Map[K, UndoStacks[F, M]]]   =
     Reusability.by[Map[K, UndoStacks[F, M]], Int](_.size) && Reusability[Map[K, UndoStacks[F, M]]](
       (a, b) =>
         a.forall { case (k, stacksA) =>
           b.get(k).exists(stacksB => undoStacksReuse.test(stacksA, stacksB))
         }
     )
-  implicit def modelUndoStacksReuse[F[_]]: Reusability[ModelUndoStacks[F]]           = Reusability.derive
+  implicit def modelUndoStacksReuse[F[_]]: Reusability[ModelUndoStacks[F]]             = Reusability.derive
+  implicit def reuseConstraintsUndoStacks[F[_]]: Reusability[ConstraintsUndoStacks[F]] =
+    Reusability.derive
   // Move to lucuma-ui
-  implicit val semesterReuse: Reusability[Semester]                                  = Reusability.derive
-  implicit val cssReuse: Reusability[Css]                                            = Reusability.by(_.htmlClass)
+  implicit val semesterReuse: Reusability[Semester]                                    = Reusability.derive
+  implicit val cssReuse: Reusability[Css]                                              = Reusability.by(_.htmlClass)
 }

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -75,8 +75,7 @@ object Routing {
           model.zoom(
             RootModel.expandedIds.andThen(ExpandedIds.constraintSetObsIds)
           ),
-          model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forConstraintList),
-          model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forBulkConstraintSet),
+          model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forConstraints),
           model.zoom(RootModel.constraintSummaryHiddenColumns),
           size
         )

--- a/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
@@ -16,6 +16,8 @@ import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.implicits._
 import explore.model.ConstraintGroup
+import explore.model.ConstraintsUndoStacks
+import explore.model.ConstraintsUndoStacks._
 import explore.model.Focused
 import explore.model.Focused._
 import explore.model.SelectedPanel
@@ -45,7 +47,7 @@ final case class ConstraintGroupObsList(
   focused:            View[Option[Focused]],
   selected:           View[SelectedPanel[SortedSet[Observation.Id]]],
   expandedIds:        View[SortedSet[SortedSet[Observation.Id]]],
-  undoStacks:         View[UndoStacks[IO, ConstraintGroupList]]
+  undoStacks:         View[ConstraintsUndoStacks[IO]]
 )(implicit val ctx:   AppContextIO)
     extends ReactProps[ConstraintGroupObsList](ConstraintGroupObsList.component)
     with ViewCommon
@@ -105,9 +107,14 @@ object ConstraintGroupObsList {
 
       val constraintGroups = props.constraintsWithObs.get.constraintGroups
 
+      val listUndoStacks: View[UndoStacks[IO, ConstraintGroupList]] =
+        props.undoStacks.zoom(_.listStacks)(mod =>
+          cus => ConstraintListUndoStacks(mod(cus.listStacks))
+        )
+
       val state   = ViewF.fromStateSyncIO($)
       val undoCtx = UndoContext(
-        props.undoStacks,
+        listUndoStacks,
         props.constraintsWithObs.zoom(ConstraintSummaryWithObervations.constraintGroups)
       )
 

--- a/explore/src/main/scala/explore/tabs/ConstraintsTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTile.scala
@@ -4,6 +4,7 @@
 package explore.tabs
 
 import cats.effect.IO
+import cats.implicits._
 import crystal.Pot
 import crystal.react.implicits._
 import crystal.react.reuse._
@@ -12,8 +13,8 @@ import explore.components.Tile
 import explore.constraints.ConstraintsPanel
 import explore.implicits._
 import explore.model.ConstraintSet
+import explore.model.ConstraintsUndoStacks
 import explore.model.reusability._
-import explore.undo._
 import explore.utils._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Observation
@@ -21,12 +22,14 @@ import lucuma.ui.reusability._
 import react.common._
 import react.common.style.Css
 
+import scala.collection.immutable.SortedSet
+
 object ConstraintsTile {
 
   def constraintsTile(
     obsId:      Observation.Id,
     csPot:      Pot[View[ConstraintSet]],
-    undoStacks: View[UndoStacks[IO, ConstraintSet]],
+    undoStacks: View[ConstraintsUndoStacks[IO]],
     control:    Option[Reuse[VdomNode]] = None,
     clazz:      Option[Css] = None
   ): Tile =
@@ -41,7 +44,7 @@ object ConstraintsTile {
         potRender[View[ConstraintSet]](
           Reuse.always(cs =>
             <.div(
-              ConstraintsPanel(List(obsId), cs, undoStacks_, renderInTitle)
+              ConstraintsPanel(SortedSet(obsId), cs, undoStacks_, renderInTitle)
             )
           )
         )(csPotView_)

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -422,8 +422,7 @@ object ObsTabContents {
                     obsId,
                     obsView.map(_.zoom(ObservationData.constraintSet)),
                     props.undoStacks
-                      .zoom(ModelUndoStacks.forConstraintSet[IO])
-                      .zoom(atMapWithDefault(obsId, UndoStacks.empty)),
+                      .zoom(ModelUndoStacks.forConstraints[IO]),
                     control = constraintsSelector.some,
                     clazz = ExploreStyles.ConstraintsTile.some
                   ),


### PR DESCRIPTION
This eliminates the separate undo stacks for ConstraintSets, ConstraintGroups and ConstraintGroupLists in favor of maintaining only one stack at a time. This eliminate most or all strange interactions between undo at the different "levels".

So, if you are editing a constraint group, the undo stack for that will be kept until you edit a different constraint group or drag and drop to change the constraint group list. Note that a editing a constraint set on the observation tab is the same as editing a single element constraint group on the constraints tab - so the same undo stack would be used both places.