### PR TITLE
Create observation and target id via API, not locally

### DIFF
--- a/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/explore/common/ObsQueriesGQL.scala
@@ -131,9 +131,50 @@ object ObsQueriesGQL {
       mutation($createObservation: CreateObservationInput!) {
         createObservation(input: $createObservation) {
           id
+          targetEnvironment {
+            asterism {
+              id
+              name
+              sidereal {
+                ra {
+                  microarcseconds
+                }
+                dec {
+                  microarcseconds
+                }
+              }
+            }
+          }
+          constraintSet {
+            imageQuality
+            cloudExtinction
+            skyBackground
+            waterVapor
+          }
+          status
+          activeStatus
+          plannedTime {
+            execution {
+              microseconds
+            }
+          }
         }
       }
     """
+
+    object Data {
+      object CreateObservation {
+        object TargetEnvironment {
+          object Asterism {
+            type Sidereal = lucuma.core.math.Coordinates
+          }
+        }
+        trait ConstraintSet extends ConstraintsSummary
+        object PlannedTime       {
+          type Execution = time.Duration
+        }
+      }
+    }
   }
 
   @GraphQL

--- a/common/src/main/scala/explore/common/ObsQueries.scala
+++ b/common/src/main/scala/explore/common/ObsQueries.scala
@@ -163,4 +163,20 @@ object ObsQueries {
     )
     UpdateConstraintSetMutation.execute[F](obsIds, editInput).void
   }
+
+  def createObservation[F[_]: Async]()(implicit
+    c: TransactionalClient[F, ObservationDB]
+  ): F[Option[ObsSummaryWithTargetsAndConstraints]] =
+    ProgramCreateObservation.execute[F](CreateObservationInput(programId = "p-2")).map { data =>
+      data.createObservation.map { obs =>
+        ObsSummaryWithTargetsAndConstraints(
+          obs.id,
+          obs.targetEnvironment.asterism.map(t => TargetSummary(t.id, t.name, t.sidereal)),
+          obs.constraintSet,
+          obs.status,
+          obs.activeStatus,
+          obs.plannedTime.execution
+        )
+      }
+    }
 }

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -5,17 +5,16 @@ package explore.observationtree
 
 import cats.effect.IO
 import cats.syntax.all._
-import clue.TransactionalClient
 import crystal.react.ReuseView
+import crystal.react.hooks._
+import crystal.react.implicits._
 import crystal.react.reuse._
-import eu.timepit.refined.types.numeric.PosLong
 import explore.AppCtx
 import explore.Icons
 import explore.common.ObsQueries
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.implicits._
-import explore.model.ConstraintsSummary
 import explore.model.ObsSummaryWithTargetsAndConstraints
 import explore.model.enum.AppTab
 import explore.observationtree.ObsBadge
@@ -28,17 +27,13 @@ import lucuma.core.enum.ObsActiveStatus
 import lucuma.core.enum.ObsStatus
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
-import lucuma.schemas.ObservationDB
 import lucuma.ui.reusability._
 import lucuma.ui.utils._
-import react.common.ReactProps
+import react.common.ReactFnProps
 import react.common.implicits._
 import react.semanticui.elements.button.Button
 import react.semanticui.shorthand._
 import react.semanticui.sizes._
-
-import java.time.Duration
-import scala.util.Random
 
 import ObsQueries._
 
@@ -48,7 +43,7 @@ final case class ObsList(
   focusedTarget:    ReuseView[Option[Target.Id]],
   undoStacks:       ReuseView[UndoStacks[IO, ObservationList]]
 )(implicit val ctx: AppContextIO)
-    extends ReactProps[ObsList](ObsList.component)
+    extends ReactFnProps[ObsList](ObsList.component) {}
 
 object ObsList {
   type Props = ObsList
@@ -60,121 +55,112 @@ object ObsList {
       ObsSummaryWithTargetsAndConstraints.id
     )
 
-  protected class Backend {
-    protected def insertObs(
-      pos:        Int,
-      focusedObs: ReuseView[Option[Observation.Id]],
-      undoCtx:    UndoContext[ObservationList]
-    )(implicit
-      c:          TransactionalClient[IO, ObservationDB]
-    ): Callback = {
-      // Temporary measure until we have id pools.
-      val newObs = CallbackTo(Random.nextInt(0xfff)).map(int =>
-        ObsSummaryWithTargetsAndConstraints(
-          Observation.Id(PosLong.unsafeFrom(int.abs.toLong + 1)),
-          targets = List.empty,
-          constraints = ConstraintsSummary.default,
-          ObsStatus.New,
-          ObsActiveStatus.Active,
-          Duration.ZERO
-        )
-      )
+  protected def insertObs(
+    pos:        Int,
+    focusedObs: ReuseView[Option[Observation.Id]],
+    undoCtx:    UndoContext[ObservationList],
+    adding:     ReuseView[Boolean]
+  )(implicit
+    ctx:        AppContextIO
+  ): IO[Unit] =
+    adding.set(true).to[IO] >>
+      createObservation[IO]().flatMap {
+        _.fold(IO.unit) { obs =>
+          ObsListActions
+            .obsExistence(obs.id, focusedObs)
+            .mod(undoCtx)(obsListMod.upsert(obs, pos))
+            .to[IO]
+        }
+      } >> adding.set(false).to[IO]
 
-      newObs.flatMap { obs =>
-        ObsListActions
-          .obsExistence(obs.id, focusedObs)
-          .mod(undoCtx)(obsListMod.upsert(obs, pos))
-      }
-    }
+  def render(props: Props, adding: ReuseView[Boolean]): VdomNode =
+    AppCtx.using { implicit ctx =>
+      val undoCtx      = UndoContext(props.undoStacks, props.observations)
+      val observations = props.observations.get.toList
 
-    def render(props: Props): VdomNode =
-      AppCtx.using { implicit ctx =>
-        val undoCtx      = UndoContext(props.undoStacks, props.observations)
-        val observations = props.observations.get.toList
-
-        <.div(ExploreStyles.ObsTreeWrapper)(
-          <.div(ExploreStyles.TreeToolbar)(
-            Button(size = Mini,
-                   compact = true,
-                   icon = Icons.New,
-                   content = "Obs",
-                   onClick = insertObs(observations.length, props.focusedObs, undoCtx)
-            ),
-            UndoButtons(undoCtx, size = Mini)
+      <.div(ExploreStyles.ObsTreeWrapper)(
+        <.div(ExploreStyles.TreeToolbar)(
+          Button(
+            size = Mini,
+            compact = true,
+            icon = Icons.New,
+            content = "Obs",
+            disabled = adding.get,
+            loading = adding.get,
+            onClick = insertObs(observations.length, props.focusedObs, undoCtx, adding).runAsync
           ),
-          <.div(ExploreStyles.ObsTree)(
-            <.div(ExploreStyles.ObsScrollTree)(
-              <.div(
-                Button(onClick = props.focusedObs.set(none), clazz = ExploreStyles.ButtonSummary)(
-                  Icons.ListIcon.clazz(ExploreStyles.PaddedRightIcon),
-                  "Observations Summary"
+          UndoButtons(undoCtx, size = Mini, disabled = adding.get)
+        ),
+        <.div(ExploreStyles.ObsTree)(
+          <.div(ExploreStyles.ObsScrollTree)(
+            <.div(
+              Button(onClick = props.focusedObs.set(none), clazz = ExploreStyles.ButtonSummary)(
+                Icons.ListIcon.clazz(ExploreStyles.PaddedRightIcon),
+                "Observations Summary"
+              )
+            ),
+            observations.toTagMod { obs =>
+              val focusedObs = obs.id
+              val selected   = props.focusedObs.get.exists(_ === focusedObs)
+              <.a(
+                ^.href := ctx.pageUrl(AppTab.Observations,
+                                      focusedObs.some,
+                                      props.focusedTarget.get
+                ),
+                ExploreStyles.ObsItem |+| ExploreStyles.SelectedObsItem.when_(selected),
+                ^.onClick ==> linkOverride(
+                  props.focusedObs.set(focusedObs.some)
                 )
-              ),
-              observations.toTagMod { obs =>
-                val focusedObs = obs.id
-                val selected   = props.focusedObs.get.exists(_ === focusedObs)
-                <.a(
-                  ^.href := ctx.pageUrl(AppTab.Observations,
-                                        focusedObs.some,
-                                        props.focusedTarget.get
-                  ),
-                  ExploreStyles.ObsItem |+| ExploreStyles.SelectedObsItem.when_(selected),
-                  ^.onClick ==> linkOverride(
-                    props.focusedObs.set(focusedObs.some)
-                  )
-                )(
-                  ObsBadge(
-                    obs,
-                    selected = selected,
-                    setStatusCB = (ObsListActions
-                      .obsStatus(obs.id)
-                      .set(undoCtx) _).compose((_: ObsStatus).some).reuseAlways.some,
-                    setActiveStatusCB = (ObsListActions
-                      .obsActiveStatus(obs.id)
-                      .set(undoCtx) _).compose((_: ObsActiveStatus).some).reuseAlways.some,
-                    deleteCB = ObsListActions
-                      .obsExistence(obs.id, props.focusedObs)
-                      .mod(undoCtx)(obsListMod.delete)
-                      .reuseAlways
-                      .some
-                  )
+              )(
+                ObsBadge(
+                  obs,
+                  selected = selected,
+                  setStatusCB = (ObsListActions
+                    .obsStatus(obs.id)
+                    .set(undoCtx) _).compose((_: ObsStatus).some).reuseAlways.some,
+                  setActiveStatusCB = (ObsListActions
+                    .obsActiveStatus(obs.id)
+                    .set(undoCtx) _).compose((_: ObsActiveStatus).some).reuseAlways.some,
+                  deleteCB = ObsListActions
+                    .obsExistence(obs.id, props.focusedObs)
+                    .mod(undoCtx)(obsListMod.delete)
+                    .reuseAlways
+                    .some
                 )
-              }
-            )
+              )
+            }
           )
         )
-      }
-  }
+      )
+    }
 
   protected val component =
-    ScalaComponent
-      .builder[Props]
-      .renderBackend[Backend]
-      .componentDidMount { $ =>
-        val observations = $.props.observations.get
-
-        // If focused observation does not exist anymore, then unfocus.
-        $.props.focusedObs.mod(_.flatMap {
-          case oid if !observations.contains(oid) => none
-          case other                              => other.some
-        })
+    ScalaFnComponent
+      .withHooks[Props]
+      // Saved index into the observation list
+      .useState(none[Int])
+      .useEffectWithDepsBy((props, _) => (props.focusedObs, props.observations)) {
+        (_, optIndex) => params =>
+          val (focusedObs, observations) = params
+          val obsList                    = observations.get
+          focusedObs.get.fold(optIndex.setState(none)) { obsId =>
+            // there is a focused obsId, look for it in the list
+            val foundIdx = obsList.getIndex(obsId)
+            (optIndex.value, foundIdx) match {
+              case (_, Some(fidx))    => optIndex.setState(fidx.some) // focused obs is in list
+              case (None, None)       => focusedObs.set(none) >> optIndex.setState(none)
+              case (Some(oidx), None) =>
+                // focused obs no longer exists, but we have a previous index.
+                val newIdx = math.min(oidx, obsList.length - 1)
+                obsList.toList
+                  .get(newIdx.toLong)
+                  .fold(optIndex.setState(none) >> focusedObs.set(none))(obsSumm =>
+                    optIndex.setState(newIdx.some) >> focusedObs.set(obsSumm.id.some)
+                  )
+            }
+          }
       }
-      .componentDidUpdate { $ =>
-        val prevObservations = $.prevProps.observations.get
-        val observations     = $.currentProps.observations.get
-
-        // If focused observation does not exist anymore, then focus on closest one.
-        $.currentProps.focusedObs.mod(_.flatMap {
-          case oid if !observations.contains(oid) =>
-            prevObservations
-              .getIndex(oid)
-              .flatMap { idx =>
-                observations.toList.get(math.min(idx, observations.length - 1).toLong)
-              }
-              .map(_.id)
-          case other                              => other.some
-        })
-      }
-      .configure(Reusability.shouldComponentUpdate)
-      .build
+      // adding new observation
+      .useStateViewWithReuse(false)
+      .renderWithReuse((props, _, adding) => render(props, adding))
 }

--- a/explore/src/main/scala/explore/observationtree/ObsListActions.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsListActions.scala
@@ -72,10 +72,8 @@ object ObsListActions {
         elemWithIndexOpt.fold {
           ProgramDeleteObservation.execute[IO](obsId).void
         } { case (obs, _) =>
-          ProgramCreateObservation
-            .execute[IO](CreateObservationInput(programId = "p-2", observationId = obs.id.assign))
-            .void >>
-            focusedObs.set(obs.id.some).to[IO]
+          // Not much to do here, the observation must be created before we get here
+          focusedObs.set(obs.id.some).to[IO]
         },
       onRestore = (_, elemWithIndexOpt) =>
         elemWithIndexOpt.fold {

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -6,9 +6,10 @@ package explore.targeteditor
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.ReuseView
+import crystal.react.View
+import crystal.react.hooks._
 import crystal.react.implicits._
 import crystal.react.reuse._
-import eu.timepit.refined.types.numeric.PosLong
 import explore.Icons
 import explore.common.AsterismQueries
 import explore.common.TargetQueriesGQL._
@@ -25,6 +26,7 @@ import explore.schemas.implicits._
 import explore.targets.TargetSelectionPopup
 import explore.undo.UndoStacks
 import japgolly.scalajs.react._
+import japgolly.scalajs.react.util.DefaultEffects.{ Sync => DefaultS }
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Target
 import lucuma.core.model.User
@@ -35,8 +37,6 @@ import react.semanticui.elements.button._
 import react.semanticui.modules.checkbox._
 import react.semanticui.shorthand._
 import react.semanticui.sizes._
-
-import scala.util.Random
 
 final case class AsterismEditor(
   userId:           User.Id,
@@ -62,24 +62,19 @@ object AsterismEditor {
     asterism:       ReuseView[List[TargetWithId]],
     oTargetId:      Option[Target.Id],
     target:         Target.Sidereal,
-    selectedTarget: ReuseView[Option[Target.Id]]
-  )(implicit ctx:   AppContextIO): Callback = {
-    val (targetId, createTarget) = oTargetId.fold(
-      (newId,
-       (tid: Target.Id) =>
-         CreateTargetMutation
-           .execute("p-2", target.toCreateTargetInput(tid.some))
-           .void
-      )
-    )(tid => (CallbackTo(tid), (_: Target.Id) => IO.unit))
-    targetId.flatMap(tid =>
-      asterism.mod(_ :+ TargetWithId(tid, target)) >> selectedTarget.set(tid.some) >>
-        (createTarget(tid) >>
-          AsterismQueries.addTargetToAsterisms[IO](
-            obsIds.toList,
-            tid
-          )).runAsync
-    )
+    selectedTarget: ReuseView[Option[Target.Id]],
+    adding:         View[Boolean]
+  )(implicit ctx:   AppContextIO): IO[Unit] = {
+    val targetId: IO[Target.Id] = oTargetId.fold(
+      CreateTargetMutation.execute("p-2", target.toCreateTargetInput()).map(_.createTarget.id)
+    )(IO(_))
+    adding.set(true).to[IO] >>
+      targetId
+        .flatMap(tid =>
+          asterism.mod(_ :+ TargetWithId(tid, target)).to[IO]
+            >> selectedTarget.set(tid.some).to[IO] >>
+            AsterismQueries.addTargetToAsterisms[IO](obsIds.toList, tid)
+        ) >> adding.set(false).to[IO]
   }
 
   private def onCloneTarget(
@@ -91,20 +86,13 @@ object AsterismEditor {
     asterism.mod(_.map(twid => if (twid.id === id) newTwid else twid)) >> selected
       .set(newTwid.id.some)
 
-  val newId =
-    CallbackTo(Random.nextInt(0xfff)).map(int => Target.Id(PosLong.unsafeFrom(int.abs.toLong + 1)))
-
   protected val component =
     ScalaFnComponent
       .withHooks[Props]
       // adding
-      .useState(false)
+      .useStateViewWithReuse(false)
       // edit target in current obs only (0), or all "instances" of the target (1)
       .useState(0)
-      // reset "loading" for add button when science targets change, which indicates server roundtrip is over
-      .useEffectWithDepsBy((props, _, _) => props.asterism)((_, adding, _) =>
-        _ => adding.setState(false)
-      )
       .useEffectWithDepsBy((props, _, _) => (props.asterism, props.selectedTargetId))(
         (props, _, _) => { case (asterism, oTargetId) =>
           // if the selected targetId is None, or not in the asterism, select the first target (if any)
@@ -123,14 +111,14 @@ object AsterismEditor {
         React.Fragment(
           props.renderInTitle(
             TargetSelectionPopup(
-              trigger = Reuse.by(adding.value)(
+              trigger = Reuse.by(adding.get)(
                 Button(
                   size = Tiny,
                   compact = true,
                   clazz = ExploreStyles.VeryCompact,
-                  disabled = adding.value,
+                  disabled = adding.get,
                   icon = Icons.New,
-                  loading = adding.value,
+                  loading = adding.get,
                   content = "Add",
                   labelPosition = LabelPosition.Left
                 )
@@ -138,7 +126,13 @@ object AsterismEditor {
               onSelected = Reuse
                 .by((props.obsIds, props.asterism, selectedTargetId))(_ match {
                   case TargetWithOptId(oid, t @ Target.Sidereal(_, _, _, _)) =>
-                    insertSiderealTarget(props.obsIds, props.asterism, oid, t, selectedTargetId)
+                    insertSiderealTarget(props.obsIds,
+                                         props.asterism,
+                                         oid,
+                                         t,
+                                         selectedTargetId,
+                                         adding
+                    ).runAsync
                   case _                                                     => Callback.empty
                 })
             )


### PR DESCRIPTION
For observations, this also means we use the observation created by the API instead of creating a temporary "default" one locally. So, defaults won't get out of sync between the UI and API.

Also converted ObsList to a function component.