### PR TITLE
Add Program Management modal popup

### DIFF
--- a/common-graphql/src/main/scala/queries/common/ProgramQueriesGQL.scala
+++ b/common-graphql/src/main/scala/queries/common/ProgramQueriesGQL.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+import lucuma.schemas.ObservationDB
+
+// gql: import explore.model.reusability._
+// gql: import lucuma.ui.reusability._
+// gql: import io.circe.refined._
+
+object ProgramQueriesGQL {
+  @GraphQL
+  trait ProgramsQuery extends GraphQLOperation[ObservationDB] {
+    val document: String = """
+      query($includeDeleted: Boolean!) {
+        programs(includeDeleted: $includeDeleted) {
+          nodes {
+            id
+            name
+            existence
+          }
+        }
+      }
+    """
+  }
+
+  @GraphQL
+  trait CreateProgramMutation extends GraphQLOperation[ObservationDB] {
+    val document: String = """
+      mutation($input: CreateProgramInput!) {
+        createProgram(input: $input) {
+          id
+          name
+        }
+      }
+    """
+  }
+
+  @GraphQL
+  trait UpdateProgramMutation extends GraphQLOperation[ObservationDB] {
+    val document: String = """
+      mutation($input: EditProgramInput!) {
+        updateProgram(input: $input) {
+          id
+        }
+      }
+    """
+  }
+
+  @GraphQL
+  trait ProgramEditSubscription extends GraphQLOperation[ObservationDB] {
+    val document: String = """
+      subscription {
+        programEdit {
+          id
+        }
+      }
+    """
+  }
+}

