### PR TITLE
Rename TargetEnv to TargetEnvGroup

### DIFF
--- a/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
@@ -253,7 +253,7 @@ object ObsQueriesGQL {
 
     object Data {
       object Observation {
-        type Targets = model.TargetEnv
+        type Targets = model.TargetEnvGroup
 
         type ConstraintSet = model.ConstraintSet
 

--- a/common-graphql/src/main/scala/explore/common/TargetListGroupQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/TargetListGroupQueriesGQL.scala
@@ -97,7 +97,7 @@ object TargetListGroupQueriesGQL {
     """
 
     object Data {
-      type ScienceTargetListGroup = model.TargetEnv
+      type ScienceTargetListGroup = model.TargetEnvGroup
       object Observations {
         object Nodes {
           trait ConstraintSet extends model.ConstraintsSummary

--- a/common/src/main/scala/explore/common/TargetListGroupQueries.scala
+++ b/common/src/main/scala/explore/common/TargetListGroupQueries.scala
@@ -14,9 +14,9 @@ import explore.AppCtx
 import explore.components.graphql.LiveQueryRenderMod
 import explore.implicits._
 import explore.model.ObsSummaryWithConstraints
-import explore.model.TargetEnv
-import explore.model.TargetEnvIdObsId
-import explore.model.TargetEnvIdObsIdSet
+import explore.model.TargetEnvGroup
+import explore.model.TargetEnvGroupId
+import explore.model.TargetEnvGroupIdSet
 import explore.schemas.implicits._
 import explore.utils._
 import japgolly.scalajs.react._
@@ -38,13 +38,13 @@ object TargetListGroupQueries {
   // The default cats ordering for sorted set sorts by size first, then contents. That's not what we want.
   // This is used for sorting the TargetListGroupObsList. If we change to sort by name or something
   // else, we can remove this.
-  implicit val orderSortedSet: Order[TargetEnvIdObsIdSet] =
-    TargetEnvIdObsIdSet.orderByObsThenTargetEnv
+  implicit val orderSortedSet: Order[TargetEnvGroupIdSet] =
+    TargetEnvGroupIdSet.orderByObsThenTargetEnv
 
   type ObservationResult = TargetListGroupObsQuery.Data.Observations.Nodes
   val ObservationResult = TargetListGroupObsQuery.Data.Observations.Nodes
 
-  type TargetListGroupList = SortedMap[TargetEnvIdObsIdSet, TargetEnv]
+  type TargetListGroupList = SortedMap[TargetEnvGroupIdSet, TargetEnvGroup]
   type ObsList             = SortedMap[Observation.Id, ObsSummaryWithConstraints]
 
   case class TargetListGroupWithObs(
@@ -55,11 +55,11 @@ object TargetListGroupQueries {
     // include a Map[TargetEnvironment.Id, NonEmptySet[Target.Id]] in the case class.
     // then use that map to find the target ids. Until then, this will not work
     // for unmoored targets when the whole group is not selected.
-    def targetIdsFor(targetEnvObsIds: TargetEnvIdObsIdSet): Set[Target.Id] =
+    def targetIdsFor(targetEnvGroupIds: TargetEnvGroupIdSet): Set[Target.Id] =
       targetListGroups
-        .get(targetEnvObsIds)
+        .get(targetEnvGroupIds)
         .fold(observations.mapFilter { obsSumm =>
-          if (targetEnvObsIds.contains(TargetEnvIdObsId((obsSumm.targetEnvId, obsSumm.id.some))))
+          if (targetEnvGroupIds.contains(TargetEnvGroupId((obsSumm.targetEnvId, obsSumm.id.some))))
             obsSumm.scienceTargetIds.some
           else none
         }.combineAll)(_.targetIds)

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -42,9 +42,9 @@ object reusability {
   implicit val targetReuse: Reusability[Target]                                                = Reusability.derive
   implicit val scienceTargetsReuse: Reusability[TreeSeqMap[TargetIdSet, Target]]               =
     Reusability.by((_: TreeSeqMap[TargetIdSet, Target]).toMap)(Reusability.map)
-  implicit val targetEnvIdObsIdReuse: Reusability[TargetEnvIdObsId]                            = Reusability.derive
-  implicit val targetEnvIdObsIdSetReuse: Reusability[TargetEnvIdObsIdSet]                      = Reusability.derive
-  implicit val targetEnvReuse: Reusability[TargetEnv]                                          = Reusability.derive
+  implicit val targetEnvGroupIdReuse: Reusability[TargetEnvGroupId]                            = Reusability.derive
+  implicit val targetEnvGroupIdSetReuse: Reusability[TargetEnvGroupIdSet]                      = Reusability.derive
+  implicit val targetEnvReuse: Reusability[TargetEnvGroup]                                     = Reusability.derive
   implicit val airMassRangeReuse: Reusability[AirMassRange]                                    = Reusability.derive
   implicit val hourAngleRangeReuse: Reusability[HourAngleRange]                                = Reusability.derive
   implicit val elevationRangeReuse: Reusability[ElevationRange]                                = Reusability.derive

--- a/explore/src/main/scala/explore/tabs/TargetTile.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTile.scala
@@ -9,7 +9,7 @@ import crystal.react.implicits._
 import crystal.react.reuse._
 import explore.components.Tile
 import explore.implicits._
-import explore.model.TargetEnv
+import explore.model.TargetEnvGroup
 import explore.model.TargetIdSet
 import explore.model.TargetVisualOptions
 import explore.model.reusability._
@@ -26,7 +26,7 @@ object TargetTile {
 
   def targetTile(
     userId:        Option[User.Id],
-    targetEnvPot:  Pot[View[TargetEnv]],
+    targetEnvPot:  Pot[View[TargetEnvGroup]],
     undoStacks:    View[Map[TargetIdSet, UndoStacks[IO, SiderealTarget]]],
     searching:     View[Set[TargetIdSet]],
     options:       View[TargetVisualOptions],
@@ -35,9 +35,9 @@ object TargetTile {
     Tile(ObsTabTiles.TargetId, "Targets", canMinimize = true)(
       Reuse.by((userId, targetEnvPot, undoStacks, searching, options))(
         (renderInTitle: Tile.RenderInTitle) =>
-          potRender[View[TargetEnv]](
+          potRender[View[TargetEnvGroup]](
             (
-              (targetEnv: View[TargetEnv]) =>
+              (targetEnv: View[TargetEnvGroup]) =>
                 userId.map(uid =>
                   <.div(
                     TargetEnvEditor(uid,

--- a/explore/src/main/scala/explore/targeteditor/TargetEnvEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetEnvEditor.scala
@@ -23,7 +23,7 @@ import explore.components.InputModal
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.implicits._
-import explore.model.TargetEnv
+import explore.model.TargetEnvGroup
 import explore.model.TargetIdSet
 import explore.model.TargetVisualOptions
 import explore.model.reusability._
@@ -49,7 +49,7 @@ import scala.collection.immutable.SortedMap
 
 final case class TargetEnvEditor(
   userId:           User.Id,
-  targetEnv:        View[TargetEnv],
+  targetEnv:        View[TargetEnvGroup],
   undoStacks:       View[Map[TargetIdSet, UndoStacks[IO, SiderealTarget]]],
   searching:        View[Set[TargetIdSet]],
   options:          View[TargetVisualOptions],
@@ -84,7 +84,7 @@ object TargetEnvEditor {
     SiderealTarget(name, SiderealTracking.const(Coordinates.Zero), SortedMap.empty)
 
   private def insertSiderealTarget(
-    targetEnv:      View[TargetEnv],
+    targetEnv:      View[TargetEnvGroup],
     name:           NonEmptyString,
     searching:      View[Set[TargetIdSet]],
     selectedTarget: View[Option[TargetIdSet]]
@@ -110,7 +110,7 @@ object TargetEnvEditor {
                 case Some(SiderealTarget(_, st, m)) =>
                   // Set locally
                   targetEnv
-                    .zoom(TargetEnv.scienceTargets)
+                    .zoom(TargetEnvGroup.scienceTargets)
                     .zoom(index(id)(indexTreeSeqMap[TargetIdSet, Target]))
                     .zoom(Target.sidereal)
                     .zoom(
@@ -185,7 +185,7 @@ object TargetEnvEditor {
             )
           ),
           TargetTable(
-            props.targetEnv.zoom(TargetEnv.scienceTargets),
+            props.targetEnv.zoom(TargetEnvGroup.scienceTargets),
             props.hiddenColumns,
             selectedTargetId,
             props.renderInTitle
@@ -194,7 +194,7 @@ object TargetEnvEditor {
             .flatMap[VdomElement] { targetId =>
               val selectedTargetView =
                 props.targetEnv
-                  .zoom(TargetEnv.scienceTargets)
+                  .zoom(TargetEnvGroup.scienceTargets)
                   .zoom(index(targetId)(indexTreeSeqMap[TargetIdSet, Target]))
 
               selectedTargetView.mapValue(targetView =>

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvGroupId.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvGroupId.scala
@@ -3,7 +3,7 @@
 
 package explore.model.arb
 
-import explore.model.TargetEnvIdObsId
+import explore.model.TargetEnvGroupId
 import lucuma.core.arb._
 import lucuma.core.model.Observation
 import lucuma.core.model.TargetEnvironment
@@ -13,15 +13,15 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 
-trait ArbTargetEnvIdObsId {
-  implicit val arbTargetEnvIdObsId = Arbitrary[TargetEnvIdObsId] {
+trait ArbTargetEnvGroupId {
+  implicit val arbTargetEnvGroupId = Arbitrary[TargetEnvGroupId] {
     for {
       tenvId   <- arbitrary[TargetEnvironment.Id]
       optObsId <- arbitrary[Option[Observation.Id]]
-    } yield TargetEnvIdObsId((tenvId, optObsId))
+    } yield TargetEnvGroupId((tenvId, optObsId))
   }
 
-  implicit val cogenTargetEnvIdObsId: Cogen[TargetEnvIdObsId] =
+  implicit val cogenTargetEnvGroupId: Cogen[TargetEnvGroupId] =
     Cogen[(TargetEnvironment.Id, Option[Observation.Id])].contramap(t =>
       (t.targetEnvId, t.optObsId)
     )
@@ -35,9 +35,9 @@ trait ArbTargetEnvIdObsId {
       s => Gen.const(s.replace(":", " "))       // change separator
     )
 
-  val stringsOftenParsable: Gen[String] = arbitrary[TargetEnvIdObsId]
-    .map(TargetEnvIdObsId.format.reverseGet)
+  val stringsOftenParsable: Gen[String] = arbitrary[TargetEnvGroupId]
+    .map(TargetEnvGroupId.format.reverseGet)
     .flatMapOneOf(Gen.const, perturbations: _*)
 }
 
-object ArbTargetEnvIdObsId extends ArbTargetEnvIdObsId
+object ArbTargetEnvGroupId extends ArbTargetEnvGroupId

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvGroupIdSet.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetEnvGroupIdSet.scala
@@ -5,23 +5,23 @@ package explore.model.arb
 
 import cats.data.NonEmptySet
 import cats.laws.discipline.arbitrary._
-import explore.model.TargetEnvIdObsId
-import explore.model.TargetEnvIdObsIdSet
+import explore.model.TargetEnvGroupId
+import explore.model.TargetEnvGroupIdSet
 import lucuma.core.arb._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Gen
 
-trait ArbTargetEnvIdObsIdSet {
-  import ArbTargetEnvIdObsId._
+trait ArbTargetEnvGroupIdSet {
+  import ArbTargetEnvGroupId._
 
-  implicit val arbTargetEnvIdObsIdSet: Arbitrary[TargetEnvIdObsIdSet] = Arbitrary {
-    arbitrary[NonEmptySet[TargetEnvIdObsId]].map(TargetEnvIdObsIdSet.apply)
+  implicit val arbTargetEnvGroupIdSet: Arbitrary[TargetEnvGroupIdSet] = Arbitrary {
+    arbitrary[NonEmptySet[TargetEnvGroupId]].map(TargetEnvGroupIdSet.apply)
   }
 
-  implicit val cogenTargetEnvIdObsIdSet: Cogen[TargetEnvIdObsIdSet] =
-    Cogen[NonEmptySet[TargetEnvIdObsId]].contramap(_.idSet)
+  implicit val cogenTargetEnvGroupIdSet: Cogen[TargetEnvGroupIdSet] =
+    Cogen[NonEmptySet[TargetEnvGroupId]].contramap(_.idSet)
 
   private val perturbations: List[String => Gen[String]] =
     List(
@@ -32,9 +32,9 @@ trait ArbTargetEnvIdObsIdSet {
       s => Gen.const(s.replace(",", ""))             // change separator
     )
 
-  val stringsOftenParsable: Gen[String] = arbitrary[TargetEnvIdObsIdSet]
-    .map(TargetEnvIdObsIdSet.format.reverseGet)
+  val stringsOftenParsable: Gen[String] = arbitrary[TargetEnvGroupIdSet]
+    .map(TargetEnvGroupIdSet.format.reverseGet)
     .flatMapOneOf(Gen.const, perturbations: _*)
 }
 
-object ArbTargetEnvIdObsIdSet extends ArbTargetEnvIdObsIdSet
+object ArbTargetEnvGroupIdSet extends ArbTargetEnvGroupIdSet

--- a/model-tests/shared/src/test/scala/explore/model/TargetEnvGroupIdSetSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/TargetEnvGroupIdSetSuite.scala
@@ -3,13 +3,13 @@
 
 package explore.model
 
-import explore.model.TargetEnvIdObsId
-import explore.model.arb.ArbTargetEnvIdObsId._
+import explore.model.TargetEnvGroupIdSet
+import explore.model.arb.ArbTargetEnvGroupIdSet._
 import lucuma.core.optics.laws.discipline.FormatTests
 import munit.DisciplineSuite
 
-class TargetEnvIdObsIdSuite extends DisciplineSuite {
-  checkAll("TargetEnvIdObsId.format",
-           FormatTests(TargetEnvIdObsId.format).formatWith(stringsOftenParsable)
+class TargetEnvGroupIdSetSuite extends DisciplineSuite {
+  checkAll("TargetEnvGroupIdSet.format",
+           FormatTests(TargetEnvGroupIdSet.format).formatWith(stringsOftenParsable)
   )
 }

--- a/model-tests/shared/src/test/scala/explore/model/TargetEnvGroupIdSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/TargetEnvGroupIdSuite.scala
@@ -3,13 +3,13 @@
 
 package explore.model
 
-import explore.model.TargetEnvIdObsIdSet
-import explore.model.arb.ArbTargetEnvIdObsIdSet._
+import explore.model.TargetEnvGroupId
+import explore.model.arb.ArbTargetEnvGroupId._
 import lucuma.core.optics.laws.discipline.FormatTests
 import munit.DisciplineSuite
 
-class TargetEnvIdObsIdSetSuite extends DisciplineSuite {
-  checkAll("TargetEnvIdObsIdSet.format",
-           FormatTests(TargetEnvIdObsIdSet.format).formatWith(stringsOftenParsable)
+class TargetEnvGroupIdSuite extends DisciplineSuite {
+  checkAll("TargetEnvGroupId.format",
+           FormatTests(TargetEnvGroupId.format).formatWith(stringsOftenParsable)
   )
 }

--- a/model/shared/src/main/scala/explore/model/TargetEnvGroup.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEnvGroup.scala
@@ -19,8 +19,8 @@ import monocle.Lens
 import scala.collection.immutable.SortedSet
 import scala.collection.immutable.TreeSeqMap
 
-case class TargetEnv(
-  id:             TargetEnvIdObsIdSet,
+case class TargetEnvGroup(
+  id:             TargetEnvGroupIdSet,
   scienceTargets: TreeSeqMap[TargetIdSet, Target]
 ) {
   lazy val targetEnvIds: TargetEnvIdSet      = id.targetEnvIds
@@ -34,13 +34,13 @@ case class TargetEnv(
   // Note: This should only be used while waiting for the server roundtrip
   // since it does not include the target ids. If we start generating
   // target ids on the ui-side, this should go away.
-  def addIds(newIds: TargetEnvIdObsIdSet): TargetEnv =
-    TargetEnv.id.modify(_ ++ newIds)(this)
+  def addIds(newIds: TargetEnvGroupIdSet): TargetEnvGroup =
+    TargetEnvGroup.id.modify(_ ++ newIds)(this)
 
-  def asObsKeyValue: (TargetEnvIdObsIdSet, TargetEnv) = (this.id, this)
+  def asObsKeyValue: (TargetEnvGroupIdSet, TargetEnvGroup) = (this.id, this)
 
-  def areScienceTargetsEqual(other: TargetEnv): Boolean =
-    TargetEnv.areScienceTargetsEqual(this, other)
+  def areScienceTargetsEqual(other: TargetEnvGroup): Boolean =
+    TargetEnvGroup.areScienceTargetsEqual(this, other)
 
   /**
    * Effectively creates a subset of the original TargetEnv, where the TargetEnv.id contains only
@@ -48,10 +48,10 @@ case class TargetEnv(
    * keys specified in targetIdsToInclude. This subset can then be passed to the TargetEnvEditor.
    */
   def filterInIds(
-    envObsIdsToInclude: TargetEnvIdObsIdSet,
+    envObsIdsToInclude: TargetEnvGroupIdSet,
     targetIdsToInclude: Set[Target.Id]
-  ): Option[TargetEnv] = {
-    val filteredIds: Option[TargetEnvIdObsIdSet] =
+  ): Option[TargetEnvGroup] = {
+    val filteredIds: Option[TargetEnvGroupIdSet] =
       this.id.filterOpt(envObsIdsToInclude.contains)
 
     val filteredTargets: Option[TreeSeqMap[TargetIdSet, Target]] =
@@ -62,7 +62,7 @@ case class TargetEnv(
             .map((_, target))
         }
         .map(TreeSeqMap.from)
-    (filteredIds, filteredTargets).mapN { case (id, targets) => TargetEnv(id, targets) }
+    (filteredIds, filteredTargets).mapN { case (id, targets) => TargetEnvGroup(id, targets) }
   }
 
   /**
@@ -73,10 +73,10 @@ case class TargetEnv(
    * original with identical targets.
    */
   def filterOutIds(
-    envObsIdsToExclude: TargetEnvIdObsIdSet,
+    envObsIdsToExclude: TargetEnvGroupIdSet,
     targetIdsToExclude: Set[Target.Id]
-  ): Option[TargetEnv] = {
-    val filteredIds: Option[TargetEnvIdObsIdSet]                 =
+  ): Option[TargetEnvGroup] = {
+    val filteredIds: Option[TargetEnvGroupIdSet]                 =
       this.id.remove(envObsIdsToExclude)
     val filteredTargets: Option[TreeSeqMap[TargetIdSet, Target]] =
       this.scienceTargets.toList
@@ -85,7 +85,7 @@ case class TargetEnv(
         }
         .sequence
         .map(TreeSeqMap.from)
-    (filteredIds, filteredTargets).mapN { case (id, targets) => TargetEnv(id, targets) }
+    (filteredIds, filteredTargets).mapN { case (id, targets) => TargetEnvGroup(id, targets) }
   }
 
   /**
@@ -95,23 +95,23 @@ case class TargetEnv(
    * instance where editing a TargetEnv makes it equal to an existing TargetEnv, making a merger
    * necessary, NOTE: The target lists of this and other are assumed to be equal.
    */
-  def merge(other: TargetEnv): TargetEnv = {
+  def merge(other: TargetEnvGroup): TargetEnvGroup = {
     val mergedTargets: TreeSeqMap[TargetIdSet, Target] =
       TreeSeqMap.from(
         (this.scienceTargets.toList, other.scienceTargets.toList)
           .parMapN { case ((ids1, target), (ids2, _)) => (ids1 ++ ids2, target) }
       )
-    TargetEnv(this.id ++ other.id, mergedTargets)
+    TargetEnvGroup(this.id ++ other.id, mergedTargets)
   }
 }
 
-object TargetEnv {
+object TargetEnvGroup {
 
   /**
    * Compare the targets in the scienceTargets of 2 TargetEnvs to see if they are all equal. This is
    * used to determine if a merger is necessary after an edit.
    */
-  def areScienceTargetsEqual(env1: TargetEnv, env2: TargetEnv): Boolean =
+  def areScienceTargetsEqual(env1: TargetEnvGroup, env2: TargetEnvGroup): Boolean =
     areTargetListsEqual(env1.scienceTargets, env2.scienceTargets)
 
   def areTargetListsEqual(
@@ -121,7 +121,7 @@ object TargetEnv {
     tl1.size === tl2.size &&
       (tl1.toList, tl2.toList).parMapN { case ((_, t1), (_, t2)) => t1 === t2 }.forall(identity)
 
-  implicit val eqTargetEnv: Eq[TargetEnv] = Eq.by(x => (x.id, x.scienceTargets.toMap))
+  implicit val eqTargetEnv: Eq[TargetEnvGroup] = Eq.by(x => (x.id, x.scienceTargets.toMap))
 
   private val singleTargetIdDecoder: Decoder[TargetIdSet]       =
     Decoder.instance(_.get[Target.Id]("id").map(id => NonEmptySet.one(id)))
@@ -141,32 +141,32 @@ object TargetEnv {
 
   private val obsIdDecoder: Decoder[Observation.Id] = Decoder.instance(_.get[Observation.Id]("id"))
 
-  private implicit val targetEnvIdDecoder: Decoder[TargetEnvIdObsId] = Decoder.instance(c =>
+  private implicit val targetEnvIdDecoder: Decoder[TargetEnvGroupId] = Decoder.instance(c =>
     for {
       targetEnvId <- c.get[TargetEnvironment.Id]("id")
       obsId       <- c.get[Option[Observation.Id]]("observation")(decodeOption(obsIdDecoder))
-    } yield TargetEnvIdObsId((targetEnvId, obsId))
+    } yield TargetEnvGroupId((targetEnvId, obsId))
   )
 
-  private val singleTargetEnvDecoder: Decoder[TargetEnv] = Decoder.instance(c =>
+  private val singleTargetEnvDecoder: Decoder[TargetEnvGroup] = Decoder.instance(c =>
     for {
-      id             <- c.as[TargetEnvIdObsId].map(id => NonEmptySet.one(id))
+      id             <- c.as[TargetEnvGroupId].map(id => NonEmptySet.one(id))
       scienceTargets <- c.get[List[TargetWithId]]("scienceTargets").map(TreeSeqMap.from)
-    } yield TargetEnv(TargetEnvIdObsIdSet(id), scienceTargets)
+    } yield TargetEnvGroup(TargetEnvGroupIdSet(id), scienceTargets)
   )
 
-  private val groupTargetEnvDecoder: Decoder[TargetEnv] = Decoder.instance(c =>
+  private val groupTargetEnvDecoder: Decoder[TargetEnvGroup] = Decoder.instance(c =>
     for {
-      id             <- c.get[List[TargetEnvIdObsId]]("targetEnvironments")
+      id             <- c.get[List[TargetEnvGroupId]]("targetEnvironments")
                           .map(list => NonEmptySet.of(list.head, list.tail: _*))
       scienceTargets <- c.get[List[TargetWithId]]("commonTargetList").map(TreeSeqMap.from)
-    } yield TargetEnv(TargetEnvIdObsIdSet(id), scienceTargets)
+    } yield TargetEnvGroup(TargetEnvGroupIdSet(id), scienceTargets)
   )
 
-  implicit val decoderTargetEnv: Decoder[TargetEnv] =
+  implicit val decoderTargetEnv: Decoder[TargetEnvGroup] =
     singleTargetEnvDecoder.or(groupTargetEnvDecoder)
 
-  val id: Lens[TargetEnv, TargetEnvIdObsIdSet]                         = Focus[TargetEnv](_.id)
-  val scienceTargets: Lens[TargetEnv, TreeSeqMap[TargetIdSet, Target]] =
-    Focus[TargetEnv](_.scienceTargets)
+  val id: Lens[TargetEnvGroup, TargetEnvGroupIdSet]                         = Focus[TargetEnvGroup](_.id)
+  val scienceTargets: Lens[TargetEnvGroup, TreeSeqMap[TargetIdSet, Target]] =
+    Focus[TargetEnvGroup](_.scienceTargets)
 }

--- a/model/shared/src/main/scala/explore/model/TargetEnvGroupId.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEnvGroupId.scala
@@ -9,7 +9,7 @@ import lucuma.core.model.Observation
 import lucuma.core.model.TargetEnvironment
 import lucuma.core.optics.Format
 
-case class TargetEnvIdObsId(id: (TargetEnvironment.Id, Option[Observation.Id])) extends AnyVal {
+case class TargetEnvGroupId(id: (TargetEnvironment.Id, Option[Observation.Id])) extends AnyVal {
   def targetEnvId: TargetEnvironment.Id = id._1
   def optObsId: Option[Observation.Id]  = id._2
 
@@ -20,17 +20,17 @@ case class TargetEnvIdObsId(id: (TargetEnvironment.Id, Option[Observation.Id])) 
   }
 }
 
-object TargetEnvIdObsId {
-  implicit val orderTargetEnvIdObsId: Order[TargetEnvIdObsId] = Order.by(_.id._1)
+object TargetEnvGroupId {
+  implicit val orderTargetEnvGroupId: Order[TargetEnvGroupId] = Order.by(_.id._1)
 
-  val format: Format[String, TargetEnvIdObsId] = Format(parse, _.toString)
+  val format: Format[String, TargetEnvGroupId] = Format(parse, _.toString)
 
-  def parse(idStr: String): Option[TargetEnvIdObsId] =
+  def parse(idStr: String): Option[TargetEnvGroupId] =
     idStr.split(":").toList match {
       case tidStr :: oidStr :: Nil =>
         TargetEnvironment.Id
           .parse(tidStr)
-          .map(tid => TargetEnvIdObsId((tid, Observation.Id.parse(oidStr))))
+          .map(tid => TargetEnvGroupId((tid, Observation.Id.parse(oidStr))))
       case _                       => none
     }
 

--- a/model/shared/src/main/scala/explore/model/TargetEnvGroupIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEnvGroupIdSet.scala
@@ -15,7 +15,7 @@ import monocle.Iso
 
 import scala.collection.immutable.SortedSet
 
-case class TargetEnvIdObsIdSet(idSet: NonEmptySet[TargetEnvIdObsId]) {
+case class TargetEnvGroupIdSet(idSet: NonEmptySet[TargetEnvGroupId]) {
   lazy val targetEnvIds: TargetEnvIdSet      = idSet.map(_.targetEnvId)
   lazy val obsIds: SortedSet[Observation.Id] = SortedSet.from(idSet.toList.mapFilter(_.optObsId))
   lazy val obsIdList: List[Observation.Id]   = obsIds.toList
@@ -31,27 +31,27 @@ case class TargetEnvIdObsIdSet(idSet: NonEmptySet[TargetEnvIdObsId]) {
     if (idSet.length === 1) idSet.head.optObsId else none
 }
 
-object TargetEnvIdObsIdSet {
-  implicit val orderTargetEnvIdObsIdSet: Order[TargetEnvIdObsIdSet] = Order.by(_.idSet)
+object TargetEnvGroupIdSet {
+  implicit val orderTargetEnvGroupIdSet: Order[TargetEnvGroupIdSet] = Order.by(_.idSet)
 
-  val iso: Iso[TargetEnvIdObsIdSet, NonEmptySet[TargetEnvIdObsId]] =
-    Iso[TargetEnvIdObsIdSet, NonEmptySet[TargetEnvIdObsId]](_.idSet)(TargetEnvIdObsIdSet.apply)
+  val iso: Iso[TargetEnvGroupIdSet, NonEmptySet[TargetEnvGroupId]] =
+    Iso[TargetEnvGroupIdSet, NonEmptySet[TargetEnvGroupId]](_.idSet)(TargetEnvGroupIdSet.apply)
 
-  implicit def nonEmptySetWrapper(ids: TargetEnvIdObsIdSet) =
-    NonEmptySetWrapper(ids, TargetEnvIdObsIdSet.iso)
+  implicit def nonEmptySetWrapper(ids: TargetEnvGroupIdSet) =
+    NonEmptySetWrapper(ids, TargetEnvGroupIdSet.iso)
 
   // alternate ordering for display
-  val orderByObsThenTargetEnv: Order[TargetEnvIdObsIdSet] =
+  val orderByObsThenTargetEnv: Order[TargetEnvGroupIdSet] =
     Order.by(_.idSet.toList.map(t => (t.optObsId, t.targetEnvId)))
 
-  val format: Format[String, TargetEnvIdObsIdSet] = Format(parse, _.toString)
+  val format: Format[String, TargetEnvGroupIdSet] = Format(parse, _.toString)
 
-  private def parse(idSetStr: String): Option[TargetEnvIdObsIdSet] =
+  private def parse(idSetStr: String): Option[TargetEnvGroupIdSet] =
     idSetStr
       .split(",")
       .toList
-      .traverse(TargetEnvIdObsId.format.getOption)
-      .flatMap(list => NonEmptySet.fromSet(SortedSet.from(list)).map(TargetEnvIdObsIdSet.apply))
+      .traverse(TargetEnvGroupId.format.getOption)
+      .flatMap(list => NonEmptySet.fromSet(SortedSet.from(list)).map(TargetEnvGroupIdSet.apply))
 
-  def one(id: TargetEnvIdObsId): TargetEnvIdObsIdSet = TargetEnvIdObsIdSet(NonEmptySet.one(id))
+  def one(id: TargetEnvGroupId): TargetEnvGroupIdSet = TargetEnvGroupIdSet(NonEmptySet.one(id))
 }

--- a/model/shared/src/main/scala/explore/model/expandedIds.scala
+++ b/model/shared/src/main/scala/explore/model/expandedIds.scala
@@ -13,7 +13,7 @@ import scala.collection.immutable.SortedSet
 case class ExpandedIds(
   targetIds:           SortedSet[Target.Id] = SortedSet.empty,
   constraintSetObsIds: SortedSet[ObsIdSet] = SortedSet.empty,
-  targetListObsIds:    SortedSet[TargetEnvIdObsIdSet] = SortedSet.empty
+  targetListObsIds:    SortedSet[TargetEnvGroupIdSet] = SortedSet.empty
 )
 
 object ExpandedIds {


### PR DESCRIPTION
Also renames `TargetEnvIdObsId` to `TargetEnvGroupId` and `TargetEnvIdObsIdSet` to `TargetEnvGroupIdSet`.