### PR TITLE
Measure the size of the surrounding div for the obs and target areas

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -242,7 +242,8 @@ tfoot {
   grid-area: body;
   max-width: 100vw;
   overflow: hidden;
-  justify-content: stretch;
+  display: grid;
+  justify-items: stretch;
 }
 
 .main-title {
@@ -870,7 +871,7 @@ tfoot {
 .programs-popup {
   .program-add {
     margin-top: 7px;
-    margin-right: 15px; 
+    margin-right: 15px;
   }
 
   .ui.button.compact.program-name-edit {

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -479,7 +479,7 @@ object ObsTabContents {
         )
       )(obsId => <.div(ExploreStyles.TreeRGLWrapper, rightSideRGL(obsId)))
 
-    val body = if (window.canFitTwoPanels) {
+    if (window.canFitTwoPanels) {
       <.div(
         ExploreStyles.TreeRGL,
         <.div(ExploreStyles.Tree, treeInner(observations))
@@ -510,7 +510,6 @@ object ObsTabContents {
         )
       )
     }
-    body.withRef(resize.ref)
   }
 
   protected val component =
@@ -554,7 +553,11 @@ object ObsTabContents {
       .useSingleEffect(debounce = 1.second)
       .renderWithReuse { (props, panels, layouts, resize, debouncer) =>
         implicit val ctx = props.ctx
-        ObsLiveQuery(props.programId, Reuse(renderFn _)(props, panels, layouts, resize, debouncer))
+        <.div(
+          ObsLiveQuery(props.programId,
+                       Reuse(renderFn _)(props, panels, layouts, resize, debouncer)
+          )
+        ).withRef(resize.ref)
       }
 
 }

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -490,7 +490,7 @@ object TargetTabContents {
     // It would be nice to make a single component here but it gets hard when you
     // have the resizable element. Instead we have either two panels with a resizable
     // or only one panel at a time (Mobile)
-    val body = if (window.canFitTwoPanels) {
+    if (window.canFitTwoPanels) {
       <.div(
         ExploreStyles.TreeRGL,
         <.div(ExploreStyles.Tree, treeInner(asterismGroupsWithObs))
@@ -522,7 +522,6 @@ object TargetTabContents {
         )
       )
     }
-    body.withRef(resize.ref)
   }
 
   protected val component =
@@ -556,7 +555,6 @@ object TargetTabContents {
           {
             implicit val ctx = props.ctx
 
-            // val i: Int = layout
             TabGridPreferencesQuery
               .queryWithDefault[IO](props.userId,
                                     GridLayoutSection.TargetLayout,
@@ -579,10 +577,12 @@ object TargetTabContents {
       .useSingleEffect(debounce = 1.second)
       .renderWithReuse { (props, tps, resize, layout, defaultLayout, debouncer) =>
         implicit val ctx = props.ctx
-        AsterismGroupLiveQuery(
-          props.programId,
-          Reuse(renderFn _)(props, tps, defaultLayout, layout, resize, debouncer)
-        )
+        <.div(
+          AsterismGroupLiveQuery(
+            props.programId,
+            Reuse(renderFn _)(props, tps, defaultLayout, layout, resize, debouncer)
+          )
+        ).withRef(resize.ref)
       }
 
 }


### PR DESCRIPTION
We need to measure the size of the areas of targets and observations but for some reason it is not working all the time.
This PR wraps each on a div that is being measured reliably.