### PR TITLE
Give some ids their own types

### DIFF
--- a/common/src/main/scala/explore/common/TargetListGroupQueries.scala
+++ b/common/src/main/scala/explore/common/TargetListGroupQueries.scala
@@ -15,6 +15,7 @@ import explore.components.graphql.LiveQueryRenderMod
 import explore.implicits._
 import explore.model.ObsSummaryWithConstraints
 import explore.model.TargetEnv
+import explore.model.TargetEnvIdObsId
 import explore.model.TargetEnvIdObsIdSet
 import explore.schemas.implicits._
 import explore.utils._
@@ -38,7 +39,7 @@ object TargetListGroupQueries {
   // This is used for sorting the TargetListGroupObsList. If we change to sort by name or something
   // else, we can remove this.
   implicit val orderSortedSet: Order[TargetEnvIdObsIdSet] =
-    Order.by(_.toList.map(t => (t._2, t._1)))
+    TargetEnvIdObsIdSet.orderByObsThenTargetEnv
 
   type ObservationResult = TargetListGroupObsQuery.Data.Observations.Nodes
   val ObservationResult = TargetListGroupObsQuery.Data.Observations.Nodes
@@ -58,7 +59,7 @@ object TargetListGroupQueries {
       targetListGroups
         .get(targetEnvObsIds)
         .fold(observations.mapFilter { obsSumm =>
-          if (targetEnvObsIds.contains((obsSumm.targetEnvId, obsSumm.id.some)))
+          if (targetEnvObsIds.contains(TargetEnvIdObsId((obsSumm.targetEnvId, obsSumm.id.some))))
             obsSumm.scienceTargetIds.some
           else none
         }.combineAll)(_.targetIds)

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -42,6 +42,8 @@ object reusability {
   implicit val targetReuse: Reusability[Target]                                                = Reusability.derive
   implicit val scienceTargetsReuse: Reusability[TreeSeqMap[TargetIdSet, Target]]               =
     Reusability.by((_: TreeSeqMap[TargetIdSet, Target]).toMap)(Reusability.map)
+  implicit val targetEnvIdObsIdReuse: Reusability[TargetEnvIdObsId]                            = Reusability.derive
+  implicit val targetEnvIdObsIdSetReuse: Reusability[TargetEnvIdObsIdSet]                      = Reusability.derive
   implicit val targetEnvReuse: Reusability[TargetEnv]                                          = Reusability.derive
   implicit val airMassRangeReuse: Reusability[AirMassRange]                                    = Reusability.derive
   implicit val hourAngleRangeReuse: Reusability[HourAngleRange]                                = Reusability.derive

--- a/explore/src/main/scala/explore/observationtree/TargetListGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/TargetListGroupObsList.scala
@@ -205,7 +205,7 @@ object TargetListGroupObsList {
         val cgObs           = obsIds.toList.map(id => observations.get(id)).flatten
         // if this group or something in it is selected
         val groupSelected   =
-          props.selected.get.optValue.exists(_.hasIntersect(targetEnvObsIds))
+          props.selected.get.optValue.exists(_.intersects(targetEnvObsIds))
 
         val unmooredTargetEnvIds =
           targetListGroup.id.unmooredTargetEnvIds.toList.sorted

--- a/explore/src/main/scala/explore/observationtree/TargetListGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/TargetListGroupObsList.scala
@@ -4,7 +4,6 @@
 package explore.observationtree
 
 import cats.Order._
-import cats.data.NonEmptySet
 import cats.effect.IO
 import cats.effect.SyncIO
 import cats.syntax.all._
@@ -68,33 +67,6 @@ object TargetListGroupObsList {
 
   class Backend($ : BackendScope[Props, State]) {
 
-    def targetEnvIdObsIdToString(id: TargetEnvIdObsId): String = {
-      // none can be anything, as long as it doesn't parse into an obs id
-      val obsIdStr = id._2.fold("none")(_.toString)
-      s"${id._1}:$obsIdStr"
-    }
-
-    def targetEnvIdObsIdSetToString(ids: TargetEnvIdObsIdSet): String =
-      ids.toSortedSet
-        .map(targetEnvIdObsIdToString)
-        .mkString(",")
-
-    def targetEnvIdObsIdStringToIds(idStr: String): Option[TargetEnvIdObsId] =
-      idStr.split(":").toList match {
-        case tid :: oid :: Nil =>
-          TargetEnvironment.Id.parse(tid).map((_, Observation.Id.parse(oid)))
-        case _                 => none
-      }
-
-    def targetEnvIdObsIdSetStringToIds(
-      targetEnvObsIdsString: String
-    ): Option[TargetEnvIdObsIdSet] =
-      targetEnvObsIdsString
-        .split(",")
-        .toList
-        .traverse(targetEnvIdObsIdStringToIds)
-        .flatMap(list => NonEmptySet.fromSet(SortedSet.from(list)))
-
     def toggleExpanded(
       targetEnvIds: TargetEnvIdObsIdSet,
       expandedIds:  View[SortedSet[TargetEnvIdObsIdSet]]
@@ -111,8 +83,9 @@ object TargetListGroupObsList {
 
     def dragIdToTargetEnvObsId(dragId: String, observations: ObsList): Option[TargetEnvIdObsId] =
       parseDragId(dragId: String).flatMap {
-        case Left(teid)   => (teid, none).some
-        case Right(obsId) => observations.get(obsId).map(summ => (summ.targetEnvId, obsId.some))
+        case Left(teid)   => TargetEnvIdObsId((teid, none)).some
+        case Right(obsId) =>
+          observations.get(obsId).map(summ => TargetEnvIdObsId((summ.targetEnvId, obsId.some)))
       }
 
     /**
@@ -123,7 +96,7 @@ object TargetListGroupObsList {
      */
     def getDraggedIds(dragId: String, props: Props): Option[TargetEnvIdObsIdSet] =
       dragIdToTargetEnvObsId(dragId, props.targetListsWithObs.get.observations).map { dId =>
-        val dIdSet = NonEmptySet.one(dId)
+        val dIdSet = TargetEnvIdObsIdSet.one(dId)
         props.selected.get.optValue.fold(dIdSet) { selectedIds =>
           if (selectedIds.contains(dId)) selectedIds
           else dIdSet
@@ -140,7 +113,7 @@ object TargetListGroupObsList {
       $.propsIn[SyncIO].flatMap { props =>
         val oData = for {
           destination <- result.destination.toOption
-          destIds     <- targetEnvIdObsIdSetStringToIds(destination.droppableId)
+          destIds     <- TargetEnvIdObsIdSet.format.getOption(destination.droppableId)
           draggedIds  <- getDraggedIds(result.draggableId, props)
           if destIds.intersect(draggedIds).isEmpty
           destTlg     <-
@@ -175,38 +148,39 @@ object TargetListGroupObsList {
               props.getDraggedStyle(provided.draggableStyle, snapshot)
         )(
           getDraggedIds(rubric.draggableId, props)
-            .flatMap(_.toList.sortBy { case (t, oo) => (oo, t) } match {
-              case (_, Some(obsId)) :: Nil =>
-                observations.get(obsId).map(obsSumm => props.renderObsBadge(obsSumm))
-              case list                    =>
-                <.div(
+            .flatMap(ids =>
+              ids.firstAndOnlyObsId.fold {
+                val list        = ids.toList.sortBy(id => (id.optObsId, id.targetEnvId))
+                val div: TagMod = <.div(
                   SegmentGroup(
-                    list.toTagMod(id => Segment(id._2.map(_.toString).getOrElse(id._1.toString())))
+                    list.toTagMod(id =>
+                      Segment(id.optObsId.map(_.show).getOrElse(id.targetEnvId.show))
+                    )
                   )
-                ).some
-            })
+                )
+                div.some
+              }(obsId => observations.get(obsId).map(summ => props.renderObsBadge(summ)))
+            )
             .getOrElse(<.span("ERROR"))
         )
 
       val handleDragEnd = onDragEnd(undoCtx, props.expandedIds, props.selected)
 
       def isTargetEnvSelected(targetEnvId: TargetEnvironment.Id): Boolean =
-        props.selected.get.optValue.exists(_.exists(_._1 === targetEnvId))
+        props.selected.get.optValue.exists(_.exists(_.targetEnvId === targetEnvId))
 
       def setSelectedPanelToSet(targetEnvIdObsIdSet: TargetEnvIdObsIdSet): SyncIO[Unit] =
         props.selected.set(SelectedPanel.editor(targetEnvIdObsIdSet))
 
       def setSelectedPanelToSingle(targetEnvIdObsId: TargetEnvIdObsId): SyncIO[Unit] =
-        setSelectedPanelToSet(NonEmptySet.one(targetEnvIdObsId))
+        setSelectedPanelToSet(TargetEnvIdObsIdSet.one(targetEnvIdObsId))
 
       def setSelectedPanelAndObs(targetEnvIdObsId: TargetEnvIdObsId): SyncIO[Unit] =
-        props.focusedObs.set(targetEnvIdObsId._2.map(FocusedObs(_))) >>
+        props.focusedObs.set(targetEnvIdObsId.optObsId.map(FocusedObs(_))) >>
           setSelectedPanelToSingle(targetEnvIdObsId)
 
       def setSelectedPanelAndObsToSet(targetEnvIdObsIdSet: TargetEnvIdObsIdSet): SyncIO[Unit] = {
-        val focused =
-          if (targetEnvIdObsIdSet.length === 1) targetEnvIdObsIdSet.head._2.map(FocusedObs(_))
-          else none
+        val focused = targetEnvIdObsIdSet.firstAndOnlyObsId.map(FocusedObs(_))
         props.focusedObs.set(focused) >> setSelectedPanelToSet(targetEnvIdObsIdSet)
       }
 
@@ -217,7 +191,7 @@ object TargetListGroupObsList {
         props.selected.get.optValue.fold(setSelectedPanelAndObs(targetEnvIdObsId)) { selectedIds =>
           if (selectedIds.forall(sid => groupIds.contains(sid))) {
             if (selectedIds.contains(targetEnvIdObsId)) {
-              NonEmptySet.fromSet(selectedIds - targetEnvIdObsId).fold(clearSelectedPanelAndObs) {
+              selectedIds.removeOne(targetEnvIdObsId).fold(clearSelectedPanelAndObs) {
                 setSelectedPanelAndObsToSet
               }
             } else
@@ -231,10 +205,10 @@ object TargetListGroupObsList {
         val cgObs           = obsIds.toList.map(id => observations.get(id)).flatten
         // if this group or something in it is selected
         val groupSelected   =
-          props.selected.get.optValue.exists(_.intersect(targetEnvObsIds).nonEmpty)
+          props.selected.get.optValue.exists(_.hasIntersect(targetEnvObsIds))
 
         val unmooredTargetEnvIds =
-          targetListGroup.id.collect { case (teid, None) => teid }.toList.sorted
+          targetListGroup.id.unmooredTargetEnvIds.toList.sorted
 
         val icon: FontAwesomeIcon = props.expandedIds.get
           .exists(_ === targetEnvObsIds)
@@ -252,60 +226,66 @@ object TargetListGroupObsList {
           )
           .fixedWidth()
 
-        Droppable(targetEnvIdObsIdSetToString(targetEnvObsIds), renderClone = renderClone) {
-          case (provided, snapshot) =>
-            val csHeader = <.span(ExploreStyles.ObsTreeGroupHeader)(
-              icon,
-              <.span(ExploreStyles.ObsGroupTitleWithWrap)(
-                targetListGroup.name.value
-              ),
-              Icons.Thumbtack.when(obsIds.size < targetEnvObsIds.size),
-              <.span(ExploreStyles.ObsCount, s"${obsIds.size} Obs")
-            )
+        Droppable(TargetEnvIdObsIdSet.format.reverseGet(targetEnvObsIds),
+                  renderClone = renderClone
+        ) { case (provided, snapshot) =>
+          val csHeader = <.span(ExploreStyles.ObsTreeGroupHeader)(
+            icon,
+            <.span(ExploreStyles.ObsGroupTitleWithWrap)(
+              targetListGroup.name.value
+            ),
+            Icons.Thumbtack.when(unmooredTargetEnvIds.nonEmpty),
+            <.span(ExploreStyles.ObsCount, s"${obsIds.size} Obs")
+          )
 
-            <.div(
-              provided.innerRef,
-              provided.droppableProps,
-              props.getListStyle(
-                snapshot.draggingOverWith.exists(id => parseDragId(id).isDefined)
-              )
-            )(
-              Segment(
-                vertical = true,
-                clazz = ExploreStyles.ObsTreeGroup |+| Option
-                  .when(groupSelected)(ExploreStyles.SelectedObsTreeGroup)
-                  .orElse(
-                    Option.when(!state.get.dragging)(ExploreStyles.UnselectedObsTreeGroup)
-                  )
-                  .orEmpty
-              )(^.cursor.pointer,
-                ^.onClick --> {
-                  props.focusedObs.set(none) >>
-                    props.selected.set(SelectedPanel.editor(targetEnvObsIds))
-                }
-              )(
-                csHeader,
-                TagMod.when(props.expandedIds.get.contains(targetEnvObsIds))(
-                  TagMod(
-                    unmooredTargetEnvIds.zipWithIndex.toTagMod { case (tenvId, idx) =>
-                      props.renderTargetEnvBadgeItem(isTargetEnvSelected(tenvId))(tenvId, idx)
-                    },
-                    cgObs.zipWithIndex.toTagMod { case (obs, idx) =>
-                      props.renderObsBadgeItem(
-                        selectable = true,
-                        highlightSelected = true,
-                        forceHighlight = isTargetEnvSelected(obs.targetEnvId),
-                        linkToObsTab = false,
-                        onSelect = _ => setSelectedPanelToSingle((obs.targetEnvId, obs.id.some)),
-                        onCtrlClick =
-                          _ => handleCtrlClick((obs.targetEnvId, obs.id.some), targetEnvObsIds)
-                      )(obs, idx)
-                    }
-                  )
-                ),
-                provided.placeholder
-              )
+          <.div(
+            provided.innerRef,
+            provided.droppableProps,
+            props.getListStyle(
+              snapshot.draggingOverWith.exists(id => parseDragId(id).isDefined)
             )
+          )(
+            Segment(
+              vertical = true,
+              clazz = ExploreStyles.ObsTreeGroup |+| Option
+                .when(groupSelected)(ExploreStyles.SelectedObsTreeGroup)
+                .orElse(
+                  Option.when(!state.get.dragging)(ExploreStyles.UnselectedObsTreeGroup)
+                )
+                .orEmpty
+            )(^.cursor.pointer,
+              ^.onClick --> {
+                props.focusedObs.set(none) >>
+                  props.selected.set(SelectedPanel.editor(targetEnvObsIds))
+              }
+            )(
+              csHeader,
+              TagMod.when(props.expandedIds.get.contains(targetEnvObsIds))(
+                TagMod(
+                  unmooredTargetEnvIds.zipWithIndex.toTagMod { case (tenvId, idx) =>
+                    props.renderTargetEnvBadgeItem(isTargetEnvSelected(tenvId))(tenvId, idx)
+                  },
+                  cgObs.zipWithIndex.toTagMod { case (obs, idx) =>
+                    props.renderObsBadgeItem(
+                      selectable = true,
+                      highlightSelected = true,
+                      forceHighlight = isTargetEnvSelected(obs.targetEnvId),
+                      linkToObsTab = false,
+                      onSelect = _ =>
+                        setSelectedPanelToSingle(
+                          TargetEnvIdObsId((obs.targetEnvId, obs.id.some))
+                        ),
+                      onCtrlClick = _ =>
+                        handleCtrlClick(TargetEnvIdObsId((obs.targetEnvId, obs.id.some)),
+                                        targetEnvObsIds
+                        )
+                    )(obs, idx)
+                  }
+                )
+              ),
+              provided.placeholder
+            )
+          )
         }
       }
 
@@ -358,14 +338,16 @@ object TargetListGroupObsList {
         case Uninitialized =>
           val infoFromFocused: Option[(TargetEnvIdObsId, TargetEnv)] =
             $.props.focusedObs.get.flatMap(fo =>
-              (observations.get(fo.obsId).map(summ => (summ.targetEnvId, summ.id.some)),
-               targetListGroups.find(_._1.exists(_._2 === fo.obsId.some)).map(_._2)
+              (observations
+                 .get(fo.obsId)
+                 .map(summ => TargetEnvIdObsId((summ.targetEnvId, summ.id.some))),
+               targetListGroups.find(_._1.exists(_.optObsId === fo.obsId.some)).map(_._2)
               ).tupled
             )
 
           selected
             .set(infoFromFocused.fold(SelectedPanel.tree[TargetEnvIdObsIdSet]) { case (id, _) =>
-              SelectedPanel.editor(NonEmptySet.one(id))
+              SelectedPanel.editor(TargetEnvIdObsIdSet.one(id))
             })
             .as(infoFromFocused.map(_._2))
         case Editor(ids)   =>

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -3,7 +3,6 @@
 
 package explore.tabs
 
-import cats.data.NonEmptySet
 import cats.effect.IO
 import cats.effect.SyncIO
 import cats.syntax.all._
@@ -155,7 +154,7 @@ object TargetTabContents {
           .mod { eids =>
             val withOld       =
               if (groupIds === editedIds) eids
-              else eids + NonEmptySet.fromSetUnsafe(groupIds -- editedIds)
+              else eids + groupIds.removeUnsafe(editedIds)
             val withOldAndNew =
               if (editedIds === tlg.id && editedIds === groupIds) withOld
               else withOld + tlg.id

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -24,7 +24,7 @@ import explore.model.TargetIdSet
 import explore.model.TargetVisualOptions
 import explore.model.formats._
 import explore.model.reusability._
-import explore.model.utils._
+import explore.model.util._
 import explore.undo.UndoContext
 import explore.undo.UndoStacks
 import japgolly.scalajs.react._

--- a/explore/src/main/scala/explore/targeteditor/TargetEnvEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetEnvEditor.scala
@@ -91,7 +91,7 @@ object TargetEnvEditor {
   )(implicit ctx:   AppContextIO): IO[Unit] =
     TargetEnvQueriesGQL.AddSiderealTarget
       .execute(
-        targetEnv.get.id.map(_._1).toList,
+        targetEnv.get.id.targetEnvIds.toList,
         newTarget(name).toCreateInput
       ) >>= { response =>
       val targetIds = response.updateScienceTargetList.flatMap(_.edits.map(_.target.id))
@@ -162,7 +162,7 @@ object TargetEnvEditor {
               label = "Name",
               placeholder = "Target name",
               okLabel = "Create",
-              onComplete = Reuse.by(props.targetEnv.get.id.toSortedSet)((name: NonEmptyString) =>
+              onComplete = Reuse.by(props.targetEnv.get.id)((name: NonEmptyString) =>
                 adding.setState(true) >>
                   insertSiderealTarget(props.targetEnv,
                                        name,

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvIdObsId.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvIdObsId.scala
@@ -1,0 +1,43 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import explore.model.TargetEnvIdObsId
+import lucuma.core.arb._
+import lucuma.core.model.Observation
+import lucuma.core.model.TargetEnvironment
+import lucuma.core.util.arb.ArbGid._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbTargetEnvIdObsId {
+  implicit val arbTargetEnvIdObsId = Arbitrary[TargetEnvIdObsId] {
+    for {
+      tenvId   <- arbitrary[TargetEnvironment.Id]
+      optObsId <- arbitrary[Option[Observation.Id]]
+    } yield TargetEnvIdObsId((tenvId, optObsId))
+  }
+
+  implicit val cogenTargetEnvIdObsId: Cogen[TargetEnvIdObsId] =
+    Cogen[(TargetEnvironment.Id, Option[Observation.Id])].contramap(t =>
+      (t.targetEnvId, t.optObsId)
+    )
+
+  private val perturbations: List[String => Gen[String]] =
+    List(
+      _ => arbitrary[String],                   // swap for a random string
+      s => Gen.const(s.replace("t", "x")),      // make target env id invalid
+      s => Gen.const(s.replace("o", "x")),      // make obs id invalid
+      s => Gen.const(s.replace("none", "fun")), // change the None indicator
+      s => Gen.const(s.replace(":", " "))       // change separator
+    )
+
+  val stringsOftenParsable: Gen[String] = arbitrary[TargetEnvIdObsId]
+    .map(TargetEnvIdObsId.format.reverseGet)
+    .flatMapOneOf(Gen.const, perturbations: _*)
+}
+
+object ArbTargetEnvIdObsId extends ArbTargetEnvIdObsId

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvIdObsIdSet.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvIdObsIdSet.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import cats.data.NonEmptySet
+import cats.laws.discipline.arbitrary._
+import explore.model.TargetEnvIdObsId
+import explore.model.TargetEnvIdObsIdSet
+import lucuma.core.arb._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Cogen
+import org.scalacheck.Gen
+
+trait ArbTargetEnvIdObsIdSet {
+  import ArbTargetEnvIdObsId._
+
+  implicit val arbTargetEnvIdObsIdSet: Arbitrary[TargetEnvIdObsIdSet] = Arbitrary {
+    arbitrary[NonEmptySet[TargetEnvIdObsId]].map(TargetEnvIdObsIdSet.apply)
+  }
+
+  implicit val cogenTargetEnvIdObsIdSet: Cogen[TargetEnvIdObsIdSet] =
+    Cogen[NonEmptySet[TargetEnvIdObsId]].contramap(_.idSet)
+
+  private val perturbations: List[String => Gen[String]] =
+    List(
+      _ => arbitrary[String],                        // swap for a random string
+      s => Gen.const(s.replaceFirst("t", "x")),      // make a target env id invalid
+      s => Gen.const(s.replaceFirst("o", "x")),      // make an obs id invalid
+      s => Gen.const(s.replaceFirst("none", "fun")), // change a None indicator
+      s => Gen.const(s.replace(",", ""))             // change separator
+    )
+
+  val stringsOftenParsable: Gen[String] = arbitrary[TargetEnvIdObsIdSet]
+    .map(TargetEnvIdObsIdSet.format.reverseGet)
+    .flatMapOneOf(Gen.const, perturbations: _*)
+}
+
+object ArbTargetEnvIdObsIdSet extends ArbTargetEnvIdObsIdSet

--- a/model-tests/shared/src/test/scala/explore/model/TargetEnvIdObsIdSetSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/TargetEnvIdObsIdSetSuite.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import explore.model.TargetEnvIdObsIdSet
+import explore.model.arb.ArbTargetEnvIdObsIdSet._
+import lucuma.core.optics.laws.discipline.FormatTests
+import munit.DisciplineSuite
+
+class TargetEnvIdObsIdSetSuite extends DisciplineSuite {
+  checkAll("TargetEnvIdObsIdSet.format",
+           FormatTests(TargetEnvIdObsIdSet.format).formatWith(stringsOftenParsable)
+  )
+}

--- a/model-tests/shared/src/test/scala/explore/model/TargetEnvIdObsIdSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/TargetEnvIdObsIdSuite.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import explore.model.TargetEnvIdObsId
+import explore.model.arb.ArbTargetEnvIdObsId._
+import lucuma.core.optics.laws.discipline.FormatTests
+import munit.DisciplineSuite
+
+class TargetEnvIdObsIdSuite extends DisciplineSuite {
+  checkAll("TargetEnvIdObsId.format",
+           FormatTests(TargetEnvIdObsId.format).formatWith(stringsOftenParsable)
+  )
+}

--- a/model/shared/src/main/scala/explore/model/NonEmptySetWrapper.scala
+++ b/model/shared/src/main/scala/explore/model/NonEmptySetWrapper.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.data.NonEmptySet
+import cats.syntax.all._
+import monocle.Iso
+
+import scala.collection.immutable.SortedSet
+
+final class NonEmptySetWrapper[IdSet, Id](self: IdSet, iso: Iso[IdSet, NonEmptySet[Id]]) {
+  private val selfSet = iso.get(self)
+
+  // expose the NonEmptySet methods
+  def ++(other: IdSet): IdSet = iso.reverseGet(selfSet ++ iso.get(other))
+
+  def --(other: IdSet): SortedSet[Id] = selfSet -- iso.get(other)
+
+  def add(id: Id): IdSet = iso.reverseGet(selfSet.add(id))
+
+  def filter(f: Id => Boolean): SortedSet[Id] = selfSet.filter(f)
+
+  def contains(id: Id): Boolean = selfSet.contains(id)
+
+  def exists(f: Id => Boolean): Boolean = selfSet.exists(f)
+
+  def forall(f: Id => Boolean): Boolean = selfSet.forall(f)
+
+  def intersect(other: IdSet): SortedSet[Id] =
+    selfSet.intersect(iso.get(other))
+
+  def size: Long = selfSet.size
+
+  def toList: List[Id] = selfSet.toList
+
+  // some helper methods
+  def remove(other: IdSet): Option[IdSet] = fromSet(this -- other)
+
+  def removeUnsafe(other: IdSet): IdSet =
+    iso.reverseGet(NonEmptySet.fromSetUnsafe(selfSet -- iso.get(other)))
+
+  def removeOne(id: Id): Option[IdSet] = fromSet(selfSet - id)
+
+  def filterOpt(f: Id => Boolean): Option[IdSet] = fromSet(selfSet.filter(f))
+
+  def hasIntersect(other: IdSet): Boolean = intersect(other).nonEmpty
+
+  private def fromSet(set: SortedSet[Id]): Option[IdSet] =
+    NonEmptySet.fromSet(set).map(iso.reverseGet)
+}
+
+object NonEmptySetWrapper {
+  def apply[IdSet, Id](
+    idSet: IdSet,
+    iso:   Iso[IdSet, NonEmptySet[Id]]
+  ): NonEmptySetWrapper[IdSet, Id] =
+    new NonEmptySetWrapper[IdSet, Id](idSet, iso)
+}

--- a/model/shared/src/main/scala/explore/model/TargetEnvIdObsId.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEnvIdObsId.scala
@@ -1,0 +1,37 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Order
+import cats.syntax.all._
+import lucuma.core.model.Observation
+import lucuma.core.model.TargetEnvironment
+import lucuma.core.optics.Format
+
+case class TargetEnvIdObsId(id: (TargetEnvironment.Id, Option[Observation.Id])) extends AnyVal {
+  def targetEnvId: TargetEnvironment.Id = id._1
+  def optObsId: Option[Observation.Id]  = id._2
+
+  override def toString: String = {
+    // none can be anything, as long as it doesn't parse into an obs id
+    val obsIdStr = id._2.fold("none")(_.toString)
+    s"${id._1}:$obsIdStr"
+  }
+}
+
+object TargetEnvIdObsId {
+  implicit val orderTargetEnvIdObsId: Order[TargetEnvIdObsId] = Order.by(_.id._1)
+
+  val format: Format[String, TargetEnvIdObsId] = Format(parse, _.toString)
+
+  def parse(idStr: String): Option[TargetEnvIdObsId] =
+    idStr.split(":").toList match {
+      case tidStr :: oidStr :: Nil =>
+        TargetEnvironment.Id
+          .parse(tidStr)
+          .map(tid => TargetEnvIdObsId((tid, Observation.Id.parse(oidStr))))
+      case _                       => none
+    }
+
+}

--- a/model/shared/src/main/scala/explore/model/TargetEnvIdObsIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEnvIdObsIdSet.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Order
+import cats.Order._
+import cats.data.NonEmptySet
+import cats.syntax.all._
+import lucuma.core.model.Observation
+import lucuma.core.model.TargetEnvironment
+import lucuma.core.optics.Format
+import monocle.Iso
+
+import scala.collection.immutable.SortedSet
+
+case class TargetEnvIdObsIdSet(idSet: NonEmptySet[TargetEnvIdObsId]) {
+  lazy val targetEnvIds: TargetEnvIdSet      = idSet.map(_.targetEnvId)
+  lazy val obsIds: SortedSet[Observation.Id] = SortedSet.from(idSet.toList.mapFilter(_.optObsId))
+  lazy val obsIdList: List[Observation.Id]   = obsIds.toList
+
+  lazy val unmooredTargetEnvIds: SortedSet[TargetEnvironment.Id] =
+    idSet.collect { case id if id.optObsId.isEmpty => id.targetEnvId }
+
+  override def toString: String = idSet.toSortedSet
+    .map(_.toString)
+    .mkString(",")
+
+  def firstAndOnlyObsId: Option[Observation.Id] =
+    if (idSet.length === 1) idSet.head.optObsId else none
+}
+
+object TargetEnvIdObsIdSet {
+  implicit val orderTargetEnvIdObsIdSet: Order[TargetEnvIdObsIdSet] = Order.by(_.idSet)
+
+  val iso: Iso[TargetEnvIdObsIdSet, NonEmptySet[TargetEnvIdObsId]] =
+    Iso[TargetEnvIdObsIdSet, NonEmptySet[TargetEnvIdObsId]](_.idSet)(TargetEnvIdObsIdSet.apply)
+
+  implicit def nonEmptySetWrapper(ids: TargetEnvIdObsIdSet) =
+    NonEmptySetWrapper(ids, TargetEnvIdObsIdSet.iso)
+
+  // alternate ordering for display
+  val orderByObsThenTargetEnv: Order[TargetEnvIdObsIdSet] =
+    Order.by(_.idSet.toList.map(t => (t.optObsId, t.targetEnvId)))
+
+  val format: Format[String, TargetEnvIdObsIdSet] = Format(parse, _.toString)
+
+  private def parse(idSetStr: String): Option[TargetEnvIdObsIdSet] =
+    idSetStr
+      .split(",")
+      .toList
+      .traverse(TargetEnvIdObsId.format.getOption)
+      .flatMap(list => NonEmptySet.fromSet(SortedSet.from(list)).map(TargetEnvIdObsIdSet.apply))
+
+  def one(id: TargetEnvIdObsId): TargetEnvIdObsIdSet = TargetEnvIdObsIdSet(NonEmptySet.one(id))
+}

--- a/model/shared/src/main/scala/explore/model/TargetEnvIdObsIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEnvIdObsIdSet.scala
@@ -7,6 +7,7 @@ import cats.Order
 import cats.Order._
 import cats.data.NonEmptySet
 import cats.syntax.all._
+import explore.model.util.NonEmptySetWrapper
 import lucuma.core.model.Observation
 import lucuma.core.model.TargetEnvironment
 import lucuma.core.optics.Format

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -40,14 +40,9 @@ package object model {
 
   type TargetEnvIdSet = NonEmptySet[TargetEnvironment.Id]
 
-  type TargetEnvIdObsId    = (TargetEnvironment.Id, Option[Observation.Id])
-  type TargetEnvIdObsIdSet = NonEmptySet[TargetEnvIdObsId]
-
   type ObsIdSet = NonEmptySet[Observation.Id]
 
   object implicits   {
-    implicit val orderTargetnEnvId: Order[TargetEnvIdObsId] = Order.by(_._1)
-
     implicit val orderNESTargetEnvId: Order[TargetEnvIdSet] =
       Order.by(_.toSortedSet)
 

--- a/model/shared/src/main/scala/explore/model/util/NonEmptySetWrapper.scala
+++ b/model/shared/src/main/scala/explore/model/util/NonEmptySetWrapper.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package explore.model
+package explore.model.util
 
 import cats.data.NonEmptySet
 import cats.syntax.all._
@@ -13,38 +13,53 @@ final class NonEmptySetWrapper[IdSet, Id](self: IdSet, iso: Iso[IdSet, NonEmptyS
   private val selfSet = iso.get(self)
 
   // expose the NonEmptySet methods
+  @inline
   def ++(other: IdSet): IdSet = iso.reverseGet(selfSet ++ iso.get(other))
 
+  @inline
   def --(other: IdSet): SortedSet[Id] = selfSet -- iso.get(other)
 
+  @inline
   def add(id: Id): IdSet = iso.reverseGet(selfSet.add(id))
 
+  @inline
   def filter(f: Id => Boolean): SortedSet[Id] = selfSet.filter(f)
 
+  @inline
   def contains(id: Id): Boolean = selfSet.contains(id)
 
+  @inline
   def exists(f: Id => Boolean): Boolean = selfSet.exists(f)
 
+  @inline
   def forall(f: Id => Boolean): Boolean = selfSet.forall(f)
 
+  @inline
   def intersect(other: IdSet): SortedSet[Id] =
     selfSet.intersect(iso.get(other))
 
+  @inline
   def size: Long = selfSet.size
 
+  @inline
   def toList: List[Id] = selfSet.toList
 
   // some helper methods
+  @inline
   def remove(other: IdSet): Option[IdSet] = fromSet(this -- other)
 
+  @inline
   def removeUnsafe(other: IdSet): IdSet =
     iso.reverseGet(NonEmptySet.fromSetUnsafe(selfSet -- iso.get(other)))
 
+  @inline
   def removeOne(id: Id): Option[IdSet] = fromSet(selfSet - id)
 
+  @inline
   def filterOpt(f: Id => Boolean): Option[IdSet] = fromSet(selfSet.filter(f))
 
-  def hasIntersect(other: IdSet): Boolean = intersect(other).nonEmpty
+  @inline
+  def intersects(other: IdSet): Boolean = intersect(other).nonEmpty
 
   private def fromSet(set: SortedSet[Id]): Option[IdSet] =
     NonEmptySet.fromSet(set).map(iso.reverseGet)

--- a/model/shared/src/main/scala/explore/model/util/utils.scala
+++ b/model/shared/src/main/scala/explore/model/util/utils.scala
@@ -7,7 +7,7 @@ import cats.Monoid
 import cats.syntax.all._
 import lucuma.core.math.ProperMotion
 
-trait utils {
+package object util {
   def attemptCombine[A: Monoid, B: Monoid](a: Option[A], b: Option[B]): Option[(A, B)] =
     (a, b) match {
       case (None, None)               => none
@@ -26,5 +26,3 @@ trait utils {
   def unsafeOptionFnUnlift[A](fn: Option[A] => Option[A]): A => A =
     a => fn(a.some).get
 }
-
-object utils extends utils


### PR DESCRIPTION
Makes types for TargetEnvIdObsId and TargetEnvIdObsIdSet. When we switch to scala 3, these can be made opaque types. This is a test PR before doing the same for all ids in model/package.scala.