### PR TITLE
Edit single observation constraint set on constraints tab.

### DIFF
--- a/common/src/main/scala/explore/model/ModelUndoStacks.scala
+++ b/common/src/main/scala/explore/model/ModelUndoStacks.scala
@@ -17,27 +17,24 @@ import monocle.Focus
 import scala.collection.immutable.SortedSet
 
 case class ModelUndoStacks[F[_]](
-  forObsList:           UndoStacks[F, ObservationList] = UndoStacks.empty[F, ObservationList],
-  forTargetList:        UndoStacks[F, PointingsWithObs] = UndoStacks.empty[F, PointingsWithObs],
-  forTarget:            Map[Target.Id, UndoStacks[F, TargetResult]] =
+  forObsList:         UndoStacks[F, ObservationList] = UndoStacks.empty[F, ObservationList],
+  forTargetList:      UndoStacks[F, PointingsWithObs] = UndoStacks.empty[F, PointingsWithObs],
+  forTarget:          Map[Target.Id, UndoStacks[F, TargetResult]] =
     Map.empty[Target.Id, UndoStacks[F, TargetResult]],
-  forConstraintList:    UndoStacks[F, ConstraintGroupList] = UndoStacks.empty[F, ConstraintGroupList],
-  forConstraintSet:     Map[Observation.Id, UndoStacks[F, ConstraintSet]] =
-    Map.empty[Observation.Id, UndoStacks[F, ConstraintSet]],
-  forBulkConstraintSet: Map[SortedSet[Observation.Id], UndoStacks[F, ConstraintSet]] =
+  forConstraintList:  UndoStacks[F, ConstraintGroupList] = UndoStacks.empty[F, ConstraintGroupList],
+  forConstraintGroup: Map[SortedSet[Observation.Id], UndoStacks[F, ConstraintSet]] =
     Map.empty[SortedSet[Observation.Id], UndoStacks[F, ConstraintSet]],
-  forScienceData:       Map[Observation.Id, UndoStacks[F, ScienceData]] =
+  forScienceData:     Map[Observation.Id, UndoStacks[F, ScienceData]] =
     Map.empty[Observation.Id, UndoStacks[F, ScienceData]]
 )
 
 object ModelUndoStacks {
-  def forObsList[F[_]]           = Focus[ModelUndoStacks[F]](_.forObsList)
-  def forTargetList[F[_]]        = Focus[ModelUndoStacks[F]](_.forTargetList)
-  def forTarget[F[_]]            = Focus[ModelUndoStacks[F]](_.forTarget)
-  def forConstraintList[F[_]]    = Focus[ModelUndoStacks[F]](_.forConstraintList)
-  def forConstraintSet[F[_]]     = Focus[ModelUndoStacks[F]](_.forConstraintSet)
-  def forBulkConstraintSet[F[_]] = Focus[ModelUndoStacks[F]](_.forBulkConstraintSet)
-  def forScienceData[F[_]]       = Focus[ModelUndoStacks[F]](_.forScienceData)
+  def forObsList[F[_]]         = Focus[ModelUndoStacks[F]](_.forObsList)
+  def forTargetList[F[_]]      = Focus[ModelUndoStacks[F]](_.forTargetList)
+  def forTarget[F[_]]          = Focus[ModelUndoStacks[F]](_.forTarget)
+  def forConstraintList[F[_]]  = Focus[ModelUndoStacks[F]](_.forConstraintList)
+  def forConstraintGroup[F[_]] = Focus[ModelUndoStacks[F]](_.forConstraintGroup)
+  def forScienceData[F[_]]     = Focus[ModelUndoStacks[F]](_.forScienceData)
 
   implicit def eqModelUndoStacks[F[_]]: Eq[ModelUndoStacks[F]] =
     Eq.by(u =>
@@ -45,8 +42,7 @@ object ModelUndoStacks {
        u.forTargetList,
        u.forTarget,
        u.forConstraintList,
-       u.forConstraintSet,
-       u.forBulkConstraintSet,
+       u.forConstraintGroup,
        u.forScienceData
       )
     )

--- a/common/src/main/scala/explore/model/RootModelRouting.scala
+++ b/common/src/main/scala/explore/model/RootModelRouting.scala
@@ -33,7 +33,10 @@ object RootModelRouting {
           }
           .getOrElse(TargetsBasePage)
       case AppTab.Configurations => ConfigurationsPage
-      case AppTab.Constraints    => ConstraintsBasePage
+      case AppTab.Constraints    =>
+        focused
+          .collect { case FocusedObs(obsId) => ConstraintsObsPage(obsId) }
+          .getOrElse(ConstraintsBasePage)
     }
 
   protected def setTab(tab: AppTab): RootModel => RootModel =
