### PR TITLE
Improvements to the Target grid layout

### DIFF
--- a/common/src/main/scala/explore/model/layout.scala
+++ b/common/src/main/scala/explore/model/layout.scala
@@ -12,8 +12,8 @@ import japgolly.scalajs.react.Reusability
 import monocle.Focus
 import monocle.Lens
 import monocle.Traversal
-import monocle.function.Each._
 import monocle.function.At._
+import monocle.function.Each._
 import react.gridlayout._
 
 import scala.collection.immutable.SortedMap
@@ -69,14 +69,15 @@ object layout {
 
   val layoutItem: Lens[Layout, List[LayoutItem]] = Focus[Layout](_.l)
   val layoutItems: Traversal[Layout, LayoutItem] = layoutItem.each
-  val layoutItemName                             = Focus[LayoutItem](_.i)
-  val layoutItemHeight                           = Focus[LayoutItem](_.h)
-  val layoutItemMaxHeight                        = Focus[LayoutItem](_.maxH)
-  val layoutItemMinHeight                        = Focus[LayoutItem](_.minH)
-  val layoutItemWidth                            = Focus[LayoutItem](_.w)
-  val layoutItemX                                = Focus[LayoutItem](_.x)
-  val layoutItemY                                = Focus[LayoutItem](_.y)
-  val layoutItemResizable                        = Focus[LayoutItem](_.isResizable)
+
+  val layoutItemName      = Focus[LayoutItem](_.i)
+  val layoutItemHeight    = Focus[LayoutItem](_.h)
+  val layoutItemMaxHeight = Focus[LayoutItem](_.maxH)
+  val layoutItemMinHeight = Focus[LayoutItem](_.minH)
+  val layoutItemWidth     = Focus[LayoutItem](_.w)
+  val layoutItemX         = Focus[LayoutItem](_.x)
+  val layoutItemY         = Focus[LayoutItem](_.y)
+  val layoutItemResizable = Focus[LayoutItem](_.isResizable)
 
   implicit val breakpointNameReuse: Reusability[BreakpointName] = Reusability.byEq
   implicit val layoutItemReuse: Reusability[LayoutItem]         = Reusability.byEq

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -2249,6 +2249,7 @@ th.sticky-header,
   width: auto;
 }
 
+/* stylelint-disable */
 .ui.form .field.field input:-webkit-autofill,
 .ui.form .field.field input:-webkit-autofill:hover,
 .ui.form .field.field input:-webkit-autofill:focus,
