### PR TITLE
Fix problem with Elevation Plot tile collapsing

### DIFF
--- a/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
+++ b/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
@@ -19,7 +19,7 @@ object ElevationPlotTile {
   def elevationPlotTile(
     coreWidth:    Int,
     coreHeight:   Int,
-    coordinates:  Coordinates
+    coordinates:  Option[Coordinates]
   )(implicit ctx: AppContextIO) =
     Tile(ObsTabTiles.PlotId,
          "Elevation Plot",
@@ -31,7 +31,7 @@ object ElevationPlotTile {
         .by(
           (coreWidth, coreHeight, coordinates)
         ) { (_: Tile.RenderInTitle) =>
-          SkyPlotSection(coordinates): VdomNode
+          coordinates.fold(EmptyVdom)(c => SkyPlotSection(c): VdomNode)
         }
         .reuseAlways
     )

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -395,7 +395,7 @@ object ObsTabContents {
             )
 
           val skyPlotTile =
-            targetCoords.map(ElevationPlotTile.elevationPlotTile(coreWidth, coreHeight, _))
+            ElevationPlotTile.elevationPlotTile(coreWidth, coreHeight, targetCoords)
 
           val targetTile = AsterismEditorTile.asterismEditorTile(
             props.userId.get,
@@ -446,12 +446,12 @@ object ObsTabContents {
             defaultLayout,
             layouts,
             List(
-              targetTile.some,
-              notesTile.some,
+              targetTile,
+              notesTile,
               skyPlotTile,
-              constraintsTile.some,
-              configurationTile.some
-            ).collect { case Some(x) => x },
+              constraintsTile,
+              configurationTile
+            ),
             GridLayoutSection.ObservationsLayout,
             clazz = ExploreStyles.ObservationTiles.some
           ): VdomNode

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -517,7 +517,6 @@ object TargetTabContents {
                                     (Constants.InitialTreeWidth.toInt, defaultLayout)
               )
               .attempt
-              .flatTap(x => IO(println(s"Query result: $x")))
               .flatMap {
                 case Right((w, l)) =>
                   (panels

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -383,16 +383,14 @@ object TargetTabContents {
         )
 
       val skyPlotTile =
-        selectedCoordinates.flatten.map(
-          ElevationPlotTile.elevationPlotTile(coreWidth, coreHeight, _)
-        )
+        ElevationPlotTile.elevationPlotTile(coreWidth, coreHeight, selectedCoordinates.flatten)
 
       TileController(
         props.userId,
         coreWidth,
         defaultLayouts,
         layouts,
-        List(asterismEditorTile.some, skyPlotTile).flatten,
+        List(asterismEditorTile, skyPlotTile),
         GridLayoutSection.TargetLayout,
         None
       )
@@ -426,7 +424,7 @@ object TargetTabContents {
       val skyPlotTile =
         ElevationPlotTile.elevationPlotTile(coreWidth,
                                             coreHeight,
-                                            Target.Sidereal.baseCoordinates.get(target)
+                                            Target.Sidereal.baseCoordinates.get(target).some
         )
 
       TileController(props.userId,
@@ -519,6 +517,7 @@ object TargetTabContents {
                                     (Constants.InitialTreeWidth.toInt, defaultLayout)
               )
               .attempt
+              .flatTap(x => IO(println(s"Query result: $x")))
               .flatMap {
                 case Right((w, l)) =>
                   (panels


### PR DESCRIPTION
The elevation plot tile was at time collapsing down to just the title. This happened mostly on the targets tab, but occasionally on the observation tab.  
<img width="183" alt="image" src="https://user-images.githubusercontent.com/6035943/154690792-cca7a841-c719-4759-8a4f-e6c5031c8038.png">

It was easy to reproduce on the targets tab: Select an asterism with no targets, then go back to an asterism with targets. The underlying cause of this issue was due to the elevation plot tile being conditionally included in the TileController. The grid layout was being updated without the elevation plot tile, and when the elevation plot tile was reintroduced the layout was messed up. Since the layout is saved in user preferences, the problem was persistent. It was possible to fix it without just logging in as a different user, but it was not obvious how to do so. I tried to fix this issue, but after significant time investment chose this solution instead.

On the observations tab, I was unable to consistently reproduce the issue, but it would happen on occasion.

The solution I came up with isn't ideal. The Elevation Plot tile is always displayed, whether there is a target selected or not. However, this matches the behavior of the asterism editor. Also, NOT having a target in an asterism should be the exception, not the norm, so maybe this behavior is acceptable.