### PR TITLE
Keep target to observation id data up to date on targets tab

### DIFF
--- a/common-graphql/src/main/scala/explore/common/AsterismQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/AsterismQueriesGQL.scala
@@ -11,7 +11,7 @@ import lucuma.schemas.ObservationDB
 import java.time
 
 // gql: import explore.model.reusability._
-// gql: import explore.model.TargetWithId._
+// gql: import explore.model.TargetGroup._
 // gql: import lucuma.schemas.decoders._
 // gql: import lucuma.ui.reusability._
 
@@ -125,9 +125,7 @@ object AsterismQueriesGQL {
 
     object Data {
       object TargetGroup {
-        object Nodes {
-          type Target = model.TargetWithId
-        }
+        type Nodes = explore.model.TargetGroup
       }
 
       object Observations {

--- a/common/src/main/scala/explore/common/AsterismQueries.scala
+++ b/common/src/main/scala/explore/common/AsterismQueries.scala
@@ -17,6 +17,7 @@ import explore.implicits._
 import explore.model.AsterismGroup
 import explore.model.ObsIdSet
 import explore.model.ObsSummaryWithConstraints
+import explore.model.TargetGroup
 import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.VdomNode
@@ -41,9 +42,6 @@ object AsterismQueries {
 
   type ObservationResult = AsterismGroupObsQuery.Data.Observations.Nodes
   val ObservationResult = AsterismGroupObsQuery.Data.Observations.Nodes
-
-  type TargetGroup = AsterismGroupObsQuery.Data.TargetGroup.Nodes
-  val TargetGroup = AsterismGroupObsQuery.Data.TargetGroup.Nodes
 
   type AsterismGroupList = SortedMap[ObsIdSet, AsterismGroup]
   type TargetGroupList   = SortedMap[Target.Id, TargetGroup]
@@ -92,7 +90,7 @@ object AsterismQueries {
       }
       .flatten
       .toSortedMap(_.obsIds)
-    val targetGroups   = data.targetGroup.nodes.toSortedMap(_.target.id)
+    val targetGroups   = data.targetGroup.nodes.toSortedMap(_.targetWithId.id)
     AsterismGroupsWithObs(
       asterismGroups,
       targetGroups,

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -62,6 +62,7 @@ object reusability {
   implicit val targetIdSetReuse: Reusability[TargetIdSet]                             = Reusability.derive
   implicit val targetWithIdReuse: Reusability[TargetWithId]                           = Reusability.derive
   implicit val targetWithOptIdReuse: Reusability[TargetWithOptId]                     = Reusability.derive
+  implicit val targetGroupReuse: Reusability[TargetGroup]                             = Reusability.derive
   implicit val airMassRangeReuse: Reusability[AirMassRange]                           = Reusability.derive
   implicit val hourAngleRangeReuse: Reusability[HourAngleRange]                       = Reusability.derive
   implicit val elevationRangeReuse: Reusability[ElevationRange]                       = Reusability.derive

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -19,6 +19,7 @@ import explore.model.FocusedObs
 import explore.model.ObsIdSet
 import explore.model.SelectedPanel
 import explore.model.SelectedPanel._
+import explore.model.TargetGroup
 import explore.model.reusability._
 import explore.undo.UndoContext
 import explore.undo._
@@ -227,7 +228,7 @@ object AsterismGroupObsList {
       def getAsterismGroupName(asterismGroup: AsterismGroup): String = {
         val targets = asterismGroup.targetIds.toList.map(targetGroupMap.get).flatten
         if (targets.isEmpty) "<No Targets>"
-        else targets.map(_.target.target.name).mkString(";")
+        else targets.map(_.targetWithId.target.name).mkString(";")
       }
 
       def renderAsterismGroup(asterismGroup: AsterismGroup): VdomNode = {
@@ -306,7 +307,7 @@ object AsterismGroupObsList {
       }
 
       def renderTarget(targetGroup: TargetGroup, index: Int): VdomNode = {
-        val targetId     = targetGroup.target.id
+        val targetId     = targetGroup.targetWithId.id
         val deleteButton = Button(
           size = Small,
           compact = true,
@@ -333,7 +334,7 @@ object AsterismGroupObsList {
                       ExploreStyles.ObsBadgeHeader,
                       <.div(
                         ExploreStyles.ObsBadgeTargetAndId,
-                        <.div(targetGroup.target.target.name.value),
+                        <.div(targetGroup.targetWithId.target.name.value),
                         <.div(ExploreStyles.ObsBadgeId, s"[${targetId.value.value.toHexString}]"),
                         deleteButton
                       )

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -11,6 +11,7 @@ import crystal.react.reuse._
 import explore.common.AsterismQueries._
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
+import explore.model.TargetGroup
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Observation
@@ -65,7 +66,7 @@ object TargetSummaryTable {
         List(
           // TODO: Add a delete button
           TargetTable
-            .Column("id", _.target.id)
+            .Column("id", _.targetWithId.id)
             .setHeader("id")
             .setCell(cell =>
               <.a(^.onClick ==> (_ => props.selectTarget(cell.value)), cell.value.toString)
@@ -73,13 +74,13 @@ object TargetSummaryTable {
             .setSortByAuto
         ) ++
           TargetColumns
-            .BaseColumnBuilder(TargetTable)(_.target.target.some)
+            .BaseColumnBuilder(TargetTable)(_.targetWithId.target.some)
             .allColumns ++
           List(
-            column("count", _.observationIds.length) // TODO Right align
+            column("count", _.obsIds.size) // TODO Right align
               .setCell(_.value.toString)
               .setSortType(DefaultSortTypes.number),
-            column("observations", _.observationIds)
+            column("observations", _.obsIds.toList)
               .setCell(cell =>
                 <.span(
                   cell.value

--- a/model/shared/src/main/scala/explore/model/TargetGroup.scala
+++ b/model/shared/src/main/scala/explore/model/TargetGroup.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.implicits._
+import io.circe.Decoder
+import io.circe.Decoder._
+import lucuma.core.model.Observation
+import monocle.Focus
+import monocle.Lens
+
+import scala.collection.immutable.SortedSet
+
+final case class TargetGroup(obsIds: SortedSet[Observation.Id], targetWithId: TargetWithId) {
+  def addObsIds(ids: ObsIdSet): TargetGroup    = TargetGroup.obsIds.modify(_ ++ ids.toSortedSet)(this)
+  def removeObsIds(ids: ObsIdSet): TargetGroup =
+    TargetGroup.obsIds.modify(_ -- ids.toSortedSet)(this)
+}
+
+object TargetGroup {
+  implicit val eqTargetGroup: Eq[TargetGroup] = Eq.by(x => (x.obsIds, x.targetWithId))
+
+  val obsIds: Lens[TargetGroup, SortedSet[Observation.Id]] = Focus[TargetGroup](_.obsIds)
+  val targetWithId: Lens[TargetGroup, TargetWithId]        = Focus[TargetGroup](_.targetWithId)
+
+  implicit val targetGroupDecode: Decoder[TargetGroup] = Decoder.instance(c =>
+    for {
+      ids  <- c.get[List[Observation.Id]]("observationIds")
+      twid <- c.get[TargetWithId]("target")
+    } yield TargetGroup(SortedSet.from(ids), twid)
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4186,6 +4186,12 @@
         }
       }
     },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
+    },
     "process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "human-format": "0.11.0",
     "less": "4.1.2",
     "less-watch-compiler": "1.16.3",
+    "prettier": "^2.5.1",
     "process": "^0.11.10",
     "rollup-plugin-visualizer": "^5.5.4",
     "sass": "^1.49.0",


### PR DESCRIPTION
During drag and drop and asterism editing, the mapping between targets and observations (in TargetGroupList) needs to be updated. Currently it isn't important since it is only used in the target summary table and gets updated via round trip. However, soon we will be needing this information when editing asterisms so we know if we are editing the target in a subset of the observations and need to warn/prevent/clone or however we are going to handle this situation.