### PR TITLE
Aligner, ReuseAligner.

### DIFF
--- a/common/src/main/scala/explore/common/package.scala
+++ b/common/src/main/scala/explore/common/package.scala
@@ -1,0 +1,73 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore
+
+import crystal.react.ReuseView
+import crystal.react.reuse.Reuse
+import explore.undo.UndoContext
+import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
+import monocle.Lens
+import monocle.Optional
+import monocle.Prism
+import org.typelevel.log4cats.Logger
+
+package object common {
+  type Aligner[A, T] = AlignerF[DefaultA, A, T]
+
+  object Aligner {
+    def apply[A, T](
+      undoCtx:         UndoContext[A],
+      remoteBaseInput: T,
+      onMod:           T => DefaultA[Unit]
+    ): Aligner[A, T] =
+      AlignerF(undoCtx, remoteBaseInput, onMod)
+  }
+
+  type ReuseAligner[A, T] = Reuse[Aligner[A, T]]
+
+  implicit class ReuseAlignerOps[A, T](val self: ReuseAligner[A, T]) extends AnyVal {
+    def get: A = self.value.get
+
+    def viewMod(toInput: A => T => T)(implicit
+      logger:            Logger[DefaultA]
+    ): ReuseView[A] = self.map(_.viewMod(toInput))
+
+    def view(toInput: A => T)(implicit
+      logger:         Logger[DefaultA]
+    ): ReuseView[A] = self.map(_.view(toInput))
+
+    def zoom[B, S](
+      modelGet:  A => B,
+      modelMod:  (B => B) => A => A,
+      remoteMod: (S => S) => T => T
+    ): ReuseAligner[B, S] =
+      self.map(_.zoom(modelGet, modelMod, remoteMod))
+
+    /** Drill-down specifying model `Lens` and delta structure modification function. */
+    def zoom[B, S](
+      lens:      Lens[A, B],
+      remoteMod: (S => S) => T => T
+    ): ReuseAligner[B, S] =
+      zoom(lens.get, lens.modify, remoteMod)
+
+    def zoomOpt[B, S](
+      modelGetOpt: A => Option[B],
+      modelMod:    (B => B) => A => A,
+      remoteMod:   (S => S) => T => T
+    ): Option[ReuseAligner[B, S]] =
+      modelGetOpt(get).map(_ => zoom(modelGetOpt.andThen(_.get), modelMod, remoteMod))
+
+    def zoomOpt[B, S](
+      prism:     Prism[A, B],
+      remoteMod: (S => S) => T => T
+    ): Option[ReuseAligner[B, S]] =
+      zoomOpt(prism.getOption _, prism.modify _, remoteMod)
+
+    def zoomOpt[B, S](
+      optional:  Optional[A, B],
+      remoteMod: (S => S) => T => T
+    ): Option[ReuseAligner[B, S]] =
+      zoomOpt(optional.getOption _, optional.modify _, remoteMod)
+  }
+}

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
@@ -18,6 +18,7 @@ import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
 import react.common._
