### PR TITLE
Expand Brigthness Table to 100% and scroll x for small width

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1350,6 +1350,8 @@ img.partner-split-flag {
   display: flex;
   flex-direction: column;
   border: none;
+  width: 100%;
+  overflow-x: scroll;
 
   .table {
     margin: 0;


### PR DESCRIPTION
This solves @cquiroz issue with the Brightness table width
![image](https://user-images.githubusercontent.com/44274704/164329782-2af33d6d-899a-4bd2-b76f-193cfe24104a.png)
![image](https://user-images.githubusercontent.com/44274704/164330112-b61f7b89-785c-4ab0-9050-8314b79f24db.png)
