### PR TITLE
ITC Requests queue

### DIFF
--- a/common/src/main/scala/reactST/reactTable/SUITable.scala
+++ b/common/src/main/scala/reactST/reactTable/SUITable.scala
@@ -5,24 +5,24 @@ package reactST.reactTable
 
 import cats.syntax.all._
 import explore.Icons
+import explore.components.ui.ExploreStyles
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.JsFn
 import japgolly.scalajs.react.internal.Box
 import japgolly.scalajs.react.vdom.html_<^._
+import react.common.implicits._
+import react.common.style.Css
 import react.semanticui.AsC
 import react.semanticui.collections.table._
 import reactST.reactTable._
 import reactST.reactTable.facade.cell.Cell
 import reactST.reactTable.facade.column.Column
+import reactST.reactTable.facade.column.HeaderGroup
 import reactST.reactTable.facade.row.Row
 import reactST.reactTable.facade.tableInstance.TableInstance
-import react.common.implicits._
 
 import scalajs.js
 import scalajs.js.|
-import react.common.style.Css
-import explore.components.ui.ExploreStyles
-import reactST.reactTable.facade.column.HeaderGroup
 
 // We can't define a package object since it's already defined in the facade.
 object definitions {

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -94,7 +94,9 @@ object ConfigurationPanel {
       .withHooks[Props]
       .useStateSnapshotWithReuse(none[ITCRequestsQueue[IO]])
       .useEffectOnMountBy { (props, st) =>
+        // Create the requests queue and put it on the state
         implicit val ctx: AppContextIO = props.ctx
+        // TODO proper cleanup
         ITCRequestsQueue.build[IO]((r: Option[ITCRequestsQueue[IO]]) => st.setState(r).to[IO])
       }
       .useStateSnapshotWithReuse[ScienceMode](ScienceMode.Spectroscopy)

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -3,6 +3,7 @@
 
 package explore.config
 
+import cats.effect.IO
 import cats.syntax.all._
 import coulomb.Quantity
 import crystal.react.implicits._
@@ -14,6 +15,7 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.implicits._
+import explore.itc._
 import explore.model.ImagingConfigurationOptions
 import explore.model.SpectroscopyConfigurationOptions
 import explore.model.display._
@@ -21,6 +23,7 @@ import explore.model.reusability._
 import explore.undo.UndoContext
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra._
+import japgolly.scalajs.react.util.syntax._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.ScienceMode
 import lucuma.core.math.Wavelength
@@ -89,52 +92,56 @@ object ConfigurationPanel {
   protected val component =
     ScalaFnComponent
       .withHooks[Props]
+      .useStateSnapshotWithReuse(none[ITCRequestsQueue[IO]])
+      .useEffectOnMountBy { (props, st) =>
+        implicit val ctx: AppContextIO = props.ctx
+        ITCRequestsQueue.build[IO]((r: Option[ITCRequestsQueue[IO]]) => st.setState(r).to[IO])
+      }
       .useStateSnapshotWithReuse[ScienceMode](ScienceMode.Spectroscopy)
       .useStateSnapshotWithReuse[ImagingConfigurationOptions](ImagingConfigurationOptions.Default)
-      .renderWithReuse { (props, mode, imaging) =>
-        implicit val ctx    = props.ctx
-        val requirementsCtx = props.scienceDataUndo.zoom(ScienceData.requirements)
+      .renderWithReuse { (props, u, mode, imaging) =>
+        u.value.map { queue =>
+          implicit val ctx: AppContextIO = props.ctx
+          val requirementsCtx            = props.scienceDataUndo.zoom(ScienceData.requirements)
 
-        val requirementsViewSet = UndoView(props.obsId, requirementsCtx)
+          val requirementsViewSet = UndoView(props.obsId, requirementsCtx)
 
-        val isSpectroscopy = mode.value === ScienceMode.Spectroscopy
+          val isSpectroscopy = mode.value === ScienceMode.Spectroscopy
 
-        val spectroscopy = requirementsViewSet(
-          ScienceRequirementsData.spectroscopyRequirements,
-          UpdateScienceRequirements.spectroscopyRequirements
-        )
+          val spectroscopy = requirementsViewSet(
+            ScienceRequirementsData.spectroscopyRequirements,
+            UpdateScienceRequirements.spectroscopyRequirements
+          )
 
-        val configurationView = props.scienceDataUndo
-          .undoableView(ScienceData.configuration)
-          .withOnMod(conf => setScienceConfiguration(props.obsId, conf).runAsync)
+          val configurationView = props.scienceDataUndo
+            .undoableView(ScienceData.configuration)
+            .withOnMod(conf => setScienceConfiguration(props.obsId, conf).runAsync)
 
-        <.div(
-          ExploreStyles.ConfigurationGrid,
-          props.renderInTitle(
-            <.span(ExploreStyles.TitleUndoButtons)(UndoButtons(props.scienceDataUndo))
-          ),
-          Form(size = Small)(
-            ExploreStyles.Grid,
-            ExploreStyles.Compact,
-            ExploreStyles.ExploreForm,
-            ExploreStyles.ConfigurationForm
-          )(
-            <.label("Mode", HelpIcon("configuration/mode.md")),
-            EnumViewSelect(id = "configuration-mode", value = mode),
-            SpectroscopyConfigurationPanel(spectroscopy.as(dataIso))
-              .when(isSpectroscopy),
-            ImagingConfigurationPanel(imaging)
-              .unless(isSpectroscopy)
-          ),
-          SpectroscopyModesTable
-            .component(
-              SpectroscopyModesTable(
-                configurationView,
-                ctx.staticData.spectroscopyMatrix,
-                spectroscopy.get
-              )
-            )
-            .when(isSpectroscopy)
-        )
+          <.div(
+            ExploreStyles.ConfigurationGrid,
+            props.renderInTitle(
+              <.span(ExploreStyles.TitleUndoButtons)(UndoButtons(props.scienceDataUndo))
+            ),
+            Form(size = Small)(
+              ExploreStyles.Grid,
+              ExploreStyles.Compact,
+              ExploreStyles.ExploreForm,
+              ExploreStyles.ConfigurationForm
+            )(
+              <.label("Mode", HelpIcon("configuration/mode.md")),
+              EnumViewSelect(id = "configuration-mode", value = mode),
+              SpectroscopyConfigurationPanel(spectroscopy.as(dataIso))
+                .when(isSpectroscopy),
+              ImagingConfigurationPanel(imaging)
+                .unless(isSpectroscopy)
+            ),
+            SpectroscopyModesTable(
+              configurationView,
+              spectroscopy.get,
+              ctx.staticData.spectroscopyMatrix,
+              queue
+            ).when(isSpectroscopy)
+          )
+        }
       }
 }

--- a/explore/src/main/scala/explore/config/ITCRequestsQueue.scala
+++ b/explore/src/main/scala/explore/config/ITCRequestsQueue.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package explore.itc
 
 import cats._

--- a/explore/src/main/scala/explore/config/ITCRequestsQueue.scala
+++ b/explore/src/main/scala/explore/config/ITCRequestsQueue.scala
@@ -1,0 +1,100 @@
+package explore.itc
+
+import cats._
+import cats.effect._
+import cats.effect.std.Queue
+import cats.effect.syntax.all._
+import cats.syntax.all._
+import clue.TransactionalClient
+import clue.data.syntax._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection._
+import eu.timepit.refined.types.numeric.PosBigDecimal
+import explore.common.ITCQueriesGQL._
+import explore.model.AirMassRange
+import explore.model.ConstraintSet
+import explore.schemas.ITC
+import explore.schemas.itcschema.implicits._
+import fs2.Stream
+import japgolly.scalajs.react.Reusability
+import japgolly.scalajs.react._
+import lucuma.core.enum.StellarLibrarySpectrum
+import lucuma.core.enum._
+import lucuma.core.math.MagnitudeValue
+import lucuma.core.math.Wavelength
+import lucuma.core.model.Magnitude
+import lucuma.core.model.SpatialProfile
+import lucuma.core.model.SpectralDistribution
+import org.typelevel.log4cats.Logger
+
+import scala.concurrent.duration._
+
+final case class ITCRequest[F[_]](
+  mode:          InstrumentModes,
+  wavelength:    Wavelength,
+  signalToNoise: PosBigDecimal,
+  callback:      SpectroscopyITCQuery.Data => F[Unit]
+)
+
+final case class ITCRequestsQueue[F[_]](f: Queue[F, Option[ITCRequest[F]]]) {
+  def run(implicit
+    E: Temporal[F],
+    L: Logger[F],
+    T: TransactionalClient[F, ITC]
+  ): F[Unit] =
+    Stream
+      .fromQueueNoneTerminated(f)
+      .meteredStartImmediately(500.milliseconds) // Limit how fasts requests are created
+      .evalMap(f => ITCRequestsQueue.doRequest(f))
+      .compile
+      .drain
+
+  def add(itc: ITCRequest[F]): F[Unit] =
+    f.offer(itc.some)
+}
+
+object ITCRequestsQueue {
+  type RequestsList[F[_]] = List[ITCRequest[F]] Refined MaxSize[4]
+
+  implicit val itcRequestsQueueReuse: Reusability[ITCRequestsQueue[IO]] = Reusability.always
+
+  def build[F[_]: Async: Logger: TransactionalClient[*[_], ITC]](
+    set: Option[ITCRequestsQueue[F]] => F[Unit]
+  ): F[Unit] =
+    for {
+      queue <- Queue.unbounded[F, Option[ITCRequest[F]]]
+      rq     = ITCRequestsQueue(queue)
+      _     <- rq.run.start
+      r     <- set(rq.some)
+    } yield r
+
+  def doRequest[F[_]: FlatMap: Logger: TransactionalClient[*[_], ITC]](
+    request: ITCRequest[F]
+  ): F[Unit] =
+    Logger[F].info(s"ITC request for mode ${request.mode}") *>
+      SpectroscopyITCQuery
+        .query(
+          ITCSpectroscopyInput(
+            request.wavelength.toITCInput,
+            request.signalToNoise,
+            // TODO Link target info to explore
+            SpatialProfile.PointSource,
+            SpectralDistribution.Library(StellarLibrarySpectrum.A0I.asLeft),
+            Magnitude(MagnitudeValue(20), MagnitudeBand.I, none, MagnitudeSystem.Vega).toITCInput,
+            BigDecimal(0.1),
+            // TODO Link constraints info to explore
+            ConstraintSet(
+              ImageQuality.PointSix,
+              CloudExtinction.PointFive,
+              SkyBackground.Dark,
+              WaterVapor.Median,
+              AirMassRange(
+                AirMassRange.DefaultMin,
+                AirMassRange.DefaultMax
+              )
+            ),
+            List(request.mode.assign)
+          ).assign
+        )
+        .flatMap(request.callback)
+}

--- a/explore/src/main/scala/explore/itc/ItcResultsCache.scala
+++ b/explore/src/main/scala/explore/itc/ItcResultsCache.scala
@@ -5,27 +5,16 @@ package explore.itc
 
 import cats.Parallel
 import cats.data._
-import cats.effect.Sync
 import cats.syntax.all._
-import clue.TransactionalClient
 import clue.data.Input
 import clue.data.syntax._
-import crystal.react.implicits._
 import eu.timepit.refined.auto._
 import eu.timepit.refined.types.numeric.PosBigDecimal
-import explore.common.ITCQueriesGQL._
-import explore.model.AirMassRange
-import explore.model.ConstraintSet
 import explore.modes._
-import explore.schemas.ITC
 import explore.schemas.itcschema.implicits._
 import japgolly.scalajs.react._
 import lucuma.core.enum._
-import lucuma.core.math.MagnitudeValue
 import lucuma.core.math.Wavelength
-import lucuma.core.model.Magnitude
-import lucuma.core.model.SpatialProfile
-import lucuma.core.model.SpectralDistribution
 import monocle.Focus
 
 import scala.concurrent.duration._
@@ -82,11 +71,13 @@ object ItcResultsCache {
 
   val updateCount = Focus[ItcResultsCache](_.updateCount)
 
-  def queryItc[F[_]: Parallel: Sync: TransactionalClient[*[_], ITC]](
+  def queryItc[F[_]: Parallel](
     wavelength:    Wavelength,
     signalToNoise: PosBigDecimal,
     modes:         List[SpectroscopyModeRow],
-    itcResults:    hooks.Hooks.UseState[ItcResultsCache]
+    cache:         ItcResultsCache,
+    cacheUpdate:   (ItcResultsCache => ItcResultsCache) => F[Unit],
+    queue:         ITCRequestsQueue[F]
   ): F[Unit] =
     modes
       .map(_.instrument)
@@ -96,56 +87,37 @@ object ItcResultsCache {
       }
       // Discard values in the cache
       .filterNot { case m =>
-        itcResults.value.cache.contains((wavelength, signalToNoise, m))
+        cache.cache.contains((wavelength, signalToNoise, m))
       }
       // ITC supports sending many modes at once, but sending them one by one
       // maximizes cache hits
       .parTraverse_ { m =>
-        SpectroscopyITCQuery
-          .query(
-            ITCSpectroscopyInput(
-              wavelength.toITCInput,
-              signalToNoise,
-              // TODO Link target info to explore
-              SpatialProfile.PointSource,
-              SpectralDistribution.Library(StellarLibrarySpectrum.A0I.asLeft),
-              Magnitude(MagnitudeValue(20), MagnitudeBand.I, none, MagnitudeSystem.Vega).toITCInput,
-              BigDecimal(0.1),
-              // TODO Link constraints info to explore
-              ConstraintSet(
-                ImageQuality.PointSix,
-                CloudExtinction.PointFive,
-                SkyBackground.Dark,
-                WaterVapor.Median,
-                AirMassRange(
-                  AirMassRange.DefaultMin,
-                  AirMassRange.DefaultMax
+        queue.add(
+          ITCRequest[F](
+            m,
+            wavelength,
+            signalToNoise,
+            { x =>
+              // Convert to usable types and update the cache
+              val update = x.spectroscopy.flatMap(_.results).map { r =>
+                val im = InstrumentModes(
+                  GmosNITCInput(r.mode.params.disperser,
+                                r.mode.params.fpu,
+                                r.mode.params.filter.orIgnore
+                  ).assign
                 )
-              ),
-              List(m.assign)
-            ).assign
-          )
-          .flatMap { x =>
-            // Convert to usable types and update the cache
-            val update = x.spectroscopy.flatMap(_.results).map { r =>
-              val im = InstrumentModes(
-                GmosNITCInput(r.mode.params.disperser,
-                              r.mode.params.fpu,
-                              r.mode.params.filter.orIgnore
-                ).assign
-              )
-              val m  = r.itc match {
-                case ItcError(m)      => ItcQueryProblems.GenericError(m).leftNec
-                case ItcSuccess(e, t) => ItcResult.Result(t.microseconds.microseconds, e).rightNec
+                val m  = r.itc match {
+                  case ItcError(m)      => ItcQueryProblems.GenericError(m).leftNec
+                  case ItcSuccess(e, t) => ItcResult.Result(t.microseconds.microseconds, e).rightNec
+                }
+                (wavelength, signalToNoise, im) -> m
               }
-              (wavelength, signalToNoise, im) -> m
-            }
-            itcResults
-              .modState(
+              cacheUpdate(
                 ItcResultsCache.updateCount.modify(_ + 1) >>> ItcResultsCache.cache
                   .modify(_ ++ update)
               )
-              .to[F]
-          }
+            }
+          )
+        )
       }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -95,7 +95,6 @@ module.exports = ({ command, mode }) => {
               cert: fs.readFileSync("server.cert"),
             },
       watch: {
-        usePolling: true,
         ignored: [
           function ignoreThisPath(_path) {
             const sjsIgnored =


### PR DESCRIPTION
The modes tables requires one ITC request per row, To support sorting we need to hit each possible row. The current naive implementation can thus send dozens or hundreds of requests and we can see it starts choking the browser. In particular the websocket downstream channel gets blocked with all those requests

This PR is maybe overkill but address the situation creating a queue of requests that are being sent at a certain intervals, thus filling the modes table a bit more slowly but on the other hand making the rest of the app more responsive.

There are a few details for future work:
* We should be able to stop the queue cleanly on unmount
* We may want the ability to cancel o de prioritize some requests
* Maybe parallelism can be increased without negatively affecting responsiveness

I have to say it is quite impressive that we can use the regular cats-effect and fs2 constructs to do this relatively complex engine on the browser