### PR TITLE
Avoid LocalDateTime.now()

### DIFF
--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -27,11 +27,9 @@ import org.typelevel.log4cats.Logger
 import queries.schemas._
 import shapeless._
 
-import java.time.LocalDateTime
 import scala.annotation.unused
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration
-import scala.scalajs.js
 
 trait ListImplicits {
 
@@ -194,18 +192,4 @@ object implicits
     ): Resource[F, fs2.Stream[F, A]] =
       reRunOnResourceSignals(NonEmptyList.of(head, tail: _*))
   }
-
-  implicit class JsDateOps(val date: js.Date) extends AnyVal {
-    def toLocalDateTime: LocalDateTime =
-      LocalDateTime.of(
-        date.getFullYear().toInt,
-        date.getMonth().toInt + 1,
-        date.getDate().toInt,
-        date.getHours().toInt,
-        date.getMinutes().toInt,
-        date.getSeconds().toInt,
-        date.getMilliseconds().toInt * 1000
-      )
-  }
-
 }

--- a/common/src/main/scala/explore/implicits.scala
+++ b/common/src/main/scala/explore/implicits.scala
@@ -27,9 +27,11 @@ import org.typelevel.log4cats.Logger
 import queries.schemas._
 import shapeless._
 
+import java.time.LocalDateTime
 import scala.annotation.unused
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration
+import scala.scalajs.js
 
 trait ListImplicits {
 
@@ -191,6 +193,19 @@ object implicits
       F:    Concurrent[F]
     ): Resource[F, fs2.Stream[F, A]] =
       reRunOnResourceSignals(NonEmptyList.of(head, tail: _*))
+  }
+
+  implicit class JsDateOps(val date: js.Date) extends AnyVal {
+    def toLocalDateTime: LocalDateTime =
+      LocalDateTime.of(
+        date.getFullYear().toInt,
+        date.getMonth().toInt + 1,
+        date.getDate().toInt,
+        date.getHours().toInt,
+        date.getMinutes().toInt,
+        date.getSeconds().toInt,
+        date.getMilliseconds().toInt * 1000
+      )
   }
 
 }

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -64,9 +64,9 @@ import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.modules.dropdown.Dropdown
 import react.semanticui.sizes._
 
-import java.time.LocalDateTime
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
+import scala.scalajs.js
 
 final case class ObsTabContents(
   userId:           ReuseViewOpt[User.Id],
@@ -497,7 +497,7 @@ object ObsTabContents {
               .runAsync
       }
       // Shared obs conf (posAngle/obsTime)
-      .useStateViewWithReuse(ObsConfiguration(PosAngle.Default, LocalDateTime.now()))
+      .useStateViewWithReuse(ObsConfiguration(PosAngle.Default, new js.Date().toLocalDateTime))
       .useSingleEffect(debounce = 1.second)
       .renderWithReuse {
         (props, twoPanelState, resize, layouts, defaultLayout, obsConf, debouncer) =>

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -64,9 +64,9 @@ import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.modules.dropdown.Dropdown
 import react.semanticui.sizes._
 
+import java.time.Instant
 import scala.collection.immutable.SortedMap
 import scala.concurrent.duration._
-import scala.scalajs.js
 
 final case class ObsTabContents(
   userId:           ReuseViewOpt[User.Id],
@@ -497,7 +497,7 @@ object ObsTabContents {
               .runAsync
       }
       // Shared obs conf (posAngle/obsTime)
-      .useStateViewWithReuse(ObsConfiguration(PosAngle.Default, new js.Date().toLocalDateTime))
+      .useStateViewWithReuse(ObsConfiguration(PosAngle.Default, Instant.now))
       .useSingleEffect(debounce = 1.second)
       .renderWithReuse {
         (props, twoPanelState, resize, layouts, defaultLayout, obsConf, debouncer) =>

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -55,9 +55,9 @@ import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.sizes._
 
-import java.time.LocalDateTime
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration._
+import scala.scalajs.js
 
 final case class TargetTabContents(
   userId:            Option[User.Id],
@@ -364,7 +364,7 @@ object TargetTabContents {
 
       // Until these are in the API
       val obsConfiguration =
-        scienceMode.map(_ => ObsConfiguration(PosAngle.Default, LocalDateTime.now()))
+        scienceMode.map(_ => ObsConfiguration(PosAngle.Default, new js.Date().toLocalDateTime))
 
       def setCurrentTarget(
         programId: Program.Id,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -55,9 +55,9 @@ import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.sizes._
 
+import java.time.Instant
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration._
-import scala.scalajs.js
 
 final case class TargetTabContents(
   userId:            Option[User.Id],
@@ -364,7 +364,7 @@ object TargetTabContents {
 
       // Until these are in the API
       val obsConfiguration =
-        scienceMode.map(_ => ObsConfiguration(PosAngle.Default, new js.Date().toLocalDateTime))
+        scienceMode.map(_ => ObsConfiguration(PosAngle.Default, Instant.now))
 
       def setCurrentTarget(
         programId: Program.Id,

--- a/model/shared/src/main/scala/explore/model/ObsConfiguration.scala
+++ b/model/shared/src/main/scala/explore/model/ObsConfiguration.scala
@@ -8,24 +8,24 @@ import monocle.Focus
 import monocle.Lens
 import org.typelevel.cats.time._
 
-import java.time.LocalDateTime
+import java.time.Instant
 
 /**
  * This class is used to transfer properties across tiles, to reduce the latency while waiting for
  * the db subscriptions to arrive
  */
 final case class ObsConfiguration(
-  posAngle: PosAngle,
-  obsTime:  LocalDateTime
+  posAngle:   PosAngle,
+  obsInstant: Instant
 )
 
 object ObsConfiguration {
   implicit val eqObsConfiguration: Eq[ObsConfiguration] =
-    Eq.by(x => (x.posAngle, x.obsTime))
+    Eq.by(x => (x.posAngle, x.obsInstant))
 
   val posAngle: Lens[ObsConfiguration, PosAngle] =
     Focus[ObsConfiguration](_.posAngle)
 
-  val obsTime: Lens[ObsConfiguration, LocalDateTime] =
-    Focus[ObsConfiguration](_.obsTime)
+  val obsInstant: Lens[ObsConfiguration, Instant] =
+    Focus[ObsConfiguration](_.obsInstant)
 }


### PR DESCRIPTION
`LocalDateTime.now()` doesn't seem to work outside of the loaded time zones (which are `Pacific/Honolulu` and `America/Santiago`).

This PR implements a workaround by explicitly getting the local date time from the JS `Date` and converting it into a `LocalDateTime`.