### PR TITLE
Fix reload issues and ObsBadge match error

### DIFF
--- a/common/src/main/scala/explore/common/AsterismQueries.scala
+++ b/common/src/main/scala/explore/common/AsterismQueries.scala
@@ -109,11 +109,13 @@ object AsterismQueries {
     ScalaFnComponent[ReuseView[AsterismGroupsWithObs] ==> VdomNode](render =>
       AppCtx.using { implicit appCtx =>
         LiveQueryRenderMod[ObservationDB, AsterismGroupObsQuery.Data, AsterismGroupsWithObs](
-          AsterismGroupObsQuery.query(programId).reuseAlways,
+          Reuse.currying(programId).in(pid => AsterismGroupObsQuery.query(pid)),
           (AsterismGroupObsQuery.Data.asAsterismGroupWithObs.get _).reuseAlways,
-          List(ObsQueriesGQL.ProgramObservationsEditSubscription.subscribe[IO](programId),
-               TargetQueriesGQL.ProgramTargetEditSubscription.subscribe[IO](programId)
-          ).reuseAlways
+          Reuse.by(programId)(
+            List(ObsQueriesGQL.ProgramObservationsEditSubscription.subscribe[IO](programId),
+                 TargetQueriesGQL.ProgramTargetEditSubscription.subscribe[IO](programId)
+            )
+          )
         )(potRender(render))
       }
     )

--- a/common/src/main/scala/explore/common/AsterismQueries.scala
+++ b/common/src/main/scala/explore/common/AsterismQueries.scala
@@ -120,9 +120,6 @@ object AsterismQueries {
       }
     )
 
-  import eu.timepit.refined.auto._
-  val AsterismGroupLiveQueryStable = AsterismGroupLiveQuery(Program.Id(2L))
-
   def replaceAsterism[F[_]: Async](
     obsIds:     List[Observation.Id],
     targetIds:  List[Target.Id]

--- a/common/src/main/scala/explore/common/AsterismQueries.scala
+++ b/common/src/main/scala/explore/common/AsterismQueries.scala
@@ -11,7 +11,6 @@ import clue.TransactionalClient
 import clue.data.syntax._
 import crystal.react.ReuseView
 import crystal.react.reuse._
-import explore.AppCtx
 import explore.components.graphql.LiveQueryRenderMod
 import explore.implicits._
 import explore.model.AsterismGroup
@@ -32,6 +31,7 @@ import monocle.Getter
 import queries.common.AsterismQueriesGQL._
 import queries.common.ObsQueriesGQL
 import queries.common.TargetQueriesGQL
+import react.common.ReactFnProps
 
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
@@ -105,20 +105,33 @@ object AsterismQueries {
     def asAsterismGroupWithObs = queryToAsterismGroupWithObsGetter
   }
 
-  def AsterismGroupLiveQuery(programId: Program.Id) =
-    ScalaFnComponent[ReuseView[AsterismGroupsWithObs] ==> VdomNode](render =>
-      AppCtx.using { implicit appCtx =>
+  final case class AsterismGroupLiveQuery(
+    programId:        Program.Id,
+    render:           ReuseView[AsterismGroupsWithObs] ==> VdomNode
+  )(implicit val ctx: AppContextIO)
+      extends ReactFnProps[AsterismGroupLiveQuery](AsterismGroupLiveQuery.component)
+
+  object AsterismGroupLiveQuery {
+    type Props = AsterismGroupLiveQuery
+
+    implicit val reuseProps: Reusability[Props] = Reusability.derive
+
+    protected val component =
+      ScalaFnComponent.withReuse[Props] { props =>
+        implicit val ctx = props.ctx
+
         LiveQueryRenderMod[ObservationDB, AsterismGroupObsQuery.Data, AsterismGroupsWithObs](
-          Reuse.currying(programId).in(pid => AsterismGroupObsQuery.query(pid)),
+          Reuse.currying(props.programId).in(pid => AsterismGroupObsQuery.query(pid)),
           (AsterismGroupObsQuery.Data.asAsterismGroupWithObs.get _).reuseAlways,
-          Reuse.by(programId)(
-            List(ObsQueriesGQL.ProgramObservationsEditSubscription.subscribe[IO](programId),
-                 TargetQueriesGQL.ProgramTargetEditSubscription.subscribe[IO](programId)
+          Reuse.by(props.programId)(
+            List(
+              ObsQueriesGQL.ProgramObservationsEditSubscription.subscribe[IO](props.programId),
+              TargetQueriesGQL.ProgramTargetEditSubscription.subscribe[IO](props.programId)
             )
           )
-        )(potRender(render))
+        )(potRender(props.render))
       }
-    )
+  }
 
   def replaceAsterism[F[_]: Async](
     obsIds:     List[Observation.Id],

--- a/common/src/main/scala/explore/common/ConstraintGroupQueries.scala
+++ b/common/src/main/scala/explore/common/ConstraintGroupQueries.scala
@@ -84,11 +84,13 @@ object ConstraintGroupQueries {
                            ConstraintGroupObsQuery.Data,
                            ConstraintSummaryWithObervations
         ](
-          ConstraintGroupObsQuery.query(programId).reuseAlways,
+          Reuse.currying(programId).in(pid => ConstraintGroupObsQuery.query(pid)),
           (ConstraintGroupObsQuery.Data.asConstraintSummWithObs.get _).reuseAlways,
-          List(
-            ObsQueriesGQL.ProgramObservationsEditSubscription.subscribe[IO](programId)
-          ).reuseAlways
+          Reuse.by(programId)(
+            List(
+              ObsQueriesGQL.ProgramObservationsEditSubscription.subscribe[IO](programId)
+            )
+          )
         )(potRender(render))
       }
     )

--- a/common/src/main/scala/explore/common/ObsQueries.scala
+++ b/common/src/main/scala/explore/common/ObsQueries.scala
@@ -129,11 +129,13 @@ object ObsQueries {
           ProgramObservationsQuery.Data,
           ObsSummariesWithConstraints
         ](
-          ProgramObservationsQuery.query(programId).reuseAlways,
+          Reuse.currying(programId).in(pid => ProgramObservationsQuery.query(pid)),
           (ProgramObservationsQuery.Data.asObsSummariesWithConstraints.get _).reuseAlways,
-          List(
-            ProgramObservationsEditSubscription.subscribe[IO](programId)
-          ).reuseAlways
+          Reuse.by(programId)(
+            List(
+              ProgramObservationsEditSubscription.subscribe[IO](programId)
+            )
+          )
         )(potRender(render))
       }
     )

