### PR TITLE
Avoid exception on ITC errors + show ITC rows again

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -263,6 +263,7 @@ object ExploreStyles {
   val ConfigurationFilter: Css       = Css("explore-configuration-filter")
   val ConfigurationFilterItem: Css   = Css("explore-configuration-filter-item")
   val ExploreTable: Css              = Css("explore-table")
+  val Virtualized: Css               = Css("virtualized")
   val TableRowSelected: Css          = Css("explore-table-row-selected")
   val ModesTableTitle: Css           = Css("explore-modes-table-title")
   val ModesHeader: Css               = Css("explore-modes-header")

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1270,6 +1270,10 @@ img.partner-split-flag {
   .table {
     min-height: 60px;
     border-collapse: collapse;
+
+    &.virtualized {
+      height: 100%;
+    }
   }
 
   tr.explore-table-row-selected,

--- a/explore/src/main/scala/explore/config/ITCRequests.scala
+++ b/explore/src/main/scala/explore/config/ITCRequests.scala
@@ -61,20 +61,16 @@ object ITCRequests {
     cache:         ViewF[F, ItcResultsCache],
     progress:      ViewF[F, Option[Progress]]
   ): F[Unit] = {
-    def itcResults(
-      r: List[ItcResults]
-    ): List[(Long, Int, EitherNec[ItcQueryProblems, ItcResult])] =
+    def itcResults(r: List[ItcResults]): List[EitherNec[ItcQueryProblems, ItcResult]] =
       // Convert to usable types
-      r.toList
-        .flatMap(x =>
-          x.spectroscopy.flatMap(_.results).map { r =>
-            r.itc match {
-              case ItcError(m)      => (Long.MinValue, 0, ItcQueryProblems.GenericError(m).leftNec)
-              case ItcSuccess(e, t) =>
-                (t.microseconds, e, ItcResult.Result(t.microseconds.microseconds, e).rightNec)
-            }
+      r.flatMap(x =>
+        x.spectroscopy.flatMap(_.results).map { r =>
+          r.itc match {
+            case ItcError(m)      => ItcQueryProblems.GenericError(m).leftNec
+            case ItcSuccess(e, t) => ItcResult.Result(t.microseconds.microseconds, e).rightNec
           }
-        )
+        }
+      )
 
     // Find the magnitude closest to the requested wavelength
     def selectedBrightness(
@@ -128,7 +124,12 @@ object ITCRequests {
           .flatTap(r =>
             Logger[F].debug(
               s"ITC: Result for mode ${request.mode}: ${itcResults(r)
-                .map(r => s"${r._2} x ${r._1.microseconds.toSeconds} s")}"
+                .map {
+                  case Left(error)                                      => s"ERRORS: $error"
+                  case Right(ItcResult.Result(exposureTime, exposures)) =>
+                    s"$exposures x ${exposureTime.toSeconds}"
+                  case Right(other)                                     => other.toString
+                }}"
             )
           )
           .flatMap(callback)
@@ -157,10 +158,12 @@ object ITCRequests {
           params,
           { r =>
             // Convert to usable types and update the cache
-            val update: EitherNec[ItcQueryProblems, ItcResult] = itcResults(r)
+            val update: EitherNec[ItcQueryProblems, ItcResult] =
               // There maybe multiple targets, take the one with the max time
-              .maxBy(_._1)
-              ._3
+              itcResults(r).maxBy {
+                case Right(ItcResult.Result(exposureTime, _)) => exposureTime.toMicros
+                case _                                        => Long.MinValue
+              }
             // Put the results in the cache
             cache.mod(ItcResultsCache.cache.modify(_ + (params -> update)))
           }

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -524,8 +524,9 @@ object SpectroscopyModesTable {
 
           React.Fragment(
             <.div(ExploreStyles.ModesTableTitle)(
-              <.label(s"${rows.length} matching configurations",
-                      HelpIcon("configuration/table.md")
+              <.label(
+                s"${rows.length} matching configurations",
+                HelpIcon("configuration/table.md")
               ),
               <.div(
                 errLabel.toTagMod
@@ -535,10 +536,12 @@ object SpectroscopyModesTable {
               ExploreStyles.ExploreTable,
               ModesTable
                 .Component(
-                  table = Table(celled = true,
-                                selectable = true,
-                                striped = true,
-                                compact = TableCompact.Very
+                  table = Table(
+                    celled = true,
+                    selectable = true,
+                    striped = true,
+                    compact = TableCompact.Very,
+                    clazz = ExploreStyles.Virtualized
                   )(),
                   header = true,
                   headerCell = (c: ModesTableDef.ColumnType) =>


### PR DESCRIPTION
An exception was being thrown to the console when logging an ITC call that resulted in an error. Errors are now logged via `Logger.debug`.

Should we log these errors via `Logger.error`? Or at least some of them?

The 2 types of errors I've seen so far are:
```
ITC: Result for mode Mode: GMOS-S, B600_G5323, Some(GPrime), IfuBlue: List(ERRORS: Chain(GenericError(Error calculating itc org.http4s.client.UnexpectedStatus: unexpected HTTP status: 400 Bad Request for request POST https://gemini-new-itc.herokuapp.com/json)))
```

and:
```
ITC: Result for mode Mode: GMOS-S, B600_G5323, None, Ifu2Slits: List(ERRORS: Chain(GenericError(Error calculating itc lucuma.itc.ItcCalculationError: S/N obtained is 0)))
```