### PR TITLE
Calculate all rows on the configuration list and support sorting

### DIFF
--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -76,6 +76,8 @@ object reusability {
         }
     )
   implicit def modelUndoStacksReuse[F[_]]: Reusability[ModelUndoStacks[F]]           = Reusability.derive
+  implicit val filterReuse: Reusability[AvailableFilter]                             = Reusability.byEq
+  implicit val optionsReuse: Reusability[ImagingConfigurationOptions]                = Reusability.derive
   // Move to lucuma-ui
   implicit val semesterReuse: Reusability[Semester]                                  = Reusability.derive
   implicit val cssReuse: Reusability[Css]                                            = Reusability.by(_.htmlClass)

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -16,6 +16,7 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.implicits._
+import explore.model.AvailableFilter
 import explore.model.ImagingConfigurationOptions
 import explore.model.SpectroscopyConfigurationOptions
 import explore.model.display._
@@ -36,6 +37,8 @@ import react.common._
 import react.semanticui.collections.form.Form
 import react.semanticui.sizes._
 
+import scala.collection.SortedSet
+
 final case class ConfigurationPanel(
   obsId:            Observation.Id,
   scienceDataUndo:  UndoCtx[ScienceData],
@@ -46,13 +49,17 @@ final case class ConfigurationPanel(
 object ConfigurationPanel {
   type Props = ConfigurationPanel
 
-  implicit val propsReuse: Reusability[Props] = Reusability.derive
-  implicit val stateReuse: Reusability[State] = Reusability.never
+  implicit val propsReuse: Reusability[Props]                          = Reusability.derive
+  implicit val filterReuse: Reusability[AvailableFilter]               = Reusability.byEq
+  implicit val filterSetReuse: Reusability[SortedSet[AvailableFilter]] = Reusability.by(_.toSet)
+  implicit val optionsReuse: Reusability[ImagingConfigurationOptions]  = Reusability.derive
+  implicit val stateReuse: Reusability[State]                          = Reusability.derive
 
   final case class State(
     mode:           ScienceMode,
     imagingOptions: ImagingConfigurationOptions
   )
+
   object State {
     val mode: Lens[State, ScienceMode]                           = Focus[State](_.mode)
     val imagingOptions: Lens[State, ImagingConfigurationOptions] = Focus[State](_.imagingOptions)

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -16,7 +16,6 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.implicits._
-import explore.model.AvailableFilter
 import explore.model.ImagingConfigurationOptions
 import explore.model.SpectroscopyConfigurationOptions
 import explore.model.display._
@@ -37,8 +36,6 @@ import react.common._
 import react.semanticui.collections.form.Form
 import react.semanticui.sizes._
 
-import scala.collection.SortedSet
-
 final case class ConfigurationPanel(
   obsId:            Observation.Id,
   scienceDataUndo:  UndoCtx[ScienceData],
@@ -49,11 +46,8 @@ final case class ConfigurationPanel(
 object ConfigurationPanel {
   type Props = ConfigurationPanel
 
-  implicit val propsReuse: Reusability[Props]                          = Reusability.derive
-  implicit val filterReuse: Reusability[AvailableFilter]               = Reusability.byEq
-  implicit val filterSetReuse: Reusability[SortedSet[AvailableFilter]] = Reusability.by(_.toSet)
-  implicit val optionsReuse: Reusability[ImagingConfigurationOptions]  = Reusability.derive
-  implicit val stateReuse: Reusability[State]                          = Reusability.derive
+  implicit val propsReuse: Reusability[Props] = Reusability.derive
+  implicit val stateReuse: Reusability[State] = Reusability.derive
 
   final case class State(
     mode:           ScienceMode,

--- a/explore/src/main/scala/explore/config/ImagingConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ImagingConfigurationPanel.scala
@@ -32,7 +32,7 @@ import react.semanticui.collections.menu.MenuHeader
 import react.semanticui.modules.dropdown._
 import spire.math.Rational
 
-import scala.collection.SortedSet
+import scala.collection.immutable.SortedSet
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -223,7 +223,7 @@ object SpectroscopyModesTable extends ItcColumn {
         .setMinWidth(50)
         .setMaxWidth(150),
       column(TimeColumnId, itc.forRow(cw, sn, _))
-        .setCell(c => Reusable.implicitly(c.value).map(p => itcCell(p)))
+        .setCell(c => itcCell(c.value))
         .setWidth(80)
         .setMinWidth(80)
         .setMaxWidth(80)
@@ -310,7 +310,6 @@ object SpectroscopyModesTable extends ItcColumn {
 
     // Put the visible rows first
     ((for { i <- s to e } yield rows.lift(i)).collect { case Some(m) => m }.toList ::: rows)
-      .distinctBy(_.id)
   }
 
   protected def updateITCOnScroll[F[_]: Parallel: Dispatcher: Sync: TransactionalClient[*[_], ITC]](

--- a/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
+++ b/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
@@ -13,6 +13,7 @@ trait SpectroscopyModesMatrixPlatform extends SpectroscopyModesMatrixDecoders {
   def loadMatrix[F[_]: Concurrent](s: Stream[F, String]): F[List[SpectroscopyModeRow]] =
     s
       .through(decodeUsingHeaders[NonEmptyList[SpectroscopyModeRow]]())
+      .map(_.zipWithIndex.map { case (row, i) => row.copy(id = i) })
       .flatMap(l => Stream(l.toList: _*))
       .compile
       .toList

--- a/model/jvm/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
+++ b/model/jvm/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
@@ -21,7 +21,7 @@ trait SpectroscopyModesMatrixPlatform extends SpectroscopyModesMatrixDecoders {
       .flatMap(l => Stream(l.toList: _*))
       .zipWithIndex
       .map { case (r, i) =>
-        r.copy(id = i)
+        r.copy(id = i.toInt)
       }
       .compile
       .toList

--- a/model/shared/src/main/scala/explore/model/ImagingConfigurationOptions.scala
+++ b/model/shared/src/main/scala/explore/model/ImagingConfigurationOptions.scala
@@ -17,7 +17,7 @@ import lucuma.core.math.units._
 import monocle.Focus
 import spire.math.interval.ValueBound
 
-import scala.collection.SortedSet
+import scala.collection.immutable.SortedSet
 
 sealed abstract class AvailableFilter {
   val tag: String

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -197,7 +197,7 @@ object InstrumentRow {
 }
 
 case class SpectroscopyModeRow(
-  id:                 Long, // Give them a local id to simplify reusability
+  id:                 Int, // Give them a local id to simplify reusability
   instrument:         InstrumentRow,
   config:             NonEmptyString,
   focalPlane:         FocalPlane,
@@ -338,7 +338,7 @@ trait SpectroscopyModesMatrixDecoders extends Decoders {
         sl  <- row.as[ModeSlitSize]("slit length")
         sw  <- row.as[ModeSlitSize]("slit width")
       } yield fs.map(f =>
-        SpectroscopyModeRow(row.line.orEmpty, i, s, f, c, a, min, max, wo, wr, r, sl, sw)
+        SpectroscopyModeRow(row.line.foldMap(_.toInt), i, s, f, c, a, min, max, wo, wr, r, sl, sw)
       )
   }
 }


### PR DESCRIPTION
At the moment we only query the visible itc rows, however to support sorting we need to query each row
This PR does it prioritizing the visible rows

Note this leads to quite many requests and though in many cases the http cache will be hit it still places some extra load on the browser. We need to add an extra layer of persistent caching to improve it