--- a/common/src/main/scala/explore/common/ObsQueries.scala
+++ b/common/src/main/scala/explore/common/ObsQueries.scala
@@ -140,9 +140,6 @@ object ObsQueries {
       }
     )
 
-  import eu.timepit.refined.auto._
-  val ObsLiveQueryStable = ObsLiveQuery(Program.Id(2L))
-
   def updateObservationConstraintSet[F[_]: Async](
     obsIds:      List[Observation.Id],
     constraints: ConstraintSet

--- a/common/src/main/scala/explore/model/TwoPanelState.scala
+++ b/common/src/main/scala/explore/model/TwoPanelState.scala
@@ -4,71 +4,65 @@
 package explore.model
 
 import cats.Eq
-import cats.syntax.all._
 import japgolly.scalajs.react.ReactCats._
 import japgolly.scalajs.react.Reusability
 import lucuma.ui.reusability._
 import monocle.Focus
 import org.scalajs.dom.window
 
-sealed abstract class SelectedPanel[+A] extends Product with Serializable {
+sealed abstract class SelectedPanel extends Product with Serializable {
   import SelectedPanel._
   def rightPanelVisible: Boolean = this match {
     case Uninitialized => false
     case Tree          => false
     case Summary       => true
-    case Editor(_)     => true
+    case Editor        => true
   }
 
   def leftPanelVisible: Boolean = !rightPanelVisible
-
-  def optValue: Option[A] = this match {
-    case Editor(value) => value.some
-    case _             => none
-  }
 }
 
 object SelectedPanel {
-  case object Uninitialized      extends SelectedPanel[Nothing]
-  case object Tree               extends SelectedPanel[Nothing]
-  case object Summary            extends SelectedPanel[Nothing]
-  case class Editor[A](value: A) extends SelectedPanel[A]
+  case object Uninitialized extends SelectedPanel
+  case object Tree          extends SelectedPanel
+  case object Summary       extends SelectedPanel
+  case object Editor        extends SelectedPanel
 
-  def unitialized[A]: SelectedPanel[A]      = Uninitialized
-  def tree[A]: SelectedPanel[A]             = Tree
-  def summary[A]: SelectedPanel[A]          = Summary
-  def editor[A](value: A): SelectedPanel[A] = Editor(value)
+  def unitialized: SelectedPanel = Uninitialized
+  def tree: SelectedPanel        = Tree
+  def summary: SelectedPanel     = Summary
+  def editor: SelectedPanel      = Editor
 
-  implicit def eqSelectedPanel[A: Eq]: Eq[SelectedPanel[A]] = Eq.instance {
+  implicit def eqSelectedPanel: Eq[SelectedPanel] = Eq.instance {
     case (Uninitialized, Uninitialized) => true
     case (Tree, Tree)                   => true
     case (Summary, Summary)             => true
-    case (Editor(a), Editor(b))         => a === b
+    case (Editor, Editor)               => true
     case _                              => false
   }
 
-  implicit def reuseSelectedPanel[A: Eq]: Reusability[SelectedPanel[A]] = Reusability.byEq
+  implicit val reuseSelectedPanel: Reusability[SelectedPanel] = Reusability.byEq
 }
 
-final case class TwoPanelState[A](treeWidth: Double, selected: SelectedPanel[A])
+final case class TwoPanelState(treeWidth: Double, selected: SelectedPanel)
 
 object TwoPanelState {
-  def selected[A]  = Focus[TwoPanelState[A]](_.selected)
-  def treeWidth[A] = Focus[TwoPanelState[A]](_.treeWidth)
+  val selected  = Focus[TwoPanelState](_.selected)
+  val treeWidth = Focus[TwoPanelState](_.treeWidth)
 
   // Keep them as def to take the value window.innerWidth at the current time
   def isTwoPanel: Boolean = window.innerWidth > Constants.TwoPanelCutoff
 
-  def initialPanelWidth[A](sp: SelectedPanel[A]): Double =
+  def initialPanelWidth(sp: SelectedPanel): Double =
     if (isTwoPanel) Constants.InitialTreeWidth
     else if (sp.rightPanelVisible) 0
     else window.innerWidth
 
-  def initial[A](sp: SelectedPanel[A]): TwoPanelState[A] =
+  def initial(sp: SelectedPanel): TwoPanelState =
     TwoPanelState(initialPanelWidth(sp), sp)
 
   private implicit def doubleReuse = Reusability.double(1.0)
 
-  implicit def stateReuse[A](implicit ev: Eq[A]): Reusability[TwoPanelState[A]] =
+  implicit val stateReuse: Reusability[TwoPanelState] =
     Reusability.by(tps => (tps.treeWidth, tps.selected))
 }

--- a/explore/src/main/scala/explore/EditableLabel.scala
+++ b/explore/src/main/scala/explore/EditableLabel.scala
@@ -11,13 +11,14 @@ import explore.implicits._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.reusability._
+import org.scalajs.dom
 import react.common.ReactFnProps
 import react.common.style.Css
 import react.semanticui.elements.button.Button
-import react.semanticui.sizes._
-import org.scalajs.dom
-import scalajs.js.|
 import react.semanticui.elements.input.Input
+import react.semanticui.sizes._
+
+import scalajs.js.|
 
 final case class EditableLabel(
   value:            Option[NonEmptyString],

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -124,6 +124,7 @@ object ObsBadge {
                         )
                       )
                       .whenDefined
+                  case _                       => TagMod.empty
                 },
                 renderEnumProgress(obs.status)
               ),

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -164,7 +164,7 @@ object ConstraintSetTabContents {
     val coreWidth  = props.size.width.getOrElse(0) - treeWidth
     val coreHeight = props.size.height.getOrElse(0)
 
-    val rightSide = state.get.selected.optValue
+    val rightSide = props.focusedObsSet
       .flatMap(ids =>
         findConstraintGroup(ids, constraintsWithObs.get.constraintGroups).map(cg => (ids, cg))
       )

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -295,10 +295,11 @@ object ConstraintSetTabContents {
           case _                               => Callback.empty
         }
       }
-      .renderWithReuse { (props, state) =>
+      .useMemoBy((props, _) => props.programId)((_, _) => pid => ConstraintGroupLiveQuery(pid))
+      .renderWithReuse { (props, state, liveQuery) =>
         implicit val ctx = props.ctx
 
-        ConstraintGroupLiveQuery(props.programId)(
+        liveQuery.value(
           Reuse(renderFn _)(props, state)
         )
       }

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -292,11 +292,11 @@ object ConstraintSetTabContents {
           case _                            => Callback.empty
         }
       }
-      .useMemoBy((props, _) => props.programId)((_, _) => pid => ConstraintGroupLiveQuery(pid))
-      .renderWithReuse { (props, state, liveQuery) =>
+      .renderWithReuse { (props, state) =>
         implicit val ctx = props.ctx
 
-        liveQuery.value(
+        ConstraintGroupLiveQuery(
+          props.programId,
           Reuse(renderFn _)(props, state)
         )
       }

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -63,13 +63,10 @@ final case class ConstraintSetTabContents(
 
 object ConstraintSetTabContents {
   type Props = ConstraintSetTabContents
-  type State = TwoPanelState[ObsIdSet]
+  type State = TwoPanelState
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive
   implicit val stateReuse: Reusability[State] = Reusability.derive
-
-  val treeWidthLens = TwoPanelState.treeWidth[ObsIdSet]
-  val selectedLens  = TwoPanelState.selected[ObsIdSet]
 
   def readWidthPreference(props: Props, state: View[State]): Callback = {
     implicit val ctx = props.ctx
@@ -78,7 +75,7 @@ object ConstraintSetTabContents {
       props.userId,
       ResizableSection.ConstraintSetsTree,
       Constants.InitialTreeWidth.toInt
-    ) >>= (w => state.zoom(treeWidthLens).async.set(w.toDouble))).runAsync
+    ) >>= (w => state.zoom(TwoPanelState.treeWidth).async.set(w.toDouble))).runAsync
   }
 
   protected def renderFn(
@@ -88,7 +85,7 @@ object ConstraintSetTabContents {
   )(implicit ctx:       AppContextIO): VdomNode = {
     val treeResize =
       (_: ReactEvent, d: ResizeCallbackData) =>
-        (state.zoom(treeWidthLens).set(d.size.width.toDouble).to[IO] *>
+        (state.zoom(TwoPanelState.treeWidth).set(d.size.width.toDouble).to[IO] *>
           UserWidthsCreation
             .storeWidthPreference[IO](props.userId,
                                       ResizableSection.ConstraintSetsTree,
@@ -109,7 +106,7 @@ object ConstraintSetTabContents {
           constraintWithObs,
           props.programId,
           props.focusedObsSet,
-          state.zoom(selectedLens).set(SelectedPanel.summary).reuseAlways,
+          state.zoom(TwoPanelState.selected).set(SelectedPanel.summary).reuseAlways,
           props.expandedIds,
           props.listUndoStacks
         )
@@ -156,7 +153,7 @@ object ConstraintSetTabContents {
         clazz = ExploreStyles.TileBackButton |+| ExploreStyles.BlendedButton,
         onClickE = linkOverride[ButtonProps](
           ctx.pushPage(AppTab.Constraints, props.programId, none, none) >>
-            state.zoom(selectedLens).set(SelectedPanel.tree)
+            state.zoom(TwoPanelState.selected).set(SelectedPanel.tree)
         )
       )(^.href := ctx.pageUrl(AppTab.Constraints, props.programId, none, none), Icons.ChevronLeft)
     )
@@ -283,16 +280,16 @@ object ConstraintSetTabContents {
   protected val component =
     ScalaFnComponent
       .withHooks[Props]
-      .useStateViewWithReuse(TwoPanelState.initial[ObsIdSet](SelectedPanel.Uninitialized))
+      .useStateViewWithReuse(TwoPanelState.initial(SelectedPanel.Uninitialized))
       .useEffectOnMountBy((props, state) => readWidthPreference(props, state))
       .useEffectWithDepsBy((props, state) =>
-        (props.focusedObsSet, state.zoom(selectedLens).value.reuseByValue)
+        (props.focusedObsSet, state.zoom(TwoPanelState.selected).value.reuseByValue)
       ) { (_, _) => params =>
         val (focusedObsSet, selected) = params
         (focusedObsSet, selected.get) match {
-          case (Some(obsIdSet), _)             => selected.set(SelectedPanel.editor(obsIdSet))
-          case (None, SelectedPanel.Editor(_)) => selected.set(SelectedPanel.Summary)
-          case _                               => Callback.empty
+          case (Some(_), _)                 => selected.set(SelectedPanel.editor)
+          case (None, SelectedPanel.Editor) => selected.set(SelectedPanel.summary)
+          case _                            => Callback.empty
         }
       }
       .useMemoBy((props, _) => props.programId)((_, _) => pid => ConstraintGroupLiveQuery(pid))

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -321,8 +321,6 @@ object ObsTabContents {
         )
       )
 
-    val obsIdOpt: Option[Observation.Id] = panels.get.selected.optValue
-
     val targetCoords: Option[Coordinates] =
       props.focusedTarget.flatMap(obsWithConstraints.get.targetMap.get).flatMap(_.coords)
 
@@ -480,7 +478,7 @@ object ObsTabContents {
       ).withKey(obsId.toString)
 
     val rightSide =
-      obsIdOpt.fold[VdomNode](
+      props.focusedObs.fold[VdomNode](
         Tile("observations", "Observations Summary", backButton.some, key = "observationsSummary")(
           Reuse.by(obsWithConstraints)((_: Tile.RenderInTitle) =>
             <.div(ExploreStyles.HVCenter |+| ExploreStyles.EmptyTreeContent,

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -563,9 +563,12 @@ object ObsTabContents {
       }
       .useResizeDetector()
       .useSingleEffect(debounce = 1.second)
-      .renderWithReuse { (props, panels, options, layouts, resize, debouncer) =>
+      .useMemoBy((props, _, _, _, _, _) => props.programId)((_, _, _, _, _, _) =>
+        pid => ObsLiveQuery(pid)
+      )
+      .renderWithReuse { (props, panels, options, layouts, resize, debouncer, liveQuery) =>
         implicit val ctx = props.ctx
-        ObsLiveQueryStable(
+        liveQuery.value(
           Reuse(renderFn _)(props, panels, options, layouts, resize, debouncer)
         )
       }

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -559,13 +559,10 @@ object ObsTabContents {
       }
       .useResizeDetector()
       .useSingleEffect(debounce = 1.second)
-      .useMemoBy((props, _, _, _, _, _) => props.programId)((_, _, _, _, _, _) =>
-        pid => ObsLiveQuery(pid)
-      )
-      .renderWithReuse { (props, panels, options, layouts, resize, debouncer, liveQuery) =>
+      .renderWithReuse { (props, panels, options, layouts, resize, debouncer) =>
         implicit val ctx = props.ctx
-        liveQuery.value(
-          Reuse(renderFn _)(props, panels, options, layouts, resize, debouncer)
+        ObsLiveQuery(props.programId,
+                     Reuse(renderFn _)(props, panels, options, layouts, resize, debouncer)
         )
       }
 

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -223,8 +223,6 @@ object ObsTabContents {
   type Props = ObsTabContents
   implicit val propsReuse: Reusability[Props] = Reusability.derive
 
-  val selectedLens = TwoPanelState.selected[Observation.Id]
-
   def makeConstraintsSelector(
     constraintGroups: ReuseView[ConstraintsList],
     obsView:          Pot[ReuseView[ObservationData]]
@@ -277,7 +275,7 @@ object ObsTabContents {
 
   protected def renderFn(
     props:              Props,
-    panels:             ReuseView[TwoPanelState[Observation.Id]],
+    panels:             ReuseView[TwoPanelState],
     options:            ReuseView[TargetVisualOptions],
     layouts:            ReuseView[LayoutsMap],
     resize:             UseResizeDetectorReturn,
@@ -289,7 +287,7 @@ object ObsTabContents {
 
     val panelsResize =
       (_: ReactEvent, d: ResizeCallbackData) =>
-        panels.zoom(TwoPanelState.treeWidth[Observation.Id]).set(d.size.width.toDouble) *>
+        panels.zoom(TwoPanelState.treeWidth).set(d.size.width.toDouble) *>
           debouncer
             .submit(
               UserWidthsCreation
@@ -301,7 +299,7 @@ object ObsTabContents {
             .runAsyncAndForget
 
     val treeWidth    = panels.get.treeWidth.toInt
-    val selectedView = panels.zoom(selectedLens)
+    val selectedView = panels.zoom(TwoPanelState.selected)
 
     // Tree area
     def tree(observations: ReuseView[ObservationList]) =
@@ -525,15 +523,15 @@ object ObsTabContents {
   protected val component =
     ScalaFnComponent
       .withHooks[Props]
-      .useStateViewWithReuse(TwoPanelState.initial[Observation.Id](SelectedPanel.Uninitialized))
+      .useStateViewWithReuse(TwoPanelState.initial(SelectedPanel.Uninitialized))
       .useEffectWithDepsBy((props, panels) =>
-        (props.focusedObs, panels.zoom(selectedLens).value.reuseByValue)
+        (props.focusedObs, panels.zoom(TwoPanelState.selected).value.reuseByValue)
       ) { (_, _) => params =>
         val (focusedObs, selected) = params
         (focusedObs, selected.get) match {
-          case (Some(obsId), _)                => selected.set(SelectedPanel.editor(obsId))
-          case (None, SelectedPanel.Editor(_)) => selected.set(SelectedPanel.Summary)
-          case _                               => Callback.empty
+          case (Some(_), _)                 => selected.set(SelectedPanel.editor)
+          case (None, SelectedPanel.Editor) => selected.set(SelectedPanel.Summary)
+          case _                            => Callback.empty
         }
       }
       .useStateViewWithReuse(TargetVisualOptions.Default)
@@ -552,7 +550,7 @@ object ObsTabContents {
               case Right((w, l)) =>
                 (panels
                   .mod(
-                    TwoPanelState.treeWidth[Observation.Id].replace(w.toDouble)
+                    TwoPanelState.treeWidth.replace(w.toDouble)
                   ) *> layout.mod(o => mergeMap(o, l)))
                   .to[IO]
               case Left(_)       => IO.unit

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -579,9 +579,12 @@ object TargetTabContents {
           }
       }
       .useSingleEffect(debounce = 1.second)
-      .renderWithReuse { (props, tps, opts, resize, layout, defaultLayout, debouncer) =>
+      .useMemoBy((props, _, _, _, _, _, _) => props.programId)((_, _, _, _, _, _, _) =>
+        pid => AsterismGroupLiveQuery(pid)
+      )
+      .renderWithReuse { (props, tps, opts, resize, layout, defaultLayout, debouncer, liveQuery) =>
         implicit val ctx = props.ctx
-        AsterismGroupLiveQueryStable(
+        liveQuery.value(
           Reuse(renderFn _)(props, tps, opts, defaultLayout, layout, resize, debouncer)
         )
       }

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -74,8 +74,6 @@ final case class TargetTabContents(
 object TargetTabContents {
   type Props = TargetTabContents
 
-  import AsterismGroupObsList.TargetOrObsSet
-
   private val TargetIntialHeightFraction   = 6
   private val SkyPlotInitialHeightFraction = 4
   private val TotalHeightFractions         = TargetIntialHeightFraction + SkyPlotInitialHeightFraction
@@ -137,9 +135,6 @@ object TargetTabContents {
 
   implicit val propsReuse: Reusability[Props] = Reusability.derive
 
-  val treeWidthLens = TwoPanelState.treeWidth[TargetOrObsSet]
-  val selectedLens  = TwoPanelState.selected[TargetOrObsSet]
-
   def otherObsCount(
     targetGroupMap: Reuse[TargetGroupList],
     obsIds:         ObsIdSet,
@@ -149,7 +144,7 @@ object TargetTabContents {
 
   protected def renderFn(
     props:                 Props,
-    panels:                ReuseView[TwoPanelState[TargetOrObsSet]],
+    panels:                ReuseView[TwoPanelState],
     options:               ReuseView[TargetVisualOptions],
     defaultLayouts:        LayoutsMap,
     layouts:               ReuseView[LayoutsMap],
@@ -160,7 +155,7 @@ object TargetTabContents {
 
     val panelsResize =
       (_: ReactEvent, d: ResizeCallbackData) =>
-        panels.zoom(treeWidthLens).set(d.size.width.toDouble) *>
+        panels.zoom(TwoPanelState.treeWidth).set(d.size.width.toDouble) *>
           debouncer
             .submit(
               UserWidthsCreation
@@ -168,8 +163,8 @@ object TargetTabContents {
             )
             .runAsyncAndForget
 
-    val treeWidth: Int                                         = panels.get.treeWidth.toInt
-    val selectedView: ReuseView[SelectedPanel[TargetOrObsSet]] = panels.zoom(selectedLens)
+    val treeWidth: Int                         = panels.get.treeWidth.toInt
+    val selectedView: ReuseView[SelectedPanel] = panels.zoom(TwoPanelState.selected)
 
     val targetMap: Reuse[TargetGroupList] = asterismGroupsWithObs.map(_.get.targetGroups)
 
@@ -541,16 +536,19 @@ object TargetTabContents {
   protected val component =
     ScalaFnComponent
       .withHooks[Props]
-      .useStateViewWithReuse(TwoPanelState.initial[TargetOrObsSet](SelectedPanel.Uninitialized))
+      .useStateViewWithReuse(TwoPanelState.initial(SelectedPanel.Uninitialized))
       .useEffectWithDepsBy((props, state) =>
-        (props.focusedObsSet, props.focusedTarget, state.zoom(selectedLens).value.reuseByValue)
+        (props.focusedObsSet,
+         props.focusedTarget,
+         state.zoom(TwoPanelState.selected).value.reuseByValue
+        )
       ) { (_, _) => params =>
         val (focusedObsSet, focusedTarget, selected) = params
         (focusedObsSet, focusedTarget, selected.get) match {
-          case (Some(obsIdSet), _, _)                => selected.set(SelectedPanel.editor(obsIdSet.asRight))
-          case (None, Some(targetId), _)             => selected.set(SelectedPanel.editor(targetId.asLeft))
-          case (None, None, SelectedPanel.Editor(_)) => selected.set(SelectedPanel.Summary)
-          case _                                     => Callback.empty
+          case (Some(_), _, _)                    => selected.set(SelectedPanel.editor)
+          case (None, Some(_), _)                 => selected.set(SelectedPanel.editor)
+          case (None, None, SelectedPanel.Editor) => selected.set(SelectedPanel.Summary)
+          case _                                  => Callback.empty
         }
       }
       .useStateViewWithReuse(TargetVisualOptions.Default)
@@ -576,7 +574,7 @@ object TargetTabContents {
                 case Right((w, l)) =>
                   (panels
                     .mod(
-                      TwoPanelState.treeWidth[TargetOrObsSet].replace(w.toDouble)
+                      TwoPanelState.treeWidth.replace(w.toDouble)
                     ) *> layout.mod(o => mergeMap(o, l)))
                     .to[IO]
                 case Left(_)       =>

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -474,8 +474,14 @@ object TargetTabContents {
     }
 
     val selectedPanel = panels.get.selected
-    val rightSide     =
-      selectedPanel.optValue
+    val optSelected   = (props.focusedObsSet, props.focusedTarget) match {
+      case (Some(obsIdSet), _)    => obsIdSet.asRight.some
+      case (None, Some(targetId)) => targetId.asLeft.some
+      case _                      => none
+    }
+
+    val rightSide =
+      optSelected
         .fold(renderSummary) {
           _ match {
             case Left(targetId) =>

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -583,12 +583,10 @@ object TargetTabContents {
           }
       }
       .useSingleEffect(debounce = 1.second)
-      .useMemoBy((props, _, _, _, _, _, _) => props.programId)((_, _, _, _, _, _, _) =>
-        pid => AsterismGroupLiveQuery(pid)
-      )
-      .renderWithReuse { (props, tps, opts, resize, layout, defaultLayout, debouncer, liveQuery) =>
+      .renderWithReuse { (props, tps, opts, resize, layout, defaultLayout, debouncer) =>
         implicit val ctx = props.ctx
-        liveQuery.value(
+        AsterismGroupLiveQuery(
+          props.programId,
           Reuse(renderFn _)(props, tps, opts, defaultLayout, layout, resize, debouncer)
         )
       }


### PR DESCRIPTION
The value inside of `SelectedPanel.Editor(value)` is no longer used. The state update came too late and was causing problems because the editor was being rendered based on old values. On the target tab, this could result in the URL being "rewritten" by the AsterismEditor. Now the focused obs/target values from props are used directly. `SelectedPanel` can be cleaned up and simplified, but I wanted to get this PR into staging because it fixes problems. I will clean up `SelectedPanel` and `TwoPanelState` in a separate PR.

Update: I pushed another commit removing the type parameter from `TwoPanelState`.