### PR TITLE
Keep target table in asterism editor from disappearing

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1081,11 +1081,10 @@ tfoot {
 }
 
 .explore-table.target-asterism-table {
-  height: unset;
+  overflow-y: scroll;
 }
 
 .target-asterism-editor {
-  height: 100%;
   align-self: stretch;
   outline: 3px solid pink !important;
 }

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -111,7 +111,7 @@ object AsterismEditor {
           case 2 => 91
           case _ => 110
         }
-        val editorHeight      = resize.height.map(h => math.max(0, h - targetTableHeight)).getOrElse(0)
+        val editorHeight      = resize.height.foldMap(h => math.max(0, h - targetTableHeight))
 
         React.Fragment(
           props.renderInTitle(


### PR DESCRIPTION
This may not be the final answer to the asterism editor layout, but it does allow the table to be displayed. We may want to consider virtualizing the TargetTable so that the table header doesn't scroll, but that would require more work to get it to behave as we want. Right now I size the table based on the number of targets. Without this, table rows would "spread out" to cover the full height, which looks strange and takes up more space than needed. After 2 targets, a partial 3rd row is shown and the whole table - including the header - scrolls.

One issue with the asterism editor is that there are a lot of elements that can react to scrolling, so sometimes you end up scrolling something other than you intended - like the Aladin control. I don't know if there is a way around this, though.
