### PR TITLE
Report brotli compressed size in bundlemon.

### DIFF
--- a/.bundlemonrc.json
+++ b/.bundlemonrc.json
@@ -8,7 +8,7 @@
       "path": "*.<hash>.css"
     }
   ],
-  "defaultCompression": "none",
+  "defaultCompression": "brotli",
   "reportOutput": [
     [
       "github",


### PR DESCRIPTION
Now that bundlemon supports reporting the brotli size, I think it gives us a better picture of the impact when loading the application. Hopefully, bundlemon will support reporting both uncompressed and compressed soon.

This is also a friendly reminder that our current Heroku setup doesn't support brotli (it's using gzip now), but Firebase does.