### PR TITLE
Don't change FOV on tile resizing

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -140,7 +140,7 @@ object AladinContainer {
               aladinRef.get.asCBO
                 .flatMapCB(r =>
                   r.backend
-                    .runOnAladinCB(updateVisualization(svg, off)) *> r.backend.recalculateView
+                    .runOnAladinCB(updateVisualization(svg, off)) *> r.backend.fixLayoutDimensions
                 )
                 .toCallback
             )

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@atlaskit/tree": "8.6.0",
-        "@cquiroz/aladin-lite": "0.7.3",
+        "@cquiroz/aladin-lite": "0.7.4",
         "@fortawesome/fontawesome-pro": "^6.0.0",
         "@fortawesome/fontawesome-svg-core": "^1.3.0",
         "@fortawesome/pro-duotone-svg-icons": "^6.0.0",
@@ -486,9 +486,9 @@
       }
     },
     "node_modules/@cquiroz/aladin-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@cquiroz/aladin-lite/-/aladin-lite-0.7.3.tgz",
-      "integrity": "sha512-tWvIzTtuhTAdmcvvgP2ivB1uRhHF1q0DvSWWF+yAuZRRykxHC5Sd7hWdX9RTT7rSj7iTUYFPXtCSnI9F99NBCg==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@cquiroz/aladin-lite/-/aladin-lite-0.7.4.tgz",
+      "integrity": "sha512-ZDaImzUWj/6/+nEhRa2Udfbt+Z3XL2AwSGq2tLQXzE2py8vPbpR7PnohEKFHuRREOZ6c9rdepDnSNJ7/4tT/5w==",
       "dependencies": {
         "loglevel": "^1.8.0",
         "raf": "^3.4.1"
@@ -9689,9 +9689,9 @@
       }
     },
     "@cquiroz/aladin-lite": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@cquiroz/aladin-lite/-/aladin-lite-0.7.3.tgz",
-      "integrity": "sha512-tWvIzTtuhTAdmcvvgP2ivB1uRhHF1q0DvSWWF+yAuZRRykxHC5Sd7hWdX9RTT7rSj7iTUYFPXtCSnI9F99NBCg==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@cquiroz/aladin-lite/-/aladin-lite-0.7.4.tgz",
+      "integrity": "sha512-ZDaImzUWj/6/+nEhRa2Udfbt+Z3XL2AwSGq2tLQXzE2py8vPbpR7PnohEKFHuRREOZ6c9rdepDnSNJ7/4tT/5w==",
       "requires": {
         "loglevel": "^1.8.0",
         "raf": "^3.4.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@atlaskit/tree": "8.6.0",
-    "@cquiroz/aladin-lite": "0.7.3",
+    "@cquiroz/aladin-lite": "0.7.4",
     "@fortawesome/fontawesome-pro": "^6.0.0",
     "@fortawesome/fontawesome-svg-core": "^1.3.0",
     "@fortawesome/pro-duotone-svg-icons": "^6.0.0",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
     val mouse               = "1.0.10"
     val mUnit               = "0.7.29"
     val mUnitCatsEffect     = "1.0.7"
-    val reactAladin         = "0.20.0"
+    val reactAladin         = "0.20.1"
     val reactAtlasKitTree   = "0.4.2"
     val reactClipboard      = "1.5.1"
     val reactCommon         = "0.17.0"


### PR DESCRIPTION
This fixes a bug where aladin's fov changes when the tile gets resized

Still there is some fov change when the aladin section is hidden and redisplayed but that will be addressed separetly