### PR TITLE
First config row was not shown. Range -> coverage.

### DIFF
--- a/common/src/main/public/instrument_spectroscopy_matrix.csv
+++ b/common/src/main/public/instrument_spectroscopy_matrix.csv
@@ -1,4 +1,4 @@
-instrument,Config,Focal Plane,fpu,slit width,slit length,disperser,filter,wave min,wave max,wave optimal,wave range,resolution,AO,capabilities,site
+instrument,Config,Focal Plane,fpu,slit width,slit length,disperser,filter,wave min,wave max,wave optimal,wave coverage,resolution,AO,capabilities,site
 GMOS-N,"B1200 0.25""","singleslit,multislit",0.25arcsec,0.250,330,B1200,none,0.36,1.03,0.463,0.164,7488,no,,n
 GMOS-N,"B1200 0.50""","singleslit,multislit",0.50arcsec,0.500,330,B1200,none,0.36,1.03,0.463,0.164,3744,no,,n
 GMOS-N,"B1200 0.75""","singleslit,multislit",0.75arcsec,0.750,330,B1200,none,0.36,1.03,0.463,0.164,2496,no,,n

--- a/common/src/main/scala/reactST/reactTable/SUITableVirtuoso.scala
+++ b/common/src/main/scala/reactST/reactTable/SUITableVirtuoso.scala
@@ -196,7 +196,8 @@ class SUITableVirtuoso[
           )
         }))
 
-      val renderRow = (_: Int, _: Int, rowData: Row[D]) => {
+      val renderRow = (index: Int, _: Int, _: Row[D]) => {
+        val rowData = tableInstance.rows(index)
         tableInstance.prepareRow(rowData)
         rowRender(rowData)(
           rowData.cells.toTagMod(cellData =>
@@ -209,8 +210,8 @@ class SUITableVirtuoso[
         props.body.copy(as = <.div)(tableInstance.getTableBodyProps())(
           TagMod.when(tableInstance.rows.nonEmpty)(
             GroupedVirtuoso[Row[D]](
-              data = tableInstance.rows,
               itemContent = renderRow,
+              groupCounts = List(tableInstance.rows.length),
               groupContent =
                 headerElement.map(header => (_: Int) => header.vdomElement).orUndefined,
               initialTopMostItemIndex = props.initialIndex.orUndefined,

--- a/model-tests/jvm/src/test/resources/instrument_spectroscopy_matrix.csv
+++ b/model-tests/jvm/src/test/resources/instrument_spectroscopy_matrix.csv
@@ -1,4 +1,4 @@
-instrument,Config,Focal Plane,fpu,slit width,slit length,disperser,filter,wave min,wave max,wave optimal,wave range,resolution,AO,capabilities,site
+instrument,Config,Focal Plane,fpu,slit width,slit length,disperser,filter,wave min,wave max,wave optimal,wave coverage,resolution,AO,capabilities,site
 GMOS-N,"B1200 0.25""","singleslit,multislit",0.25arcsec,0.250,330,B1200,none,0.36,1.03,0.463,0.164,7488,no,,n
 GMOS-N,"B1200 0.50""","singleslit,multislit",0.50arcsec,0.500,330,B1200,none,0.36,1.03,0.463,0.164,3744,no,,n
 GMOS-N,"B1200 0.75""","singleslit,multislit",0.75arcsec,0.750,330,B1200,none,0.36,1.03,0.463,0.164,2496,no,,n


### PR DESCRIPTION
We were not showing the first row of the configuration table, due to https://github.com/toddburnside/scalajs-react-virtuoso/pull/62.

Also in this PR:
- More `range` -> `coverage` renaming.
- Add help icon for configuration table.