+
 import scala.reflect.ClassTag
 
 final case class LiveQueryRender[S, D, A](

--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -21,6 +21,7 @@ import japgolly.scalajs.react.component.builder.Lifecycle.RenderScope
 import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
+
 import scala.reflect.ClassTag
 
 object Render {

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
@@ -17,6 +17,7 @@ import japgolly.scalajs.react.util.Effect
 import japgolly.scalajs.react.vdom.html_<^._
 import org.typelevel.log4cats.Logger
 import react.common._
+
 import scala.reflect.ClassTag
 
 final case class SubscriptionRender[D, A](

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -11,12 +11,9 @@ import clue.data.syntax._
 import crystal.Pot
 import crystal.react.reuse._
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.common.RemoteSyncUndoableF
 import explore.model.enum.ExecutionEnvironment
 import explore.model.enum.ExecutionEnvironment.Development
 import explore.model.enum.Theme
-import explore.undo.UndoContext
-import japgolly.scalajs.react.util.DefaultEffects.{ Async => DefaultA }
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.utils.versionDateFormatter
 import lucuma.ui.utils.versionDateTimeFormatter
@@ -80,25 +77,12 @@ package object utils {
       uri.withPath(uri.path.concat(p))
   }
 
-  type RemoteSyncUndoable[A, T] = RemoteSyncUndoableF[DefaultA, A, T]
-  object RemoteSyncUndoable {
-    def apply[A, T](
-      undoCtx:         UndoContext[A],
-      remoteBaseInput: T,
-      onMod:           T => DefaultA[Unit]
-    ): RemoteSyncUndoable[A, T] =
-      RemoteSyncUndoableF(undoCtx, remoteBaseInput, onMod)
-  }
-
   def forceAssign[T, S](mod: Endo[Input[S]] => Endo[T])(base: S): Endo[S] => Endo[T] =
     modS =>
       mod {
         case Assign(edit) => modS(edit).assign
         case _            => modS(base).assign
       }
-
-  def reuseOpt2OptReuse[A](reuseOpt: Reuse[Option[A]]): Option[Reuse[A]] =
-    reuseOpt.value.map(a => reuseOpt.map(_ => a))
 }
 
 package utils {

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -8,6 +8,7 @@ import coulomb.Quantity
 import crystal.react.ReuseView
 import crystal.react.hooks._
 import crystal.react.implicits._
+import crystal.react.reuse.Reuse
 import eu.timepit.refined.auto._
 import explore.common.ObsQueries._
 import explore.common.ScienceQueries._
@@ -37,7 +38,6 @@ import monocle.Iso
 import react.common._
 import react.semanticui.collections.form.Form
 import react.semanticui.sizes._
-import crystal.react.reuse.Reuse
 
 final case class ConfigurationPanel(
   obsId:            Observation.Id,

--- a/explore/src/main/scala/explore/config/ImagingConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ImagingConfigurationPanel.scala
@@ -8,6 +8,7 @@ import coulomb.Quantity
 import crystal.react.ReuseView
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
+import eu.timepit.refined.types.numeric.PosBigDecimal
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
 import explore.implicits._
@@ -20,6 +21,7 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.feature.ReactFragment
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.enum.FilterType
+import lucuma.core.math.Angle
 import lucuma.core.math.units._
 import lucuma.core.util.Display
 import lucuma.ui.forms.EnumViewOptionalSelect
@@ -35,8 +37,6 @@ import spire.math.Rational
 import scala.collection.immutable.SortedSet
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
-import lucuma.core.math.Angle
-import eu.timepit.refined.types.numeric.PosBigDecimal
 
 final case class ImagingConfigurationPanel(
   options: ReuseView[ImagingConfigurationOptions]

--- a/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
@@ -3,10 +3,13 @@
 
 package explore.config
 
+import coulomb.Quantity
 import coulomb.cats.implicits._
 import crystal.react.ReuseView
 import eu.timepit.refined.auto._
 import eu.timepit.refined.cats._
+import eu.timepit.refined.types.numeric.PosBigDecimal
+import eu.timepit.refined.types.numeric.PosInt
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
 import explore.implicits._
@@ -18,6 +21,9 @@ import explore.targeteditor.InputWithUnits
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.feature.ReactFragment
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.enum.FocalPlane
+import lucuma.core.enum.SpectroscopyCapabilities
+import lucuma.core.math.Angle
 import lucuma.core.math.units._
 import lucuma.ui.forms.EnumViewOptionalSelect
 import lucuma.ui.forms.FormInputEV
@@ -25,12 +31,6 @@ import lucuma.ui.optics.ChangeAuditor
 import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.reusability._
 import react.common._
-import coulomb.Quantity
-import eu.timepit.refined.types.numeric.PosInt
-import eu.timepit.refined.types.numeric.PosBigDecimal
-import lucuma.core.math.Angle
-import lucuma.core.enum.FocalPlane
-import lucuma.core.enum.SpectroscopyCapabilities
 
 final case class SpectroscopyConfigurationPanel(
   options: ReuseView[SpectroscopyConfigurationOptions]

--- a/explore/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalDetailsEditor.scala
@@ -23,8 +23,8 @@ import explore.components.ui._
 import explore.implicits._
 import explore.model._
 import explore.model.display._
-import explore.model.enum._
 import explore.model.enum.ProposalClass._
+import explore.model.enum._
 import explore.model.refined._
 import explore.model.reusability._
 import japgolly.scalajs.react.Reusability._

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -6,9 +6,10 @@ package explore.tabs
 import cats.effect.IO
 import cats.syntax.all._
 import crystal.react.ReuseView
+import crystal.react.View
+import crystal.react.hooks._
 import crystal.react.implicits._
 import crystal.react.reuse._
-import crystal.react.hooks._
 import eu.timepit.refined.auto._
 import explore.Icons
 import explore.common.ConstraintGroupQueries._
@@ -44,7 +45,6 @@ import react.semanticui.sizes._
 
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration._
-import crystal.react.View
 
 final case class ConstraintSetTabContents(
   userId:           Option[User.Id],

--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -9,6 +9,7 @@ import crystal.react._
 import crystal.react.hooks._
 import crystal.react.reuse._
 import eu.timepit.refined.auto._
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.implicits._
@@ -22,6 +23,7 @@ import lucuma.core.math.BrightnessValue
 import lucuma.core.math.dimensional._
 import lucuma.core.util.Enumerated
 import lucuma.ui.forms.EnumViewSelect
+import lucuma.ui.forms.FormInputEV
 import lucuma.ui.optics.ChangeAuditor
 import lucuma.ui.optics.ValidFormatInput
 import lucuma.ui.reusability._
@@ -35,8 +37,6 @@ import reactST.reactTable._
 import reactST.reactTable.mod.SortingRule
 
 import scala.collection.immutable.SortedMap
-import lucuma.ui.forms.FormInputEV
-import eu.timepit.refined.types.string.NonEmptyString
 
 sealed trait BrightnessesEditor[T] {
   val brightnesses: ReuseView[SortedMap[Band, BrightnessMeasure[T]]]

--- a/explore/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/explore/src/main/scala/explore/targeteditor/RVInput.scala
@@ -16,7 +16,9 @@ import explore.model.conversions._
 import explore.model.formats._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.math.ApparentRadialVelocity
 import lucuma.core.math.RadialVelocity
+import lucuma.core.math.Redshift
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 import lucuma.ui.forms.EnumViewSelect
@@ -28,8 +30,6 @@ import monocle.Focus
 import react.common._
 import react.common.implicits._
 import react.semanticui.elements.label.LabelPointing
-import lucuma.core.math.Redshift
-import lucuma.core.math.ApparentRadialVelocity
 
 final case class RVInput(
   rv:       ReuseView[Option[RadialVelocity]],

--- a/model/shared/src/main/scala/explore/model/display.scala
+++ b/model/shared/src/main/scala/explore/model/display.scala
@@ -7,9 +7,10 @@ import cats.syntax.all._
 import eu.timepit.refined.cats._
 import explore.model.enum._
 import lucuma.core.enum._
-import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
 import lucuma.core.util.Display
+
+import lucuma.core.model.ConstraintSet
 
 object display {
   implicit val displayProposalClass: Display[ProposalClass] =


### PR DESCRIPTION
- Rename `RemoteSyncUndoable` -> `Aligner`.
- Introduce `ReuseAligner` alias, and extensions methods to make it more straightforward to work with it.
- Organize imports.