@@ -58,6 +61,8 @@ object RootModelRouting {
         setTab(AppTab.Targets) >>> RootModel.focused.replace(FocusedObs(obsId).some)
       case ConstraintsBasePage             =>
         setTab(AppTab.Constraints)
+      case ConstraintsObsPage(obsId)       =>
+        setTab(AppTab.Constraints) >>> RootModel.focused.replace(FocusedObs(obsId).some)
       case ConfigurationsPage              =>
         setTab(AppTab.Configurations)
       case HomePage                        =>

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -726,7 +726,8 @@ tfoot {
   opacity: 0.5;
 }
 
-.selected-obs-item .card.obs-badge {
+.selected-obs-item .card.obs-badge,
+.obs-tree-item .card.obs-badge.raised {
   background-color: var(--obs-selected-badge-background);
 }
 

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -76,7 +76,7 @@ object Routing {
             RootModel.expandedIds.andThen(ExpandedIds.constraintSetObsIds)
           ),
           model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forConstraintList),
-          model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forBulkConstraintSet),
+          model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forConstraintGroup),
           model.zoom(RootModel.constraintSummaryHiddenColumns),
           model.zoom(RootModel.constraintSummarySorting),
           size
@@ -116,7 +116,10 @@ object Routing {
             targetTab
           )
           | staticRoute("/configurations", ConfigurationsPage) ~> render(SequenceEditor())
-          | staticRoute("/constraints", ConstraintsBasePage) ~> renderP(constraintSetTab))
+          | staticRoute("/constraints", ConstraintsBasePage) ~> renderP(constraintSetTab)
+          | dynamicRouteCT(
+            ("/constraints/obs" / id[Observation.Id]).xmapL(ConstraintsObsPage.obsId)
+          ) ~> renderP(constraintSetTab))
 
       val configuration =
         rules

--- a/explore/src/main/scala/explore/constraints/ConstraintsSummaryTable.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsSummaryTable.scala
@@ -166,7 +166,7 @@ object ConstraintsSummaryTable {
                       ^.onClick ==> (_ =>
                         (props.focused.set(FocusedObs(obsId).some)
                           >> props.expandedIds.mod(_ + cell.value)
-                          >> props.selectedPanel.set(SelectedPanel.editor(cell.value)))
+                          >> props.selectedPanel.set(SelectedPanel.editor(SortedSet(obsId))))
                       ),
                       obsId.toString
                     )

