### PR TITLE
Use resize-detector as a hook

### DIFF
--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -16,14 +16,14 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{ facade => Raw }
 import lucuma.ui.reusability._
+import org.scalajs.dom.HTMLElement
+import org.scalajs.dom.Node
 import org.scalajs.dom.html
 import react.common._
 import react.common.implicits._
 import react.common.style._
 import react.semanticui.collections.menu._
 import react.semanticui.elements.button.Button
-import org.scalajs.dom.HTMLElement
-import org.scalajs.dom.Node
 
 import scalajs.js
 

--- a/common/src/main/scala/explore/model/ModelUndoStacks.scala
+++ b/common/src/main/scala/explore/model/ModelUndoStacks.scala
@@ -4,10 +4,10 @@
 package explore.model
 
 import cats.Eq
+import explore.common.AsterismQueries.AsterismGroupList
 import explore.common.ConstraintGroupQueries.ConstraintGroupList
 import explore.common.ObsQueries.ObservationList
 import explore.common.ObsQueries.ScienceData
-import explore.common.AsterismQueries.AsterismGroupList
 import explore.model.ObsIdSet
 import explore.undo.UndoStacks
 import lucuma.core.model.Observation

--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -3,8 +3,8 @@
 
 package explore.syntax
 
-import org.scalajs.dom.Window
 import explore.model.Constants