@@ -2264,9 +2265,9 @@ th.sticky-header,
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
-input:-webkit-autofill:active
-{
+input:-webkit-autofill:active {
   box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
   -webkit-box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
   -webkit-text-fill-color: var(--input-color);
 }
+/* stylelint-enable */

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -2264,9 +2264,9 @@ th.sticky-header,
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
-input:-webkit-autofill:active {
+input:-webkit-autofill:active
+{
   box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
   -webkit-box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
   -webkit-text-fill-color: var(--input-color);
 }
-

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -2264,9 +2264,9 @@ th.sticky-header,
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
-input:-webkit-autofill:active
-{
+input:-webkit-autofill:active {
   box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
   -webkit-box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
   -webkit-text-fill-color: var(--input-color);
 }
+

--- a/common/src/main/webapp/less/vendor/react-grid-layout.less
+++ b/common/src/main/webapp/less/vendor/react-grid-layout.less
@@ -62,3 +62,12 @@
 .react-resizable-hide > .react-resizable-handle {
   display: none;
 }
+
+.rgl-tile-overlay {
+  display: none; // Enable for grid debugging
+  position: absolute;
+  top: 5px;
+  left: 300px;
+  font-size: smaller;
+  color: yellow;
+}

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -28,7 +28,6 @@ import explore.model._
 import explore.model.display._
 import explore.model.enum.AppTab
 import explore.model.layout._
-import explore.model.layout.unsafe._
 import explore.observationtree.ObsList
 import explore.optics._
 import explore.syntax.ui._

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -529,27 +529,28 @@ object ObsTabContents {
         }
       }
       .useStateViewWithReuse(defaultLayout)
-      .useEffectWithDepsBy((p, _, _) => p.focusedObs) { (props, panels, layout) =>
-        implicit val ctx = props.ctx
-        _ =>
-          TabGridPreferencesQuery
-            .queryWithDefault[IO](props.userId.get,
-                                  GridLayoutSection.ObservationsLayout,
-                                  ResizableSection.ObservationsTree,
-                                  (Constants.InitialTreeWidth.toInt, defaultLayout)
-            )
-            .attempt
-            .flatMap {
-              case Right((w, l)) =>
-                (panels
-                  .mod(
-                    TwoPanelState.treeWidth.replace(w.toDouble)
-                  ) *> layout.mod(o => mergeMap(o, l)))
-                  .to[IO]
-              case Left(_)       => IO.unit
-            }
-            .runAsync
-      }
+      // TODO Rework the obs tab layout
+      // .useEffectWithDepsBy((p, _, _) => p.focusedObs) { (props, panels, layout) =>
+      //   implicit val ctx = props.ctx
+      //   _ =>
+      //     TabGridPreferencesQuery
+      //       .queryWithDefault[IO](props.userId.get,
+      //                             GridLayoutSection.ObservationsLayout,
+      //                             ResizableSection.ObservationsTree,
+      //                             (Constants.InitialTreeWidth.toInt, defaultLayout)
+      //       )
+      //       .attempt
+      //       .flatMap {
+      //         case Right((w, l)) =>
+      //           (panels
+      //             .mod(
+      //               TwoPanelState.treeWidth.replace(w.toDouble)
+      //             ) *> layout.mod(o => mergeMap(o, l)))
+      //             .to[IO]
+      //         case Left(_)       => IO.unit
+      //       }
+      //       .runAsync
+      // }
       .useResizeDetector()
       .useSingleEffect(debounce = 1.second)
       .renderWithReuse { (props, panels, layouts, resize, debouncer) =>

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -113,32 +113,6 @@ object TargetTabContents {
     )
   )
 
-  // def layoutLens(height: Int) =
-  //   layoutItemHeight
-  //     .replace(height)
-  //     .andThen(layoutItemMaxHeight.replace(2 * height))
-  //     .andThen(layoutItemMinHeight.replace(height / 2))
-  //
-  // private def scaleLayout(l: Layout, h: Int): Layout =
-  //   layoutItems.modify { l =>
-  //     l.i match {
-  //       case r if r === ObsTabTiles.TargetId.value =>
-  //         val height =
-  //           (h * TargetIntialHeightFraction / TotalHeightFractions) / (Constants.GridRowHeight + Constants.GridRowPadding)
-  //         layoutLens(height)(l)
-  //       case r if r === ObsTabTiles.PlotId.value   =>
-  //         val height =
-  //           (h * SkyPlotInitialHeightFraction / TotalHeightFractions) / (Constants.GridRowHeight + Constants.GridRowPadding)
-  //         layoutLens(height)(l)
-  //       case _                                     => l
-  //     }
-  //   }(l)
-  //
-  // private def scaledLayout(h: Int, l: LayoutsMap): LayoutsMap =
-  //   l.map { case (k, (a, b, l)) =>
-  //     (k, (a, b, scaleLayout(l, h)))
-  //   }
-
   implicit val propsReuse: Reusability[Props] = Reusability.derive
 
   def otherObsCount(

--- a/model/shared/src/main/scala/explore/model/Constants.scala
+++ b/model/shared/src/main/scala/explore/model/Constants.scala
@@ -11,6 +11,7 @@ trait Constants {
   val MinLeftPanelWidth                = 270.0
   val GridRowHeight                    = 36
   val GridRowPadding                   = 5
+  val GridColCount                     = 12
   val InitialFov: Angle                = Angle.fromDoubleDegrees(0.25)
   val AngleSizeFovFactor: Long => Long = v => (v * 3) / 2
   val SimbadResultLimit                = 50


### PR DESCRIPTION
Currently the grid layouts has some issues when resizing and on resetting the value stored in user preferences.
This PR brings several improvements:

* Remove the attempt to scale the tiles depending on the height. Though it sounds nice in practice it is difficult to implement
* Add some debugging aids to show the tiles' properties
* Put limits on how small tiles can be. In practice very small tiles are hard to layout

This is a first step we still need to improve the obs tab layout and some other improvements when resizing