### PR TITLE
Fix charset warning

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -80,6 +80,13 @@ module.exports = ({ command, mode }) => {
         },
       ],
     },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          charset: false
+        }
+      }
+    },
     server: {
       strictPort: true,
       fsServe: {


### PR DESCRIPTION
A full build generates a set of extra @charset entries which are not needed. This PR fixes it:
See
https://github.com/vitejs/vite/issues/5519