+import org.scalajs.dom.Window
 
 package object ui {
   implicit class WindowOps(val self: Window) extends AnyVal {

--- a/common/src/main/scala/react/resizeDetector/ResizeDetector.scala
+++ b/common/src/main/scala/react/resizeDetector/ResizeDetector.scala
@@ -112,7 +112,7 @@ object ResizeDetector {
   @js.native
   trait Props extends js.Object {
     var children: RenderJS
-    var onResize: js.UndefOr[js.Function2[Int, Int, Unit]]
+    var onResize: js.UndefOr[js.Function2[Raw.JsNumber, Raw.JsNumber, Unit]]
     var handleHeight: js.UndefOr[Boolean]
     var handleWidth: js.UndefOr[Boolean]
     var skipOnMount: js.UndefOr[Boolean]
@@ -136,7 +136,13 @@ object ResizeDetector {
     ): Props = {
       val p = (new js.Object).asInstanceOf[Props]
       p.children = renderPropsJS => children(RenderProps(renderPropsJS)).rawNode
-      onResize.foreach(v => p.onResize = v: js.Function2[Int, Int, Unit])
+      onResize.foreach(v =>
+        p.onResize =
+          ((x: Raw.JsNumber, y: Raw.JsNumber) => v(x.toInt, y.toInt)): js.Function2[Raw.JsNumber,
+                                                                                    Raw.JsNumber,
+                                                                                    Unit
+          ]
+      )
       handleHeight.foreach(v => p.handleHeight = v)
       handleWidth.foreach(v => p.handleWidth = v)
       skipOnMount.foreach(v => p.skipOnMount = v)

--- a/common/src/main/scala/react/resizeDetector/hooks.scala
+++ b/common/src/main/scala/react/resizeDetector/hooks.scala
@@ -1,0 +1,150 @@
+package react.resizeDetector
+
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.{ facade => Raw }
+import org.scalajs.dom.html
+import react.common._
+import react.resizeDetector.ResizeDetector._
+
+import scala.annotation.nowarn
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import scala.scalajs.js.|
+
+@js.native
+protected trait ReactResizeDetectorDimensions extends js.Object {
+  val height: js.UndefOr[Raw.JsNumber]
+  val width: js.UndefOr[Raw.JsNumber]
+}
+
+@js.native
+trait UseResizeDetectorReturnJS extends ReactResizeDetectorDimensions {
+  val ref: Raw.React.RefFn[html.Element]
+}
+
+sealed trait UseResizeDetectorReturn {
+  val height: Option[Int]
+  val width: Option[Int]
+  val ref: Ref.Simple[html.Element]
+}
+
+object UseResizeDetectorReturn {
+  def fromJS(r: UseResizeDetectorReturnJS): UseResizeDetectorReturn = new UseResizeDetectorReturn {
+    val height = r.height.toOption.map(_.toInt)
+    val width  = r.width.toOption.map(_.toInt)
+    val ref    =
+      Ref.fromJs(r.ref.asInstanceOf[facade.React.RefHandle[html.Element | Null]])
+  }
+
+  implicit val reusabilityUseResizeDetectorReturn: Reusability[UseResizeDetectorReturn] =
+    Reusability.by(x => (x.height, x.width))
+}
+
+@js.native
+protected trait UseResizeDetectorProps extends Props {
+  var targetRef: Raw.React.RefFn[html.Element]
+}
+
+object UseResizeDetectorProps {
+
+  def apply(
+    onResize:        js.UndefOr[(Int, Int) => Callback] = js.undefined,
+    handleHeight:    js.UndefOr[Boolean] = js.undefined,
+    handleWidth:     js.UndefOr[Boolean] = js.undefined,
+    skipOnMount:     js.UndefOr[Boolean] = js.undefined,
+    refreshMode:     js.UndefOr[RefreshMode] = js.undefined,
+    refreshRate:     js.UndefOr[Int] = js.undefined,
+    refreshOptions:  js.UndefOr[RefreshOptions] = js.undefined,
+    observerOptions: js.UndefOr[ObserverOptions] = js.undefined
+  ): UseResizeDetectorProps = {
+    val p = (new js.Object).asInstanceOf[UseResizeDetectorProps]
+    onResize.foreach(v =>
+      p.onResize = { case (x: Raw.JsNumber, y: Raw.JsNumber) =>
+        v(x.toInt, y.toInt).runNow()
+      }: js.Function2[
+        Raw.JsNumber,
+        Raw.JsNumber,
+        Unit
+      ]
+    )
+    handleHeight.foreach(v => p.handleHeight = v)
+    handleWidth.foreach(v => p.handleWidth = v)
+    skipOnMount.foreach(v => p.skipOnMount = v)
+    refreshMode.toJs.foreach(v => p.refreshMode = v)
+    refreshRate.foreach(v => p.refreshRate = v)
+    refreshOptions.foreach(v => p.refreshOptions = v)
+    observerOptions.foreach(v => p.observerOptions = v)
+    p
+  }
+}
+
+object HooksApiExt {
+
+  object mod {
+    @JSImport("react-resize-detector", JSImport.Namespace)
+    @js.native
+    @nowarn
+    val base: js.Any = js.native
+
+    @scala.inline
+    def useResizeDetector(): UseResizeDetectorReturn                              = UseResizeDetectorReturn.fromJS(
+      base
+        .asInstanceOf[js.Dynamic]
+        .applyDynamic("useResizeDetector")()
+        .asInstanceOf[UseResizeDetectorReturnJS]
+    )
+    @scala.inline
+    def useResizeDetector(props: UseResizeDetectorProps): UseResizeDetectorReturn =
+      UseResizeDetectorReturn.fromJS(
+        base
+          .asInstanceOf[js.Dynamic]
+          .applyDynamic("useResizeDetector")(props.asInstanceOf[js.Any])
+          .asInstanceOf[UseResizeDetectorReturnJS]
+      )
+  }
+
+  val hook =
+    CustomHook[UseResizeDetectorProps]
+      .buildReturning { pos =>
+        mod.useResizeDetector(pos)
+      }
+
+  sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+    final def useResizeDetector(pos: UseResizeDetectorProps)(implicit
+      step:                          Step
+    ): step.Next[UseResizeDetectorReturn] =
+      useResizeDetectorBy(_ => pos)
+
+    final def useResizeDetectorBy(pos: Ctx => UseResizeDetectorProps)(implicit
+      step:                            Step
+    ): step.Next[UseResizeDetectorReturn] =
+      api.customBy(ctx => hook(pos(ctx)))
+  }
+
+  final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ) extends Primary[Ctx, Step](api) {
+
+    def useResizeDetectorBy(pos: CtxFn[UseResizeDetectorProps])(implicit
+      step:                      Step
+    ): step.Next[UseResizeDetectorReturn] =
+      useResizeDetectorBy(step.squash(pos)(_))
+  }
+}
+
+trait HooksApiExt {
+  import HooksApiExt._
+
+  implicit def hooksExtFloating1[Ctx, Step <: HooksApi.AbstractStep](
+    api: HooksApi.Primary[Ctx, Step]
+  ): Primary[Ctx, Step] =
+    new Primary(api)
+
+  implicit def hooksExtFloating2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ): Secondary[Ctx, CtxFn, Step] =
+    new Secondary(api)
+}
+
+object hooks extends HooksApiExt

--- a/common/src/main/scala/react/resizeDetector/hooks.scala
+++ b/common/src/main/scala/react/resizeDetector/hooks.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package react.resizeDetector
 
 import japgolly.scalajs.react._

--- a/common/src/main/scala/react/resizeDetector/hooks.scala
+++ b/common/src/main/scala/react/resizeDetector/hooks.scala
@@ -84,10 +84,10 @@ object UseResizeDetectorProps {
 object HooksApiExt {
 
   object mod {
-    @JSImport("react-resize-detector", JSImport.Namespace)
     @js.native
+    @JSImport("react-resize-detector", JSImport.Namespace)
     @nowarn
-    val base: js.Any = js.native
+    private val base: js.Any = js.native
 
     @scala.inline
     def useResizeDetector(): UseResizeDetectorReturn                              = UseResizeDetectorReturn.fromJS(
@@ -114,15 +114,15 @@ object HooksApiExt {
 
   sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
 
-    final def useResizeDetector(pos: UseResizeDetectorProps)(implicit
-      step:                          Step
-    ): step.Next[UseResizeDetectorReturn] =
-      useResizeDetectorBy(_ => pos)
-
-    final def useResizeDetectorBy(pos: Ctx => UseResizeDetectorProps)(implicit
+    final def useResizeDetector(props: UseResizeDetectorProps = UseResizeDetectorProps())(implicit
       step:                            Step
     ): step.Next[UseResizeDetectorReturn] =
-      api.customBy(ctx => hook(pos(ctx)))
+      useResizeDetectorBy(_ => props)
+
+    final def useResizeDetectorBy(props: Ctx => UseResizeDetectorProps)(implicit
+      step:                              Step
+    ): step.Next[UseResizeDetectorReturn] =
+      api.customBy(ctx => hook(props(ctx)))
   }
 
   final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -39,20 +39,17 @@ object Routing {
     }
 
   private def targetTab(@unused model: View[RootModel]): VdomElement =
-    withSize { size =>
-      AppCtx.using(implicit ctx =>
-        TargetTabContents(
-          model.zoom(RootModel.userId).get,
-          model.zoom(RootModel.focusedObs),
-          model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forAsterismGroupList),
-          model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forSiderealTarget),
-          model.zoom(RootModel.searchingTarget),
-          model.zoom(RootModel.expandedIds.andThen(ExpandedIds.asterismObsIds)),
-          model.zoom(RootModel.targetSummaryHiddenColumns),
-          size
-        )
+    AppCtx.using(implicit ctx =>
+      TargetTabContents(
+        model.zoom(RootModel.userId).get,
+        model.zoom(RootModel.focusedObs),
+        model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forAsterismGroupList),
+        model.zoom(RootModel.undoStacks).zoom(ModelUndoStacks.forSiderealTarget),
+        model.zoom(RootModel.searchingTarget),
+        model.zoom(RootModel.expandedIds.andThen(ExpandedIds.asterismObsIds)),
+        model.zoom(RootModel.targetSummaryHiddenColumns)
       )
-    }
+    )
 
   private def obsTab(model: View[RootModel]): VdomElement =
     withSize(size =>

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -24,8 +24,8 @@ import explore.model.enum.AppTab
 import explore.model.reusability._
 import explore.observationtree.ConstraintGroupObsList
 import explore.optics._
-import explore.undo._
 import explore.syntax.ui._
+import explore.undo._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.builder.Lifecycle.ComponentDidMount
 import japgolly.scalajs.react.vdom.html_<^._

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -22,9 +22,9 @@ import explore.model._
 import explore.model.enum.AppTab
 import explore.model.reusability._
 import explore.observationtree.AsterismGroupObsList
+import explore.syntax.ui._
 import explore.targeteditor.AsterismEditor
 import explore.undo._
-import explore.syntax.ui._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.SiderealTarget
@@ -37,7 +37,9 @@ import react.common._
 import react.common.implicits._
 import react.draggable.Axis
 import react.resizable._
-import react.resizeDetector.ResizeDetector
+import react.resizeDetector.UseResizeDetectorProps
+import react.resizeDetector._
+import react.resizeDetector.hooks._
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.sizes._
@@ -52,8 +54,7 @@ final case class TargetTabContents(
   targetsUndoStacks: View[Map[Target.Id, UndoStacks[IO, SiderealTarget]]],
   searching:         View[Set[Target.Id]],
   expandedIds:       View[SortedSet[ObsIdSet]],
-  hiddenColumns:     View[Set[String]],
-  size:              ResizeDetector.Dimensions
+  hiddenColumns:     View[Set[String]]
 )(implicit val ctx:  AppContextIO)
     extends ReactFnProps[TargetTabContents](TargetTabContents.component)
 
@@ -69,17 +70,16 @@ object TargetTabContents {
     props:                Props,
     panelState:           View[TwoPanelState[ObsIdSet]],
     options:              View[TargetVisualOptions],
+    resize:               UseResizeDetectorReturn,
     asterismGroupWithObs: View[AsterismGroupsWithObs]
   )(implicit ctx:         AppContextIO): VdomNode = {
     val treeResize =
       (_: ReactEvent, d: ResizeCallbackData) =>
-        (panelState.zoom(treeWidthLens).set(d.size.width).to[IO] *>
-          UserWidthsCreation
-            .storeWidthPreference[IO](props.userId,
-                                      ResizableSection.TargetsTree,
-                                      d.size.width
-            )).runAsync
-          .debounce(1.second)
+        panelState.zoom(treeWidthLens).set(d.size.width) *>
+          (UserWidthsCreation
+            .storeWidthPreference[IO](props.userId, ResizableSection.TargetsTree, d.size.width))
+            .runAsync
+            .debounce(1.second)
 
     val treeWidth    = panelState.get.treeWidth.toInt
     val selectedView = panelState.zoom(selectedLens)
@@ -257,8 +257,8 @@ object TargetTabContents {
       )
     }
 
-    val coreWidth  = props.size.width.getOrElse(0) - treeWidth
-    val coreHeight = props.size.height.getOrElse(0)
+    val coreWidth  = resize.width.getOrElse(0) - treeWidth
+    val coreHeight = resize.height.getOrElse(0)
 
     val selectedPanel = panelState.get.selected
     val rightSide     = selectedPanel.optValue
@@ -272,7 +272,7 @@ object TargetTabContents {
     // It would be nice to make a single component here but it gets hard when you
     // have the resizable element. Instead we have either two panels with a resizable
     // or only one panel at a time (Mobile)
-    if (window.canFitTwoPanels) {
+    val body = if (window.canFitTwoPanels) {
       <.div(
         ExploreStyles.TreeRGL,
         <.div(ExploreStyles.Tree, treeInner(asterismGroupWithObs))
@@ -304,6 +304,7 @@ object TargetTabContents {
         )
       )
     }
+    body.withRef(resize.ref)
   }
 
   protected val component =
@@ -319,20 +320,21 @@ object TargetTabContents {
                                 Constants.InitialTreeWidth.toInt
           )
           .attempt
-          .map {
+          .flatMap {
             case Right(w) =>
-              Callback.log(s"Set $w") *>
-                panels
-                  .zoom(TwoPanelState.treeWidth[ObsIdSet])
-                  .set(w)
-            case Left(u)  => Callback.log(u.toString)
+              panels
+                .zoom(TwoPanelState.treeWidth[ObsIdSet])
+                .set(w)
+                .to[IO]
+            case Left(_)  => IO.unit
           }
-          .runAsyncAndForget
+          .runAsync
       }
-      .renderWithReuse { (props, tps, opts) =>
+      .useResizeDetector(UseResizeDetectorProps())
+      .renderWithReuse { (props, tps, opts, resize) =>
         implicit val ctx = props.ctx
         AsterismGroupLiveQuery(
-          Reuse(renderFn _)(props, tps, opts)
+          Reuse(renderFn _)(props, tps, opts, resize)
         )
       }
 

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -37,7 +37,6 @@ import react.common._
 import react.common.implicits._
 import react.draggable.Axis
 import react.resizable._
-import react.resizeDetector.UseResizeDetectorProps
 import react.resizeDetector._
 import react.resizeDetector.hooks._
 import react.semanticui.elements.button.Button
@@ -330,7 +329,7 @@ object TargetTabContents {
           }
           .runAsync
       }
-      .useResizeDetector(UseResizeDetectorProps())
+      .useResizeDetector()
       .renderWithReuse { (props, tps, opts, resize) =>
         implicit val ctx = props.ctx
         AsterismGroupLiveQuery(

--- a/explore/src/main/scala/explore/tabs/TargetTile.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTile.scala
@@ -11,8 +11,8 @@ import crystal.react.reuse._
 import explore.components.Tile
 import explore.implicits._
 import explore.model.ObsIdSet
-import explore.model.TargetWithId
 import explore.model.TargetVisualOptions
+import explore.model.TargetWithId
 import explore.model.reusability._
 import explore.targeteditor.AsterismEditor
 import explore.undo.UndoStacks

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -16,8 +16,8 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.ObsIdSet
-import explore.model.TargetWithId
 import explore.model.TargetVisualOptions
+import explore.model.TargetWithId
 import explore.model.reusability._
 import explore.optics._
 import explore.targets.TargetSelectionPopup

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -4,14 +4,14 @@
 package explore
 
 import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Decoder
+import io.circe.Decoder._
 import lucuma.core.enum.MagnitudeBand
 import lucuma.core.model.Magnitude
 import lucuma.core.model.NonsiderealTarget
 import lucuma.core.model.SiderealTarget
 import lucuma.core.model.Target
 import lucuma.schemas.decoders._
-import io.circe.Decoder
-import io.circe.Decoder._
 import monocle.Focus
 import monocle.Lens
 import monocle.Prism

--- a/package-lock.json
+++ b/package-lock.json
@@ -2753,11 +2753,6 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
@@ -4666,14 +4661,12 @@
       }
     },
     "react-resize-detector": {
-      "version": "6.7.7",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-6.7.7.tgz",
-      "integrity": "sha512-91QlSn3IpeLWX6aP7GDIH2IFGNR9hs8oD5xvjZdDFW9Zr27dFiTpzhIoC96T4ahHd/3Au64JUNiynpkf4Z0Zkg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.0.0.tgz",
+      "integrity": "sha512-Xd1POfpVzH9O3F/xB/0xYy2ijtKjE/z7y4c/aJP593YSzhPy2vDhsNPjes+uQbgL1RezxJajQ679qPs8K5LAFw==",
       "requires": {
         "@types/resize-observer-browser": "^0.1.6",
-        "lodash.debounce": "^4.0.8",
-        "lodash.throttle": "^4.1.1",
-        "resize-observer-polyfill": "^1.5.1"
+        "lodash": "^4.17.21"
       }
     },
     "react-table": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-moon": "2.0.2",
     "react-reflex": "4.0.3",
     "react-resizable": "3.0.4",
-    "react-resize-detector": "6.7.7",
+    "react-resize-detector": "7.0.0",
     "react-table": "7.7.0",
     "react-virtuoso": "2.2.8",
     "rehype-katex": "^6.0.2",


### PR DESCRIPTION
I found out that `resizeDetector` can be used as a hook. This PR adds a facade and ports `TargetTabContents` to use it. We may want to port the other components and delete the component based facade

It also fixes a bug on setting the width of the resizable part of the UI