### PR TITLE
Fix runtime error on the constraints tab from #1188

### DIFF
--- a/explore/src/main/scala/explore/constraints/ConstraintsSummaryTable.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsSummaryTable.scala
@@ -156,7 +156,7 @@ object ConstraintsSummaryTable {
               case AirMassRange(_, _)     => HourAngleRange.MinHour - 1
               case HourAngleRange(_, max) => max.value
             }),
-          column("count", _.obsIds.size)
+          column("count", _.obsIds.length)
             .setSortType(DefaultSortTypes.number),
           column("observations", ConstraintGroup.obsIds.get)
             .setCell(cell =>


### PR DESCRIPTION
Fun facts: 

- `SortedSet.size` is an `Int`. 
- `NonEmptySet.size` (provided by cats.syntax) is a `Long`.