--- a/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
@@ -105,6 +105,9 @@ object ConstraintGroupObsList {
 
       val constraintGroups = props.constraintsWithObs.get.constraintGroups
 
+      // if a single observation is selected
+      val singleObsSelected = props.focused.get.collect { case FocusedObs(_) => true }.nonEmpty
+
       val state   = ViewF.fromStateSyncIO($)
       val undoCtx = UndoContext(
         props.undoStacks,
@@ -152,6 +155,7 @@ object ConstraintGroupObsList {
               constraintGroups.toTagMod { case (_, constraintGroup) =>
                 val obsIds        = constraintGroup.obsIds
                 val cgObs         = obsIds.toList.map(id => observations.get(id)).flatten
+                // if this group or something in it is selected
                 val groupSelected = props.selected.get.optValue.exists(_.intersect(obsIds).nonEmpty)
 
                 val icon: FontAwesomeIcon = props.expandedIds.get
@@ -205,6 +209,7 @@ object ConstraintGroupObsList {
                             props.renderObsBadgeItem(
                               selectable = true,
                               highlightSelected = true,
+                              forceHighlight = groupSelected && !singleObsSelected,
                               linkToObsTab = false,
                               onSelect =
                                 id => props.selected.set(SelectedPanel.editor(SortedSet(id)))

--- a/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
@@ -126,6 +126,11 @@ object ConstraintGroupObsList {
 
       val handleDragEnd = onDragEnd(undoCtx, props.expandedIds, props.selected)
 
+      def unfocusIfObs(of: Option[Focused]) = of match {
+        case Some(FocusedObs(_)) => none
+        case _                   => of
+      }
+
       DragDropContext(
         onDragStart =
           (_: DragStart, _: ResponderProvided) => state.zoom(State.dragging).set(true).toCB,
@@ -147,18 +152,18 @@ object ConstraintGroupObsList {
               constraintGroups.toTagMod { case (_, constraintGroup) =>
                 val obsIds        = constraintGroup.obsIds
                 val cgObs         = obsIds.toList.map(id => observations.get(id)).flatten
-                val groupSelected = props.selected.get.optValue.exists(_ === obsIds)
+                val groupSelected = props.selected.get.optValue.exists(_.intersect(obsIds).nonEmpty)
 
                 val icon: FontAwesomeIcon = props.expandedIds.get
                   .exists((ids: SortedSet[Observation.Id]) => ids === obsIds)
                   .fold(Icons.ChevronDown, Icons.ChevronRight)
                   .addModifiers(
-                    Seq(^.cursor.pointer,
-                        ^.onClick ==> { e: ReactEvent =>
-                          e.stopPropagationCB >> toggleExpanded(obsIds, props.expandedIds).toCB
-                            .asEventDefault(e)
-                            .void
-                        }
+                    Seq(
+                      ^.cursor.pointer,
+                      ^.onClick ==> { e: ReactEvent =>
+                        e.stopPropagationCB >>
+                          toggleExpanded(obsIds, props.expandedIds).toCB.asEventDefault(e).void
+                      }
                     )
                   )
                   .fixedWidth()
@@ -189,16 +194,20 @@ object ConstraintGroupObsList {
                           )
                           .orEmpty
                       )(^.cursor.pointer,
-                        ^.onClick --> props.selected.set(
-                          SelectedPanel.editor(constraintGroup.obsIds)
-                        )
+                        ^.onClick --> {
+                          props.focused.mod(unfocusIfObs) >>
+                            props.selected.set(SelectedPanel.editor(constraintGroup.obsIds))
+                        }
                       )(
                         csHeader,
                         TagMod.when(props.expandedIds.get.contains(obsIds))(
                           cgObs.zipWithIndex.toTagMod { case (obs, idx) =>
-                            props.renderObsBadgeItem(selectable = false,
-                                                     highlightSelected = false,
-                                                     linkToObsTab = true
+                            props.renderObsBadgeItem(
+                              selectable = true,
+                              highlightSelected = true,
+                              linkToObsTab = false,
+                              onSelect =
+                                id => props.selected.set(SelectedPanel.editor(SortedSet(id)))
                             )(obs, idx)
                           }
                         ),
@@ -233,18 +242,20 @@ object ConstraintGroupObsList {
 
       val setAndGetSelected = selected.get match {
         case Uninitialized =>
-          val constraintGroupFromFocused = $.props.focused.get.collect { case FocusedObs(obsId) =>
-            constraintGroups.find(_._1.contains(obsId)).map(_._2)
-          }.flatten
+          val infoFromFocused: Option[(Observation.Id, ConstraintGroup)] =
+            $.props.focused.get.collect { case FocusedObs(obsId) =>
+              constraintGroups.find(_._1.contains(obsId)).map { case (_, cg) => (obsId, cg) }
+            }.flatten
 
           selected
             .set(
-              constraintGroupFromFocused.fold(SelectedPanel.tree[SortedSet[Observation.Id]])(cg =>
-                SelectedPanel.editor(cg.obsIds)
-              )
+              infoFromFocused.fold(SelectedPanel.tree[SortedSet[Observation.Id]]) { case (id, _) =>
+                SelectedPanel.editor(SortedSet(id))
+              }
             )
-            .as(constraintGroupFromFocused)
-        case Editor(ids)   => SyncIO.delay(constraintGroups.get(ids))
+            .as(infoFromFocused.map(_._2))
+        case Editor(ids)   =>
+          SyncIO.delay(constraintGroups.find(_._1.intersect(ids).nonEmpty).map(_._2))
         case _             => SyncIO.delay(none)
       }
 

--- a/explore/src/main/scala/explore/observationtree/ViewCommon.scala
+++ b/explore/src/main/scala/explore/observationtree/ViewCommon.scala
@@ -20,15 +20,21 @@ import react.beautifuldnd._
 trait ViewCommon {
   def focused: View[Option[Focused]]
 
-  def renderObsBadge(obs: ObsSummary, highlightSelected: Boolean = true): TagMod =
+  def renderObsBadge(
+    obs:               ObsSummary,
+    highlightSelected: Boolean = true,
+    forceHighlight:    Boolean = false // if true, overrides highlightSelected
+  ): TagMod =
     ObsBadge(
       obs,
-      selected = highlightSelected && focused.get.exists(_ === FocusedObs(obs.id))
+      selected =
+        forceHighlight || (highlightSelected && focused.get.exists(_ === FocusedObs(obs.id)))
     )
 
   def renderObsBadgeItem(
     selectable:        Boolean,
     highlightSelected: Boolean = true,
+    forceHighlight:    Boolean = false,
     linkToObsTab:      Boolean = false,
     onSelect:          Observation.Id => Callback = _ => Callback.empty
   )(
@@ -48,7 +54,7 @@ trait ViewCommon {
             e.stopPropagationCB >>
               ctx.setPage(explore.model.enum.AppTab.Observations, FocusedObs(obs.id).some)
           }).when(linkToObsTab)
-        )(<.span(provided.dragHandleProps)(renderObsBadge(obs, highlightSelected)))
+        )(<.span(provided.dragHandleProps)(renderObsBadge(obs, highlightSelected, forceHighlight)))
       }
     )
 

--- a/explore/src/main/scala/explore/observationtree/ViewCommon.scala
+++ b/explore/src/main/scala/explore/observationtree/ViewCommon.scala
@@ -10,9 +10,11 @@ import explore.components.ui.ExploreStyles
 import explore.model.Focused
 import explore.model.Focused._
 import explore.model.ObsSummary
+import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.ReactEvent
 import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.model.Observation
 import react.beautifuldnd._
 
 trait ViewCommon {
@@ -27,7 +29,8 @@ trait ViewCommon {
   def renderObsBadgeItem(
     selectable:        Boolean,
     highlightSelected: Boolean = true,
-    linkToObsTab:      Boolean = false
+    linkToObsTab:      Boolean = false,
+    onSelect:          Observation.Id => Callback = _ => Callback.empty
   )(
     obs:               ObsSummary,
     idx:               Int
@@ -39,7 +42,7 @@ trait ViewCommon {
           provided.draggableProps,
           getDraggedStyle(provided.draggableStyle, snapshot),
           (^.onClick ==> { e: ReactEvent =>
-            e.stopPropagationCB >> focused.set(FocusedObs(obs.id).some)
+            e.stopPropagationCB >> focused.set(FocusedObs(obs.id).some) >> onSelect(obs.id)
           }).when(selectable),
           (^.onDoubleClick ==> { e: ReactEvent =>
             e.stopPropagationCB >>

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -422,8 +422,8 @@ object ObsTabContents {
                     obsId,
                     obsView.map(_.zoom(ObservationData.constraintSet)),
                     props.undoStacks
-                      .zoom(ModelUndoStacks.forConstraintSet[IO])
-                      .zoom(atMapWithDefault(obsId, UndoStacks.empty)),
+                      .zoom(ModelUndoStacks.forConstraintGroup[IO])
+                      .zoom(atMapWithDefault(SortedSet(obsId), UndoStacks.empty)),
                     control = constraintsSelector.some,
                     clazz = ExploreStyles.ConstraintsTile.some
                   ),

--- a/model/shared/src/main/scala/explore/model/Page.scala
+++ b/model/shared/src/main/scala/explore/model/Page.scala
@@ -24,6 +24,7 @@ object Page {
   final case class TargetsObsPage(obsId: Observation.Id)        extends Page
   case object ConfigurationsPage                                extends Page
   final case object ConstraintsBasePage                         extends Page
+  final case class ConstraintsObsPage(obsId: Observation.Id)    extends Page
 
   implicit val eqPage: Eq[Page] = Eq.instance {
     case (HomePage, HomePage)                             => true
@@ -37,6 +38,7 @@ object Page {
     case (TargetsObsPage(a), TargetsObsPage(b))           => a === b
     case (ConfigurationsPage, ConfigurationsPage)         => true
     case (ConstraintsBasePage, ConstraintsBasePage)       => true
+    case (ConstraintsObsPage(a), ConstraintsObsPage(b))   => a === b
     case _                                                => false
   }
 
@@ -63,5 +65,10 @@ object Page {
   object TargetsObsPage {
     final val obsId: Iso[Observation.Id, TargetsObsPage] =
       Iso[Observation.Id, TargetsObsPage](TargetsObsPage.apply)(_.obsId)
+  }
+
+  object ConstraintsObsPage {
+    final val obsId: Iso[Observation.Id, ConstraintsObsPage] =
+      Iso[Observation.Id, ConstraintsObsPage](ConstraintsObsPage.apply)(_.obsId)
   }
 }


### PR DESCRIPTION
This also optimistically updates the constraint group list in memory. Waiting for a round trip from the server became too painful with all of the changes that can happen when editing the constraints for a single observation.