### PR TITLE
Relocate elevation plot to its own panel

### DIFF
--- a/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
@@ -28,6 +28,14 @@ object ObsQueriesGQL {
               asterism {
                 id
                 name
+                sidereal {
+                  ra {
+                    microarcseconds
+                  }
+                  dec {
+                    microarcseconds
+                  }
+                }
               }
             }
             constraintSet {
@@ -77,8 +85,13 @@ object ObsQueriesGQL {
     object Data {
       object Observations {
         object Nodes {
+          object TargetEnvironment {
+            object Asterism {
+              type Sidereal = lucuma.core.math.Coordinates
+            }
+          }
           trait ConstraintSet extends ConstraintsSummary
-          object PlannedTime {
+          object PlannedTime       {
             type Execution = time.Duration
           }
         }

--- a/common-graphql/src/main/scala/explore/common/TargetQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/TargetQueriesGQL.scala
@@ -50,7 +50,7 @@ object TargetQueriesGQL {
                   name
                   id
                   objectType
-                }                
+                }
               }
               sourceProfile {
                 point {

--- a/common-graphql/src/main/scala/explore/common/UserPreferencesQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/UserPreferencesQueriesGQL.scala
@@ -74,7 +74,7 @@ object UserPreferencesQueriesGQL {
    * Read the grid layout for a given section
    */
   @GraphQL
-  trait ObsTabPreferencesQuery extends GraphQLOperation[UserPreferencesDB] {
+  trait TabGridPreferencesQuery extends GraphQLOperation[UserPreferencesDB] {
     val document = """
       query
         obs_tab_preferences($user_id: String!, $criteria: grid_layout_positions_bool_exp!, $section: resizable_area!) {

--- a/common/src/main/scala/explore/common/ConstraintGroupQueries.scala
+++ b/common/src/main/scala/explore/common/ConstraintGroupQueries.scala
@@ -37,7 +37,7 @@ object ConstraintGroupQueries {
 
   private def convertTarget(
     target: ConstraintGroupObsQuery.Data.Observations.Nodes.TargetEnvironment.Asterism
-  ): TargetSummary = TargetSummary(target.id, target.name)
+  ): TargetSummary = TargetSummary(target.id, target.name, none)
 
   type ConstraintGroupList = SortedMap[ObsIdSet, ConstraintGroup]
   type ObsList             = SortedMap[Observation.Id, ObsSummaryWithTargetsAndConf]

--- a/common/src/main/scala/explore/common/ObsQueries.scala
+++ b/common/src/main/scala/explore/common/ObsQueries.scala
@@ -94,7 +94,7 @@ object ObsQueries {
   private def convertTarget(
     target: ProgramObservationsQuery.Data.Observations.Nodes.TargetEnvironment.Asterism
   ): TargetSummary =
-    TargetSummary(target.id, target.name)
+    TargetSummary(target.id, target.name, target.sidereal)
 
   private val queryToObsSummariesWithConstraintsGetter
     : Getter[ProgramObservationsQuery.Data, ObsSummariesWithConstraints] = data =>

--- a/common/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/common/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -145,7 +145,7 @@ object UserPreferencesQueries {
                 )
             }
           }
-        ).adaptErr { r => println(r); r }.attempt
+        ).attempt
       }.void
   }
 

--- a/common/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/common/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -67,7 +67,7 @@ object UserPreferencesQueries {
       } yield w).value.map(_.flatten.getOrElse(defaultValue))
   }
 
-  implicit class ObsTabPreferencesQueryOps(val self: ObsTabPreferencesQuery.type) extends AnyVal {
+  implicit class TabGridPreferencesQueryOps(val self: TabGridPreferencesQuery.type) extends AnyVal {
     import self._
     import UserPreferencesDB.Scalars._
 
@@ -88,7 +88,7 @@ object UserPreferencesQueries {
     // there is no data or errors
     def queryWithDefault[F[_]: MonadError[*[_], Throwable]](
       userId:        Option[User.Id],
-      // layoutSection: GridLayoutSection,
+      layoutSection: GridLayoutSection,
       resizableArea: ResizableSection,
       defaultValue:  (Int, LayoutsMap)
     )(implicit cl:   TransactionalClient[F, UserPreferencesDB]): F[(Int, LayoutsMap)] =
@@ -96,7 +96,10 @@ object UserPreferencesQueries {
         uid <- OptionT.fromOption[F](userId)
         c   <-
           OptionT.pure(
-            GridLayoutPositionsBoolExp(user_id = StringComparisonExp(uid.show.assign).assign)
+            GridLayoutPositionsBoolExp(
+              user_id = StringComparisonExp(uid.show.assign).assign,
+              section = GridLayoutAreaComparisonExp(layoutSection.value.assign).assign
+            )
           )
         r   <-
           OptionT

--- a/common/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/common/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -128,7 +128,7 @@ object UserPreferencesQueries {
       userId.traverse { uid =>
         execute[F](
           layouts.layouts.flatMap { bl =>
-            bl.layout.l.collect {
+            val rl = bl.layout.l.collect {
               case i if i.i.nonEmpty =>
                 GridLayoutPositionsInsertInput(
                   user_id = uid.show.assign,
@@ -141,8 +141,10 @@ object UserPreferencesQueries {
                   tile = i.i.getOrElse("").assign
                 )
             }
+            println(rl)
+            rl
           }
-        ).attempt
+        ).adaptErr { r => println(r); r }.attempt
       }.void
   }
 

--- a/common/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/common/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -131,7 +131,7 @@ object UserPreferencesQueries {
       userId.traverse { uid =>
         execute[F](
           layouts.layouts.flatMap { bl =>
-            val rl = bl.layout.l.collect {
+            bl.layout.l.collect {
               case i if i.i.nonEmpty =>
                 GridLayoutPositionsInsertInput(
                   user_id = uid.show.assign,
@@ -144,8 +144,6 @@ object UserPreferencesQueries {
                   tile = i.i.getOrElse("").assign
                 )
             }
-            println(rl)
-            rl
           }
         ).adaptErr { r => println(r); r }.attempt
       }.void

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -37,7 +37,9 @@ final case class Tile(
   state:             TileSizeState = TileSizeState.Normal,
   sizeStateCallback: TileSizeState ==> Callback = Reuse.always(_ => Callback.empty),
   key:               js.UndefOr[Key] = js.undefined,
-  controllerClass:   Option[Css] = None // applied to wrapping div when in a TileController.
+  controllerClass:   Option[Css] = None, // applied to wrapping div when in a TileController.
+  bodyClass:         Option[Css] = None, // applied to tile body
+  tileClass:         Option[Css] = None  // applied to the tile
 )(val render:        Tile.RenderInTitle ==> VdomNode)
     extends ReactFnProps[Tile](Tile.component) {
   def showMaximize: Boolean =
@@ -105,7 +107,9 @@ object Tile {
         def setInfoRef(node: dom.Node | Null): Unit =
           infoRef.set(Option(node.asInstanceOf[html.Element])).runNow()
 
-        <.div(ExploreStyles.Tile |+| ExploreStyles.FadeIn, p.key.whenDefined(^.key := _))(
+        <.div(ExploreStyles.Tile |+| ExploreStyles.FadeIn |+| p.tileClass.orEmpty,
+              p.key.whenDefined(^.key := _)
+        )(
           <.div(
             ExploreStyles.TileTitle,
             p.back.map(b => <.div(ExploreStyles.TileButton, b)),
@@ -130,7 +134,7 @@ object Tile {
               ResponsiveComponent(
                 widthBreakpoints,
                 heightBreakpoints,
-                clazz = ExploreStyles.TileBody
+                clazz = ExploreStyles.TileBody |+| p.bodyClass.orEmpty
               )(
                 p.render(
                   Reuse

--- a/common/src/main/scala/explore/components/TileController.scala
+++ b/common/src/main/scala/explore/components/TileController.scala
@@ -118,8 +118,6 @@ object TileController {
                   val resizable     =
                     tileResizable(id).headOption(p.defaultLayout).getOrElse(true: Boolean | Unit)
                   // TODO: Restore to the previous size
-                  println(scala.math.max(l.minH.getOrElse(1), defaultHeight))
-                  println(defaultHeight)
                   l.copy(h = defaultHeight,
                          isResizable = resizable,
                          minH = scala.math.max(l.minH.getOrElse(1), defaultHeight)

--- a/common/src/main/scala/explore/components/TileController.scala
+++ b/common/src/main/scala/explore/components/TileController.scala
@@ -34,7 +34,7 @@ import scala.scalajs.js.|
 
 final case class TileController(
   userId:           Option[User.Id],
-  coreWidth:        Int,
+  gridWidth:        Int,
   defaultLayout:    LayoutsMap,
   layoutMap:        View[LayoutsMap],
   tiles:            List[Tile],
@@ -124,9 +124,9 @@ object TileController {
             }
 
         ResponsiveReactGridLayout(
-          width = p.coreWidth,
-          margin = (5, 5),
-          containerPadding = (5, 0),
+          width = p.gridWidth,
+          margin = (Constants.GridRowPadding, Constants.GridRowPadding),
+          containerPadding = (Constants.GridRowPadding, 0),
           rowHeight = Constants.GridRowHeight,
           draggableHandle = s".${ExploreStyles.TileTitleMenu.htmlClass}",
           onLayoutChange =

--- a/common/src/main/scala/explore/components/TileController.scala
+++ b/common/src/main/scala/explore/components/TileController.scala
@@ -111,13 +111,15 @@ object TileController {
             .mod {
               case l if l.i.forall(_ === id.value) =>
                 if (st === TileSizeState.Minimized)
-                  l.copy(h = 1, isResizable = false)
+                  l.copy(h = 1, minH = 1, isResizable = false)
                 else if (st === TileSizeState.Normal) {
                   val defaultHeight = unsafeTileHeight(id).headOption(p.defaultLayout).getOrElse(1)
                   // restore the resizable state
                   val resizable     =
                     tileResizable(id).headOption(p.defaultLayout).getOrElse(true: Boolean | Unit)
                   // TODO: Restore to the previous size
+                  println(scala.math.max(l.minH.getOrElse(1), defaultHeight))
+                  println(defaultHeight)
                   l.copy(h = defaultHeight,
                          isResizable = resizable,
                          minH = scala.math.max(l.minH.getOrElse(1), defaultHeight)

--- a/common/src/main/scala/explore/components/TileController.scala
+++ b/common/src/main/scala/explore/components/TileController.scala
@@ -118,7 +118,10 @@ object TileController {
                   val resizable     =
                     tileResizable(id).headOption(p.defaultLayout).getOrElse(true: Boolean | Unit)
                   // TODO: Restore to the previous size
-                  l.copy(h = defaultHeight, isResizable = resizable)
+                  l.copy(h = defaultHeight,
+                         isResizable = resizable,
+                         minH = scala.math.max(l.minH.getOrElse(1), defaultHeight)
+                  )
                 } else l
               case l                               => l
             }

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -192,7 +192,6 @@ object ExploreStyles {
 
   val TargetAladinCell: Css    = Css("target-aladin-cell")
   val TargetAladin: Css        = Css("aladin-target")
-  // val TargetSkyplotCell: Css   = Css("target-skyplot-cell")
   val TargetRaDecMinWidth: Css = Css("target-ra-dec-min-width")
   val TargetForm: Css          = Css("target-form")
   val SearchForm: Css          = Css("target-search-form")

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -124,6 +124,8 @@ object ExploreStyles {
 
   val DraggingOver: Css = Css("dragging-over")
 
+  val SkyPlotTile: Css               = Css("sky-plot-tile")
+  val SkyPlotTileBody: Css           = Css("sky-plot-tile-body")
   val SkyPlot: Css                   = Css("sky-plot")
   val SkyPlotSection: Css            = Css("sky-plot-section")
   val SkyPlotControls: Css           = Css("sky-plot-controls")
@@ -185,7 +187,7 @@ object ExploreStyles {
   val TargetGrid: Css          = Css("target-grid")
   val TargetAladinCell: Css    = Css("target-aladin-cell")
   val TargetAladin: Css        = Css("aladin-target")
-  val TargetSkyplotCell: Css   = Css("target-skyplot-cell")
+  // val TargetSkyplotCell: Css   = Css("target-skyplot-cell")
   val TargetRaDecMinWidth: Css = Css("target-ra-dec-min-width")
   val TargetForm: Css          = Css("target-form")
   val SearchForm: Css          = Css("target-search-form")

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -184,10 +184,10 @@ object ExploreStyles {
   val ConstraintsTile: Css  = Css("constraints-tile")
 
   // The Target tab contents
-  val TargetGrid: Css      = Css("target-grid")
-  val TargetTileBody: Css  = Css("target-tile-body")
-  val AsterismEditor: Css  = Css("target-asterism-editor")
-  val AsterismTable: Css   = Css("target-asterism-table")
+  val TargetGrid: Css     = Css("target-grid")
+  val TargetTileBody: Css = Css("target-tile-body")
+  val AsterismEditor: Css = Css("target-asterism-editor")
+  val AsterismTable: Css  = Css("target-asterism-table")
   val BrightnessCell: Css = Css("target-brightness-cell")
 
   val TargetAladinCell: Css    = Css("target-aladin-cell")
@@ -235,7 +235,7 @@ object ExploreStyles {
   val BrightnessesTableFooter: Css             = Css("explore-brightnesses-footer")
   val BrightnessesTableUnitsDropdown: Css      = Css("explore-brightnesses-units-dropdown")
   val BrightnessesTableDeletButtonWrapper: Css = Css("explore-brightnesses-delete-button-wrapper")
-  val EmptyTreeContent: Css = Css("explore-empty-tree-content")
+  val EmptyTreeContent: Css                    = Css("explore-empty-tree-content")
 
   // This is rendered without React, so we include SUI classes.
   val CrashMessage: Css = Css(List("ui", "large", "label", "crash-message"))

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -184,9 +184,11 @@ object ExploreStyles {
   val ConstraintsTile: Css  = Css("constraints-tile")
 
   // The Target tab contents
-  val TargetGrid: Css     = Css("target-grid")
-  val TargetTileBody: Css = Css("target-tile-body")
-  val AsterismEditor: Css = Css("target-asterism-editor")
+  val TargetGrid: Css      = Css("target-grid")
+  val TargetTileBody: Css  = Css("target-tile-body")
+  val AsterismEditor: Css  = Css("target-asterism-editor")
+  val AsterismTable: Css   = Css("target-asterism-table")
+  val BrightnessCell: Css = Css("target-brightness-cell")
 
   val TargetAladinCell: Css    = Css("target-aladin-cell")
   val TargetAladin: Css        = Css("aladin-target")
@@ -234,8 +236,6 @@ object ExploreStyles {
   val BrightnessesTableFooter: Css             = Css("explore-brightnesses-footer")
   val BrightnessesTableUnitsDropdown: Css      = Css("explore-brightnesses-units-dropdown")
   val BrightnessesTableDeletButtonWrapper: Css = Css("explore-brightnesses-delete-button-wrapper")
-  val BrightnessesTableSection: Css            = Css("explore-brightnesses-section")
-
   val EmptyTreeContent: Css = Css("explore-empty-tree-content")
 
   // This is rendered without React, so we include SUI classes.

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -184,7 +184,10 @@ object ExploreStyles {
   val ConstraintsTile: Css  = Css("constraints-tile")
 
   // The Target tab contents
-  val TargetGrid: Css          = Css("target-grid")
+  val TargetGrid: Css     = Css("target-grid")
+  val TargetTileBody: Css = Css("target-tile-body")
+  val AsterismEditor: Css = Css("target-asterism-editor")
+
   val TargetAladinCell: Css    = Css("target-aladin-cell")
   val TargetAladin: Css        = Css("aladin-target")
   // val TargetSkyplotCell: Css   = Css("target-skyplot-cell")

--- a/common/src/main/scala/explore/model/layout.scala
+++ b/common/src/main/scala/explore/model/layout.scala
@@ -54,6 +54,8 @@ object layout {
   val layoutItems: Traversal[Layout, LayoutItem]                = layoutItem.each
   val layoutItemName                                            = Focus[LayoutItem](_.i)
   val layoutItemHeight                                          = Focus[LayoutItem](_.h)
+  val layoutItemMaxHeight                                       = Focus[LayoutItem](_.maxH)
+  val layoutItemMinHeight                                       = Focus[LayoutItem](_.minH)
   val layoutItemWidth                                           = Focus[LayoutItem](_.w)
   val layoutItemX                                               = Focus[LayoutItem](_.x)
   val layoutItemY                                               = Focus[LayoutItem](_.y)

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -966,6 +966,7 @@ tfoot {
 .aladin-container-body {
   grid-area: aladin;
   margin-bottom: 0.2em;
+  background: pink;
 }
 
 .aladin-status-fov {
@@ -1069,6 +1070,17 @@ tfoot {
   }
 }
 
+.target-tile-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.target-asterism-editor {
+  height: 100%;
+  align-self: stretch;
+  outline: 3px solid pink !important;
+}
+
 .target-grid {
   display: grid;
   grid-gap: 1em;
@@ -1090,7 +1102,7 @@ tfoot {
 
   .target-aladin-cell {
     grid-row: span 3;
-    max-height: 500px;
+    max-height: 100px;
   }
 
 }

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -952,7 +952,7 @@ tfoot {
 }
 
 .aladin-container-column {
-  min-height: 500px;
+  // min-height: 500px;
   height: 100%;
   display: grid;
   grid-template-rows: 1fr min-content;
@@ -966,7 +966,6 @@ tfoot {
 .aladin-container-body {
   grid-area: aladin;
   margin-bottom: 0.2em;
-  background: pink;
 }
 
 .aladin-status-fov {
@@ -1075,6 +1074,21 @@ tfoot {
   flex-direction: column;
 }
 
+.target-brightness-cell {
+  .form {
+    height: 100%;
+  }
+}
+
+.explore-table.target-asterism-table {
+  height: unset;
+}
+
+// .explore-brightnesses-section {
+//   outline: 6px solid blue;
+//   height: 100%;
+// }
+
 .target-asterism-editor {
   height: 100%;
   align-self: stretch;
@@ -1083,26 +1097,23 @@ tfoot {
 
 .target-grid {
   display: grid;
-  grid-gap: 1em;
+  grid-gap: 0.5em;
   padding: 0.5em;
+  // flex-shrink: 2;
+  height: 100%;
 }
 
 .tile-xl-width,
 .tile-lg-width,
 .tile-md-width {
   .target-grid {
-    grid-template-columns: repeat(auto-fit, minmax(40ch, 1fr));
-  }
-
-  @supports (grid-template-rows: masonry) {
-    .target-grid {
-      grid-template-rows: masonry;
-    }
+    // grid-template-columns: repeat(auto-fit, minmax(40ch, 1fr));
+    grid-template-columns: 1fr 2fr;
+    grid-template-rows: min-content min-content 1fr;
   }
 
   .target-aladin-cell {
     grid-row: span 3;
-    max-height: 100px;
   }
 
 }
@@ -1295,6 +1306,16 @@ img.partner-split-flag {
 
   & .selected-down {
     bottom: 1.1em;
+  }
+}
+
+.explore-brightnesses-container {
+  display: flex;
+  flex-direction: column;
+  border: none;
+
+  .table {
+    margin: 0;
   }
 }
 
@@ -1611,7 +1632,10 @@ html {
 
 .explore-brightnesses-footer {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  padding: 0.2em;
+  border-top: 0.2px solid var(--under-tab-border-color);
+  background-color: var(--table-footer-background);
 }
 
 .obs-badge-header {
@@ -1852,7 +1876,6 @@ html {
 }
 
 .explore-title-undo-buttons {
-  flex-grow: 2;
   text-align: right;
 }
 

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -843,16 +843,8 @@ tfoot {
   justify-content: stretch;
 }
 
-// .target-skyplot-cell {
-//   min-width: 1px; // Needed to help highcharts recompute width on the fly.
-//   display: flex;
-//   justify-content: stretch;
-//   align-content: stretch;
-// }
-//
 .sky-plot {
   height: 100%;
-  outline: 1px solid red;
 
   .highcharts-xaxis .highcharts-axis-title {
     fill: hsl(0, 87%, 66%);
@@ -861,7 +853,6 @@ tfoot {
   > div {
     height: 100%;
     div[data-highcharts-chart] {
-  //background-color: red;
       height: 100%;
     }
   }
@@ -873,8 +864,6 @@ tfoot {
   position: relative;
   display: flex;
   flex-direction: column;
-  // justify-content: stretch;
-  // align-content: stretch;
   background-color: var(--plot-background-color);
   color: var(--plot-text-color);
 }

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -852,6 +852,7 @@ tfoot {
 
   > div {
     height: 100%;
+
     div[data-highcharts-chart] {
       height: 100%;
     }
@@ -1107,7 +1108,6 @@ tfoot {
   .target-aladin-cell {
     grid-row: span 3;
   }
-
 }
 
 .target-rv-controls {

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -952,7 +952,6 @@ tfoot {
 }
 
 .aladin-container-column {
-  // min-height: 500px;
   height: 100%;
   display: grid;
   grid-template-rows: 1fr min-content;
@@ -1084,11 +1083,6 @@ tfoot {
   height: unset;
 }
 
-// .explore-brightnesses-section {
-//   outline: 6px solid blue;
-//   height: 100%;
-// }
-
 .target-asterism-editor {
   height: 100%;
   align-self: stretch;
@@ -1099,7 +1093,6 @@ tfoot {
   display: grid;
   grid-gap: 0.5em;
   padding: 0.5em;
-  // flex-shrink: 2;
   height: 100%;
 }
 
@@ -1107,7 +1100,6 @@ tfoot {
 .tile-lg-width,
 .tile-md-width {
   .target-grid {
-    // grid-template-columns: repeat(auto-fit, minmax(40ch, 1fr));
     grid-template-columns: 1fr 2fr;
     grid-template-rows: min-content min-content 1fr;
   }

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -834,8 +834,25 @@ tfoot {
   background-color: var(--explore-group-dragging) !important;
 }
 
+.sky-plot-tile {
+  background-color: var(--plot-background-color);
+}
+
+.sky-plot-tile-body {
+  display: flex;
+  justify-content: stretch;
+  align-content: stretch;
+}
+
+// .target-skyplot-cell {
+//   min-width: 1px; // Needed to help highcharts recompute width on the fly.
+//   display: flex;
+//   justify-content: stretch;
+//   align-content: stretch;
+// }
+//
 .sky-plot {
-  height: 350px;
+  height: 100%;
 
   .highcharts-xaxis .highcharts-axis-title {
     fill: hsl(0, 87%, 66%);
@@ -843,8 +860,13 @@ tfoot {
 }
 
 .sky-plot-section {
-  height: 390px;
-  padding: 0 !important;
+  min-width: 1px; // Needed to help highcharts recompute width on the fly.
+  width: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: stretch;
+  align-content: stretch;
   background-color: var(--plot-background-color);
   color: var(--plot-text-color);
 }
@@ -859,6 +881,7 @@ tfoot {
   align-items: baseline;
   background-color: var(--plot-background-color);
   color: var(--plot-text-color);
+  margin-bottom: 0em;
 
   .ui.compact.buttons .button,
   .ui.compact.button {
@@ -1055,12 +1078,6 @@ tfoot {
   padding: 0.5em;
 }
 
-.target-skyplot-cell {
-  margin: 0 1em 1em;
-  position: relative;
-  min-width: 1px; // Needed to help highcharts recompute width on the fly.
-}
-
 .tile-xl-width,
 .tile-lg-width,
 .tile-md-width {
@@ -1079,10 +1096,6 @@ tfoot {
     max-height: 500px;
   }
 
-  .target-skyplot-cell {
-    grid-column-start: 1;
-    grid-column-end: 3;
-  }
 }
 
 .target-rv-controls {

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -841,7 +841,6 @@ tfoot {
 .sky-plot-tile-body {
   display: flex;
   justify-content: stretch;
-  align-content: stretch;
 }
 
 // .target-skyplot-cell {
@@ -853,9 +852,18 @@ tfoot {
 //
 .sky-plot {
   height: 100%;
+  outline: 1px solid red;
 
   .highcharts-xaxis .highcharts-axis-title {
     fill: hsl(0, 87%, 66%);
+  }
+
+  > div {
+    height: 100%;
+    div[data-highcharts-chart] {
+  //background-color: red;
+      height: 100%;
+    }
   }
 }
 
@@ -865,8 +873,8 @@ tfoot {
   position: relative;
   display: flex;
   flex-direction: column;
-  justify-content: stretch;
-  align-content: stretch;
+  // justify-content: stretch;
+  // align-content: stretch;
   background-color: var(--plot-background-color);
   color: var(--plot-text-color);
 }
@@ -881,7 +889,7 @@ tfoot {
   align-items: baseline;
   background-color: var(--plot-background-color);
   color: var(--plot-text-color);
-  margin-bottom: 0em;
+  margin: 0.2em;
 
   .ui.compact.buttons .button,
   .ui.compact.button {

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -80,9 +80,9 @@ object SpectroscopyModesTable {
 
   protected val ModesTableDef = TableDef[SpectroscopyModeRow].withSortBy.withBlockLayout
 
-  val decFormat = new DecimalFormat("0.###")
-
   protected val ModesTable = new SUITableVirtuoso(ModesTableDef)
+
+  val decFormat = new DecimalFormat("0.###")
 
   val disperserDisplay: Display[ModeDisperser] = Display.byShortName {
     case ModeDisperser.NoDisperser      => "-"

--- a/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
+++ b/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
@@ -6,13 +6,13 @@ package explore.tabs
 import cats.syntax.all._
 import crystal.react.reuse._
 import explore.components.Tile
+import explore.components.ui.ExploreStyles
 import explore.implicits._
+import explore.targeteditor.SkyPlotSection
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.math.Coordinates
 import lucuma.ui.reusability._
 import react.common._
-import explore.components.ui.ExploreStyles
-import explore.targeteditor.SkyPlotSection
-import lucuma.core.math.Coordinates
 
 object ElevationPlotTile {
 

--- a/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
+++ b/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
@@ -4,28 +4,23 @@
 package explore.tabs
 
 import cats.syntax.all._
-import crystal.react._
 import crystal.react.reuse._
-import crystal.react.implicits._
 import explore.components.Tile
 import explore.implicits._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.Target
-import lucuma.core.model.User
-import explore.model.reusability._
 import lucuma.ui.reusability._
 import react.common._
 import explore.components.ui.ExploreStyles
 import explore.targeteditor.SkyPlotSection
+import lucuma.core.math.Coordinates
 
 object ElevationPlotTile {
 
   def elevationPlotTile(
-    userId:         Option[User.Id],
-    coreWidth:      Int,
-    coreHeight:     Int,
-    selectedTarget: Option[ViewOpt[Target]]
-  )(implicit ctx:   AppContextIO) =
+    coreWidth:    Int,
+    coreHeight:   Int,
+    coordinates:  Coordinates
+  )(implicit ctx: AppContextIO) =
     Tile(ObsTabTiles.PlotId,
          "Elevation Plot",
          canMinimize = true,
@@ -34,21 +29,9 @@ object ElevationPlotTile {
     )(
       Reuse
         .by(
-          (userId, coreWidth, coreHeight, selectedTarget)
+          (coreWidth, coreHeight, coordinates)
         ) { (_: Tile.RenderInTitle) =>
-          selectedTarget
-            .flatMap(
-              _.mapValue(targetView =>
-                targetView.get match {
-                  case t @ Target.Sidereal(_, _, _, _) =>
-                    val baseCoordinates =
-                      Target.Sidereal.baseCoordinates.get(t)
-                    SkyPlotSection(baseCoordinates): VdomNode
-                  case _                               => EmptyVdom
-                }
-              )
-            )
-            .getOrElse(EmptyVdom)
+          SkyPlotSection(coordinates): VdomNode
         }
         .reuseAlways
     )

--- a/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
+++ b/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.tabs
+
+import cats.syntax.all._
+import crystal.react._
+import crystal.react.reuse._
+import crystal.react.implicits._
+import explore.components.Tile
+import explore.implicits._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.model.Target
+import lucuma.core.model.User
+import explore.model.reusability._
+import lucuma.ui.reusability._
+import react.common._
+import explore.components.ui.ExploreStyles
+import explore.targeteditor.SkyPlotSection
+
+object ElevationPlotTile {
+
+  def elevationPlotTile(
+    userId:         Option[User.Id],
+    coreWidth:      Int,
+    coreHeight:     Int,
+    selectedTarget: Option[ViewOpt[Target]]
+  )(implicit ctx:   AppContextIO) =
+    Tile(ObsTabTiles.PlotId,
+         "Elevation Plot",
+         canMinimize = true,
+         bodyClass = ExploreStyles.SkyPlotTileBody.some,
+         tileClass = ExploreStyles.SkyPlotTile.some
+    )(
+      Reuse
+        .by(
+          (userId, coreWidth, coreHeight, selectedTarget)
+        ) { (_: Tile.RenderInTitle) =>
+          selectedTarget
+            .flatMap(
+              _.mapValue(targetView =>
+                targetView.get match {
+                  case t @ Target.Sidereal(_, _, _, _) =>
+                    val baseCoordinates =
+                      Target.Sidereal.baseCoordinates.get(t)
+                    SkyPlotSection(baseCoordinates): VdomNode
+                  case _                               => EmptyVdom
+                }
+              )
+            )
+            .getOrElse(EmptyVdom)
+        }
+        .reuseAlways
+    )
+
+}

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -39,6 +39,7 @@ import explore.undo.UndoStacks
 import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.math.Coordinates
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
 import lucuma.core.model.User
@@ -61,7 +62,6 @@ import react.semanticui.modules.dropdown.Dropdown
 import react.semanticui.sizes._
 
 import scala.concurrent.duration._
-import lucuma.core.math.Coordinates
 
 final case class ObsTabContents(
   userId:           ViewOpt[User.Id],
@@ -395,49 +395,48 @@ object ObsTabContents {
             )
 
           val skyPlotTile =
-            targetCoords.map( ElevationPlotTile.elevationPlotTile(coreWidth, coreHeight, _))
+            targetCoords.map(ElevationPlotTile.elevationPlotTile(coreWidth, coreHeight, _))
 
           val targetTile = TargetTile.targetTile(
-                props.userId.get,
-                ObsIdSet.one(obsId),
-                obsView.map(
-                  _.zoom(
-                    ObservationData.targetEnvironment.andThen(
-                      ObservationData.TargetEnvironment.asterism
-                    )
-                  )
-                ),
-                props.undoStacks.zoom(ModelUndoStacks.forSiderealTarget),
-                props.searching,
-                options,
-                "Targets",
-                none,
-                props.hiddenColumns
-              )
-
-              // The ExploreStyles.ConstraintsTile css adds a z-index to the constraints tile react-grid wrapper
-              // so that the constraints selector dropdown always appears in front of any other tiles. If more
-              // than one tile ends up having dropdowns in the tile header, we'll need something more complex such
-              // as changing the css classes on the various tiles when the dropdown is clicked to control z-index.
-              val constraintsTile = ConstraintsTile
-                .constraintsTile(
-                  obsId,
-                  obsView.map(_.zoom(ObservationData.constraintSet)),
-                  props.undoStacks
-                    .zoom(ModelUndoStacks.forConstraintGroup[IO])
-                    .zoom(atMapWithDefault(ObsIdSet.one(obsId), UndoStacks.empty)),
-                  control = constraintsSelector.some,
-                  clazz = ExploreStyles.ConstraintsTile.some
+            props.userId.get,
+            ObsIdSet.one(obsId),
+            obsView.map(
+              _.zoom(
+                ObservationData.targetEnvironment.andThen(
+                  ObservationData.TargetEnvironment.asterism
                 )
-
-              val configurationTile = ConfigurationTile.configurationTile(
-
-                obsId,
-                obsView.map(_.zoom(scienceDataForObs)),
-                props.undoStacks
-                  .zoom(ModelUndoStacks.forScienceData[IO])
-                  .zoom(atMapWithDefault(obsId, UndoStacks.empty))
               )
+            ),
+            props.undoStacks.zoom(ModelUndoStacks.forSiderealTarget),
+            props.searching,
+            options,
+            "Targets",
+            none,
+            props.hiddenColumns
+          )
+
+          // The ExploreStyles.ConstraintsTile css adds a z-index to the constraints tile react-grid wrapper
+          // so that the constraints selector dropdown always appears in front of any other tiles. If more
+          // than one tile ends up having dropdowns in the tile header, we'll need something more complex such
+          // as changing the css classes on the various tiles when the dropdown is clicked to control z-index.
+          val constraintsTile = ConstraintsTile
+            .constraintsTile(
+              obsId,
+              obsView.map(_.zoom(ObservationData.constraintSet)),
+              props.undoStacks
+                .zoom(ModelUndoStacks.forConstraintGroup[IO])
+                .zoom(atMapWithDefault(ObsIdSet.one(obsId), UndoStacks.empty)),
+              control = constraintsSelector.some,
+              clazz = ExploreStyles.ConstraintsTile.some
+            )
+
+          val configurationTile = ConfigurationTile.configurationTile(
+            obsId,
+            obsView.map(_.zoom(scienceDataForObs)),
+            props.undoStacks
+              .zoom(ModelUndoStacks.forScienceData[IO])
+              .zoom(atMapWithDefault(obsId, UndoStacks.empty))
+          )
 
           TileController(
             props.userId.get,
@@ -449,8 +448,8 @@ object ObsTabContents {
               notesTile.some,
               skyPlotTile,
               constraintsTile.some,
-              configurationTile.some,
-              ).collect { case Some(x) => x },
+              configurationTile.some
+            ).collect { case Some(x) => x },
             GridLayoutSection.ObservationsLayout,
             clazz = ExploreStyles.ObservationTiles.some
           ): VdomNode

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -463,8 +463,9 @@ object ObsTabContents {
       .useEffectWithDepsBy((p, _, _, _) => p.focusedObs) { (props, panels, _, layout) =>
         implicit val ctx = props.ctx
         _ =>
-          ObsTabPreferencesQuery
+          TabGridPreferencesQuery
             .queryWithDefault[IO](props.userId.get,
+                                  GridLayoutSection.ObservationsLayout,
                                   ResizableSection.ObservationsTree,
                                   (Constants.InitialTreeWidth.toInt, defaultLayout)
             )

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -475,7 +475,7 @@ object ObsTabContents {
                 (panels
                   .mod(
                     TwoPanelState.treeWidth[Observation.Id].replace(w)
-                  ) *> layout.set(mergeMap(layout.get, l)))
+                  ) *> layout.mod(o => mergeMap(o, l)))
                   .to[IO]
               case Left(_)       => IO.unit
             }

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -77,6 +77,7 @@ final case class ObsTabContents(
 object ObsTabTiles {
   val NotesId: NonEmptyString         = "notes"
   val TargetId: NonEmptyString        = "target"
+  val PlotId: NonEmptyString          = "elevationPlot"
   val ConstraintsId: NonEmptyString   = "constraints"
   val ConfigurationId: NonEmptyString = "configuration"
 }
@@ -84,6 +85,7 @@ object ObsTabTiles {
 object ObsTabContents {
   private val NotesMaxHeight: NonNegInt         = 3
   private val TargetMinHeight: NonNegInt        = 12
+  private val ElevationPlotMinHeight: NonNegInt = 8
   private val ConstraintsMaxHeight: NonNegInt   = 6
   private val ConfigurationMaxHeight: NonNegInt = 10
   private val DefaultWidth: NonNegInt           = 12
@@ -106,12 +108,20 @@ object ObsTabContents {
       LayoutItem(x = 0,
                  y = (NotesMaxHeight |+| TargetMinHeight).value,
                  w = DefaultWidth.value,
-                 h = ConstraintsMaxHeight.value,
-                 i = ObsTabTiles.ConstraintsId.value
+                 h = ElevationPlotMinHeight.value,
+                 i = ObsTabTiles.PlotId.value
       ),
       LayoutItem(
         x = 0,
-        y = (NotesMaxHeight |+| TargetMinHeight |+| ConstraintsMaxHeight).value,
+        y = (NotesMaxHeight |+| TargetMinHeight |+| ElevationPlotMinHeight).value,
+        w = DefaultWidth.value,
+        h = ConstraintsMaxHeight.value,
+        i = ObsTabTiles.ConstraintsId.value
+      ),
+      LayoutItem(
+        x = 0,
+        y =
+          (NotesMaxHeight |+| TargetMinHeight |+| ElevationPlotMinHeight |+| ConstraintsMaxHeight).value,
         w = DefaultWidth.value,
         h = ConfigurationMaxHeight.value,
         i = ObsTabTiles.ConfigurationId.value
@@ -137,12 +147,20 @@ object ObsTabContents {
       LayoutItem(x = 0,
                  y = (NotesMaxHeight |+| TargetMinHeight).value,
                  w = DefaultWidth.value,
-                 h = ConstraintsMaxHeight.value,
-                 i = ObsTabTiles.ConstraintsId.value
+                 h = ElevationPlotMinHeight.value,
+                 i = ObsTabTiles.PlotId.value
       ),
       LayoutItem(
         x = 0,
-        y = (NotesMaxHeight |+| TargetMinHeight |+| ConstraintsMaxHeight).value,
+        y = (NotesMaxHeight |+| TargetMinHeight |+| ElevationPlotMinHeight).value,
+        w = DefaultWidth.value,
+        h = ConstraintsMaxHeight.value,
+        i = ObsTabTiles.ConstraintsId.value
+      ),
+      LayoutItem(
+        x = 0,
+        y =
+          (NotesMaxHeight |+| TargetMinHeight |+| ElevationPlotMinHeight |+| ConstraintsMaxHeight).value,
         w = DefaultWidth.value,
         h = ConfigurationMaxHeight.value,
         i = ObsTabTiles.ConfigurationId.value
@@ -168,14 +186,22 @@ object ObsTabContents {
       LayoutItem(x = 0,
                  y = (NotesMaxHeight |+| TargetMinHeight).value,
                  w = DefaultWidth.value,
-                 h = ConstraintsMaxHeight.value,
-                 i = ObsTabTiles.ConstraintsId.value
+                 h = ElevationPlotMinHeight.value,
+                 i = ObsTabTiles.PlotId.value
       ),
       LayoutItem(
         x = 0,
-        y = (NotesMaxHeight |+| TargetMinHeight |+| ConstraintsMaxHeight).value,
+        y = (NotesMaxHeight |+| TargetMinHeight |+| ElevationPlotMinHeight).value,
         w = DefaultWidth.value,
-        h = 2 * ConfigurationMaxHeight.value,
+        h = ConstraintsMaxHeight.value,
+        i = ObsTabTiles.ConstraintsId.value
+      ),
+      LayoutItem(
+        x = 0,
+        y =
+          (NotesMaxHeight |+| TargetMinHeight |+| ElevationPlotMinHeight |+| ConstraintsMaxHeight).value,
+        w = DefaultWidth.value,
+        h = ConfigurationMaxHeight.value,
         i = ObsTabTiles.ConfigurationId.value
       )
     )
@@ -300,12 +326,13 @@ object ObsTabContents {
       )(^.href := ctx.pageUrl(AppTab.Observations, none), Icons.ChevronLeft)
     )
 
-    val coreWidth =
+    val coreWidth  =
       if (window.canFitTwoPanels) {
         resize.width.getOrElse(0)
       } else {
         resize.width.getOrElse(0) - treeWidth
       }
+    val coreHeight = resize.height.getOrElse(0)
 
     val notesTile =
       Tile(
@@ -358,6 +385,13 @@ object ObsTabContents {
               makeConstraintsSelector(constraintGroups, obsView)
             )
 
+          val skyPlotTile =
+            ElevationPlotTile.elevationPlotTile(props.userId.get,
+                                                coreWidth,
+                                                coreHeight,
+                                                props.baseCoordinates
+            )
+
           TileController(
             props.userId.get,
             coreWidth,
@@ -367,7 +401,7 @@ object ObsTabContents {
               notesTile,
               TargetTile.targetTile(
                 props.userId.get,
-                obsId,
+                ObsIdSet.one(obsId),
                 obsView.map(
                   _.zoom(
                     ObservationData.targetEnvironment.andThen(
@@ -378,8 +412,11 @@ object ObsTabContents {
                 props.undoStacks.zoom(ModelUndoStacks.forSiderealTarget),
                 props.searching,
                 options,
+                "Targets",
+                none,
                 props.hiddenColumns
               ),
+              skyPlotTile,
               // The ExploreStyles.ConstraintsTile css adds a z-index to the constraints tile react-grid wrapper
               // so that the constraints selector dropdown always appears in front of any other tiles. If more
               // than one tile ends up having dropdowns in the tile header, we'll need something more complex such

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -430,8 +430,6 @@ object TargetTabContents {
     body.withRef(resize.ref)
   }
 
-  var u = 0
-
   protected val component =
     ScalaFnComponent
       .withHooks[Props]
@@ -443,9 +441,6 @@ object TargetTabContents {
         // Memoize the initial result
         h.map(h => scaledLayout(h, l.get)).getOrElse(l.get)
       }
-      // .useEffectWithDepsBy((_, _, _, r, _, _) => r.height) { (_, _, _, _, l, _) => h =>
-      //   h.map(h => l.mod(l => scaledLayout(h, l))).getOrEmpty
-      // }
       .useEffectWithDepsBy((p, _, _, r, _, _) => (p.userId, r.height)) {
         (props, panels, _, _, layout, defaultLayout) =>
           implicit val ctx = props.ctx

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -321,15 +321,26 @@ object TargetTabContents {
                               props.hiddenColumns
         )
 
+        val selectedCoordinates = selectedTarget
+          .flatMap(
+            _.mapValue(targetView =>
+              targetView.get match {
+                case t @ Target.Sidereal(_, _, _, _) =>
+                    Target.Sidereal.baseCoordinates.get(t).some
+                case _                               => none
+              }
+            )
+          )
+
       val skyPlotTile =
-        ElevationPlotTile.elevationPlotTile(props.userId, coreWidth, coreHeight, selectedTarget)
+        selectedCoordinates.flatten.map(ElevationPlotTile.elevationPlotTile( coreWidth, coreHeight, _))
 
       TileController(
         props.userId,
         coreWidth,
         defaultLayouts,
         layouts,
-        List(targetEditorTile, skyPlotTile),
+        List(targetEditorTile.some, skyPlotTile).collect { case Some(x) => x},
         GridLayoutSection.TargetLayout,
         None
       )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -6,7 +6,9 @@ package explore.tabs
 import cats.Order._
 import cats.effect.IO
 import cats.syntax.all._
+import crystal.Pot
 import crystal.react.View
+import crystal.react._
 import crystal.react.hooks._
 import crystal.react.implicits._
 import crystal.react.reuse._
@@ -17,27 +19,29 @@ import explore.common.AsterismQueries._
 import explore.common.UserPreferencesQueries._
 import explore.common.UserPreferencesQueriesGQL._
 import explore.components.Tile
+import explore.components.TileController
 import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model._
 import explore.model.enum.AppTab
 import explore.model.layout._
-import explore.model.reusability._
 import explore.model.layout.unsafe._
+import explore.model.reusability._
 import explore.observationtree.AsterismGroupObsList
-import explore.undo._
 import explore.syntax.ui._
-import react.gridlayout._
+import explore.undo._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.ui.reusability._
 import lucuma.ui.utils._
+import monocle.Optional
 import org.scalajs.dom.window
 import react.common._
 import react.common.implicits._
 import react.draggable.Axis
+import react.gridlayout._
 import react.resizable._
 import react.resizeDetector._
 import react.resizeDetector.hooks._
@@ -47,10 +51,6 @@ import react.semanticui.sizes._
 
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration._
-import monocle.Optional
-import explore.components.TileController
-import crystal.Pot
-import crystal.react._
 
 final case class TargetTabContents(
   userId:            Option[User.Id],
@@ -321,26 +321,28 @@ object TargetTabContents {
                               props.hiddenColumns
         )
 
-        val selectedCoordinates = selectedTarget
-          .flatMap(
-            _.mapValue(targetView =>
-              targetView.get match {
-                case t @ Target.Sidereal(_, _, _, _) =>
-                    Target.Sidereal.baseCoordinates.get(t).some
-                case _                               => none
-              }
-            )
+      val selectedCoordinates = selectedTarget
+        .flatMap(
+          _.mapValue(targetView =>
+            targetView.get match {
+              case t @ Target.Sidereal(_, _, _, _) =>
+                Target.Sidereal.baseCoordinates.get(t).some
+              case _                               => none
+            }
           )
+        )
 
       val skyPlotTile =
-        selectedCoordinates.flatten.map(ElevationPlotTile.elevationPlotTile( coreWidth, coreHeight, _))
+        selectedCoordinates.flatten.map(
+          ElevationPlotTile.elevationPlotTile(coreWidth, coreHeight, _)
+        )
 
       TileController(
         props.userId,
         coreWidth,
         defaultLayouts,
         layouts,
-        List(targetEditorTile.some, skyPlotTile).collect { case Some(x) => x},
+        List(targetEditorTile.some, skyPlotTile).collect { case Some(x) => x },
         GridLayoutSection.TargetLayout,
         None
       )

--- a/explore/src/main/scala/explore/tabs/TargetTile.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTile.scala
@@ -3,6 +3,7 @@
 
 package explore.tabs
 
+import cats.syntax.all._
 import cats.effect.IO
 import crystal.Pot
 import crystal.react.View
@@ -18,25 +19,32 @@ import explore.targeteditor.AsterismEditor
 import explore.undo.UndoStacks
 import explore.utils._
 import japgolly.scalajs.react.vdom.html_<^._
-import lucuma.core.model.Observation
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.ui.reusability._
 import react.common._
+import explore.components.ui.ExploreStyles
 
 object TargetTile {
 
   def targetTile(
     userId:        Option[User.Id],
-    obsId:         Observation.Id,
+    obsId:         ObsIdSet,
     asterismPot:   Pot[View[List[TargetWithId]]],
     undoStacks:    View[Map[Target.Id, UndoStacks[IO, Target.Sidereal]]],
     searching:     View[Set[Target.Id]],
     options:       View[TargetVisualOptions],
+    title:         String,
+    backButton:    Option[Reuse[VdomNode]] = None,
     hiddenColumns: View[Set[String]]
   )(implicit ctx:  AppContextIO) =
-    Tile(ObsTabTiles.TargetId, "Targets", canMinimize = true)(
-      Reuse.by((userId, obsId, asterismPot, undoStacks, searching, options))(
+    Tile(ObsTabTiles.TargetId,
+         title,
+         back = backButton,
+         canMinimize = true,
+         bodyClass = ExploreStyles.TargetTileBody.some
+    )(
+      Reuse.by((userId, obsId, asterismPot, undoStacks, searching, options, hiddenColumns))(
         (renderInTitle: Tile.RenderInTitle) =>
           potRender[View[List[TargetWithId]]](
             (
@@ -44,7 +52,7 @@ object TargetTile {
                 userId.map(uid =>
                   <.div(
                     AsterismEditor(uid,
-                                   ObsIdSet.one(obsId),
+                                   obsId,
                                    asterism,
                                    undoStacks,
                                    searching,

--- a/explore/src/main/scala/explore/tabs/TargetTile.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTile.scala
@@ -3,13 +3,14 @@
 
 package explore.tabs
 
-import cats.syntax.all._
 import cats.effect.IO
+import cats.syntax.all._
 import crystal.Pot
 import crystal.react.View
 import crystal.react.implicits._
 import crystal.react.reuse._
 import explore.components.Tile
+import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.model.ObsIdSet
 import explore.model.TargetVisualOptions
@@ -23,7 +24,6 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.ui.reusability._
 import react.common._
-import explore.components.ui.ExploreStyles
 
 object TargetTile {
 

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -249,17 +249,17 @@ object AladinContainer {
     def render(props: Props) =
       <.div(
         ExploreStyles.AladinContainerBody,
-        // AladinComp.withRef(aladinRef) {
-        //   Aladin(
-        //     ExploreStyles.TargetAladin,
-        //     showReticle = false,
-        //     showLayersControl = false,
-        //     target = props.aladinCoordsStr,
-        //     fov = props.options.fovAngle.toDoubleDegrees,
-        //     showGotoControl = false,
-        //     customize = includeSvg _
-        //   )
-        // }
+        AladinComp.withRef(aladinRef) {
+          Aladin(
+            ExploreStyles.TargetAladin,
+            showReticle = false,
+            showLayersControl = false,
+            target = props.aladinCoordsStr,
+            fov = props.options.fovAngle.toDoubleDegrees,
+            showGotoControl = false,
+            customize = includeSvg _
+          )
+        }
       )
 
     def recalculateView =

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -249,17 +249,17 @@ object AladinContainer {
     def render(props: Props) =
       <.div(
         ExploreStyles.AladinContainerBody,
-        AladinComp.withRef(aladinRef) {
-          Aladin(
-            ExploreStyles.TargetAladin,
-            showReticle = false,
-            showLayersControl = false,
-            target = props.aladinCoordsStr,
-            fov = props.options.fovAngle.toDoubleDegrees,
-            showGotoControl = false,
-            customize = includeSvg _
-          )
-        }
+        // AladinComp.withRef(aladinRef) {
+        //   Aladin(
+        //     ExploreStyles.TargetAladin,
+        //     showReticle = false,
+        //     showLayersControl = false,
+        //     target = props.aladinCoordsStr,
+        //     fov = props.options.fovAngle.toDoubleDegrees,
+        //     showGotoControl = false,
+        //     customize = includeSvg _
+        //   )
+        // }
       )
 
     def recalculateView =

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -98,7 +98,6 @@ object AsterismEditor {
           )
 
         React.Fragment(
-          // ExploreStyles.AsterismEditor,
           props.renderInTitle(
             TargetSelectionPopup(
               trigger = Reuse.by(adding.value)(

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -46,7 +46,7 @@ final case class AsterismEditor(
   hiddenColumns:    View[Set[String]],
   renderInTitle:    Tile.RenderInTitle
 )(implicit val ctx: AppContextIO)
-    extends ReactFnProps[AsterismEditor](AsterismEditor.component)
+    extends ReactFnProps[AsterismEditor](AsterismEditor.component) {}
 
 object AsterismEditor {
   type Props = AsterismEditor

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -97,7 +97,8 @@ object AsterismEditor {
             (mod, _) => selectedTargetIdState.modState(mod)
           )
 
-        <.div(
+        React.Fragment(
+          // ExploreStyles.AsterismEditor,
           props.renderInTitle(
             TargetSelectionPopup(
               trigger = Reuse.by(adding.value)(
@@ -156,7 +157,6 @@ object AsterismEditor {
                 }
               )
             }
-            .whenDefined
         )
       }
 }

--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -33,8 +33,6 @@ import react.common.implicits._
 import react.semanticui.collections.form.Form
 import react.semanticui.collections.table._
 import react.semanticui.elements.button.Button
-import react.semanticui.elements.segment.Segment
-import react.semanticui.elements.segment.SegmentAttached
 import react.semanticui.sizes._
 import reactST.reactTable._
 import reactST.reactTable.mod.SortingRule

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -249,10 +249,10 @@ object SiderealTargetEditor {
                 ),
                 RVInput(radialVelocityView, disabled)
               ),
-              SourceProfileEditor(sourceProfileView, disabled = disabled),
-              <.div(ExploreStyles.TargetSkyplotCell)(
-                SkyPlotSection(props.baseCoordinates)
-              )
+              SourceProfileEditor(sourceProfileView, disabled = disabled)
+              // <.div(ExploreStyles.TargetSkyplotCell)(
+              //   SkyPlotSection(props.baseCoordinates)
+              // )
             )
           )
         }

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -42,7 +42,6 @@ import lucuma.ui.reusability._
 import monocle.Iso
 import react.common._
 import react.semanticui.collections.form.Form
-import react.semanticui.elements.divider._
 import react.semanticui.elements.label.LabelPointing
 import react.semanticui.sizes.Small
 
@@ -163,8 +162,7 @@ object SiderealTargetEditor {
           val disabled = props.searching.get.exists(_ === props.id)
 
           React.Fragment(
-            Divider(hidden = true, fitted = true),
-            <.span(ExploreStyles.TitleUndoButtons, UndoButtons(undoCtx, disabled = disabled)),
+            <.div(ExploreStyles.TitleUndoButtons, UndoButtons(undoCtx, disabled = disabled)),
             <.div(ExploreStyles.TargetGrid)(
               <.div(ExploreStyles.Grid, ExploreStyles.Compact, ExploreStyles.TargetForm)(
                 // Keep the search field and the coords always together
@@ -250,9 +248,6 @@ object SiderealTargetEditor {
                 RVInput(radialVelocityView, disabled)
               ),
               SourceProfileEditor(sourceProfileView, disabled = disabled)
-              // <.div(ExploreStyles.TargetSkyplotCell)(
-              //   SkyPlotSection(props.baseCoordinates)
-              // )
             )
           )
         }

--- a/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
+++ b/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
@@ -265,7 +265,7 @@ object SkyPlotNight {
             .data(seriesData)
             .forall(_.asInstanceOf[PointOptionsObject].y.forall(_.asInstanceOf[Double] <= 0))
 
-        def options = Options()
+        val options = Options()
           .setChart(
             ChartOptions()
               .setHeight(resize.height.getOrElse(1).toDouble)

--- a/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
+++ b/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
@@ -159,7 +159,7 @@ object SkyPlotNight {
       .withHooks[Props]
       .useState(HashSet.from(Enumerated[ElevationSeries].all))
       .useResizeDetector()
-      .renderWithReuse { (props, shownSeries, resize) =>
+      .render { (props, shownSeries, resize) =>
         def showSeriesCB(series: ElevationSeries, chart: Chart_): Callback =
           shownSeries.modState(_ + series) >>
             Callback(
@@ -387,8 +387,8 @@ object SkyPlotNight {
         val (moonPhase, moonIllum) = skyCalcResults(
           skyCalcResults.length / 2
         ).bimap(MoonCalc.approxPhase, _.lunarIlluminatedFraction.toDouble)
-        println(resize.height)
-        org.scalajs.dom.window.console.log(resize.ref.raw.current)
+        // println(resize.height)
+        // org.scalajs.dom.window.console.log(resize.ref.raw.current)
 
         <.div(
           Chart(options).withKey(props.toString),

--- a/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
+++ b/explore/src/main/scala/explore/targeteditor/SkyPlotNight.scala
@@ -10,7 +10,6 @@ import explore.implicits._
 import gpp.highcharts.highchartsStrings.line
 import gpp.highcharts.mod.XAxisLabelsOptions
 import gpp.highcharts.mod._
-import japgolly.scalajs.react.ReactMonocle._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.Site
@@ -21,10 +20,10 @@ import lucuma.core.math.skycalc.ImprovedSkyCalc
 import lucuma.core.model.ObservingNight
 import lucuma.core.util.Enumerated
 import lucuma.ui.reusability._
-import monocle.Focus
 import react.common._
 import react.highcharts.Chart
 import react.moon.MoonPhase
+import react.resizeDetector.hooks._
 import shapeless._
 
 import java.time.Duration
@@ -43,25 +42,16 @@ final case class SkyPlotNight(
   site:        Site,
   coords:      Coordinates,
   date:        LocalDate,
-  timeDisplay: SkyPlotNight.TimeDisplay,
-  height:      Int
-) extends ReactProps[SkyPlotNight](SkyPlotNight.component)
+  timeDisplay: SkyPlotNight.TimeDisplay
+) extends ReactFnProps[SkyPlotNight](SkyPlotNight.component)
 
 object SkyPlotNight {
   type Props = SkyPlotNight
 
-  case class State(
-    shownSeries: HashSet[ElevationSeries] = HashSet.from(Enumerated[ElevationSeries].all)
-  )
-
-  object State {
-    val shownSeries = Focus[State](_.shownSeries)
-  }
-
-  implicit private val propsReuse: Reusability[Props] = Reusability.derive
-  // State doesn't trigger rerenders. We keep track of what is shown in case there is a
+  implicit private val propsReuse: Reusability[Props]                    = Reusability.derive
+  // series doesn't trigger rerenders. We keep track of what is shown in case there is a
   // rerender due to a change of properties.
-  implicit private val stateReuse: Reusability[State] = Reusability.always
+  implicit private val stateReuse: Reusability[HashSet[ElevationSeries]] = Reusability.always
 
   sealed trait TimeDisplay
   object TimeDisplay {
@@ -164,252 +154,255 @@ object SkyPlotNight {
         .setZIndex(1)
     )
 
-  class Backend($ : BackendScope[Props, State]) {
-    def hideSeries(series: ElevationSeries, chart: Chart_): Callback =
-      $.modStateL(State.shownSeries)(_ - series) >>
-        Callback(
-          skyBrightnessPercentiles
-            .flatMap(_.id.toList)
-            .foreach(id => chart.yAxis(2).removePlotLine(id))
-        )
-          .when(series === ElevationSeries.SkyBrightness)
-          .void
-
-    def showSeries(series: ElevationSeries, chart: Chart_): Callback =
-      $.modStateL(State.shownSeries)(_ + series) >>
-        Callback(
-          skyBrightnessPercentiles
-            .foreach(line => chart.yAxis(2).addPlotLine(line))
-        )
-          .when(series === ElevationSeries.SkyBrightness)
-          .void
-
-    def render(props: Props, state: State) = {
-      val observingNight  = ObservingNight.fromSiteAndLocalDate(props.site, props.date)
-      val tbOfficialNight = observingNight.twilightBoundedUnsafe(TwilightType.Official)
-      val tbNauticalNight = observingNight.twilightBoundedUnsafe(TwilightType.Nautical)
-
-      val start          = tbOfficialNight.start
-      val end            = tbOfficialNight.end
-      val skyCalcResults =
-        SkyCalc.forInterval(props.site, start, end, PlotEvery, _ => props.coords)
-      val series         = skyCalcResults
-        .map { case (instant, results) =>
-          val millisSinceEpoch = instant.toEpochMilli.toDouble
-
-          def point(value: Double): Chart.Data =
-            PointOptionsObject(js.undefined)
-              .setX(millisSinceEpoch)
-              .setY(value)
-
-          def pointWithAirmass(value: Double, airmass: Double): Chart.Data =
-            point(value).asInstanceOf[PointOptionsWithAirmass].setAirMass(airmass)
-
-          pointWithAirmass(results.altitude.toAngle.toSignedDoubleDegrees, results.airmass) ::
-            point(results.totalSkyBrightness) ::
-            point(results.parallacticAngle.toSignedDoubleDegrees) ::
-            point(results.lunarElevation.toAngle.toSignedDoubleDegrees) ::
-            HNil
-        }
-
-      val seriesData = seriesDataGen.from(series.unzipN)
-
-      def timezoneInstantFormat(instant: Instant, zoneId: ZoneId): String =
-        ZonedDateTime
-          .ofInstant(instant, zoneId)
-          .format(dateTimeFormatter)
-
-      def instantFormat(instant: Instant): String =
-        props.timeDisplay match {
-          case TimeDisplay.Site     => timezoneInstantFormat(instant, props.site.timezone)
-          case TimeDisplay.UTC      => timezoneInstantFormat(instant, ZoneOffset.UTC)
-          case TimeDisplay.Sidereal =>
-            val skycalc = ImprovedSkyCalc(props.site.place)
-            val sid     = skycalc.getSiderealTime(instant)
-            val hours   = sid.toInt
-            val minutes = Math.round((sid % 1) * 60).toInt
-            f"$hours%02d:$minutes%02d"
-        }
-
-      def timeFormat(value: Double): String =
-        instantFormat(Instant.ofEpochMilli(value.toLong))
-
-      val timeDisplay: String =
-        props.timeDisplay match {
-          case TimeDisplay.Site     => props.site.timezone.getId
-          case TimeDisplay.UTC      => "UTC"
-          case TimeDisplay.Sidereal => "Site Sidereal"
-        }
-
-      val tickFormatter: AxisLabelsFormatterCallbackFunction =
-        (
-          labelValue: AxisLabelsFormatterContextObject,
-          _:          AxisLabelsFormatterContextObject
-        ) => timeFormat(labelValue.value.asInstanceOf[Double])
-
-      val tooltipFormatter: TooltipFormatterCallbackFunction = {
-        (ctx: TooltipFormatterContextObject, _: Tooltip) =>
-          val time  = timeFormat(ctx.x)
-          val value = ctx.series.index match {
-            case 0 =>                      // Target elevation with airmass
-              formatAngle(ctx.y) + s"<br/>Airmass: ${"%.3f".format(ctx.point.asInstanceOf[ElevationPointWithAirmass].airmass)}"
-            case 2 => "%.2f".format(ctx.y) // Sky Brightness
-            case _ => formatAngle(ctx.y)   // Other elevations
-          }
-          s"<strong>$time ($timeDisplay)</strong><br/>${ctx.series.name}: $value"
-      }
-
-      val sunset  = instantFormat(tbNauticalNight.start)
-      val sunrise = instantFormat(tbNauticalNight.end)
-
-      val targetBelowHorizon =
-        ElevationSeries.Elevation
-          .data(seriesData)
-          .forall(_.asInstanceOf[PointOptionsObject].y.forall(_.asInstanceOf[Double] <= 0))
-
-      val options = Options()
-        .setChart(ChartOptions().setHeight(props.height).setStyledMode(true).setAlignTicks(false))
-        .setTitle(
-          TitleOptions().setText(
-            s"Sunset ${observingNight.toLocalDate.minusDays(1)} ➟ Sunrise ${observingNight.toLocalDate} "
-          )
-        )
-        .setCredits(CreditsOptions().setEnabled(false))
-        .setTooltip(TooltipOptions().setFormatter(tooltipFormatter))
-        .setXAxis(
-          XAxisOptions()
-            .setType(AxisTypeValue.datetime)
-            .setLabels(XAxisLabelsOptions().setFormatter(tickFormatter))
-            .setTickInterval(MillisPerHour)
-            .setMinorTickInterval(MillisPerHour / 2)
-            .setTitle(
-              if (targetBelowHorizon) XAxisTitleOptions().setText("Target is below horizon")
-              else XAxisTitleOptions()
-            )
-            .setPlotBands(
-              List(
-                XAxisPlotBandsOptions()
-                  .setFrom(tbNauticalNight.start.toEpochMilli.toDouble)
-                  .setTo(tbNauticalNight.end.toEpochMilli.toDouble)
-                  .setClassName("plot-band-twilight-nautical")
-                  // We need z-index > 0 to display over grid. But not too high, or it will display over tooltips.
-                  .setZIndex(1)
-                  .setLabel(
-                    XAxisPlotBandsLabelOptions()
-                      .setText(s"  Evening 12° - Twilight: $sunset")
-                      .setRotation(270)
-                      .setAlign(AlignValue.left)
-                      .setTextAlign(AlignValue.center)
-                      .setVerticalAlign(VerticalAlignValue.middle)
-                  ),
-                XAxisPlotBandsOptions() // Empty band, just to draw the label
-                  .setFrom(tbNauticalNight.end.toEpochMilli.toDouble)
-                  .setTo(tbNauticalNight.end.toEpochMilli.toDouble)
-                  .setClassName("plot-band-twilight-nautical-end")
-                  .setZIndex(1)
-                  .setLabel(
-                    XAxisPlotBandsLabelOptions()
-                      .setText(s"  Morning 12° - Twilight: $sunrise")
-                      .setRotation(270)
-                      .setAlign(AlignValue.left)
-                      .setTextAlign(AlignValue.center)
-                      .setVerticalAlign(VerticalAlignValue.middle)
-                  )
-              ).toJSArray
-            )
-        )
-        .setYAxis(
-          List(
-            YAxisOptions()
-              .setTitle(YAxisTitleOptions().setText("Elevation"))
-              .setAllowDecimals(false)
-              .setMin(0)
-              .setMax(90)
-              .setTickInterval(10)
-              .setMinorTickInterval(5)
-              .setLabels(YAxisLabelsOptions().setFormat("{value}°")),
-            YAxisOptions()
-              .setOpposite(true)
-              .setTitle(YAxisTitleOptions().setText("Parallactic angle"))
-              .setMin(-180)
-              .setMax(180)
-              .setTickInterval(60)
-              .setClassName("plot-axis-parallactic-angle")
-              .setShowEmpty(false)
-              .setLabels(YAxisLabelsOptions().setFormat("{value}°")),
-            YAxisOptions()
-              .setOpposite(true)
-              .setTitle(YAxisTitleOptions().setText("Brightness (mags/arcsec²)"))
-              .setMin(17)
-              .setMax(22)
-              .setReversed(true)
-              .setTickInterval(1)
-              .setClassName("plot-axis-sky-brightness")
-              .setShowEmpty(false)
-              .setLabels(YAxisLabelsOptions().setFormat("{value}"))
-              .setPlotLines(
-                if (state.shownSeries.contains(ElevationSeries.SkyBrightness))
-                  skyBrightnessPercentiles.toJSArray
-                else
-                  js.Array()
-              )
-          ).toJSArray
-        )
-        .setPlotOptions(
-          PlotOptions()
-            .setSeries(
-              PlotSeriesOptions()
-                .setLineWidth(4)
-                .setMarker(PointMarkerOptionsObject().setEnabled(false))
-                .setStates(
-                  SeriesStatesOptionsObject()
-                    .setHover(SeriesStatesHoverOptionsObject().setEnabled(false))
-                )
-            )
-        )
-        .setSeries(
-          Enumerated[ElevationSeries].all
-            .map(series =>
-              SeriesLineOptions((), (), line)
-                .setName(series.name)
-                .setYAxis(series.yAxis)
-                .setData(series.data(seriesData).toJSArray)
-                .setVisible(state.shownSeries.contains(series))
-                .setEvents(
-                  SeriesEventsOptionsObject()
-                    .setHide((s, _) => hideSeries(series, s.chart).runNow())
-                    .setShow((s, _) => showSeries(series, s.chart).runNow())
-                )
-            )
-            .map(_.asInstanceOf[SeriesOptionsType])
-            .toJSArray
-        )
-
-      val (moonPhase, moonIllum) = skyCalcResults(
-        skyCalcResults.length / 2
-      ).bimap(MoonCalc.approxPhase, _.lunarIlluminatedFraction.toDouble)
-
-      <.span(
-        Chart(options).withKey(props.toString),
-        <.div(ExploreStyles.MoonPhase)(
-          <.span(
-            MoonPhase(phase = moonPhase,
-                      size = 20,
-                      border = "1px solid black",
-                      darkColor = "#303030"
-            ),
-            <.small("%1.0f%%".format(moonIllum * 100))
-          )
-        )
-      )
-    }
-  }
-
   val component =
-    ScalaComponent
-      .builder[Props]
-      .initialState(State())
-      .renderBackend[Backend]
-      .configure(Reusability.shouldComponentUpdate)
-      .build
+    ScalaFnComponent
+      .withHooks[Props]
+      .useState(HashSet.from(Enumerated[ElevationSeries].all))
+      .useResizeDetector()
+      .renderWithReuse { (props, shownSeries, resize) =>
+        def showSeriesCB(series: ElevationSeries, chart: Chart_): Callback =
+          shownSeries.modState(_ + series) >>
+            Callback(
+              skyBrightnessPercentiles
+                .foreach(line => chart.yAxis(2).addPlotLine(line))
+            )
+              .when(series === ElevationSeries.SkyBrightness)
+              .void
+
+        def hideSeriesCB(series: ElevationSeries, chart: Chart_): Callback =
+          shownSeries.modState(_ - series) >>
+            Callback(
+              skyBrightnessPercentiles
+                .flatMap(_.id.toList)
+                .foreach(id => chart.yAxis(2).removePlotLine(id))
+            )
+              .when(series === ElevationSeries.SkyBrightness)
+              .void
+
+        val observingNight  = ObservingNight.fromSiteAndLocalDate(props.site, props.date)
+        val tbOfficialNight = observingNight.twilightBoundedUnsafe(TwilightType.Official)
+        val tbNauticalNight = observingNight.twilightBoundedUnsafe(TwilightType.Nautical)
+
+        val start          = tbOfficialNight.start
+        val end            = tbOfficialNight.end
+        val skyCalcResults =
+          SkyCalc.forInterval(props.site, start, end, PlotEvery, _ => props.coords)
+        val series         = skyCalcResults
+          .map { case (instant, results) =>
+            val millisSinceEpoch = instant.toEpochMilli.toDouble
+
+            def point(value: Double): Chart.Data =
+              PointOptionsObject(js.undefined)
+                .setX(millisSinceEpoch)
+                .setY(value)
+
+            def pointWithAirmass(value: Double, airmass: Double): Chart.Data =
+              point(value).asInstanceOf[PointOptionsWithAirmass].setAirMass(airmass)
+
+            pointWithAirmass(results.altitude.toAngle.toSignedDoubleDegrees, results.airmass) ::
+              point(results.totalSkyBrightness) ::
+              point(results.parallacticAngle.toSignedDoubleDegrees) ::
+              point(results.lunarElevation.toAngle.toSignedDoubleDegrees) ::
+              HNil
+          }
+
+        val seriesData = seriesDataGen.from(series.unzipN)
+
+        def timezoneInstantFormat(instant: Instant, zoneId: ZoneId): String =
+          ZonedDateTime
+            .ofInstant(instant, zoneId)
+            .format(dateTimeFormatter)
+
+        def instantFormat(instant: Instant): String =
+          props.timeDisplay match {
+            case TimeDisplay.Site     => timezoneInstantFormat(instant, props.site.timezone)
+            case TimeDisplay.UTC      => timezoneInstantFormat(instant, ZoneOffset.UTC)
+            case TimeDisplay.Sidereal =>
+              val skycalc = ImprovedSkyCalc(props.site.place)
+              val sid     = skycalc.getSiderealTime(instant)
+              val hours   = sid.toInt
+              val minutes = Math.round((sid % 1) * 60).toInt
+              f"$hours%02d:$minutes%02d"
+          }
+
+        def timeFormat(value: Double): String =
+          instantFormat(Instant.ofEpochMilli(value.toLong))
+
+        val timeDisplay: String =
+          props.timeDisplay match {
+            case TimeDisplay.Site     => props.site.timezone.getId
+            case TimeDisplay.UTC      => "UTC"
+            case TimeDisplay.Sidereal => "Site Sidereal"
+          }
+
+        val tickFormatter: AxisLabelsFormatterCallbackFunction =
+          (
+            labelValue: AxisLabelsFormatterContextObject,
+            _:          AxisLabelsFormatterContextObject
+          ) => timeFormat(labelValue.value.asInstanceOf[Double])
+
+        val tooltipFormatter: TooltipFormatterCallbackFunction = {
+          (ctx: TooltipFormatterContextObject, _: Tooltip) =>
+            val time  = timeFormat(ctx.x)
+            val value = ctx.series.index match {
+              case 0 =>                      // Target elevation with airmass
+                formatAngle(ctx.y) + s"<br/>Airmass: ${"%.3f".format(ctx.point.asInstanceOf[ElevationPointWithAirmass].airmass)}"
+              case 2 => "%.2f".format(ctx.y) // Sky Brightness
+              case _ => formatAngle(ctx.y)   // Other elevations
+            }
+            s"<strong>$time ($timeDisplay)</strong><br/>${ctx.series.name}: $value"
+        }
+
+        val sunset  = instantFormat(tbNauticalNight.start)
+        val sunrise = instantFormat(tbNauticalNight.end)
+
+        val targetBelowHorizon =
+          ElevationSeries.Elevation
+            .data(seriesData)
+            .forall(_.asInstanceOf[PointOptionsObject].y.forall(_.asInstanceOf[Double] <= 0))
+
+        val options = Options()
+          .setChart(
+            ChartOptions()
+              .setHeight(resize.height.getOrElse(10).toDouble)
+              .setStyledMode(true)
+              .setAlignTicks(false)
+          )
+          .setTitle(
+            TitleOptions().setText(
+              s"Sunset ${observingNight.toLocalDate.minusDays(1)} ➟ Sunrise ${observingNight.toLocalDate} "
+            )
+          )
+          .setCredits(CreditsOptions().setEnabled(false))
+          .setTooltip(TooltipOptions().setFormatter(tooltipFormatter))
+          .setXAxis(
+            XAxisOptions()
+              .setType(AxisTypeValue.datetime)
+              .setLabels(XAxisLabelsOptions().setFormatter(tickFormatter))
+              .setTickInterval(MillisPerHour)
+              .setMinorTickInterval(MillisPerHour / 2)
+              .setTitle(
+                if (targetBelowHorizon) XAxisTitleOptions().setText("Target is below horizon")
+                else XAxisTitleOptions()
+              )
+              .setPlotBands(
+                List(
+                  XAxisPlotBandsOptions()
+                    .setFrom(tbNauticalNight.start.toEpochMilli.toDouble)
+                    .setTo(tbNauticalNight.end.toEpochMilli.toDouble)
+                    .setClassName("plot-band-twilight-nautical")
+                    // We need z-index > 0 to display over grid. But not too high, or it will display over tooltips.
+                    .setZIndex(1)
+                    .setLabel(
+                      XAxisPlotBandsLabelOptions()
+                        .setText(s"  Evening 12° - Twilight: $sunset")
+                        .setRotation(270)
+                        .setAlign(AlignValue.left)
+                        .setTextAlign(AlignValue.center)
+                        .setVerticalAlign(VerticalAlignValue.middle)
+                    ),
+                  XAxisPlotBandsOptions() // Empty band, just to draw the label
+                    .setFrom(tbNauticalNight.end.toEpochMilli.toDouble)
+                    .setTo(tbNauticalNight.end.toEpochMilli.toDouble)
+                    .setClassName("plot-band-twilight-nautical-end")
+                    .setZIndex(1)
+                    .setLabel(
+                      XAxisPlotBandsLabelOptions()
+                        .setText(s"  Morning 12° - Twilight: $sunrise")
+                        .setRotation(270)
+                        .setAlign(AlignValue.left)
+                        .setTextAlign(AlignValue.center)
+                        .setVerticalAlign(VerticalAlignValue.middle)
+                    )
+                ).toJSArray
+              )
+          )
+          .setYAxis(
+            List(
+              YAxisOptions()
+                .setTitle(YAxisTitleOptions().setText("Elevation"))
+                .setAllowDecimals(false)
+                .setMin(0)
+                .setMax(90)
+                .setTickInterval(10)
+                .setMinorTickInterval(5)
+                .setLabels(YAxisLabelsOptions().setFormat("{value}°")),
+              YAxisOptions()
+                .setOpposite(true)
+                .setTitle(YAxisTitleOptions().setText("Parallactic angle"))
+                .setMin(-180)
+                .setMax(180)
+                .setTickInterval(60)
+                .setClassName("plot-axis-parallactic-angle")
+                .setShowEmpty(false)
+                .setLabels(YAxisLabelsOptions().setFormat("{value}°")),
+              YAxisOptions()
+                .setOpposite(true)
+                .setTitle(YAxisTitleOptions().setText("Brightness (mags/arcsec²)"))
+                .setMin(17)
+                .setMax(22)
+                .setReversed(true)
+                .setTickInterval(1)
+                .setClassName("plot-axis-sky-brightness")
+                .setShowEmpty(false)
+                .setLabels(YAxisLabelsOptions().setFormat("{value}"))
+                .setPlotLines(
+                  if (shownSeries.value.contains(ElevationSeries.SkyBrightness))
+                    skyBrightnessPercentiles.toJSArray
+                  else
+                    js.Array()
+                )
+            ).toJSArray
+          )
+          .setPlotOptions(
+            PlotOptions()
+              .setSeries(
+                PlotSeriesOptions()
+                  .setLineWidth(4)
+                  .setMarker(PointMarkerOptionsObject().setEnabled(false))
+                  .setStates(
+                    SeriesStatesOptionsObject()
+                      .setHover(SeriesStatesHoverOptionsObject().setEnabled(false))
+                  )
+              )
+          )
+          .setSeries(
+            Enumerated[ElevationSeries].all
+              .map(series =>
+                SeriesLineOptions((), (), line)
+                  .setName(series.name)
+                  .setYAxis(series.yAxis)
+                  .setData(series.data(seriesData).toJSArray)
+                  .setVisible(shownSeries.value.contains(series))
+                  .setEvents(
+                    SeriesEventsOptionsObject()
+                      .setHide((s, _) => hideSeriesCB(series, s.chart).runNow())
+                      .setShow((s, _) => showSeriesCB(series, s.chart).runNow())
+                  )
+              )
+              .map(_.asInstanceOf[SeriesOptionsType])
+              .toJSArray
+          )
+
+        val (moonPhase, moonIllum) = skyCalcResults(
+          skyCalcResults.length / 2
+        ).bimap(MoonCalc.approxPhase, _.lunarIlluminatedFraction.toDouble)
+        println(resize.height)
+        org.scalajs.dom.window.console.log(resize.ref.raw.current)
+
+        <.div(
+          Chart(options).withKey(props.toString),
+          <.div(ExploreStyles.MoonPhase)(
+            <.span(
+              MoonPhase(phase = moonPhase,
+                        size = 20,
+                        border = "1px solid black",
+                        darkColor = "#303030"
+              ),
+              <.small("%1.0f%%".format(moonIllum * 100))
+            )
+          )
+        )
+          .withRef(resize.ref)
+      }
 }

--- a/explore/src/main/scala/explore/targeteditor/SkyPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/SkyPlotSection.scala
@@ -21,7 +21,6 @@ import react.datepicker._
 import react.semanticui.collections.form.Form
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.ButtonGroup
-import react.semanticui.elements.segment.Segment
 
 import java.time.ZonedDateTime
 
@@ -54,16 +53,16 @@ object SkyPlotSection {
       .renderWithReuse { (props, site, date, plotPeriod, timeDisplay) =>
         implicit val ctx = props.ctx
 
-        Segment(ExploreStyles.SkyPlotSection)(
+        <.div(ExploreStyles.SkyPlotSection)(
           HelpIcon("target/main/elevation-plot.md", ExploreStyles.HelpIconFloating),
           <.div(ExploreStyles.SkyPlot) {
             plotPeriod.value match {
               case PlotPeriod.Night    =>
-                SkyPlotNight(site.value, props.coords, date.value, timeDisplay.value, 350)
+                SkyPlotNight(site.value, props.coords, date.value, timeDisplay.value)
               case PlotPeriod.Semester =>
                 val coords   = props.coords
                 val semester = Semester.fromLocalDate(date.value)
-                SkyPlotSemester(site.value, coords, semester, 350).withKey(
+                SkyPlotSemester(site.value, coords, semester).withKey(
                   s"$site-$coords-$semester"
                 )
             }

--- a/explore/src/main/scala/explore/targeteditor/SkyPlotSemester.scala
+++ b/explore/src/main/scala/explore/targeteditor/SkyPlotSemester.scala
@@ -6,9 +6,10 @@ package explore.targeteditor
 import cats.Eval
 import cats.effect.IO
 import cats.syntax.all._
-import crystal.react.implicits._
 import crystal.react.hooks._
+import crystal.react.implicits._
 import explore.implicits._
+import explore.model.reusability._
 import fs2.Stream
 import gpp.highcharts.highchartsStrings.line
 import gpp.highcharts.mod.XAxisLabelsOptions
@@ -26,7 +27,6 @@ import lucuma.core.model.TwilightBoundedNight
 import lucuma.core.syntax.boundedInterval._
 import lucuma.core.syntax.time._
 import lucuma.ui.reusability._
-import explore.model.reusability._
 import org.typelevel.cats.time._
 import react.common._
 import react.highcharts.Chart

--- a/explore/src/main/scala/explore/targeteditor/SkyPlotSemester.scala
+++ b/explore/src/main/scala/explore/targeteditor/SkyPlotSemester.scala
@@ -7,6 +7,7 @@ import cats.Eval
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.implicits._
+import crystal.react.hooks._
 import explore.implicits._
 import fs2.Stream
 import gpp.highcharts.highchartsStrings.line
@@ -27,6 +28,7 @@ import lucuma.core.syntax.time._
 import org.typelevel.cats.time._
 import react.common._
 import react.highcharts.Chart
+import react.resizeDetector.hooks._
 import spire.math.Bounded
 
 import java.time.Duration
@@ -43,10 +45,9 @@ import js.JSConverters._
 final case class SkyPlotSemester(
   site:             Site,
   coords:           Coordinates,
-  semester:         Semester,
-  height:           Int
+  semester:         Semester
 )(implicit val ctx: AppContextIO)
-    extends ReactProps[SkyPlotSemester](SkyPlotSemester.component)
+    extends ReactFnProps[SkyPlotSemester](SkyPlotSemester.component)
 
 final case class SemesterPlotCalc(semester: Semester, site: Site) {
   protected val SampleRate: Duration = Duration.ofMinutes(1)
@@ -102,150 +103,151 @@ object SkyPlotSemester {
 
   val dateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
-  class Backend($ : BackendScope[Props, State]) {
-
-    def render(props: Props) = {
-      implicit val ct = props.ctx
-
-      val plotter = SemesterPlotCalc(props.semester, props.site)
-
-      def renderPoints(chart: Chart_): IO[IO[Unit]] = {
-        val series = chart.series(0)
-        val xAxis  = chart.xAxis(0)
-        Stream
-          .fromIterator[IO](plotter.samples(_ => props.coords, PlotDayRate).iterator, 1)
-          .evalMap { case (instant, visibilityDuration) =>
-            val value = instant.toEpochMilli.toDouble
-            IO(
-              xAxis.addPlotLine(
-                AxisPlotLinesOptions
-                  .XAxisPlotLinesOptions()
-                  .setId("progress")
-                  .setValue(value - PlotDayRate * MillisPerDay) // Draw line on last drawn point.
-                  .setZIndex(1000)
-                  .setClassName("plot-plot-line-progress")
-              )
-            ) >>
-              IO.cede >>
-              IO {
-                val visibility = visibilityDuration.toMillis
-                series.addPoint(
-                  PointOptionsObject(accessibility = js.undefined)
-                    .setX(value)
-                    // Trick to leave small values out of the plot
-                    .setY(if (visibility > 0.1) visibility / MillisPerHour else -1),
-                  redraw = true,
-                  shift = false,
-                  animation = false
-                )
-              } >>
-              IO(xAxis.removePlotLine("progress"))
-          }
-          .compile
-          .drain
-          .start
-          .map(_.cancel)
-      }
-
-      def timeFormat(value: Double): String =
-        ZonedDateTime
-          .ofInstant(Instant.ofEpochMilli(value.toLong), props.site.timezone)
-          .format(dateTimeFormatter)
-
-      val tickFormatter: AxisLabelsFormatterCallbackFunction =
-        (
-          labelValue: AxisLabelsFormatterContextObject, // [Double],
-          _:          AxisLabelsFormatterContextObject  // [String]
-        ) =>
-          (labelValue.value: Any) match {
-            case ms: Double => timeFormat(ms)
-            case s          => s.toString
-          }
-
-      def dateFormat(value: Double): String =
-        ZonedDateTime
-          .ofInstant(Instant.ofEpochMilli(value.toLong), ZoneOffset.UTC)
-          .format(dateTimeFormatter)
-
-      val tooltipFormatter: TooltipFormatterCallbackFunction = {
-        (ctx: TooltipFormatterContextObject, _: Tooltip) =>
-          val date       = dateFormat(ctx.x)
-          val visibility = Duration.ofMillis((ctx.y * MillisPerHour).toLong)
-          val minutes    = visibility.getSeconds / 60
-          s"<strong>$date</strong><br/>${ctx.series.name}: ${minutes / 60}h${minutes % 60}m"
-      }
-
-      val options = Options()
-        .setChart(ChartOptions().setHeight(props.height).setStyledMode(true).setAlignTicks(false))
-        .setTitle(
-          TitleOptions().setText(
-            s"Semester ${props.semester.format}"
-          )
-        )
-        .setCredits(CreditsOptions().setEnabled(false))
-        .setTooltip(TooltipOptions().setFormatter(tooltipFormatter))
-        .setXAxis(
-          XAxisOptions()
-            .setType(AxisTypeValue.datetime)
-            .setLabels(XAxisLabelsOptions().setFormatter(tickFormatter))
-            .setTickInterval(MillisPerDay * 10)
-            .setMinorTickInterval(MillisPerDay * 5)
-            .setMin(plotter.interval.lower.toEpochMilli.toDouble)
-            .setMax(plotter.interval.upper.toEpochMilli.toDouble)
-        )
-        .setYAxis(
-          List(
-            YAxisOptions()
-              .setTitle(YAxisTitleOptions().setText("Hours"))
-              .setAllowDecimals(false)
-              .setMin(0)
-              .setMax(15)
-              .setTickInterval(1)
-              .setMinorTickInterval(0.5)
-              .setLabels(YAxisLabelsOptions().setFormat("{value}"))
-          ).toJSArray
-        )
-        .setPlotOptions(
-          PlotOptions()
-            .setSeries(
-              PlotSeriesOptions()
-                .setLineWidth(4)
-                .setMarker(PointMarkerOptionsObject().setEnabled(false))
-                .setStates(
-                  SeriesStatesOptionsObject()
-                    .setHover(SeriesStatesHoverOptionsObject().setEnabled(false))
-                )
-            )
-        )
-        .setSeries(
-          List(
-            SeriesLineOptions((), (), line)
-              .setName("Visibility")
-              .setYAxis(0)
-            // .setData(series.toJSArray)
-          )
-            .map(_.asInstanceOf[SeriesOptionsType])
-            .toJSArray
-        )
-
-      <.span(
-        Chart(options,
-              chart =>
-                (renderPoints(chart) >>= (cancelToken =>
-                  $.setStateIn[IO](State(cancelToken.some))
-                )).runAsync
-        )
-          .withKey(props.toString)
-      )
-    }
-  }
-
   val component =
-    ScalaComponent
-      .builder[Props]
-      .initialState(State(none))
-      .renderBackend[Backend]
-      .shouldComponentUpdateConst(false) // This component can't be updated, it must be rerendered.
-      .componentWillUnmount($ => $.state.cancelToken.orEmpty)
-      .build
+    ScalaFnComponent
+      .withHooks[Props]
+      .useStateView(none[IO[Unit]])
+      .useResizeDetector()
+      // This component can't be updated, it must be rerendered. Don't add reuse
+      .render { (props, cancel, resize) =>
+        implicit val ct = props.ctx
+
+        val plotter = SemesterPlotCalc(props.semester, props.site)
+
+        def renderPoints(chart: Chart_): IO[IO[Unit]] = {
+          val series = chart.series(0)
+          val xAxis  = chart.xAxis(0)
+          Stream
+            .fromIterator[IO](plotter.samples(_ => props.coords, PlotDayRate).iterator, 1)
+            .evalMap { case (instant, visibilityDuration) =>
+              val value = instant.toEpochMilli.toDouble
+              IO(
+                xAxis.addPlotLine(
+                  AxisPlotLinesOptions
+                    .XAxisPlotLinesOptions()
+                    .setId("progress")
+                    .setValue(value - PlotDayRate * MillisPerDay) // Draw line on last drawn point.
+                    .setZIndex(1000)
+                    .setClassName("plot-plot-line-progress")
+                )
+              ) >>
+                IO.cede >>
+                IO {
+                  val visibility = visibilityDuration.toMillis
+                  series.addPoint(
+                    PointOptionsObject(accessibility = js.undefined)
+                      .setX(value)
+                      // Trick to leave small values out of the plot
+                      .setY(if (visibility > 0.1) visibility / MillisPerHour else -1),
+                    redraw = true,
+                    shift = false,
+                    animation = false
+                  )
+                } >>
+                IO(xAxis.removePlotLine("progress"))
+            }
+            .compile
+            .drain
+            .start
+            .map(_.cancel)
+        }
+
+        def timeFormat(value: Double): String =
+          ZonedDateTime
+            .ofInstant(Instant.ofEpochMilli(value.toLong), props.site.timezone)
+            .format(dateTimeFormatter)
+
+        val tickFormatter: AxisLabelsFormatterCallbackFunction =
+          (
+            labelValue: AxisLabelsFormatterContextObject, // [Double],
+            _:          AxisLabelsFormatterContextObject  // [String]
+          ) =>
+            (labelValue.value: Any) match {
+              case ms: Double => timeFormat(ms)
+              case s          => s.toString
+            }
+
+        def dateFormat(value: Double): String =
+          ZonedDateTime
+            .ofInstant(Instant.ofEpochMilli(value.toLong), ZoneOffset.UTC)
+            .format(dateTimeFormatter)
+
+        val tooltipFormatter: TooltipFormatterCallbackFunction = {
+          (ctx: TooltipFormatterContextObject, _: Tooltip) =>
+            val date       = dateFormat(ctx.x)
+            val visibility = Duration.ofMillis((ctx.y * MillisPerHour).toLong)
+            val minutes    = visibility.getSeconds / 60
+            s"<strong>$date</strong><br/>${ctx.series.name}: ${minutes / 60}h${minutes % 60}m"
+        }
+
+        val options = Options()
+          .setChart(
+            ChartOptions()
+              .setHeight(resize.height.getOrElse(1).toDouble)
+              .setStyledMode(true)
+              .setAlignTicks(false)
+          )
+          .setTitle(
+            TitleOptions().setText(
+              s"Semester ${props.semester.format}"
+            )
+          )
+          .setCredits(CreditsOptions().setEnabled(false))
+          .setTooltip(TooltipOptions().setFormatter(tooltipFormatter))
+          .setXAxis(
+            XAxisOptions()
+              .setType(AxisTypeValue.datetime)
+              .setLabels(XAxisLabelsOptions().setFormatter(tickFormatter))
+              .setTickInterval(MillisPerDay * 10)
+              .setMinorTickInterval(MillisPerDay * 5)
+              .setMin(plotter.interval.lower.toEpochMilli.toDouble)
+              .setMax(plotter.interval.upper.toEpochMilli.toDouble)
+          )
+          .setYAxis(
+            List(
+              YAxisOptions()
+                .setTitle(YAxisTitleOptions().setText("Hours"))
+                .setAllowDecimals(false)
+                .setMin(0)
+                .setMax(15)
+                .setTickInterval(1)
+                .setMinorTickInterval(0.5)
+                .setLabels(YAxisLabelsOptions().setFormat("{value}"))
+            ).toJSArray
+          )
+          .setPlotOptions(
+            PlotOptions()
+              .setSeries(
+                PlotSeriesOptions()
+                  .setLineWidth(4)
+                  .setMarker(PointMarkerOptionsObject().setEnabled(false))
+                  .setStates(
+                    SeriesStatesOptionsObject()
+                      .setHover(SeriesStatesHoverOptionsObject().setEnabled(false))
+                  )
+              )
+          )
+          .setSeries(
+            List(
+              SeriesLineOptions((), (), line)
+                .setName("Visibility")
+                .setYAxis(0)
+              // .setData(series.toJSArray)
+            )
+              .map(_.asInstanceOf[SeriesOptionsType])
+              .toJSArray
+          )
+
+        <.span(
+          Chart(
+            options,
+            chart =>
+              (renderPoints(chart) >>= (cancelToken =>
+                cancel.set(cancelToken.some).to[IO]
+              )).runAsync
+          )
+            .withKey(props.toString)
+        )
+          .withRef(resize.ref)
+      }
 }

--- a/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
@@ -10,6 +10,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.SourceProfile
 import react.common._
+import explore.components.ui.ExploreStyles
 
 case class SourceProfileEditor(sourceProfile: View[SourceProfile], disabled: Boolean)
     extends ReactFnProps[SourceProfileEditor](SourceProfileEditor.component)
@@ -21,6 +22,7 @@ object SourceProfileEditor {
 
   val component = ScalaFnComponent.withReuse[Props](props =>
     <.div(
+      ExploreStyles.BrightnessCell,
       props.sourceProfile
         .zoom(SourceProfile.integratedBrightnesses)
         .mapValue(integratedBrightnessesView =>

--- a/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
@@ -5,12 +5,12 @@ package explore.targeteditor
 
 import crystal.react.View
 import crystal.react.implicits._
+import explore.components.ui.ExploreStyles
 import explore.model.reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.SourceProfile
 import react.common._
-import explore.components.ui.ExploreStyles
 
 case class SourceProfileEditor(sourceProfile: View[SourceProfile], disabled: Boolean)
     extends ReactFnProps[SourceProfileEditor](SourceProfileEditor.component)

--- a/explore/src/main/scala/explore/targeteditor/TargetTable.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetTable.scala
@@ -160,7 +160,7 @@ object TargetTable {
               )
             )
           ),
-          <.div(ExploreStyles.ExploreTable)(
+          <.div(ExploreStyles.ExploreTable |+| ExploreStyles.AsterismTable)(
             TargetTableComponent(
               table = Table(celled = true,
                             selectable = true,

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetSummary.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetSummary.scala
@@ -10,22 +10,25 @@ import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
 import org.scalacheck.Cogen._
 import lucuma.core.util.arb.ArbGid._
+import lucuma.core.math.arb.ArbCoordinates._
 import lucuma.core.model.Target
 import eu.timepit.refined.scalacheck._
 import eu.timepit.refined.scalacheck.string._
 import eu.timepit.refined.types.string._
+import lucuma.core.math.Coordinates
 
 trait ArbTargetSummary {
   implicit val arbTargetSummary =
     Arbitrary[TargetSummary] {
       for {
-        id   <- arbitrary[Target.Id]
-        name <- arbitrary[NonEmptyString]
-      } yield TargetSummary(id, name)
+        id     <- arbitrary[Target.Id]
+        name   <- arbitrary[NonEmptyString]
+        coords <- arbitrary[Option[Coordinates]]
+      } yield TargetSummary(id, name, coords)
     }
 
   implicit val cogenTargetSummary: Cogen[TargetSummary] =
-    Cogen[(Target.Id, NonEmptyString)].contramap(t => (t.id, t.name))
+    Cogen[(Target.Id, NonEmptyString, Option[Coordinates])].contramap(t => (t.id, t.name, t.coords))
 }
 
 object ArbTargetSummary extends ArbTargetSummary

--- a/model/shared/src/main/scala/explore/model/Constants.scala
+++ b/model/shared/src/main/scala/explore/model/Constants.scala
@@ -10,6 +10,7 @@ trait Constants {
   val InitialTreeWidth         = 300.0
   val MinLeftPanelWidth        = 270.0
   val GridRowHeight            = 36
+  val GridRowPadding           = 5
   val InitialFov: Angle        = Angle.fromDoubleDegrees(0.25)
   val AngleSizeFovFactor       = 1.5
   val SimbadResultLimit        = 50

--- a/model/shared/src/main/scala/explore/model/TargetSummary.scala
+++ b/model/shared/src/main/scala/explore/model/TargetSummary.scala
@@ -6,8 +6,8 @@ package explore.model
 import cats.Eq
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.core.model.Target
 import lucuma.core.math.Coordinates
+import lucuma.core.model.Target
 
 case class TargetSummary(id: Target.Id, name: NonEmptyString, coords: Option[Coordinates])
 

--- a/model/shared/src/main/scala/explore/model/TargetSummary.scala
+++ b/model/shared/src/main/scala/explore/model/TargetSummary.scala
@@ -7,14 +7,10 @@ import cats.Eq
 import eu.timepit.refined.cats._
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.model.Target
+import lucuma.core.math.Coordinates
 
-// trait TargetSummary {
-//   val id: Target.Id
-//   val name: NonEmptyString
-// }
-
-case class TargetSummary(id: Target.Id, val name: NonEmptyString)
+case class TargetSummary(id: Target.Id, name: NonEmptyString, coords: Option[Coordinates])
 
 object TargetSummary {
-  implicit val targetSummaryEq: Eq[TargetSummary] = Eq.by(t => (t.id, t.name))
+  implicit val targetSummaryEq: Eq[TargetSummary] = Eq.by(t => (t.id, t.name, t.coords))
 }


### PR DESCRIPTION
This is a fairly big PR . It moves the elevation plot to its own tile and makes the target tab use grid layout too. 
Several components were converted to functional and styling made more flexible to e.g. allow the graph to be resized

There is still some work to do but this would unblock other developers and let me get some feedback

It is also an opportunity to test the new bulid