### PR TITLE
Pass the targets to be used on ITC calculations

### DIFF
--- a/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
@@ -249,8 +249,7 @@ object ObsQueriesGQL {
 
     object Data {
       object Observation {
-        type Targets = model.TargetEnvGroup
-
+        type Targets       = model.TargetEnvGroup
         type ConstraintSet = model.ConstraintSet
 
         object ScienceRequirements {

--- a/common/src/main/scala/explore/common/ObsQueries.scala
+++ b/common/src/main/scala/explore/common/ObsQueries.scala
@@ -50,6 +50,7 @@ object ObsQueries {
   val ObservationData = ObsEditQuery.Data.Observation
   type ScienceRequirementsData = ObservationData.ScienceRequirements
   val ScienceRequirementsData = ObservationData.ScienceRequirements
+  type Targets                      = ObservationData.Targets
   type SpectroscopyRequirementsData = ObservationData.ScienceRequirements.SpectroscopyRequirements
   val SpectroscopyRequirementsData = ObservationData.ScienceRequirements.SpectroscopyRequirements
   type ScienceConfigurationData = ObservationData.ScienceConfiguration
@@ -58,8 +59,10 @@ object ObsQueries {
   case class ScienceData(
     requirements:  ScienceRequirementsData,
     configuration: Option[ScienceConfigurationData],
-    constraints:   ConstraintSet
+    constraints:   ConstraintSet,
+    targets:       Targets
   )
+
   object ScienceData {
     val requirements: Lens[ScienceData, ScienceRequirementsData]           =
       Focus[ScienceData](_.requirements)
@@ -73,7 +76,8 @@ object ObsQueries {
   val scienceDataForObs: Lens[ObservationData, ScienceData] =
     disjointZip(ObservationData.scienceRequirements,
                 ObservationData.scienceConfiguration,
-                ObservationData.constraintSet
+                ObservationData.constraintSet,
+                ObservationData.targets
     )
       .andThen(GenIso.fields[ScienceData].reverse)
 

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -35,6 +35,7 @@ object reusability {
     Reusability.by(_.toSortedSet.unsorted)
 
   // Model
+  implicit val itcTargetProps: Reusability[ITCTarget]                                 = Reusability.byEq
   implicit def appContextReuse[F[_]]: Reusability[AppContext[F]]                      = Reusability.always
   implicit val targetSummaryReuse: Reusability[TargetSummary]                         = Reusability.derive
   implicit val statusReuse: Reusability[PersistentClientStatus]                       = Reusability.derive

--- a/common/src/main/scala/explore/schemas/implicits.scala
+++ b/common/src/main/scala/explore/schemas/implicits.scala
@@ -157,10 +157,7 @@ object itcschema {
     implicit class ScienceDataOps(val s: ObsQueries.ScienceData) extends AnyVal {
       // From the list of targets selects the ones relevant for ITC
       def itcTargets: List[ITCTarget] = s.targets.scienceTargets
-        .collect { case (_, s: SiderealTarget) =>
-          s.tracking.radialVelocity
-        }
-        .collect { case Some(rv) =>
+        .collect { case (_, SiderealTarget(_, SiderealTracking(_, _, _, _, Some(rv), _), _, _)) =>
           // We can only process targets with a radial velocity
           ITCTarget(rv)
         }

--- a/common/src/main/scala/explore/schemas/implicits.scala
+++ b/common/src/main/scala/explore/schemas/implicits.scala
@@ -3,9 +3,12 @@
 
 package explore.schemas
 
+import cats.syntax.all._
 import clue.data.Input
 import clue.data.syntax._
 import explore.common.ITCQueriesGQL
+import explore.common.ObsQueries
+import explore.model.ITCTarget
 import explore.modes.GmosNorthSpectroscopyRow
 import lucuma.core.math._
 import lucuma.core.model._
@@ -117,7 +120,8 @@ object itcschema {
     val ITCWavelengthInput = ITC.Types.WavelengthModelInput
     type ITCSpectroscopyInput = ITC.Types.SpectroscopyModeInput
     val ITCSpectroscopyInput = ITC.Types.SpectroscopyModeInput
-    type ItcError = ITCQueriesGQL.SpectroscopyITCQuery.Data.Spectroscopy.Results.Itc.ItcError
+    type ItcResults = ITCQueriesGQL.SpectroscopyITCQuery.Data
+    type ItcError   = ITCQueriesGQL.SpectroscopyITCQuery.Data.Spectroscopy.Results.Itc.ItcError
     val ItcError = ITCQueriesGQL.SpectroscopyITCQuery.Data.Spectroscopy.Results.Itc.ItcError
     type ItcSuccess = ITCQueriesGQL.SpectroscopyITCQuery.Data.Spectroscopy.Results.Itc.ItcSuccess
     val ItcSuccess = ITCQueriesGQL.SpectroscopyITCQuery.Data.Spectroscopy.Results.Itc.ItcSuccess
@@ -148,6 +152,20 @@ object itcschema {
     implicit class RadialVelocityOps(val r: RadialVelocity) extends AnyVal {
       def toITCInput: RadialVelocityInput =
         RadialVelocityInput(metersPerSecond = r.rv.value.assign)
+    }
+
+    implicit class ScienceDataOps(val s: ObsQueries.ScienceData) extends AnyVal {
+      // From the list of targets selects the ones relevant for ITC
+      def itcTargets: List[ITCTarget] = s.targets.scienceTargets
+        .collect { case (_, s: SiderealTarget) =>
+          s.tracking.radialVelocity
+        }
+        .collect { case Some(rv) =>
+          // We can only process targets with a radial velocity
+          ITCTarget(rv)
+        }
+        .toList
+        .hashDistinct
     }
   }
 }

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -15,6 +15,8 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.implicits._
+import explore.model.ConstraintSet
+import explore.model.ITCTarget
 import explore.model.ImagingConfigurationOptions
 import explore.model.SpectroscopyConfigurationOptions
 import explore.model.display._
@@ -34,12 +36,12 @@ import monocle.Iso
 import react.common._
 import react.semanticui.collections.form.Form
 import react.semanticui.sizes._
-import explore.model.ConstraintSet
 
 final case class ConfigurationPanel(
   obsId:            Observation.Id,
   scienceDataUndo:  UndoContext[ScienceData],
   constraints:      ConstraintSet,
+  itcTargets:       List[ITCTarget],
   renderInTitle:    Tile.RenderInTitle
 )(implicit val ctx: AppContextIO)
     extends ReactFnProps[ConfigurationPanel](ConfigurationPanel.component)
@@ -133,6 +135,7 @@ object ConfigurationPanel {
             configurationView,
             spectroscopy.get,
             props.constraints,
+            if (props.itcTargets.isEmpty) none else props.itcTargets.some,
             ctx.staticData.spectroscopyMatrix
           ).when(isSpectroscopy)
         )

--- a/explore/src/main/scala/explore/config/ITCRequests.scala
+++ b/explore/src/main/scala/explore/config/ITCRequests.scala
@@ -4,6 +4,7 @@
 package explore.itc
 
 import cats._
+import cats.data._
 import cats.effect._
 import cats.effect.std.Semaphore
 import cats.syntax.all._
@@ -16,6 +17,7 @@ import eu.timepit.refined.types.numeric.PosBigDecimal
 import explore.common.ITCQueriesGQL._
 import explore.model.Constants
 import explore.model.ConstraintSet
+import explore.model.ITCTarget
 import explore.model.Progress
 import explore.modes.GmosNorthSpectroscopyRow
 import explore.modes.SpectroscopyModeRow
@@ -25,7 +27,6 @@ import japgolly.scalajs.react._
 import lucuma.core.enum.StellarLibrarySpectrum
 import lucuma.core.enum._
 import lucuma.core.math.MagnitudeValue
-import lucuma.core.math.Redshift
 import lucuma.core.math.Wavelength
 import lucuma.core.model.Magnitude
 import lucuma.core.model.SpatialProfile
@@ -33,6 +34,14 @@ import lucuma.core.model.SpectralDistribution
 import org.typelevel.log4cats.Logger
 
 import scala.concurrent.duration._
+
+final case class ITCRequestParams(
+  wavelength:    Wavelength,
+  signalToNoise: PosBigDecimal,
+  constraints:   ConstraintSet,
+  target:        NonEmptyList[ITCTarget],
+  mode:          InstrumentModes
+)
 
 object ITCRequests {
   // Copied from https://gist.github.com/gvolpe/44e2263f9068efe298a1f30390de6d22
@@ -58,6 +67,7 @@ object ITCRequests {
     wavelength:    Wavelength,
     signalToNoise: PosBigDecimal,
     constraints:   ConstraintSet,
+    targets:       NonEmptyList[ITCTarget],
     modes:         List[SpectroscopyModeRow],
     cache:         ViewF[F, ItcResultsCache],
     progress:      ViewF[F, Option[Progress]]
@@ -69,64 +79,68 @@ object ITCRequests {
         InstrumentModes(m.toGmosNITCInput)
       }
       // Discard values in the cache
-      .filterNot { case m =>
-        cache.get.cache.contains((wavelength, signalToNoise, constraints, m))
+      .filterNot { case mode =>
+        val params = ITCRequestParams(wavelength, signalToNoise, constraints, targets, mode)
+        cache.get.cache.contains(params)
       }
 
     progress.set(Progress.initial(NonNegInt.unsafeFrom(itcRows.length)).some) >>
       parTraverseN(
         Constants.MaxConcurrentItcRequests.toLong,
         itcRows
-      )(m =>
+      ) { mode =>
+        val params = ITCRequestParams(wavelength, signalToNoise, constraints, targets, mode)
         // ITC supports sending many modes at once, but sending them one by one
         // maximizes cache hits
         doRequest(
-          m,
-          wavelength,
-          signalToNoise,
-          constraints,
+          params,
           { x =>
             // Convert to usable types and update the cache
-            val update = x.spectroscopy.flatMap(_.results).map { r =>
-              val im = InstrumentModes(
-                GmosNITCInput(r.mode.params.disperser,
-                              r.mode.params.fpu,
-                              r.mode.params.filter.orIgnore
-                ).assign
+            val update: EitherNec[ItcQueryProblems, ItcResult] = x.toList
+              .flatMap(x =>
+                x.spectroscopy.flatMap(_.results).map { r =>
+                  val (t, m) = r.itc match {
+                    case ItcError(m)      => (Long.MinValue, ItcQueryProblems.GenericError(m).leftNec)
+                    case ItcSuccess(e, t) =>
+                      (t.microseconds, ItcResult.Result(t.microseconds.microseconds, e).rightNec)
+                  }
+                  (t, m)
+                }
               )
-              val m  = r.itc match {
-                case ItcError(m)      => ItcQueryProblems.GenericError(m).leftNec
-                case ItcSuccess(e, t) => ItcResult.Result(t.microseconds.microseconds, e).rightNec
-              }
-              (wavelength, signalToNoise, constraints, im) -> m
-            }
-            cache.mod(ItcResultsCache.cache.modify(_ ++ update))
+              // There maybe multiple targets, take the one with the max time
+              .maxBy(_._1)
+              ._2
+            cache.mod(ItcResultsCache.cache.modify(_ + (params -> update)))
           }
         ) >> progress.mod(_.map(_.increment()))
-      ) >> progress.set(none)
+      } >> progress.set(none)
   }
 
-  private def doRequest[F[_]: FlatMap: Logger: TransactionalClient[*[_], ITC]](
-    mode:          InstrumentModes,
-    wavelength:    Wavelength,
-    signalToNoise: PosBigDecimal,
-    constraints:   ConstraintSet,
-    callback:      SpectroscopyITCQuery.Data => F[Unit]
+  private def doRequest[F[_]: Monad: Logger: TransactionalClient[*[_], ITC]](
+    request:  ITCRequestParams,
+    callback: NonEmptyList[ItcResults] => F[Unit]
   ): F[Unit] =
-    Logger[F].debug(s"ITC request for mode $mode") *>
-      SpectroscopyITCQuery
-        .query(
-          ITCSpectroscopyInput(
-            wavelength.toITCInput,
-            signalToNoise,
-            // TODO Link target info to explore
-            SpatialProfile.PointSource,
-            SpectralDistribution.Library(StellarLibrarySpectrum.A0I.asLeft),
-            Magnitude(MagnitudeValue(20), MagnitudeBand.I, none, MagnitudeSystem.Vega).toITCInput,
-            Redshift(0.1).toRadialVelocity.get.toITCInput,
-            constraints,
-            List(mode.assign)
-          ).assign
-        )
+    Logger[F].debug(s"ITC request for mode ${request.mode}") *>
+      request.target
+        .traverse { t =>
+          SpectroscopyITCQuery
+            .query(
+              ITCSpectroscopyInput(
+                request.wavelength.toITCInput,
+                request.signalToNoise,
+                // TODO Link sp and SED info to explore
+                SpatialProfile.PointSource,
+                SpectralDistribution.Library(StellarLibrarySpectrum.A0I.asLeft),
+                Magnitude(MagnitudeValue(20),
+                          MagnitudeBand.I,
+                          none,
+                          MagnitudeSystem.Vega
+                ).toITCInput,
+                t.rv.toITCInput,
+                request.constraints,
+                List(request.mode.assign)
+              ).assign
+            )
+        }
         .flatMap(callback)
 }

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -22,6 +22,7 @@ import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.itc._
 import explore.model.ConstraintSet
+import explore.model.ITCTarget
 import explore.model.Progress
 import explore.model.reusability._
 import explore.modes._
@@ -56,6 +57,7 @@ final case class SpectroscopyModesTable(
   scienceConfiguration:     View[Option[ScienceConfigurationData]],
   spectroscopyRequirements: SpectroscopyRequirementsData,
   constraints:              ConstraintSet,
+  targets:                  Option[List[ITCTarget]],
   matrix:                   SpectroscopyModesMatrix
 )(implicit val ctx:         AppContextIO)
     extends ReactFnProps[SpectroscopyModesTable](SpectroscopyModesTable.component)
@@ -66,7 +68,9 @@ object SpectroscopyModesTable {
   type ColId = NonEmptyString
 
   implicit val reuseProps: Reusability[Props] =
-    Reusability.by(x => (x.scienceConfiguration, x.spectroscopyRequirements, x.constraints))
+    Reusability.by(x =>
+      (x.scienceConfiguration, x.spectroscopyRequirements, x.constraints, x.targets)
+    )
 
   implicit val listRangeReuse: Reusability[ListRange] =
     Reusability.by(x => (x.startIndex.toInt, x.endIndex.toInt))
@@ -190,7 +194,8 @@ object SpectroscopyModesTable {
     itc:         ItcResultsCache,
     cw:          Option[Wavelength],
     sn:          Option[PosBigDecimal],
-    constraints: ConstraintSet
+    constraints: ConstraintSet,
+    target:      Option[List[ITCTarget]]
   ): SortByFn[SpectroscopyModeRow] =
     (
       rowA: UseTableRowProps[SpectroscopyModeRow],
@@ -198,8 +203,8 @@ object SpectroscopyModesTable {
       _:    String | String,
       desc: Boolean | Unit
     ) =>
-      (itc.forRow(cw, sn, constraints, rowA.original),
-       itc.forRow(cw, sn, constraints, rowB.original)
+      (itc.forRow(cw, sn, constraints, target, rowA.original),
+       itc.forRow(cw, sn, constraints, target, rowB.original)
       ) match {
         case (Right(ItcResult.Result(e1, t1)), Right(ItcResult.Result(e2, t2))) =>
           (e1.toMillis * t1 - e2.toMillis * t2).toDouble
@@ -220,6 +225,7 @@ object SpectroscopyModesTable {
     fpu:         Option[FocalPlane],
     sn:          Option[PosBigDecimal],
     constraints: ConstraintSet,
+    target:      Option[List[ITCTarget]],
     itc:         ItcResultsCache,
     progress:    Option[Progress]
   ) =
@@ -229,7 +235,7 @@ object SpectroscopyModesTable {
         .setWidth(120)
         .setMinWidth(50)
         .setMaxWidth(150),
-      column(TimeColumnId, itc.forRow(cw, sn, constraints, _))
+      column(TimeColumnId, itc.forRow(cw, sn, constraints, target, _))
         .setCell(c => itcCell(c.value))
         .setWidth(80)
         .setMinWidth(80)
@@ -246,7 +252,7 @@ object SpectroscopyModesTable {
               )
           )
         )
-        .setSortType(sortItcFun(itc, cw, sn, constraints))
+        .setSortType(sortItcFun(itc, cw, sn, constraints, target))
         .setDisableSortBy(progress.isDefined),
       column(SlitWidthColumnId, SpectroscopyModeRow.slitWidth.get)
         .setCell(c => formatSlitWidth(c.value))
@@ -348,7 +354,7 @@ object SpectroscopyModesTable {
       // itc results cache
       .useSerialStateView(
         ItcResultsCache(
-          Map.empty[ItcResultsCache.CacheKey, EitherNec[ItcQueryProblems, ItcResult]]
+          Map.empty[ITCRequestParams, EitherNec[ItcQueryProblems, ItcResult]]
         )
       )
       // itcProgress
@@ -358,11 +364,12 @@ object SpectroscopyModesTable {
         (props.spectroscopyRequirements.wavelength,
          props.spectroscopyRequirements.focalPlane,
          props.spectroscopyRequirements.signalToNoise,
+         props.targets,
          itc,
          itcProgress
         )
-      }((props, _, _, _) => { case (wavelength, focalPlane, sn, itc, itcProgress) =>
-        columns(wavelength, focalPlane, sn, props.constraints, itc.get, itcProgress.get)
+      }((props, _, _, _) => { case (wavelength, focalPlane, sn, targets, itc, itcProgress) =>
+        columns(wavelength, focalPlane, sn, props.constraints, targets, itc.get, itcProgress.get)
       })
       // selectedIndex
       .useStateBy((props, rows, _, _, _) => selectedRowIndex(props.scienceConfiguration.get, rows))
@@ -389,10 +396,11 @@ object SpectroscopyModesTable {
           props.spectroscopyRequirements.wavelength,
           props.spectroscopyRequirements.signalToNoise,
           props.constraints,
+          props.targets,
           rows
         )
       ) { (props, _, itcResults, itcProgress, _, _, _, _, _, _, singleEffect) =>
-        { case (wavelength, signalToNoise, constraints, rows) =>
+        { case (wavelength, signalToNoise, constraints, targets, rows) =>
           implicit val ctx = props.ctx
 
           // Efect is executed multiple rows if IO.unit is not there. It seems to be executed once for each query (probably its modState afterward).
@@ -401,9 +409,17 @@ object SpectroscopyModesTable {
           IO.unit >>
             singleEffect
               .submit(
-                (wavelength, signalToNoise).mapN { (w, sn) =>
-                  ITCRequests
-                    .queryItc[IO](w, sn, constraints, rows, itcResults.async, itcProgress.async)
+                (wavelength, signalToNoise, targets.flatMap(NonEmptyList.fromList)).mapN {
+                  (w, sn, t) =>
+                    ITCRequests
+                      .queryItc[IO](w,
+                                    sn,
+                                    constraints,
+                                    t,
+                                    rows,
+                                    itcResults.async,
+                                    itcProgress.async
+                      )
                 }.orEmpty
               )
         }

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -67,10 +67,8 @@ object SpectroscopyModesTable {
 
   type ColId = NonEmptyString
 
-  implicit val reuseProps: Reusability[Props] =
-    Reusability.by(x =>
-      (x.scienceConfiguration, x.spectroscopyRequirements, x.constraints, x.targets)
-    )
+  implicit val matrixProps: Reusability[SpectroscopyModesMatrix] = Reusability.always
+  implicit val reuseProps: Reusability[Props]                    = Reusability.derive
 
   implicit val listRangeReuse: Reusability[ListRange] =
     Reusability.by(x => (x.startIndex.toInt, x.endIndex.toInt))

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -14,6 +14,7 @@ import explore.components.Tile
 import explore.config.ConfigurationPanel
 import explore.implicits._
 import explore.model.reusability._
+import explore.schemas.itcschema.implicits._
 import explore.undo._
 import explore.utils.potRender
 import lucuma.core.model.Observation
@@ -37,6 +38,7 @@ object ConfigurationTile {
             ConfigurationPanel(obsId,
                                UndoContext(undoStacks_, scienceData_),
                                scienceData_.get.constraints,
+                               scienceData_.get.itcTargets,
                                renderInTitle
             )
           )

--- a/model/shared/src/main/scala/explore/model/ITCTarget.scala
+++ b/model/shared/src/main/scala/explore/model/ITCTarget.scala
@@ -1,0 +1,13 @@
+package explore.model
+
+import cats.Hash
+import lucuma.core.math.RadialVelocity
+
+final case class ITCTarget(rv: RadialVelocity)
+
+object ITCTarget {
+  // We may consider adjusting this to consider small variations of RV identical for the
+  // purpose of doing ITC calculations
+  implicit val hashRadialVelocity: Hash[RadialVelocity] = Hash.by(_.rv.value)
+  implicit val hashITCTarget: Hash[ITCTarget]           = Hash.by(x => x.rv)
+}

--- a/model/shared/src/main/scala/explore/model/ITCTarget.scala
+++ b/model/shared/src/main/scala/explore/model/ITCTarget.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package explore.model
 
 import cats.Hash

--- a/model/shared/src/main/scala/explore/optics/package.scala
+++ b/model/shared/src/main/scala/explore/optics/package.scala
@@ -138,6 +138,16 @@ package object optics {
       (s: S) => l3.replace(abc._3)(l2.replace(abc._2)(l1.replace(abc._1)(s)))
     )
 
+  def disjointZip[S, A, B, C, D](
+    l1: Lens[S, A],
+    l2: Lens[S, B],
+    l3: Lens[S, C],
+    l4: Lens[S, D]
+  ): Lens[S, (A, B, C, D)] =
+    Lens((s: S) => (l1.get(s), l2.get(s), l3.get(s), l4.get(s)))((abc: (A, B, C, D)) =>
+      (s: S) => l4.replace(abc._4)(l3.replace(abc._3)(l2.replace(abc._2)(l1.replace(abc._1)(s))))
+    )
+
   val fromKilometersPerSecondCZ: Iso[BigDecimal, ApparentRadialVelocity] =
     Iso[BigDecimal, ApparentRadialVelocity](b =>
       ApparentRadialVelocity(b.withUnit[KilometersPerSecond])


### PR DESCRIPTION
We need some parameters coming from the observation target in ITC. Previously it was hardcoded but now it will be taken from teh values entered on the UI

This PR highlighted that ITC expects one target but there maybe N defined on the asterism. In that case we'll calculate ITC for each science target and take the maxiumum time indicated for the set of targets