### PR TITLE
Revert inadvertent commit of vite.config.js

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -91,6 +91,8 @@ module.exports = ({ command, mode }) => {
         mode == "production"
           ? {}
           : {
+              key: fs.readFileSync("server.key"),
+              cert: fs.readFileSync("server.cert"),
             },
       watch: {
         usePolling: true,


### PR DESCRIPTION
This puts vite.config.js back to what is was before my last PR.

I'm not getting the prompt to accept the certificate very often anymore, so I'm not sure this is still needed.