--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -43,6 +43,10 @@ object Icons {
   val faTrash: FAIcon = js.native
 
   @js.native
+  @JSImport("@fortawesome/pro-solid-svg-icons", "faTrashCanUndo")
+  val faTrashUndo: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-solid-svg-icons", "faCrosshairs")
   val faCrosshairs: FAIcon = js.native
 
@@ -57,6 +61,10 @@ object Icons {
   @js.native
   @JSImport("@fortawesome/pro-solid-svg-icons", "faPenToSquare")
   val faEdit: FAIcon = js.native
+
+  @js.native
+  @JSImport("@fortawesome/pro-solid-svg-icons", "faEraser")
+  val faEraser: FAIcon = js.native
 
   @js.native
   @JSImport("@fortawesome/pro-solid-svg-icons", "faMagnifyingGlass")
@@ -151,6 +159,10 @@ object Icons {
   val faListAlt: FAIcon = js.native
 
   @js.native
+  @JSImport("@fortawesome/pro-solid-svg-icons", "faListCheck")
+  val faListCheck: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-light-svg-icons", "faCompress")
   val faCompress: FAIcon = js.native
 
@@ -192,9 +204,11 @@ object Icons {
     faRedo,
     faPlus,
     faTrash,
+    faTrashUndo,
     faBullseye,
     faCrosshairs,
     faEdit,
+    faEraser,
     faSearch,
     faBan,
     faMousePointer,
@@ -218,6 +232,7 @@ object Icons {
     faChevronDoubleUp,
     faChevronDoubleDown,
     faListAlt,
+    faListCheck,
     faCompress,
     faExpand,
     faStar,
@@ -236,9 +251,11 @@ object Icons {
   val Redo                = FontAwesomeIcon(faRedo)
   val New                 = FontAwesomeIcon(faPlus)
   val Trash               = FontAwesomeIcon(faTrash).clazz(ExploreStyles.TrashIcon)
+  val TrashUndo           = FontAwesomeIcon(faTrashUndo)
   val Bullseye            = FontAwesomeIcon(faBullseye)
   val Crosshairs          = FontAwesomeIcon(faCrosshairs)
   val Edit                = FontAwesomeIcon(faEdit)
+  val Eraser              = FontAwesomeIcon(faEraser).clazz(ExploreStyles.EraserIcon)
   val Search              = FontAwesomeIcon(faSearch)
   val ChevronRight        = FontAwesomeIcon(faChevronRight)
   val ChevronRightLight   = FontAwesomeIcon(faChevronRightLight)
@@ -264,6 +281,7 @@ object Icons {
   val Maximize            = FontAwesomeIcon(faExpand)
   val Checkmark           = FontAwesomeIcon(faCheck)
   val ListIcon            = FontAwesomeIcon(faListAlt)
+  val ListCheck           = FontAwesomeIcon(faListCheck)
   val Star                = FontAwesomeIcon(faStar)
   val Stars               = FontAwesomeIcon(faStars)
   val Spinner             = FontAwesomeIcon(faSpinner)

--- a/common/src/main/scala/explore/common/ProgramQueries.scala
+++ b/common/src/main/scala/explore/common/ProgramQueries.scala
@@ -1,0 +1,101 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.common
+
+import cats.effect.Async
+import cats.effect.IO
+import cats.implicits._
+import clue.TransactionalClient
+import clue.data.syntax._
+import crystal.react.ReuseView
+import crystal.react.reuse._
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.components.graphql.LiveQueryRenderMod
+import explore.implicits._
+import explore.utils._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.VdomNode
+import lucuma.core.model.Program
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.ObservationDB.Types._
+import lucuma.schemas.ObservationDB.Enums._
+import lucuma.ui.reusability._
+import monocle.Focus
+import monocle.Lens
+import queries.common.ProgramQueriesGQL._
+import react.common.ReactFnProps
+
+object ProgramQueries {
+  final case class ProgramInfo(id: Program.Id, name: Option[NonEmptyString], deleted: Boolean)
+
+  object ProgramInfo {
+    implicit val reuseProgramInfo: Reusability[ProgramInfo] = Reusability.derive
+
+    val id: Lens[ProgramInfo, Program.Id]               = Focus[ProgramInfo](_.id)
+    val name: Lens[ProgramInfo, Option[NonEmptyString]] = Focus[ProgramInfo](_.name)
+    val deleted: Lens[ProgramInfo, Boolean]             = Focus[ProgramInfo](_.deleted)
+  }
+
+  implicit class ProgramsQueryDataOps(val self: ProgramsQuery.Data.type) extends AnyVal {
+    def asProgramInfoList: ProgramsQuery.Data => List[ProgramInfo] =
+      _.programs.nodes.map(p => ProgramInfo(p.id, p.name, p.existence === Existence.Deleted))
+  }
+
+  final case class ProgramsLiveQuery(
+    render:           ReuseView[List[ProgramInfo]] ==> VdomNode,
+    includeDeleted:   Boolean,
+    onNewData:        Reuse[List[ProgramInfo] => IO[Unit]]
+  )(implicit val ctx: AppContextIO)
+      extends ReactFnProps[ProgramsLiveQuery](ProgramsLiveQuery.component)
+
+  object ProgramsLiveQuery {
+    type Props = ProgramsLiveQuery
+
+    implicit val reuseProps: Reusability[Props] = Reusability.derive
+
+    protected val component =
+      ScalaFnComponent.withReuse[Props] { props =>
+        implicit val ctx = props.ctx
+        LiveQueryRenderMod[ObservationDB, ProgramsQuery.Data, List[ProgramInfo]](
+          ProgramsQuery.query(props.includeDeleted).reuseAlways,
+          (ProgramsQuery.Data.asProgramInfoList _).reuseAlways,
+          List(ProgramEditSubscription.subscribe[IO]()).reuseAlways
+        )(potRender(props.render), props.onNewData)
+      }
+  }
+
+  def createProgram[F[_]: Async](name: Option[NonEmptyString])(implicit
+    c:                                 TransactionalClient[F, ObservationDB]
+  ): F[Option[ProgramInfo]] =
+    CreateProgramMutation
+      .execute[F](CreateProgramInput(name = name.orIgnore))
+      .map(_.createProgram.map(p => ProgramInfo(p.id, p.name, false)))
+
+  def deleteProgram[F[_]: Async](id: Program.Id)(implicit
+    c:                               TransactionalClient[F, ObservationDB]
+  ): F[Unit] =
+    UpdateProgramMutation
+      .execute[F](
+        EditProgramInput(programId = id, existence = Existence.Deleted.assign)
+      )
+      .void
+
+  def undeleteProgram[F[_]: Async](id: Program.Id)(implicit
+    c:                                 TransactionalClient[F, ObservationDB]
+  ): F[Unit] =
+    UpdateProgramMutation
+      .execute[F](
+        EditProgramInput(programId = id, existence = Existence.Present.assign)
+      )
+      .void
+
+  def updateProgramName[F[_]: Async](id: Program.Id, name: Option[NonEmptyString])(implicit
+    c:                                   TransactionalClient[F, ObservationDB]
+  ): F[Unit] =
+    UpdateProgramMutation
+      .execute[F](
+        EditProgramInput(programId = id, name = name.orUnassign)
+      )
+      .void
+}

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRender.scala
@@ -27,7 +27,7 @@ final case class LiveQueryRender[S, D, A](
   changeSubscriptions: Reuse[List[IO[GraphQLSubscription[IO, _]]]]
 )(
   val render:          Pot[A] ==> VdomNode,
-  val onNewData:       Reuse[IO[Unit]] = Reuse.always(IO.unit)
+  val onNewData:       Reuse[A => IO[Unit]] = Reuse.always((_: A) => IO.unit)
 )(implicit
   val F:               Async[IO],
   val dispatcher:      Effect.Dispatch[IO],

--- a/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/LiveQueryRenderMod.scala
@@ -28,7 +28,7 @@ final case class LiveQueryRenderMod[S, D, A](
   changeSubscriptions: Reuse[List[IO[GraphQLSubscription[IO, _]]]]
 )(
   val render:          Pot[ReuseView[A]] ==> VdomNode,
-  val onNewData:       Reuse[IO[Unit]] = Reuse.always(IO.unit)
+  val onNewData:       Reuse[A => IO[Unit]] = Reuse.always((_: A) => IO.unit)
 )(implicit
   val F:               Async[IO],
   val dispatcher:      Effect.Dispatch[IO],

--- a/common/src/main/scala/explore/components/graphql/Render.scala
+++ b/common/src/main/scala/explore/components/graphql/Render.scala
@@ -27,7 +27,7 @@ import scala.reflect.ClassTag
 object Render {
   trait Props[F[_], G[_], A] {
     val render: Pot[G[A]] ==> VdomNode
-    val onNewData: Reuse[F[Unit]]
+    val onNewData: Reuse[A => F[Unit]]
 
     implicit val F: Async[F]
     implicit val dispatcher: Effect.Dispatch[F]
@@ -122,7 +122,7 @@ object Render {
           for {
             result <- $.props.query.value.map($.props.extract)
             _      <- queue.offer(result)
-            _      <- $.props.onNewData.value
+            _      <- $.props.onNewData.value(result)
           } yield ()
 
         // Once run, this effect will end when all subscriptions end.

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRender.scala
@@ -26,7 +26,7 @@ final case class SubscriptionRender[D, A](
     Reuse.always(identity[fs2.Stream[IO, D]] _)
 )(
   val render:     Pot[A] ==> VdomNode,
-  val onNewData:  Reuse[IO[Unit]] = Reuse.always(IO.unit)
+  val onNewData:  Reuse[A => IO[Unit]] = Reuse.always((_: A) => IO.unit)
 )(implicit
   val F:          Async[IO],
   val dispatcher: Effect.Dispatch[IO],
@@ -69,7 +69,7 @@ object SubscriptionRender {
                   .build(
                     $.props
                       .streamModifier(subscription.stream)
-                      .flatTap(_ => fs2.Stream.eval($.props.onNewData))
+                      .flatTap(a => fs2.Stream.eval($.props.onNewData(a)))
                   )
               ).some
             )

--- a/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
+++ b/common/src/main/scala/explore/components/graphql/SubscriptionRenderMod.scala
@@ -27,7 +27,7 @@ final case class SubscriptionRenderMod[D, A](
     Reuse.always(identity[fs2.Stream[IO, D]] _)
 )(
   val render:     Pot[ReuseView[A]] ==> VdomNode,
-  val onNewData:  Reuse[IO[Unit]] = Reuse.always(IO.unit)
+  val onNewData:  Reuse[A => IO[Unit]] = Reuse.always((_: A) => IO.unit)
 )(implicit
   val F:          Async[IO],
   val dispatcher: Effect.Dispatch[IO],
@@ -72,7 +72,7 @@ object SubscriptionRenderMod {
                   .build(
                     $.props
                       .streamModifier(subscription.stream)
-                      .flatTap(_ => fs2.Stream.eval($.props.onNewData)),
+                      .flatTap(a => fs2.Stream.eval($.props.onNewData(a))),
                     holdAfterMod = (2 seconds).some
                   )
               ).some

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -124,6 +124,15 @@ object ExploreStyles {
   val SelectedObsItem: Css        = Css("selected-obs-item")
   val ObsItem: Css                = Css("obs-item")
   val TrashIcon: Css              = Css("trash-icon")
+  val EraserIcon: Css             = Css("eraser-icon")
+
+  val ProgramsPopup     = Css("programs-popup")
+  val ProgramTable      = Css("program-table")
+  val ProgramAdd        = Css("program-add")
+  val ProgramName       = Css("program-name")
+  val ProgramNameInput  = Css("program-name-input")
+  val ProgramNameEdit   = Css("program-name-edit")
+  val ProgramNameDelete = Css("program-name-delete")
 
   val ObserverNotes: Css = Css("observer-notes")
   val NotesWrapper: Css  = Css("observer-notes-wrapper")

--- a/common/src/main/scala/explore/model/RoutingInfo.scala
+++ b/common/src/main/scala/explore/model/RoutingInfo.scala
@@ -17,10 +17,14 @@ import lucuma.ui.reusability._
 
 final case class RoutingInfo(
   appTab:        AppTab,
-  programId:     Program.Id,
+  optProgramId:  Option[Program.Id],
   focusedObsSet: Option[ObsIdSet],
   focusedTarget: Option[Target.Id]
-)
+) {
+  // The only Page that doesn't have a program ID is the NoProgramPage, so instead of forcing everyplace to deal
+  // Option[Program.Id], we'll just associate a dummy id with it. NoProgramPage will need special handling, anyways.
+  def programId: Program.Id = optProgramId.getOrElse(RoutingInfo.dummyProgramId)
+}
 
 object RoutingInfo {
   implicit val reuseRoutingInfo: Reusability[RoutingInfo] = Reusability.derive
@@ -30,22 +34,22 @@ object RoutingInfo {
   val dummyProgramId = Program.Id(Long.MaxValue: PosLong)
 
   def from(page: Page): RoutingInfo = page match {
-    case NoProgramPage                         => RoutingInfo(AppTab.Overview, dummyProgramId, none, none)
-    case HomePage(p)                           => RoutingInfo(AppTab.Overview, p, none, none)
-    case ProposalPage(p)                       => RoutingInfo(AppTab.Proposal, p, none, none)
-    case ObservationsBasePage(p)               => RoutingInfo(AppTab.Observations, p, none, none)
+    case NoProgramPage                         => RoutingInfo(AppTab.Overview, none, none, none)
+    case HomePage(p)                           => RoutingInfo(AppTab.Overview, p.some, none, none)
+    case ProposalPage(p)                       => RoutingInfo(AppTab.Proposal, p.some, none, none)
+    case ObservationsBasePage(p)               => RoutingInfo(AppTab.Observations, p.some, none, none)
     case ObsPage(p, obsId)                     =>
-      RoutingInfo(AppTab.Observations, p, ObsIdSet.one(obsId).some, none)
+      RoutingInfo(AppTab.Observations, p.some, ObsIdSet.one(obsId).some, none)
     case ObsTargetPage(p, obsId, targetId)     =>
-      RoutingInfo(AppTab.Observations, p, ObsIdSet.one(obsId).some, targetId.some)
-    case TargetsBasePage(p)                    => RoutingInfo(AppTab.Targets, p, none, none)
-    case TargetsObsPage(p, obsId)              => RoutingInfo(AppTab.Targets, p, obsId.some, none)
-    case TargetPage(p, targetId)               => RoutingInfo(AppTab.Targets, p, none, targetId.some)
+      RoutingInfo(AppTab.Observations, p.some, ObsIdSet.one(obsId).some, targetId.some)
+    case TargetsBasePage(p)                    => RoutingInfo(AppTab.Targets, p.some, none, none)
+    case TargetsObsPage(p, obsId)              => RoutingInfo(AppTab.Targets, p.some, obsId.some, none)
+    case TargetPage(p, targetId)               => RoutingInfo(AppTab.Targets, p.some, none, targetId.some)
     case TargetWithObsPage(p, obsId, targetId) =>
-      RoutingInfo(AppTab.Targets, p, obsId.some, targetId.some)
-    case ConfigurationsPage(p)                 => RoutingInfo(AppTab.Configurations, p, none, none)
-    case ConstraintsBasePage(p)                => RoutingInfo(AppTab.Constraints, p, none, none)
-    case ConstraintsObsPage(p, obsId)          => RoutingInfo(AppTab.Constraints, p, obsId.some, none)
+      RoutingInfo(AppTab.Targets, p.some, obsId.some, targetId.some)
+    case ConfigurationsPage(p)                 => RoutingInfo(AppTab.Configurations, p.some, none, none)
+    case ConstraintsBasePage(p)                => RoutingInfo(AppTab.Constraints, p.some, none, none)
+    case ConstraintsObsPage(p, obsId)          => RoutingInfo(AppTab.Constraints, p.some, obsId.some, none)
   }
 
   def getPage(

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -11,6 +11,7 @@ import japgolly.scalajs.react.Reusability
 import lucuma.catalog.AngularSize
 import lucuma.catalog.CatalogTargetResult
 import lucuma.core.model.Target
+import lucuma.schemas.ObservationDB.Enums.Existence
 import lucuma.ui.reusability._
 
 import scala.collection.immutable.TreeSeqMap
@@ -70,4 +71,6 @@ object reusability {
   implicit val catalogTargetResultReuse: Reusability[CatalogTargetResult]          = Reusability.derive
   implicit val scienceConfigurationnResultReuse: Reusability[ScienceConfiguration] =
     Reusability.byEq
+
+  implicit val existenceReuse: Reusability[Existence] = Reusability.derive
 }

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -842,6 +842,7 @@ tfoot {
   flex-direction: column;
 }
 
+.eraser-icon,
 .trash-icon {
   color: var(--negative-icon-color);
 }
@@ -864,6 +865,41 @@ tfoot {
 
   white-space: normal;
   overflow: visible;
+}
+
+.programs-popup {
+  .program-add {
+    margin-top: 7px;
+    margin-right: 15px; 
+  }
+
+  .ui.button.compact.program-name-edit {
+    margin-left: 0.5em;
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .ui.button.compact.program-name-delete {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+  }
+
+  .program-table {
+    .ui.table {
+      height: 400px;
+    }
+  }
+
+  .program-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: 100%;
+  }
+
+  .program-name-input {
+    width: 100%;
+  }
 }
 
 .justify-right {

--- a/explore/src/main/scala/explore/EditableLabel.scala
+++ b/explore/src/main/scala/explore/EditableLabel.scala
@@ -14,6 +14,7 @@ import lucuma.ui.reusability._
 import org.scalajs.dom
 import react.common.ReactFnProps
 import react.common.style.Css
+import react.fa.FontAwesomeIcon
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.input.Input
 import react.semanticui.sizes._
@@ -28,7 +29,8 @@ final case class EditableLabel(
   addButtonLabel:   Reuse[VdomNode] = ("Add": VdomNode).reuseAlways,
   addButtonClass:   Css = Css.Empty,
   leftButtonClass:  Css = Css.Empty,
-  rightButtonClass: Css = Css.Empty
+  rightButtonClass: Css = Css.Empty,
+  rightButtonIcon:  Reuse[FontAwesomeIcon] = Icons.Trash.reuseAlways
 ) extends ReactFnProps[EditableLabel](EditableLabel.component)
 
 object EditableLabel {
@@ -41,7 +43,8 @@ object EditableLabel {
     addButtonLabel:    Reuse[VdomNode] = ("Add": VdomNode).reuseAlways,
     addButtonClass:    Css = Css.Empty,
     editButtonClass:   Css = Css.Empty,
-    deleteButtonClass: Css = Css.Empty
+    deleteButtonClass: Css = Css.Empty,
+    deleteButtonIcon:  Reuse[FontAwesomeIcon] = Icons.Trash.reuseAlways
   ): EditableLabel =
     EditableLabel(
       value.get,
@@ -51,7 +54,8 @@ object EditableLabel {
       addButtonLabel,
       addButtonClass,
       editButtonClass,
-      deleteButtonClass
+      deleteButtonClass,
+      deleteButtonIcon
     )
 
   private implicit val reuseProps: Reusability[Props] = Reusability.derive
@@ -130,7 +134,7 @@ object EditableLabel {
                 clazz = props.rightButtonClass,
                 onClickE = (e: ReactMouseEvent, _: Button.ButtonProps) =>
                   e.stopPropagationCB >> e.preventDefaultCB >> props.mod(none)
-              )(Icons.Trash)
+              )(props.rightButtonIcon.value)
             )
           )
       }

--- a/explore/src/main/scala/explore/EditableLabel.scala
+++ b/explore/src/main/scala/explore/EditableLabel.scala
@@ -30,7 +30,7 @@ final case class EditableLabel(
   addButtonClass:   Css = Css.Empty,
   leftButtonClass:  Css = Css.Empty,
   rightButtonClass: Css = Css.Empty,
-  rightButtonIcon:  Reuse[FontAwesomeIcon] = Icons.Trash.reuseAlways
+  rightButtonIcon:  Reuse[FontAwesomeIcon] = Icons.Eraser.reuseAlways
 ) extends ReactFnProps[EditableLabel](EditableLabel.component)
 
 object EditableLabel {
@@ -44,7 +44,7 @@ object EditableLabel {
     addButtonClass:    Css = Css.Empty,
     editButtonClass:   Css = Css.Empty,
     deleteButtonClass: Css = Css.Empty,
-    deleteButtonIcon:  Reuse[FontAwesomeIcon] = Icons.Trash.reuseAlways
+    deleteButtonIcon:  Reuse[FontAwesomeIcon] = Icons.Eraser.reuseAlways
   ): EditableLabel =
     EditableLabel(
       value.get,

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -55,6 +55,8 @@ object ExploreLayout {
                 onLogout: IO[Unit]
               ) =>
                 AppCtx.using { implicit ctx =>
+                  val routingInfo = RoutingInfo.from(props.r.page)
+
                   HelpCtx.usingView { helpCtx =>
                     val helpView = helpCtx.zoom(HelpContext.displayedHelp)
                     GlobalHotKeys(
@@ -81,13 +83,16 @@ object ExploreLayout {
                         SidebarPusher(dimmed = helpView.get.isDefined)(
                           <.div(
                             ExploreStyles.MainGrid,
-                            TopBar(vault.user,
-                                   props.view.zoom(RootModel.localPreferences).get,
-                                   onLogout >> props.view.zoom(RootModel.vault).set(none).to[IO]
+                            TopBar(
+                              vault.user,
+                              routingInfo.optProgramId,
+                              props.view.zoom(RootModel.localPreferences).get,
+                              props.view.zoom(RootModel.undoStacks),
+                              onLogout >> props.view.zoom(RootModel.vault).set(none).to[IO]
                             ),
                             <.div(
                               ExploreStyles.SideTabs,
-                              SideTabs(RoutingInfo.from(props.r.page))
+                              SideTabs(routingInfo)
                             ),
                             <.div(
                               ExploreStyles.MainBody,

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -12,6 +12,7 @@ import explore.config.SequenceEditor
 import explore.model.Page
 import explore.model.Page._
 import explore.model._
+import explore.programs.ProgramsPopup
 import explore.proposal._
 import explore.tabs._
 import japgolly.scalajs.react.ReactMonocle._
@@ -101,6 +102,11 @@ object Routing {
   private def configurationsTab(page: Page): VdomElement =
     SequenceEditor(RoutingInfo.from(page).programId)
 
+  private def showProgramSelectionPopup(model: ReuseView[RootModel]): VdomElement =
+    AppCtx.using { implicit ctx =>
+      ProgramsPopup(currentProgramId = none, undoStacks = model.zoom(RootModel.undoStacks))
+    }
+
   def config: RouterWithPropsConfig[Page, ReuseView[RootModel]] =
     RouterWithPropsConfigDsl[Page, ReuseView[RootModel]].buildConfig { dsl =>
       import dsl._
@@ -125,8 +131,8 @@ object Routing {
 
       val rules =
         (emptyRule
-        // temporarily redirect to p-2 until we have program selection available.
-          | staticRoute(root, NoProgramPage) ~> redirectToPath("/p-2")(SetRouteVia.HistoryReplace)
+          | staticRoute(root, NoProgramPage) ~> renderP(showProgramSelectionPopup _)
+
           | dynamicRouteCT((root / id[Program.Id]).xmapL(HomePage.iso)) ~> dynRenderP {
             case (_, _) => homeTab()
           }

--- a/explore/src/main/scala/explore/programs/ProgramTable.scala
+++ b/explore/src/main/scala/explore/programs/ProgramTable.scala
@@ -131,8 +131,7 @@ object ProgramTable {
                 textClass = ExploreStyles.ProgramName,
                 inputClass = ExploreStyles.ProgramNameInput,
                 editButtonClass = ExploreStyles.BlendedButton |+| ExploreStyles.ProgramNameEdit,
-                deleteButtonClass = ExploreStyles.BlendedButton |+| ExploreStyles.ProgramNameDelete,
-                deleteButtonIcon = Icons.Eraser.reuseAlways
+                deleteButtonClass = ExploreStyles.BlendedButton |+| ExploreStyles.ProgramNameDelete
               )
             )
             .setWidth(1)

--- a/explore/src/main/scala/explore/programs/ProgramTable.scala
+++ b/explore/src/main/scala/explore/programs/ProgramTable.scala
@@ -1,0 +1,168 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.programs
+
+import cats.Order._
+import cats.effect.IO
+import cats.syntax.all._
+import crystal.react.ReuseView
+import crystal.react.implicits._
+import crystal.react.reuse._
+import explore.EditableLabel
+import explore.Icons
+import explore.common.ProgramQueries
+import explore.common.ProgramQueries.ProgramInfo
+import explore.components.ui.ExploreStyles
+import explore.implicits._
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.VdomNode
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.model.Program
+import lucuma.ui.reusability._
+import react.common.ReactFnProps
+import react.common.implicits._
+import react.semanticui.collections.table._
+import reactST.reactTable._
+import react.semanticui.collections.table.TableCompact
+import react.semanticui.elements.button._
+import react.semanticui.shorthand._
+import react.semanticui.sizes._
+
+final case class ProgramTable(
+  currentProgramId: Option[Program.Id],
+  programs:         ReuseView[List[ProgramInfo]],
+  showDeleted:      Boolean,
+  selectProgram:    Program.Id ==> Callback
+)(implicit val ctx: AppContextIO)
+    extends ReactFnProps[ProgramTable](ProgramTable.component)
+
+object ProgramTable {
+  type Props = ProgramTable
+
+  implicit protected val reuseProps: Reusability[Props] = Reusability.derive
+
+  protected val ProgsTableDef = TableDef[ReuseView[ProgramInfo]].withSortBy.withFlexLayout
+
+  protected val ProgsTable = new SUITableVirtuoso(ProgsTableDef)
+
+  protected def deleteProgram(pinf: ReuseView[ProgramInfo])(implicit ctx: AppContextIO): IO[Unit] =
+    pinf.zoom(ProgramInfo.deleted).set(true).to[IO] >>
+      ProgramQueries.deleteProgram[IO](pinf.get.id)
+
+  protected def undeleteProgram(pinf: ReuseView[ProgramInfo])(implicit
+    ctx:                              AppContextIO
+  ): IO[Unit] =
+    pinf.zoom(ProgramInfo.deleted).set(false).to[IO] >>
+      ProgramQueries.undeleteProgram[IO](pinf.get.id)
+
+  protected def onModName(pinf: ProgramInfo)(implicit ctx: AppContextIO): Callback =
+    ProgramQueries.updateProgramName[IO](pinf.id, pinf.name).runAsync
+
+  val component = ScalaFnComponent
+    .withHooks[Props]
+    // Columns
+    .useMemoBy(props => (props.currentProgramId, props.programs.get.length, props.selectProgram)) {
+      props => deps =>
+        val (currentProgramId, programCount, selectProgram) = deps
+        implicit val ctx                                    = props.ctx
+
+        List(
+          ProgsTableDef
+            .Column("actions", identity[ReuseView[ProgramInfo]] _)
+            .setHeader("Actions")
+            .setCell { cell =>
+              val programId = cell.value.get.id
+              val isDeleted = cell.value.get.deleted
+              <.div(
+                Button(
+                  content = "Select",
+                  size = Mini,
+                  compact = true,
+                  icon = Icons.Checkmark,
+                  disabled = currentProgramId.exists(_ === programId),
+                  onClickE = (e: ReactMouseEvent, _: Button.ButtonProps) =>
+                    e.preventDefaultCB >>
+                      e.stopPropagationCB >>
+                      selectProgram(programId)
+                ).unless(cell.row.original.get.deleted),
+                Button(
+                  size = Mini,
+                  compact = true,
+                  icon = Icons.Trash,
+                  // can't delete the current or last one
+                  disabled = currentProgramId.exists(_ === programId) || programCount < 2,
+                  onClickE = (e: ReactMouseEvent, _: Button.ButtonProps) =>
+                    e.preventDefaultCB >>
+                      e.stopPropagationCB >>
+                      deleteProgram(cell.value).runAsync
+                ).unless(isDeleted),
+                Button(
+                  content = "Undelete",
+                  size = Mini,
+                  compact = true,
+                  icon = Icons.TrashUndo,
+                  onClickE = (e: ReactMouseEvent, _: Button.ButtonProps) =>
+                    e.preventDefaultCB >>
+                      e.stopPropagationCB >>
+                      undeleteProgram(cell.value).runAsync
+                ).when(isDeleted)
+              )
+            }
+            .setWidth(0)
+            .setMinWidth(120)
+            .setMaxWidth(0)
+            .setSortByFn(_.get.deleted),
+          ProgsTableDef
+            .Column("id", _.get.id)
+            .setHeader("Id")
+            .setCell(_.value.toString)
+            .setWidth(0)
+            .setMinWidth(50)
+            .setMaxWidth(0)
+            .setSortByAuto,
+          ProgsTableDef
+            .Column("name", _.withOnMod(onModName).zoom(ProgramInfo.name))
+            .setHeader("Name")
+            .setCell(cell =>
+              EditableLabel.fromView(
+                value = cell.value,
+                addButtonLabel = ("Add program name": VdomNode).reuseAlways,
+                textClass = ExploreStyles.ProgramName,
+                inputClass = ExploreStyles.ProgramNameInput,
+                editButtonClass = ExploreStyles.BlendedButton |+| ExploreStyles.ProgramNameEdit,
+                deleteButtonClass = ExploreStyles.BlendedButton |+| ExploreStyles.ProgramNameDelete,
+                deleteButtonIcon = Icons.Eraser.reuseAlways
+              )
+            )
+            .setWidth(1)
+            .setMinWidth(200)
+            .setMaxWidth(1000)
+            .setSortByFn(_.get.foldMap(_.value))
+        )
+    }
+    // Rows
+    .useMemoBy((props, _) => (props.programs, props.showDeleted)) { (props, _) => _ =>
+      props.programs.toListOfViews
+        .filter(vpi => props.showDeleted || !vpi.get.deleted)
+        .sortBy(_.get.id)
+    }
+    .useTableBy((_, cols, rows) =>
+      ProgsTableDef(
+        cols,
+        rows,
+        ((options: ProgsTableDef.OptionsType) => options.setAutoResetSortBy(false)).reuseAlways
+      )
+    )
+    .renderWithReuse((_, _, _, tableInstance) =>
+      <.div(
+        ExploreStyles.ProgramTable,
+        ProgsTable.Component(
+          table =
+            Table(celled = true, striped = true, unstackable = true, compact = TableCompact.Very),
+          header = TableHeader(),
+          emptyMessage = "No programs available"
+        )(tableInstance)
+      )
+    )
+}

--- a/explore/src/main/scala/explore/programs/ProgramsPopup.scala
+++ b/explore/src/main/scala/explore/programs/ProgramsPopup.scala
@@ -125,7 +125,6 @@ object ProgramsPopup {
           <.div(
             Button(
               clazz = ExploreStyles.ProgramAdd,
-              // size = Small,
               compact = true,
               icon = Icons.New,
               content = "Program",

--- a/explore/src/main/scala/explore/programs/ProgramsPopup.scala
+++ b/explore/src/main/scala/explore/programs/ProgramsPopup.scala
@@ -1,0 +1,170 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.programs
+
+import cats.effect.IO
+import cats.syntax.all._
+import crystal.react.ReuseView
+import crystal.react.hooks._
+import crystal.react.implicits._
+import crystal.react.reuse._
+import explore.Icons
+import explore.common.ProgramQueries
+import explore.common.ProgramQueries.ProgramInfo
+import explore.components.ui.ExploreStyles
+import explore.implicits._
+import explore.model.ModelUndoStacks
+import explore.model.enum.AppTab
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.core.model.Program
+import lucuma.ui.reusability._
+import react.common.ReactFnProps
+import react.semanticui.elements.button.Button
+import react.semanticui.modules.checkbox.Checkbox
+import react.semanticui.modules.modal.Modal
+import react.semanticui.modules.modal._
+import react.semanticui.shorthand._
+import react.semanticui.sizes._
+
+import scalajs.js
+
+final case class ProgramsPopup(
+  currentProgramId: Option[Program.Id],
+  undoStacks:       ReuseView[ModelUndoStacks[IO]],
+  trigger:          Option[Callback ==> VdomNode] = none
+)(implicit val ctx: AppContextIO)
+    extends ReactFnProps[ProgramsPopup](ProgramsPopup.component)
+
+object ProgramsPopup {
+  type Props = ProgramsPopup
+
+  implicit val reuseProps: Reusability[Props] = Reusability.derive
+
+  protected def addProgram(programs: ReuseView[List[ProgramInfo]], adding: ReuseView[Boolean])(
+    implicit ctx:                    AppContextIO
+  ): IO[Unit] =
+    adding.async.set(true) >>
+      ProgramQueries
+        .createProgram[IO](none)
+        .flatMap {
+          _.foldMap(pi => programs.async.mod(_ :+ pi))
+        }
+        .guarantee(adding.async.set(false))
+
+  protected def selectProgram(
+    isRequired: Boolean,
+    isOpen:     ReuseView[Boolean],
+    undoStacks: ReuseView[ModelUndoStacks[IO]],
+    programId:  Program.Id
+  )(implicit
+    ctx:        AppContextIO
+  ): Callback =
+    isOpen.set(false) >>
+      undoStacks.set(ModelUndoStacks[IO]()) >>
+      (if (isRequired) ctx.replacePage(AppTab.Overview, programId, none, none)
+       else ctx.pushPage(AppTab.Overview, programId, none, none))
+
+  protected def onNewData(
+    isOpen:     ReuseView[Boolean],
+    isRequired: Boolean,
+    programs:   List[ProgramInfo]
+  )(implicit
+    ctx:        AppContextIO
+  ): IO[Unit] =
+    (isRequired, programs) match {
+      case (false, _)          => IO.unit
+      case (true, head :: Nil) => ctx.replacePage(AppTab.Overview, head.id, none, none).to[IO]
+      case _                   => isOpen.set(true).to[IO]
+    }
+
+  protected def showModal(
+    props:       Props,
+    isOpen:      ReuseView[Boolean],
+    adding:      ReuseView[Boolean],
+    showDeleted: ReuseView[Boolean],
+    isRequired:  Boolean,
+    programs:    ReuseView[List[ProgramInfo]]
+  ): VdomNode = {
+    implicit val ctx = props.ctx
+
+    val actions =
+      if (isRequired) List.empty
+      else
+        List(
+          Button(size = Small, icon = true)(Icons.Close, "Cancel")(^.tpe := "button",
+                                                                   ^.key := "input-cancel"
+          )
+        )
+
+    React.Fragment(
+      Modal(
+        clazz = ExploreStyles.ProgramsPopup,
+        actions = actions,
+        centered = false,
+        open = isOpen.get,
+        closeOnDimmerClick = !isRequired,
+        closeOnEscape = !isRequired,
+        closeIcon =
+          if (isRequired) js.undefined
+          else Icons.Close.clazz(ExploreStyles.ModalCloseButton),
+        dimmer = Dimmer.Blurring,
+        size = ModalSize.Small,
+        onClose = isOpen.set(false),
+        header = ModalHeader(
+          "Programs"
+        ),
+        content = ModalContent(
+          ProgramTable(
+            props.currentProgramId,
+            programs,
+            showDeleted.get,
+            selectProgram = Reuse.currying(isRequired, isOpen, props.undoStacks).in(selectProgram _)
+          ),
+          <.div(
+            Button(
+              clazz = ExploreStyles.ProgramAdd,
+              // size = Small,
+              compact = true,
+              icon = Icons.New,
+              content = "Program",
+              disabled = adding.get,
+              loading = adding.get,
+              onClick = addProgram(programs, adding).runAsync
+            ),
+            Checkbox(label = "Show deleted",
+                     checked = showDeleted.get,
+                     onChange = showDeleted.set _
+            )
+          )
+        )
+      )
+    )
+  }
+
+  protected val component = ScalaFnComponent
+    .withHooks[Props]
+    .useStateViewWithReuse(false) // isOpen
+    .useStateViewWithReuse(false) // Adding new program
+    .useStateViewWithReuse(false) // Show deleted
+    .useMemoBy((props, _, _, _) => props.trigger)((_, _, _, _) =>
+      _.isEmpty                   // if no trigger, program id was missing or invalid
+    )
+    .useMemoBy((props, isOpen, adding, showDeleted, isRequired) =>
+      (props, isOpen, adding, showDeleted, isRequired)
+    ) { (props, isOpen, adding, showDeleted, isRequired) => _ =>
+      implicit val ctx = props.ctx
+      if (isOpen.get || isRequired)
+        ProgramQueries
+          .ProgramsLiveQuery(Reuse(showModal _)(props, isOpen, adding, showDeleted, isRequired),
+                             true,
+                             Reuse(onNewData _)(isOpen, isRequired)
+          )
+          .some
+      else none
+    }
+    .renderWithReuse { (props, isOpen, _, _, _, popup) =>
+      React.Fragment(props.trigger.map(_(isOpen.set(true))), popup.value)
+    }
+}


### PR DESCRIPTION
Adds the ability to select/add/delete/edit programs from the menu, or in the case where a program is not specified in the URL. In the latter case, if the user only has one program, it will select that program without showing the popup. This does not yet handle the case of an invalid ID in the URL. 

Also, at this point editing the program name does not persist because the API version in development and staging does not support it. It is supported in API master, but upgrading Explore to use it is not straight forward since API master also contains change to the sequences. I think it will be better to wait for Raul's changes.

I opted for the ability to show deleted programs over undo/redo because I think it could be important for a user to be able to undelete a program even if they do something like reload the page. Undo/redo could be added as well if it becomes regarded as important for name editing.

<img width="729" alt="image" src="https://user-images.githubusercontent.com/6035943/165307493-b6b8cc35-5fdb-4802-a4ad-619f04fa06b6.png">

