### PR TITLE
Client logging

### DIFF
--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -31,6 +31,10 @@ object Icons {
   val faBars: FAIcon = js.native
 
   @js.native
+  @JSImport("@fortawesome/pro-light-svg-icons", "faBarcodeRead")
+  val faBarCodeRead: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-solid-svg-icons", "faTrashAlt")
   val faTrash: FAIcon = js.native
 
@@ -178,6 +182,7 @@ object Icons {
   IconLibrary.add(
     faCogs,
     faBars,
+    faBarCodeRead,
     faUndo,
     faRedo,
     faPlus,
@@ -219,6 +224,7 @@ object Icons {
   )
 
   val Bars                = FontAwesomeIcon(faBars)
+  val BarCodeRead         = FontAwesomeIcon(faBarCodeRead)
   val Cogs                = FontAwesomeIcon(faCogs)
   val Undo                = FontAwesomeIcon(faUndo)
   val Redo                = FontAwesomeIcon(faRedo)

--- a/common/src/main/scala/explore/model/ExploreLocalPreferences.scala
+++ b/common/src/main/scala/explore/model/ExploreLocalPreferences.scala
@@ -13,6 +13,7 @@ import io.circe.Json
 import io.circe.parser.decode
 import io.circe.syntax._
 import log4cats.loglevel.LogLevelLogger
+import lucuma.core.util.Enumerated
 import monocle.Focus
 import org.scalajs.dom.window
 import typings.loglevel.mod.LogLevelDesc
@@ -21,6 +22,25 @@ import typings.loglevel.mod.LogLevelDesc
 case class ExploreLocalPreferences(level: LogLevelDesc)
 
 object ExploreLocalPreferences {
+  implicit val levelEnumerated: Enumerated[LogLevelDesc] =
+    new Enumerated[LogLevelDesc] {
+      val all = List(LogLevelDesc.TRACE,
+                     LogLevelDesc.DEBUG,
+                     LogLevelDesc.INFO,
+                     LogLevelDesc.WARN,
+                     LogLevelDesc.ERROR,
+                     LogLevelDesc.SILENT
+      )
+
+      def tag(l: LogLevelDesc): String =
+        if (l == LogLevelDesc.TRACE) "TRACE"
+        else if (l == LogLevelDesc.DEBUG) "DEBUG"
+        else if (l == LogLevelDesc.INFO) "INFO"
+        else if (l == LogLevelDesc.WARN) "WARN"
+        else if (l == LogLevelDesc.ERROR) "ERROR"
+        else "SILENT"
+    }
+
   val Default = ExploreLocalPreferences(LogLevelLogger.Level.INFO)
 
   val StorageKey = "ExplorePreferences"
@@ -28,7 +48,7 @@ object ExploreLocalPreferences {
 
   val level = Focus[ExploreLocalPreferences](_.level)
 
-  implicit val eqExploreLocalpreferences: Eq[ExploreLocalPreferences] = Eq.by(_.level.toString)
+  implicit val eqExploreLocalpreferences: Eq[ExploreLocalPreferences] = Eq.by(_.level)
 
   implicit class LevelOps(val l: LogLevelDesc) extends AnyVal {
     def value: String =
@@ -55,7 +75,7 @@ object ExploreLocalPreferences {
     )
   }
 
-  implicit val decodeFoo: Decoder[ExploreLocalPreferences] = new Decoder[ExploreLocalPreferences] {
+  implicit val decoder: Decoder[ExploreLocalPreferences] = new Decoder[ExploreLocalPreferences] {
     final def apply(c: HCursor): Decoder.Result[ExploreLocalPreferences] =
       for {
         l <- c.downField(LevelKey).as[Option[String]]

--- a/common/src/main/scala/explore/model/ExploreLocalPreferences.scala
+++ b/common/src/main/scala/explore/model/ExploreLocalPreferences.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.effect.Sync
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.HCursor
+import io.circe.Json
+import io.circe.parser.decode
+import io.circe.syntax._
+import log4cats.loglevel.LogLevelLogger
+import monocle.Focus
+import org.scalajs.dom.window
+import typings.loglevel.mod.LogLevelDesc
+
+// Preferences stored at the browser level
+case class ExploreLocalPreferences(level: LogLevelDesc)
+
+object ExploreLocalPreferences {
+  val Default = ExploreLocalPreferences(LogLevelLogger.Level.DEBUG)
+  val level   = Focus[ExploreLocalPreferences](_.level)
+
+  implicit val eqExploreLocalpreferences: Eq[ExploreLocalPreferences] = Eq.by(_.level.toString)
+
+  implicit class LevelOps(val l: LogLevelDesc) extends AnyVal {
+    def value: String =
+      if (l == LogLevelDesc.TRACE) "TRACE"
+      else if (l == LogLevelDesc.DEBUG) "DEBUG"
+      else if (l == LogLevelDesc.INFO) "INFO"
+      else if (l == LogLevelDesc.WARN) "WARN"
+      else if (l == LogLevelDesc.ERROR) "ERROR"
+      else "SILENT"
+  }
+
+  def levelFromString(s: String): LogLevelDesc = s match {
+    case "TRACE"  => LogLevelDesc.TRACE
+    case "DEBUG"  => LogLevelDesc.DEBUG
+    case "WARN"   => LogLevelDesc.WARN
+    case "ERROR"  => LogLevelDesc.ERROR
+    case "SILENT" => LogLevelDesc.SILENT
+    case _        => LogLevelDesc.INFO
+  }
+
+  implicit val encoder: Encoder[ExploreLocalPreferences] = new Encoder[ExploreLocalPreferences] {
+    final def apply(a: ExploreLocalPreferences): Json = Json.obj(
+      ("logLevel", Json.fromString(a.level.value))
+    )
+  }
+
+  implicit val decodeFoo: Decoder[ExploreLocalPreferences] = new Decoder[ExploreLocalPreferences] {
+    final def apply(c: HCursor): Decoder.Result[ExploreLocalPreferences] =
+      for {
+        l <- c.downField("logLevel").as[Option[String]]
+      } yield ExploreLocalPreferences(levelFromString(l.orEmpty))
+  }
+
+  // Preferences at the browser level (unlike those stored in heroku)
+  def loadPreferences[F[_]: Sync]: F[ExploreLocalPreferences] = Sync[F]
+    .delay {
+      val preferences: Option[ExploreLocalPreferences] = for {
+        ls <- Option(window.localStorage)
+        d  <- Option(ls.getItem("ExplorePreferences"))
+        l  <- decode[ExploreLocalPreferences](d).toOption
+      } yield l
+      preferences.getOrElse(Default)
+    }
+    .handleErrorWith(_ => storePreferences[F](Default).as(Default))
+
+  def storePreferences[F[_]: Sync](p: ExploreLocalPreferences): F[Unit] = Sync[F]
+    .delay {
+      for {
+        ls <- Option(window.localStorage)
+        _  <- Option(ls.setItem("ExplorePreferences", p.asJson.spaces2))
+      } yield println(p.asJson.spaces2)
+    }
+    .handleError(_ => ().some)
+    .void
+}

--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -23,6 +23,7 @@ import scala.collection.immutable.HashSet
 case class RootModel(
   vault:                          Option[UserVault],
   tabs:                           EnumZipper[AppTab],
+  localPreferences:               ExploreLocalPreferences,
   focusedObs:                     Option[FocusedObs] = none,
   expandedIds:                    ExpandedIds = ExpandedIds(),
   searchingTarget:                Set[TargetIdSet] = HashSet.empty,
@@ -48,6 +49,7 @@ object RootModel {
   val targetSummaryHiddenColumns     = Focus[RootModel](_.targetSummaryHiddenColumns)
   val constraintSummaryHiddenColumns = Focus[RootModel](_.constraintSummaryHiddenColumns)
   val constraintSummarySorting       = Focus[RootModel](_.constraintSummarySorting)
+  val localPreferences               = Focus[RootModel](_.localPreferences)
 
   val userUserId = Lens[User, User.Id](_.id)(s =>
     a =>

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -65,6 +65,7 @@ object reusability {
   implicit val proposalDetailsReuse: Reusability[ProposalDetails]                     = Reusability.byEq
   implicit val partnerSplitReuse: Reusability[PartnerSplit]                           = Reusability.derive
   implicit val obsSummaryReuse: Reusability[ObsSummary]                               = Reusability.byEq
+  implicit val localPreferencesReuse: Reusability[ExploreLocalPreferences]            = Reusability.byEq
   implicit val obsSummaryWithConstraintsReuse: Reusability[ObsSummaryWithConstraints] =
     Reusability.derive
   implicit val obsSummaryWithTargetsAndConstraintsReuse

--- a/common/src/test/scala/explore/model/arb/ArbExploreLocalPreferences.scala
+++ b/common/src/test/scala/explore/model/arb/ArbExploreLocalPreferences.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import explore.model.ExploreLocalPreferences
+import org.scalacheck.Arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Cogen._
+import org.scalacheck.Gen
+import typings.loglevel.mod.LogLevelDesc
+
+trait ArbExploreLocalPreferences {
+
+  implicit val localPreferencesArb = Arbitrary[ExploreLocalPreferences] {
+    for {
+      level <- Gen.const(LogLevelDesc.INFO)
+    } yield ExploreLocalPreferences(level)
+  }
+
+  implicit def localPreferencesCogen: Cogen[ExploreLocalPreferences] =
+    Cogen[String].contramap(_.level.toString)
+}
+
+object ArbExploreLocalPreferences extends ArbExploreLocalPreferences

--- a/common/src/test/scala/explore/model/arb/ArbExploreLocalPreferences.scala
+++ b/common/src/test/scala/explore/model/arb/ArbExploreLocalPreferences.scala
@@ -4,17 +4,19 @@
 package explore.model.arb
 
 import explore.model.ExploreLocalPreferences
+import explore.model.ExploreLocalPreferences._
+import lucuma.core.util.arb.ArbEnumerated._
 import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
-import org.scalacheck.Gen
 import typings.loglevel.mod.LogLevelDesc
 
 trait ArbExploreLocalPreferences {
 
   implicit val localPreferencesArb = Arbitrary[ExploreLocalPreferences] {
     for {
-      level <- Gen.const(LogLevelDesc.INFO)
+      level <- arbitrary[LogLevelDesc]
     } yield ExploreLocalPreferences(level)
   }
 

--- a/common/src/test/scala/explore/model/arb/ArbRootModel.scala
+++ b/common/src/test/scala/explore/model/arb/ArbRootModel.scala
@@ -11,6 +11,7 @@ import explore.model.arb.all._
 import explore.model.enum.AppTab
 import lucuma.core.data.EnumZipper
 import lucuma.core.data.arb.ArbEnumZipper._
+import lucuma.core.util.arb.ArbEnumerated._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen

--- a/common/src/test/scala/explore/model/arb/ArbRootModel.scala
+++ b/common/src/test/scala/explore/model/arb/ArbRootModel.scala
@@ -3,6 +3,7 @@
 
 package explore.model.arb
 
+import explore.model.ExploreLocalPreferences
 import explore.model.FocusedObs
 import explore.model.RootModel
 import explore.model.UserVault
@@ -18,19 +19,20 @@ import org.scalacheck.Gen
 
 trait ArbRootModel {
   import explore.model.arb.ArbFocusedObs._
+  import explore.model.arb.ArbExploreLocalPreferences._
 
   implicit val rootModelArb = Arbitrary[RootModel] {
     for {
       vault      <- Gen.option(arbitrary[UserVault])
+      lp         <- arbitrary[ExploreLocalPreferences]
       tabs       <- arbitrary[EnumZipper[AppTab]]
       focusedObs <- arbitrary[Option[FocusedObs]]
-    } yield RootModel(vault, tabs, focusedObs)
+    } yield RootModel(vault, tabs, lp, focusedObs)
   }
 
   implicit def rootModelCogen: Cogen[RootModel] =
-    Cogen[(Option[UserVault], EnumZipper[AppTab], Option[FocusedObs])].contramap(m =>
-      (m.vault, m.tabs, m.focusedObs)
-    )
+    Cogen[(Option[UserVault], EnumZipper[AppTab], ExploreLocalPreferences, Option[FocusedObs])]
+      .contramap(m => (m.vault, m.tabs, m.localPreferences, m.focusedObs))
 }
 
 object ArbRootModel extends ArbRootModel

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -131,8 +131,7 @@ object ExploreMain extends IOApp.Simple {
         } yield (d, l, p)
       }
       .flatMap { param =>
-        implicit val (dispatcher, logger, _)                     = param
-        implicit val localPreferences                            = param._3
+        implicit val (dispatcher, logger, localPreferences)      = param
         implicit val FetchBackend: FetchJSBackend[IO]            = FetchJSBackend[IO](FetchMethod.GET)
         implicit val gqlStreamingBackend: WebSocketJSBackend[IO] =
           WebSocketJSBackend[IO](dispatcher)

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -79,6 +79,7 @@ object ExploreLayout {
                           <.div(
                             ExploreStyles.MainGrid,
                             TopBar(vault.user,
+                                   props.view.zoom(RootModel.localPreferences).get,
                                    onLogout >> props.view.zoom(RootModel.vault).set(none).to[IO]
                             ),
                             <.div(

--- a/explore/src/main/scala/explore/HelpBody.scala
+++ b/explore/src/main/scala/explore/HelpBody.scala
@@ -31,19 +31,19 @@ import scala.util.Try
 
 final case class HelpBody(base: HelpContext, helpId: Help.Id)(implicit val ctx: AppContextIO)
     extends ReactFnProps[HelpBody](HelpBody.component) {
-  private val path        = Uri.Path.unsafeFromString(helpId.value)
-  private val rootUrl     = base.rawUrl / base.user.value / base.project.value
-  private val baseUrl     =
+  private val path: Uri.Path = Uri.Path.unsafeFromString(helpId.value)
+  private val rootUrl        = base.rawUrl / base.user.value / base.project.value
+  private val baseUrl        =
     path.segments.init.foldLeft(base.rawUrl / base.user.value / base.project.value / "main")(
       (uri, segment) => uri / segment.encoded
     )
-  private val url         = rootUrl / "main" / path
-  private val rootEditUrl = base.editUrl / base.user.value / base.project.value
-  private val newPage     = (rootEditUrl / "new" / "main")
+  private val url            = rootUrl / "main" / path
+  private val rootEditUrl    = base.editUrl / base.user.value / base.project.value
+  private val newPage        = (rootEditUrl / "new" / "main")
     .withQueryParam("filename", path.segments.mkString("/"))
     .withQueryParam("value", s"# Title")
     .withQueryParam("message", s"Create $helpId")
-  private val editPage    = (rootEditUrl / "edit" / "main" / path)
+  private val editPage       = (rootEditUrl / "edit" / "main" / path)
     .withQueryParam("message", s"Update $helpId")
 }
 

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -14,6 +14,7 @@ import explore.components.ConnectionsStatus
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.ExploreLocalPreferences
+import explore.model.ExploreLocalPreferences._
 import explore.model.enum.ExecutionEnvironment
 import explore.model.enum.Theme
 import japgolly.scalajs.react._
@@ -75,11 +76,10 @@ object TopBar {
           val level = props.preferences.level
 
           def setLogLevel(l: LogLevelDesc): Callback =
-            ExploreLocalPreferences
+            (ExploreLocalPreferences
               .storePreferences[IO](
                 props.preferences.copy(level = l)
-              )
-              .runAsync *> Callback(window.location.reload(false))
+              ) *> IO(window.location.reload(false))).runAsync
 
           React.Fragment(
             <.div(
@@ -149,10 +149,12 @@ object TopBar {
                         "Log Level",
                         DropdownMenu(
                           DropdownItem(onClick = setLogLevel(LogLevelDesc.INFO))(
-                            Checkbox(label = "Info", checked = level != LogLevelDesc.DEBUG)
+                            Checkbox(label = "Info", checked = level =!= LogLevelDesc.DEBUG)
                           ),
                           DropdownItem(onClick = setLogLevel(LogLevelDesc.DEBUG))(
-                            Checkbox(label = "Debug", checked = level == LogLevelLogger.Level.DEBUG)
+                            Checkbox(label = "Debug",
+                                     checked = level === LogLevelLogger.Level.DEBUG
+                            )
                           )
                         )
                       ).when(appCtx.environment =!= ExecutionEnvironment.Production),

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -13,17 +13,18 @@ import explore.components.About
 import explore.components.ConnectionsStatus
 import explore.components.ui.ExploreStyles
 import explore.implicits._
+import explore.model.ExploreLocalPreferences
 import explore.model.enum.ExecutionEnvironment
 import explore.model.enum.Theme
-import japgolly.scalajs.react.ReactMonocle._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.callback.CallbackCatsEffect._
 import japgolly.scalajs.react.vdom.html_<^._
+import log4cats.loglevel.LogLevelLogger
 import lucuma.core.model.GuestRole
 import lucuma.core.model.User
 import lucuma.ui.reusability._
-import monocle.Focus
 import org.scalajs.dom
+import org.scalajs.dom.window
 import react.clipboard.CopyToClipboard
 import react.common._
 import react.semanticui.collections.menu._
@@ -35,26 +36,18 @@ import react.semanticui.modules.dropdown.DropdownItem
 import react.semanticui.modules.dropdown.DropdownMenu
 import react.semanticui.shorthand._
 import react.semanticui.views.item.Item
+import typings.loglevel.mod.LogLevelDesc
 
 final case class TopBar(
-  user:     User,
-  onLogout: IO[Unit]
-) extends ReactProps[TopBar](TopBar.component)
+  user:        User,
+  preferences: ExploreLocalPreferences,
+  onLogout:    IO[Unit]
+) extends ReactFnProps[TopBar](TopBar.component)
 
 object TopBar {
   type Props = TopBar
 
-  protected case class State(copied: Boolean = false, theme: Theme) {
-    def flip: State =
-      if (theme === Theme.Dark) copy(theme = Theme.Light) else copy(theme = Theme.Dark)
-  }
-
-  object State {
-    val copied = Focus[State](_.copied)
-  }
-
   implicit val propsReuse: Reusability[Props] = Reusability.by(_.user)
-  implicit val stateReuse: Reusability[State] = Reusability.derive
 
   def currentTheme: Theme =
     if (dom.document.body.classList.contains(Theme.Light.clazz.htmlClass))
@@ -62,19 +55,31 @@ object TopBar {
     else
       Theme.Dark
 
-  private val component =
-    ScalaComponent
-      .builder[TopBar]
-      .initialState(State(false, currentTheme))
-      .render { $ =>
-        val p            = $.props
-        val currentTheme = $.state.theme
+  def flipTheme(theme: Theme): Theme =
+    if (theme === Theme.Dark) Theme.Light else Theme.Dark
 
+  private val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      // copied
+      .useState(false)
+      // theme
+      .useState(currentTheme)
+      .renderWithReuse { (props, copied, theme) =>
         AppCtx.using { implicit appCtx =>
-          val role = p.user.role
+          val role = props.user.role
 
           def logout: IO[Unit] =
-            appCtx.sso.logout >> p.onLogout
+            appCtx.sso.logout >> props.onLogout
+
+          val level = props.preferences.level
+
+          def setLogLevel(l: LogLevelDesc): Callback =
+            ExploreLocalPreferences
+              .storePreferences[IO](
+                props.preferences.copy(level = l)
+              )
+              .runAsync *> Callback(window.location.reload(false))
 
           React.Fragment(
             <.div(
@@ -92,7 +97,7 @@ object TopBar {
                 ),
                 Item(
                   ExploreStyles.MainUserName,
-                  p.user.displayName
+                  props.user.displayName
                 ),
                 ConnectionsStatus(),
                 MenuMenu(position = MenuMenuPosition.Right, clazz = ExploreStyles.MainMenu)(
@@ -108,20 +113,19 @@ object TopBar {
                         Reuse.always(
                           DropdownItem(text = "About Explore", icon = Icons.Info.fixedWidth())
                         ),
-                        Reuse.always(
+                        Reuse.never(
                           <.span(ExploreStyles.Version,
-                                 ExploreStyles.VersionUncopied.when(! $.state.copied)
+                                 ExploreStyles.VersionUncopied.when(!copied.value)
                           )(
                             s"Version: ${appCtx.version}",
                             CopyToClipboard(
                               text = appCtx.version.value,
-                              onCopy = (_, copied) =>
-                                $.setStateL(State.copied)(copied) >>
-                                  $.setStateL(State.copied)(false).delayMs(1500).toCallback
+                              onCopy = (_, copiedCallback) =>
+                                copied.setState(copiedCallback) *>
+                                  copied.setState(false).delayMs(1500).toCallback
                             )(
-                              <.span(
-                                Icons.Clipboard.when(! $.state.copied),
-                                Icons.ClipboardCheck.when($.state.copied)
+                              <.span(Icons.Clipboard.unless(copied.value),
+                                     Icons.ClipboardCheck.when(copied.value)
                               )
                             )
                           )
@@ -140,11 +144,23 @@ object TopBar {
                                    icon = Icons.Logout.fixedWidth(),
                                    onClick = logout.runAsync
                       ),
+                      DropdownItem()(
+                        Icons.BarCodeRead.fixedWidth(),
+                        "Log Level",
+                        DropdownMenu(
+                          DropdownItem(onClick = setLogLevel(LogLevelDesc.INFO))(
+                            Checkbox(label = "Info", checked = level != LogLevelDesc.DEBUG)
+                          ),
+                          DropdownItem(onClick = setLogLevel(LogLevelDesc.DEBUG))(
+                            Checkbox(label = "Debug", checked = level == LogLevelLogger.Level.DEBUG)
+                          )
+                        )
+                      ).when(appCtx.environment =!= ExecutionEnvironment.Production),
                       DropdownItem(onClick =
                         utils
                           .setupScheme[CallbackTo](
-                            if (currentTheme === Theme.Dark) Theme.Light else Theme.Dark
-                          ) *> $.modState(_.flip)
+                            if (theme.value === Theme.Dark) Theme.Light else Theme.Dark
+                          ) *> theme.modState(flipTheme)
                       )(
                         Checkbox(label = "Dark/Light", checked = currentTheme === Theme.Dark)
                       )
@@ -157,7 +173,5 @@ object TopBar {
           )
         }
       }
-      .configure(Reusability.shouldComponentUpdate)
-      .build
 
 }

--- a/explore/src/main/scala/explore/config/ITCRequests.scala
+++ b/explore/src/main/scala/explore/config/ITCRequests.scala
@@ -127,7 +127,7 @@ object ITCRequests {
     callback: List[ItcResults] => F[Unit]
   ): F[Unit] =
     Logger[F].debug(
-      s"ITC request for mode ${request.mode} and target count: ${request.target.length}"
+      s"ITC: Request for mode ${request.mode} and target count: ${request.target.length}"
     ) *>
       request.target
         .fproduct(t => selectedMagnitude(t.magnitudes, request.wavelength))
@@ -150,7 +150,8 @@ object ITCRequests {
         .parSequence
         .flatTap(r =>
           Logger[F].debug(
-            s"Result for mode ${request.mode}: ${itcResults(r).map(r => s"${r._2} x ${r._1 / 10e6}s")}"
+            s"ITC: Result for mode ${request.mode}: ${itcResults(r)
+              .map(r => s"${r._2} x ${r._1 / 10e6}s")}"
           )
         )
         .flatMap(callback)

--- a/explore/src/main/scala/explore/config/ITCRequests.scala
+++ b/explore/src/main/scala/explore/config/ITCRequests.scala
@@ -92,6 +92,7 @@ object ITCRequests {
               // There maybe multiple targets, take the one with the max time
               .maxBy(_._1)
               ._3
+            // Put the results in the cache
             cache.mod(ItcResultsCache.cache.modify(_ + (params -> update)))
           }
         ) >> progress.mod(_.map(_.increment()))
@@ -101,7 +102,7 @@ object ITCRequests {
   private def itcResults(
     r: List[ItcResults]
   ): List[(Long, Int, EitherNec[ItcQueryProblems, ItcResult])] =
-    // Convert to usable types and update the cache
+    // Convert to usable types
     r.toList
       .flatMap(x =>
         x.spectroscopy.flatMap(_.results).map { r =>


### PR DESCRIPTION
It was requested to see more ITC logging. This PR adds a control to change the log level (Only in dev and staging)

![image](https://user-images.githubusercontent.com/3615303/145583732-368df92e-e712-4780-9626-6e0d76d8c98d.png)

The log level is stored in the browser local storage.

Given how  logging is setup it cannot be changed at runtime. Instead the value is changed and  we do a page reload