### PR TITLE
Some improvements to brightness/emission table width

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -246,6 +246,7 @@ object ExploreStyles {
   val BrightnessesTableFooter: Css             = Css("explore-brightnesses-footer")
   val BrightnessesTableUnitsDropdown: Css      = Css("explore-brightnesses-units-dropdown")
   val BrightnessesTableDeletButtonWrapper: Css = Css("explore-brightnesses-delete-button-wrapper")
+  val BrightnessAddButton: Css                 = Css("explore-brightnesses-add-button")
   val EmptyTreeContent: Css                    = Css("explore-empty-tree-content")
 
   // This is rendered without React, so we include SUI classes.

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1700,7 +1700,7 @@ html {
   justify-content: center;
 
   .ui.button.delete-button {
-    padding: 0.4em 0.4em 0.4em 0.4em;
+    padding: 0.4em 0;
   }
 }
 
@@ -1710,6 +1710,10 @@ html {
   padding: 0.2em;
   border-top: 0.2px solid var(--under-tab-border-color);
   background-color: var(--table-footer-background);
+}
+
+.ui.button.explore-brightnesses-add-button {
+  margin-left: 5px;
 }
 
 .obs-badge-header {

--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -94,9 +94,9 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
               .Column("band", _._1)
               .setHeader("Band")
               .setCell(_.value.shortName)
-              .setWidth(66)
-              .setMinWidth(66)
-              .setMaxWidth(66)
+              .setWidth(60)
+              .setMinWidth(50)
+              .setMaxWidth(60)
               .setSortByAuto,
             BrightnessTableDef
               .Column("value", _._2.zoom(Measure.valueTagged[BigDecimal, Brightness[T]]))
@@ -109,7 +109,10 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                   changeAuditor = ChangeAuditor.bigDecimal(2, 3).allowExp(2),
                   disabled = disabled
                 )
-              ),
+              )
+              .setWidth(80)
+              .setMinWidth(60)
+              .setMaxWidth(160),
             BrightnessTableDef
               .Column("units", _._2.zoom(Measure.unitsTagged[BigDecimal, Brightness[T]]))
               .setHeader("Units")
@@ -121,23 +124,25 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                   disabled = disabled,
                   clazz = ExploreStyles.BrightnessesTableUnitsDropdown
                 )
-              ),
+              )
+              .setWidth(100)
+              .setMinWidth(100)
+              .setMaxWidth(160),
             BrightnessTableDef
               .Column("delete", _._1)
               .setCell(cell =>
                 <.div(ExploreStyles.BrightnessesTableDeletButtonWrapper)(
                   Button(
                     size = Small,
-                    compact = true,
                     clazz = ExploreStyles.DeleteButton,
                     disabled = disabled,
                     onClick = brightnesses.mod(_ - cell.value)
                   )(Icons.Trash)
                 )
               )
-              .setWidth(46)
-              .setMinWidth(46)
-              .setMaxWidth(46)
+              .setWidth(20)
+              .setMinWidth(20)
+              .setMaxWidth(20)
               .setDisableSortBy(true)
           )
         }
@@ -181,8 +186,9 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                   Button(size = Mini,
                          compact = true,
                          onClick = addBrightness,
+                         clazz = ExploreStyles.BrightnessAddButton,
                          disabled = props.disabled
-                  )(^.marginLeft := "5px")(
+                  )(
                     Icons.New
                   )
                 )

--- a/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
@@ -74,8 +74,8 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
                 .setScale(3, RoundingMode.HALF_UP)
                 .toString
             )
-            .setWidth(80)
-            .setMinWidth(80)
+            .setWidth(60)
+            .setMinWidth(50)
             .setMaxWidth(80)
             .setSortByAuto,
           EmissionLineTableRef
@@ -92,7 +92,10 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
                 changeAuditor = ChangeAuditor.posBigDecimal(3).allowEmpty,
                 disabled = disabled
               )
-            ),
+            )
+            .setWidth(90)
+            .setMinWidth(80)
+            .setMaxWidth(160),
           EmissionLineTableRef
             .Column(
               "lineValue",
@@ -109,7 +112,10 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
                 changeAuditor = ChangeAuditor.posScientificNotation(),
                 disabled = disabled
               )
-            ),
+            )
+            .setWidth(80)
+            .setMinWidth(70)
+            .setMaxWidth(160),
           EmissionLineTableRef
             .Column(
               "lineUnits",
@@ -127,7 +133,9 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
                 clazz = ExploreStyles.BrightnessesTableUnitsDropdown
               )
             )
-            .setMaxWidth(60),
+            .setWidth(80)
+            .setMinWidth(40)
+            .setMaxWidth(80),
           EmissionLineTableRef
             .Column("delete", _._1)
             .setCell(cell =>
@@ -135,16 +143,15 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
                 ExploreStyles.BrightnessesTableDeletButtonWrapper,
                 Button(
                   size = Small,
-                  compact = true,
                   clazz = ExploreStyles.DeleteButton,
                   disabled = disabled,
                   onClick = emissionLines.mod(_ - cell.value)
                 )(Icons.Trash)
               )
             )
-            .setWidth(46)
-            .setMinWidth(46)
-            .setMaxWidth(46)
+            .setWidth(25)
+            .setMinWidth(25)
+            .setMaxWidth(25)
             .setDisableSortBy(true)
         )
       }
@@ -198,9 +205,8 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
           Button(size = Mini,
                  compact = true,
                  onClick = addLine,
+                 clazz = ExploreStyles.BrightnessAddButton,
                  disabled = props.disabled || addDisabled.get
-          )(
-            ^.marginLeft := "5px"
           )(
             Icons.New
           )


### PR DESCRIPTION
The brightness table tends to be too wide. This PR brings some improvements to reduce the need to have horizontal scrolling though still if it is too narrow there is no way around
