### PR TITLE
Fix reuse issue on target tab.

### DIFF
--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -330,12 +330,10 @@ object TargetTabContents {
       }
 
       val asterismView: ReuseView[List[TargetWithId]] =
-        asterismGroupsWithObs
-          .map(
-            _.withOnMod(onModAsterismsWithObs(groupIds, idsToEdit))
-              .zoom(getAsterism)(modAsterism)
-          )
-          .addReuseByFrom(panels)
+        asterismGroupsWithObs.value
+          .withOnMod(onModAsterismsWithObs(groupIds, idsToEdit))
+          .zoom(getAsterism)(modAsterism)
+          .reuseByValue
 
       val title = idsToEdit.single match {
         case Some(id) => s"Observation $id"


### PR DESCRIPTION
Fixes issue where switching observation on the target tab would change the URL and the sidereal target editor, but the target table in the asterism editor wouldn't update.