### PR TITLE
Multi-target ids.

### DIFF
--- a/common/src/main/scala/explore/common/TargetQueries.scala
+++ b/common/src/main/scala/explore/common/TargetQueries.scala
@@ -8,6 +8,7 @@ import cats.syntax.all._
 import clue.data.syntax._
 import crystal.react.implicits._
 import explore.implicits._
+import explore.model.ScienceTarget
 import explore.schemas.implicits._
 import lucuma.core.enum.MagnitudeBand
 import lucuma.core.math.Declination
@@ -21,7 +22,6 @@ import lucuma.core.model.CatalogId
 import lucuma.core.model.Magnitude
 import lucuma.core.model.SiderealTarget
 import lucuma.core.model.SiderealTracking
-import lucuma.core.model.Target
 import lucuma.schemas.ObservationDB.Types._
 import monocle.Lens
 
@@ -32,7 +32,7 @@ import TargetQueriesGQL._
 object TargetQueries {
 
   case class UndoView(
-    id:           Target.Id,
+    id:           ScienceTarget.Id,
     undoCtx:      UndoCtx[SiderealTarget]
   )(implicit ctx: AppContextIO) {
     def apply[A](
@@ -45,7 +45,7 @@ object TargetQueries {
         .withOnMod(value =>
           SiderealTargetMutation
             .execute(
-              remoteSet(value)(EditSiderealInput(SelectTargetInput(targetIds = List(id).assign)))
+              remoteSet(value)(EditSiderealInput(SelectTargetInput(targetIds = id.toList.assign)))
             )
             .void
             .runAsync

--- a/common/src/main/scala/explore/model/ModelUndoStacks.scala
+++ b/common/src/main/scala/explore/model/ModelUndoStacks.scala
@@ -7,10 +7,10 @@ import cats.Eq
 import explore.common.ConstraintGroupQueries.ConstraintGroupList
 import explore.common.ObsQueries.ObservationList
 import explore.common.ObsQueries.ScienceData
+import explore.model.ScienceTarget
 import explore.undo.UndoStacks
 import lucuma.core.model.Observation
 import lucuma.core.model.SiderealTarget
-import lucuma.core.model.Target
 import monocle.Focus
 
 import scala.collection.immutable.SortedSet
@@ -19,8 +19,8 @@ case class ModelUndoStacks[F[_]](
   forObsList:         UndoStacks[F, ObservationList] = UndoStacks.empty[F, ObservationList],
   forTargetList:      UndoStacks[F, Nothing] = UndoStacks.empty[F, Nothing],
   // forTargetList:        UndoStacks[F, PointingsWithObs] = UndoStacks.empty[F, PointingsWithObs],
-  forSiderealTarget:  Map[Target.Id, UndoStacks[F, SiderealTarget]] =
-    Map.empty[Target.Id, UndoStacks[F, SiderealTarget]],
+  forSiderealTarget:  Map[ScienceTarget.Id, UndoStacks[F, SiderealTarget]] =
+    Map.empty[ScienceTarget.Id, UndoStacks[F, SiderealTarget]],
   forConstraintList:  UndoStacks[F, ConstraintGroupList] = UndoStacks.empty[F, ConstraintGroupList],
   forConstraintGroup: Map[SortedSet[Observation.Id], UndoStacks[F, ConstraintSet]] =
     Map.empty[SortedSet[Observation.Id], UndoStacks[F, ConstraintSet]],

--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -14,7 +14,6 @@ import lucuma.core.enum.MagnitudeBand
 import lucuma.core.model.GuestUser
 import lucuma.core.model.ServiceUser
 import lucuma.core.model.StandardUser
-import lucuma.core.model.Target
 import lucuma.core.model.User
 import monocle.Focus
 import monocle.Lens
@@ -26,7 +25,7 @@ case class RootModel(
   tabs:                           EnumZipper[AppTab],
   focused:                        Option[Focused] = none,
   expandedIds:                    ExpandedIds = ExpandedIds(),
-  searchingTarget:                Set[Target.Id] = HashSet.empty,
+  searchingTarget:                Set[ScienceTarget.Id] = HashSet.empty,
   userSelectionMessage:           Option[NonEmptyString] = none,
   targetSummaryHiddenColumns:     Set[String] =
     Set("epoch", "pmra", "pmdec", "z", "cz", "parallax", "morphology", "sed") ++

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -3,6 +3,7 @@
 
 package explore.model
 
+import cats.data.NonEmptySet
 import clue.PersistentClientStatus
 import crystal.react.implicits._
 import explore.data.KeyedIndexedList
@@ -26,21 +27,22 @@ import scala.collection.immutable.TreeSeqMap
  */
 object reusability {
   // Model
-  implicit val targetSummaryReuse: Reusability[TargetSummary]                         = Reusability.derive
-  implicit val statusReuse: Reusability[PersistentClientStatus]                       = Reusability.derive
-  implicit val targetOptionsReuse: Reusability[TargetVisualOptions]                   = Reusability.derive
-  implicit val userVaultReuse: Reusability[UserVault]                                 = Reusability.derive
-  implicit val targetViewExpandedIdsReuse: Reusability[ExpandedIds]                   = Reusability.derive
-  implicit val rootModelReuse: Reusability[RootModel]                                 = Reusability.derive
-  implicit val focusedReuse: Reusability[Focused]                                     = Reusability.derive
-  implicit def idListReuse[Id, A: Reusability]: Reusability[KeyedIndexedList[Id, A]]  =
+  implicit val targetSummaryReuse: Reusability[TargetSummary]                                = Reusability.derive
+  implicit val statusReuse: Reusability[PersistentClientStatus]                              = Reusability.derive
+  implicit val targetOptionsReuse: Reusability[TargetVisualOptions]                          = Reusability.derive
+  implicit val userVaultReuse: Reusability[UserVault]                                        = Reusability.derive
+  implicit val targetViewExpandedIdsReuse: Reusability[ExpandedIds]                          = Reusability.derive
+  implicit val rootModelReuse: Reusability[RootModel]                                        = Reusability.derive
+  implicit val focusedReuse: Reusability[Focused]                                            = Reusability.derive
+  implicit def idListReuse[Id, A: Reusability]: Reusability[KeyedIndexedList[Id, A]]         =
     Reusability.by(_.toList)
-  implicit val ephemerisKeyReuse: Reusability[EphemerisKey]                           = Reusability.derive
-  implicit val siderealTargetReuse: Reusability[SiderealTarget]                       = Reusability.derive
-  implicit val nonsiderealTargetReuse: Reusability[NonsiderealTarget]                 = Reusability.derive
-  implicit val targetReuse: Reusability[Target]                                       = Reusability.derive
-  implicit val scienceTargetReuse: Reusability[ScienceTarget]                         = Reusability.derive
-  implicit val scienceTargetsReuse: Reusability[TreeSeqMap[Target.Id, ScienceTarget]] =
+  implicit val ephemerisKeyReuse: Reusability[EphemerisKey]                                  = Reusability.derive
+  implicit val siderealTargetReuse: Reusability[SiderealTarget]                              = Reusability.derive
+  implicit val nonsiderealTargetReuse: Reusability[NonsiderealTarget]                        = Reusability.derive
+  implicit val targetReuse: Reusability[Target]                                              = Reusability.derive
+  implicit val scienceIdTargetReuse: Reusability[ScienceTarget.Id]                           = Reusability.derive
+  implicit val scienceTargetReuse: Reusability[ScienceTarget]                                = Reusability.derive
+  implicit val scienceTargetsReuse: Reusability[TreeSeqMap[ScienceTarget.Id, ScienceTarget]] =
     Reusability.never // It's faster to rerender than to compare the whole thing.
   implicit val targetEnvReuse: Reusability[TargetEnv]                                          = Reusability.derive
   implicit val airMassRangeReuse: Reusability[AirMassRange]                                    = Reusability.derive
@@ -75,4 +77,6 @@ object reusability {
   // Move to lucuma-ui
   implicit val semesterReuse: Reusability[Semester]                                  = Reusability.derive
   implicit val cssReuse: Reusability[Css]                                            = Reusability.by(_.htmlClass)
+  implicit def nonEmptySetReuse[A]: Reusability[NonEmptySet[A]]                      =
+    Reusability.by(_.toSortedSet.unsorted)
 }

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -26,6 +26,7 @@ import explore.components.TileController
 import explore.components.graphql.LiveQueryRenderMod
 import explore.components.ui.ExploreStyles
 import explore.implicits._
+import explore.model.ScienceTarget
 import explore.model._
 import explore.model.enum.AppTab
 import explore.model.layout._
@@ -66,7 +67,7 @@ final case class ObsTabContents(
   userId:           ViewOpt[User.Id],
   focused:          View[Option[Focused]],
   undoStacks:       View[ModelUndoStacks[IO]],
-  searching:        View[Set[Target.Id]],
+  searching:        View[Set[ScienceTarget.Id]],
   hiddenColumns:    View[Set[String]],
   size:             ResizeDetector.Dimensions
 )(implicit val ctx: AppContextIO)

--- a/explore/src/main/scala/explore/tabs/TargetTile.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTile.scala
@@ -9,6 +9,7 @@ import crystal.react.implicits._
 import crystal.react.reuse._
 import explore.components.Tile
 import explore.implicits._
+import explore.model.ScienceTarget
 import explore.model.TargetEnv
 import explore.model.TargetVisualOptions
 import explore.model.reusability._
@@ -17,7 +18,6 @@ import explore.undo.UndoStacks
 import explore.utils._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.SiderealTarget
-import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.ui.reusability._
 import react.common._
@@ -38,8 +38,8 @@ object TargetTile {
   def targetTile(
     userId:        Option[User.Id],
     targetEnvPot:  Pot[View[TargetEnv]],
-    undoStacks:    View[Map[Target.Id, UndoStacks[IO, SiderealTarget]]],
-    searching:     View[Set[Target.Id]],
+    undoStacks:    View[Map[ScienceTarget.Id, UndoStacks[IO, SiderealTarget]]],
+    searching:     View[Set[ScienceTarget.Id]],
     options:       View[TargetVisualOptions],
     hiddenColumns: View[Set[String]]
   ) = //(implicit ctx: AppContextIO) =

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -15,6 +15,7 @@ import explore.common.UserPreferencesQueriesGQL._
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.ModelOptics
+import explore.model.ScienceTarget
 import explore.model.TargetVisualOptions
 import explore.model.reusability._
 import japgolly.scalajs.react.ReactMonocle._
@@ -22,7 +23,6 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
-import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.ui.reusability._
 import monocle.Focus
@@ -38,7 +38,7 @@ import scala.concurrent.duration._
 
 final case class AladinCell(
   uid:              User.Id,
-  tid:              Target.Id,
+  tid:              ScienceTarget.Id,
   target:           View[Coordinates],
   options:          View[TargetVisualOptions]
 )(implicit val ctx: AppContextIO)
@@ -84,7 +84,8 @@ object AladinCell extends ModelOptics {
         implicit val ctx = props.ctx
         $.setStateL(State.fov)(fov) >>
           UserTargetPreferencesUpsert
-            .updateFov[IO](props.uid, props.tid, fov.x)
+            // TODO Accept multiple Target ids.
+            .updateFov[IO](props.uid, props.tid.toList.head, fov.x)
             .runAsyncAndForgetCB
             .debounce(1.seconds)
       }

--- a/explore/src/main/scala/explore/targeteditor/MagnitudeForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/MagnitudeForm.scala
@@ -13,14 +13,15 @@ import eu.timepit.refined.auto._
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.implicits._
+import explore.model.ScienceTarget
 import explore.model.display._
+import explore.model.reusability._
 import explore.utils.ReactTableHelpers
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.MagnitudeBand
 import lucuma.core.math.MagnitudeValue
 import lucuma.core.model.Magnitude
-import lucuma.core.model.Target
 import lucuma.ui.forms.EnumViewSelect
 import lucuma.ui.optics.ChangeAuditor
 import lucuma.ui.optics.ValidFormatInput
@@ -39,7 +40,7 @@ import reactST.reactTable.mod.SortingRule
 import scala.collection.immutable.SortedMap
 
 final case class MagnitudeForm(
-  targetId:   Target.Id,
+  targetId:   ScienceTarget.Id,
   magnitudes: View[SortedMap[MagnitudeBand, Magnitude]],
   disabled:   Boolean
 ) extends ReactFnProps[MagnitudeForm](MagnitudeForm.component)

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -14,6 +14,8 @@ import explore.Icons
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
 import explore.implicits._
+import explore.model.ScienceTarget
+import explore.model.reusability._
 import japgolly.scalajs.react.ReactMonocle._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
@@ -32,9 +34,9 @@ import react.semanticui.shorthand._
 import scalajs.js.JSConverters._
 
 final case class SearchForm(
-  id:          Target.Id,
+  id:          ScienceTarget.Id,
   name:        NonEmptyString,
-  searching:   View[Set[Target.Id]],
+  searching:   View[Set[ScienceTarget.Id]],
   searchAndGo: SearchCallback ==> Callback
 ) extends ReactProps[SearchForm](SearchForm.component) {
   def submit(

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -21,6 +21,7 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.implicits._
+import explore.model.ScienceTarget
 import explore.model.TargetVisualOptions
 import explore.model.formats._
 import explore.model.reusability._
@@ -57,10 +58,10 @@ final case class SearchCallback(
 
 final case class SiderealTargetEditor(
   uid:           User.Id,
-  id:            Target.Id,
+  id:            ScienceTarget.Id,
   target:        View[SiderealTarget],
   undoStacks:    View[UndoStacks[IO, SiderealTarget]],
-  searching:     View[Set[Target.Id]],
+  searching:     View[Set[ScienceTarget.Id]],
   options:       View[TargetVisualOptions],
   renderInTitle: Tile.RenderInTitle
 ) extends ReactProps[SiderealTargetEditor](SiderealTargetEditor.component) {

--- a/explore/src/main/scala/explore/targeteditor/TargetEnvEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetEnvEditor.scala
@@ -18,7 +18,6 @@ import explore.undo.UndoStacks
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.SiderealTarget
-import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.ui.reusability._
 import monocle.function.At._
@@ -27,8 +26,8 @@ import react.common.ReactFnProps
 final case class TargetEnvEditor(
   userId:        User.Id,
   targetEnv:     View[TargetEnv],
-  undoStacks:    View[Map[Target.Id, UndoStacks[IO, SiderealTarget]]],
-  searching:     View[Set[Target.Id]],
+  undoStacks:    View[Map[ScienceTarget.Id, UndoStacks[IO, SiderealTarget]]],
+  searching:     View[Set[ScienceTarget.Id]],
   options:       View[TargetVisualOptions],
   hiddenColumns: View[Set[String]],
   renderInTitle: Tile.RenderInTitle
@@ -68,7 +67,7 @@ object TargetEnvEditor {
               val selectedTargetView =
                 props.targetEnv
                   .zoom(TargetEnv.scienceTargets)
-                  .zoom(at(targetId)(atTreeSeqMap[Target.Id, ScienceTarget]))
+                  .zoom(at(targetId)(atTreeSeqMap[ScienceTarget.Id, ScienceTarget]))
 
               selectedTargetView.mapValue(targetView =>
                 targetView.get match {

--- a/model/shared/src/main/scala/explore/model/ScienceTarget.scala
+++ b/model/shared/src/main/scala/explore/model/ScienceTarget.scala
@@ -4,7 +4,8 @@
 package explore.model
 
 import cats.Eq
-import cats.syntax.functor._
+import cats.data.NonEmptySet
+import cats.syntax.all._
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.decoders._
 import io.circe.Decoder
@@ -27,23 +28,24 @@ import monocle.Optional
 import scala.collection.immutable.SortedMap
 
 /**
- * Target.Id + Target
+ * Target.Id(s) + Target
  */
 sealed trait ScienceTarget {
-  val id: Target.Id
+  val id: ScienceTarget.Id
   val target: Target
 }
 
-final case class SiderealScienceTarget(id: Target.Id, target: SiderealTarget) extends ScienceTarget
+final case class SiderealScienceTarget(id: ScienceTarget.Id, target: SiderealTarget)
+    extends ScienceTarget
 object SiderealScienceTarget {
   implicit val decoderSiderealTargetEnv: Decoder[SiderealScienceTarget] = Decoder.instance(c =>
     for {
-      id     <- c.downField("id").as[Target.Id]
+      id     <- c.downField("id").as[ScienceTarget.Id]
       target <- c.as[SiderealTarget]
     } yield SiderealScienceTarget(id, target)
   )
 
-  val id: Lens[SiderealScienceTarget, Target.Id]                                   = Focus[SiderealScienceTarget](_.id)
+  val id: Lens[SiderealScienceTarget, ScienceTarget.Id]                            = Focus[SiderealScienceTarget](_.id)
   val target: Lens[SiderealScienceTarget, SiderealTarget]                          = Focus[SiderealScienceTarget](_.target)
   val name: Lens[SiderealScienceTarget, NonEmptyString]                            = target.andThen(SiderealTarget.name)
   val magnitudes: Lens[SiderealScienceTarget, SortedMap[MagnitudeBand, Magnitude]] =
@@ -65,19 +67,19 @@ object SiderealScienceTarget {
     target.andThen(SiderealTarget.parallax)
 }
 
-final case class NonsiderealScienceTarget(id: Target.Id, target: NonsiderealTarget)
+final case class NonsiderealScienceTarget(id: ScienceTarget.Id, target: NonsiderealTarget)
     extends ScienceTarget
 
 object NonsiderealScienceTarget {
   implicit val decoderNonsiderealTargetEnv: Decoder[NonsiderealScienceTarget] =
     Decoder.instance(c =>
       for {
-        id     <- c.downField("id").as[Target.Id]
+        id     <- c.downField("id").as[ScienceTarget.Id]
         target <- c.as[NonsiderealTarget]
       } yield NonsiderealScienceTarget(id, target)
     )
 
-  val id: Lens[NonsiderealScienceTarget, Target.Id]                                   = Focus[NonsiderealScienceTarget](_.id)
+  val id: Lens[NonsiderealScienceTarget, ScienceTarget.Id]                            = Focus[NonsiderealScienceTarget](_.id)
   val target: Lens[NonsiderealScienceTarget, NonsiderealTarget]                       =
     Focus[NonsiderealScienceTarget](_.target)
   val name: Lens[NonsiderealScienceTarget, NonEmptyString]                            = target.andThen(NonsiderealTarget.name)
@@ -89,6 +91,44 @@ object NonsiderealScienceTarget {
 }
 
 object ScienceTarget {
+
+  sealed trait Id {
+    def toList: List[Target.Id]
+  }
+
+  final case class SingleId(targetId: Target.Id) extends Id {
+    lazy val toList: List[Target.Id] = List(targetId)
+  }
+  object SingleId {
+    implicit val eqSingleId: Eq[SingleId] = Eq.by(_.targetId)
+
+    implicit val decoderSingleId: Decoder[SingleId] =
+      Decoder.instance(_.as[Target.Id].map(SingleId.apply))
+  }
+
+  final case class MultipleId(targetIds: NonEmptySet[Target.Id]) extends Id {
+    lazy val toList: List[Target.Id] = targetIds.toList
+  }
+  object MultipleId {
+    implicit val eqMultipleId: Eq[MultipleId] = Eq.by(_.targetIds)
+
+    implicit val decoderMultipleId: Decoder[MultipleId] =
+      Decoder.instance(
+        _.as[List[Target.Id]].map(list => MultipleId(NonEmptySet.of(list.head, list.tail: _*)))
+      )
+  }
+
+  object Id {
+    implicit val eqId: Eq[Id] = Eq.instance {
+      case (a @ SingleId(_), b @ SingleId(_))     => a === b
+      case (a @ MultipleId(_), b @ MultipleId(_)) => a === b
+      case _                                      => false
+    }
+
+    implicit val decoderId: Decoder[Id] =
+      List[Decoder[Id]](Decoder[SingleId].widen, Decoder[MultipleId].widen).reduceLeft(_ or _)
+  }
+
   implicit val eqScienceTarget: Eq[ScienceTarget] = Eq.by(x => (x.id, x.target))
 
   implicit val decoderTargetEnv: Decoder[ScienceTarget] =
@@ -96,8 +136,8 @@ object ScienceTarget {
                                  Decoder[NonsiderealScienceTarget].widen
     ).reduceLeft(_ or _)
 
-  val id: Lens[ScienceTarget, Target.Id] =
-    Lens[ScienceTarget, Target.Id](_.id)(v => {
+  val id: Lens[ScienceTarget, ScienceTarget.Id] =
+    Lens[ScienceTarget, ScienceTarget.Id](_.id)(v => {
       case t @ SiderealScienceTarget(_, _)    => SiderealScienceTarget.id.replace(v)(t)
       case t @ NonsiderealScienceTarget(_, _) => NonsiderealScienceTarget.id.replace(v)(t)
     })

--- a/model/shared/src/main/scala/explore/model/TargetEnv.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEnv.scala
@@ -5,7 +5,6 @@ package explore.model
 
 import cats.Eq
 import io.circe.Decoder
-import lucuma.core.model.Target
 import lucuma.core.model.TargetEnvironment
 import monocle.Focus
 import monocle.Lens
@@ -14,7 +13,7 @@ import scala.collection.immutable.TreeSeqMap
 
 case class TargetEnv(
   id:             TargetEnvironment.Id,
-  scienceTargets: TreeSeqMap[Target.Id, ScienceTarget]
+  scienceTargets: TreeSeqMap[ScienceTarget.Id, ScienceTarget]
 )
 
 object TargetEnv {
@@ -30,7 +29,7 @@ object TargetEnv {
     } yield TargetEnv(id, scienceTargets)
   )
 
-  val id: Lens[TargetEnv, TargetEnvironment.Id]                             = Focus[TargetEnv](_.id)
-  val scienceTargets: Lens[TargetEnv, TreeSeqMap[Target.Id, ScienceTarget]] =
+  val id: Lens[TargetEnv, TargetEnvironment.Id]                                    = Focus[TargetEnv](_.id)
+  val scienceTargets: Lens[TargetEnv, TreeSeqMap[ScienceTarget.Id, ScienceTarget]] =
     Focus[TargetEnv](_.scienceTargets)
 }


### PR DESCRIPTION
Target editor can now edit a single or multiple targets. Depending on the case, we may receive from the API a single `Target.Id` or multiple ones.

This PR introduces `ScienceTarget.Id` which is a sum type containing cases to wrap a single `Target.Id` or a `NonEmptySet[Target.Id]`.

All relevant mentions of `Target.Id` (undo stacks, searching, etc) are switched to `ScienceTarget.Id`.