### PR TITLE
Unstackable target tables.

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/TargetTable.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetTable.scala
@@ -163,34 +163,36 @@ object TargetTable {
               )
             )
           ),
-          TargetTableComponent(
-            table = Table(celled = true,
-                          selectable = true,
-                          striped = true,
-                          compact = TableCompact.Very,
-                          clazz = ExploreStyles.ExploreTable
-            )(),
-            header = true,
-            headerCell = (col: TargetTable.ColumnType) =>
-              TableHeaderCell(clazz = columnClasses.get(col.id.toString).orUndefined)(
-                ^.textTransform.none,
-                ^.whiteSpace.nowrap
-              ),
-            row = (rowData: TargetTable.RowType) =>
-              TableRow(
-                clazz = ExploreStyles.TableRowSelected.when_(
-                  props.selectedTarget.get.exists(_ === TargetWithId.id.get(rowData.original))
+          <.div(ExploreStyles.ExploreTable)(
+            TargetTableComponent(
+              table = Table(celled = true,
+                            selectable = true,
+                            striped = true,
+                            compact = TableCompact.Very,
+                            unstackable = true
+              )(),
+              header = true,
+              headerCell = (col: TargetTable.ColumnType) =>
+                TableHeaderCell(clazz = columnClasses.get(col.id.toString).orUndefined)(
+                  ^.textTransform.none,
+                  ^.whiteSpace.nowrap
+                ),
+              row = (rowData: TargetTable.RowType) =>
+                TableRow(
+                  clazz = ExploreStyles.TableRowSelected.when_(
+                    props.selectedTarget.get.exists(_ === TargetWithId.id.get(rowData.original))
+                  )
+                )(
+                  ^.onClick --> props.selectedTarget
+                    .set(TargetWithId.id.get(rowData.original).some),
+                  props2Attrs(rowData.getRowProps())
+                ),
+              cell = (cell: TargetTable.CellType[_]) =>
+                TableCell(clazz = columnClasses.get(cell.column.id.toString).orUndefined)(
+                  ^.whiteSpace.nowrap
                 )
-              )(
-                ^.onClick --> props.selectedTarget
-                  .set(TargetWithId.id.get(rowData.original).some),
-                props2Attrs(rowData.getRowProps())
-              ),
-            cell = (cell: TargetTable.CellType[_]) =>
-              TableCell(clazz = columnClasses.get(cell.column.id.toString).orUndefined)(
-                ^.whiteSpace.nowrap
-              )
-          )(tableInstance)
+            )(tableInstance)
+          )
         )
       )
 }

--- a/explore/src/main/scala/explore/targets/TargetSelectionTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionTable.scala
@@ -88,6 +88,7 @@ object TargetSelectionTable {
                       selectable = true,
                       striped = true,
                       compact = TableCompact.Very,
+                      unstackable = true,
                       clazz = ExploreStyles.ExploreTable
         )(),
         header = true,

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -246,6 +246,7 @@ object TargetSummaryTable {
                           selectable = true,
                           striped = true,
                           compact = TableCompact.Very,
+                          unstackable = true,
                           clazz = ExploreStyles.ExploreTable
             )(),
             header = true,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -42,7 +42,7 @@ object Settings {
     val reactHotkeys      = "0.4.0"
     val reactResizable    = "0.7.1"
     val reactSemanticUI   = "0.13.1"
-    val reactTable        = "0.7.2"
+    val reactTable        = "0.7.3"
     val reactVirtuoso     = "0.2.2"
     val scalaJsReact      = "2.0.0"
     val pprint            = "0.6.6"


### PR DESCRIPTION
Don't stack columns in target tables in small screens.

Changes in `SUITable` are just general improvements, which are necessary when using `useFlexLayout` (which I ended up not using, but I'm leaving the changes there in case we ever do).
