### PR TITLE
Setup workers

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -64,3 +64,11 @@ pull_request_rules:
       add:
       - model-tests
       remove: []
+- name: Label workers PRs
+  conditions:
+  - files~=^workers/
+  actions:
+    label:
+      add:
+      - workers
+      remove: []

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,6 @@ ThisBuild / scalafixDependencies += "com.github.liancheng"           %% "organiz
 
 ThisBuild / evictionErrorLevel := Level.Info
 
-ThisBuild / resolvers += Resolver.sonatypeRepo("snapshots")
-
 addCommandAlias(
   "quickTest",
   "modelTestsJVM/test"
@@ -83,13 +81,6 @@ lazy val workers = project
   .settings(commonJsLibSettings: _*)
   .settings(esModule: _*)
   .enablePlugins(ScalaJSPlugin)
-  .settings(
-    libraryDependencies ++=
-      Log4Cats.value ++
-        ScalaJSDOM.value ++
-        ScalaWebAppUtil.value
-  )
-  .enablePlugins(ScalaJSPlugin)
 
 lazy val graphql = project
   .in(file("common-graphql"))
@@ -117,7 +108,6 @@ lazy val common = project
         ReactCommon.value ++
         ReactTable.value ++
         ReactVirtuoso.value ++
-        ScalaJSDOM.value ++
         SecureRandom.value,
     buildInfoKeys    := Seq[BuildInfoKey](
       scalaVersion,
@@ -162,8 +152,7 @@ lazy val explore: Project = project
         ReactGridLayout.value ++
         ReactHighcharts.value ++
         ReactHotkeys.value ++
-        ReactResizable.value ++
-        ScalaJSDOM.value,
+        ReactResizable.value,
     // Build workers when you build explore
     Compile / fastLinkJS := (Compile / fastLinkJS)
       .dependsOn((workers / Compile / fastLinkJS))
@@ -173,10 +162,6 @@ lazy val explore: Project = project
 
 lazy val commonSettings = lucumaGlobalSettings ++ Seq(
   scalacOptions ~= (_.filterNot(Set("-Vtype-diffs")))
-)
-
-lazy val common3Settings = commonSettings ++ Seq(
-  scalacOptions ~= (_.filterNot(Set("-Ymacro-annotations")))
 )
 
 lazy val commonLibSettings = Seq(
@@ -243,7 +228,7 @@ lazy val esModule = Seq(
   Compile / fullLinkJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
   Compile / fastLinkJS / scalaJSLinkerConfig ~= (_.withModuleSplitStyle(
     // If the browser is too slow for the SmallModulesFor switch to ModuleSplitStyle.FewestModules
-    ModuleSplitStyle.SmallModulesFor(List("worker", "explore"))
+    ModuleSplitStyle.SmallModulesFor(List("explore"))
   )),
   Compile / fullLinkJS / scalaJSLinkerConfig ~= (_.withModuleSplitStyle(
     ModuleSplitStyle.FewestModules

--- a/common/src/main/public/development.conf.json
+++ b/common/src/main/public/development.conf.json
@@ -1,6 +1,6 @@
 {
   "environment": "DEVELOPMENT",
-  "odbURI": "wss://lucuma-odb-development.herokuapp.com/ws",
+  "odbURI": "wss://lucuma-odb-staging.herokuapp.com/ws",
   "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-staging.lucuma.xyz/itc",
   "sso": {

--- a/common/src/main/public/development.conf.json
+++ b/common/src/main/public/development.conf.json
@@ -1,6 +1,6 @@
 {
   "environment": "DEVELOPMENT",
-  "odbURI": "wss://lucuma-odb-staging.herokuapp.com/ws",
+  "odbURI": "wss://lucuma-odb-development.herokuapp.com/ws",
   "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-staging.lucuma.xyz/itc",
   "sso": {

--- a/common/src/main/scala/workers/WebWorkerF.scala
+++ b/common/src/main/scala/workers/WebWorkerF.scala
@@ -6,10 +6,11 @@ package workers
 import cats.effect.Async
 import cats.effect.Sync
 import cats.effect.std.Dispatcher
-import scala.scalajs.js
-import org.scalajs.dom
 import fs2.Stream
 import fs2.concurrent.Channel
+import org.scalajs.dom
+
+import scala.scalajs.js
 
 /**
  * WebWorker abstraction running on F. it is possible to post messages and get a stream of events

--- a/common/src/main/scala/workers/WebWorkerF.scala
+++ b/common/src/main/scala/workers/WebWorkerF.scala
@@ -1,0 +1,59 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package workers
+
+import cats.effect.Async
+import cats.effect.Sync
+import cats.effect.std.Dispatcher
+import scala.scalajs.js
+import org.scalajs.dom
+import fs2.Stream
+import fs2.concurrent.Channel
+
+/**
+ * WebWorker abstraction running on F. it is possible to post messages and get a stream of events
+ * from the web worker
+ */
+trait WebWorkerF[F[_]] {
+
+  /**
+   * Post a message on effect F
+   */
+  def postMessage(message: js.Any): F[Unit]
+
+  /**
+   * Terminate the web worker
+   */
+  def terminate: F[Unit]
+
+  /**
+   * Streams of events from the worker
+   */
+  def stream: Stream[F, dom.MessageEvent]
+}
+
+object WebWorkerF {
+
+  def apply[F[_]: Async](worker: dom.Worker) = new WebWorkerF[F] {
+    def postMessage(message: js.Any): F[Unit] = Sync[F].delay(worker.postMessage(message))
+
+    def terminate: F[Unit] = Sync[F].delay(worker.terminate())
+
+    def stream: Stream[F, dom.MessageEvent] =
+      for {
+        dispatcher <- Stream.resource(Dispatcher[F])
+        channel    <- Stream.eval(Channel.unbounded[F, dom.MessageEvent])
+        _          <- Stream.eval(
+                        Sync[F].delay(worker.onmessage =
+                          (e: dom.MessageEvent) =>
+                            dispatcher.unsafeRunAndForget(
+                              channel
+                                .send(e)
+                            )
+                        )
+                      )
+        stream     <- channel.stream
+      } yield stream
+  }
+}

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -499,10 +499,15 @@ object ObsTabContents {
       // Shared obs conf (posAngle/obsTime)
       .useStateViewWithReuse(ObsConfiguration(PosAngle.Default, Instant.now))
       .useSingleEffect(debounce = 1.second)
+      // worker usage demo Delete soon
+      .useEffectOnMountBy((props, _, _, _, _, _, _) =>
+        props.ctx.worker.stream.evalMap(msg => IO.println(msg.data.toString)).compile.drain
+      )
       .renderWithReuse {
         (props, twoPanelState, resize, layouts, defaultLayout, obsConf, debouncer) =>
           implicit val ctx = props.ctx
           <.div(
+            <.button("test", ^.onClick --> ctx.worker.postMessage(1000)).when(true), // TODO delete
             ObsLiveQuery(
               props.programId,
               Reuse(renderFn _)(props,

--- a/explore/src/main/webapp/workers.js
+++ b/explore/src/main/webapp/workers.js
@@ -1,0 +1,3 @@
+import { IDBWorker } from '@workers/worker.js';
+
+IDBWorker.runWorker();

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -47,6 +47,8 @@ object Settings {
     val scalaJsReact        = "2.1.1"
     val pprint              = "0.7.3"
     val scalaJSSecureRandom = "1.0.0"
+    val scalaJSDom          = "2.1.0+92-8d9ae46a-SNAPSHOT"
+    var webAppUtil          = "2.0.0-RC1"
 
   }
 
@@ -346,6 +348,18 @@ object Settings {
       deps(
         "com.lihaoyi" %%% "pprint"
       )(pprint)
+    )
+
+    val ScalaWebAppUtil = Def.setting(
+      deps(
+        "com.github.japgolly.webapp-util" %%% "core"
+      )(webAppUtil)
+    )
+
+    val ScalaJSDOM = Def.setting(
+      deps(
+        "org.scala-js" %%% "scalajs-dom"
+      )(scalaJSDom)
     )
   }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -47,7 +47,6 @@ object Settings {
     val scalaJsReact        = "2.1.1"
     val pprint              = "0.7.3"
     val scalaJSSecureRandom = "1.0.0"
-    val scalaJSDom          = "2.1.0+92-8d9ae46a-SNAPSHOT"
     var webAppUtil          = "2.0.0-RC1"
 
   }
@@ -356,10 +355,5 @@ object Settings {
       )(webAppUtil)
     )
 
-    val ScalaJSDOM = Def.setting(
-      deps(
-        "org.scala-js" %%% "scalajs-dom"
-      )(scalaJSDom)
-    )
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,6 +25,11 @@ module.exports = ({ command, mode }) => {
     isProduction
       ? path.resolve(scalaClassesDir, 'explore-opt')
       : path.resolve(scalaClassesDir, 'explore-fastopt');
+  const workersScalaClassesDir = path.resolve(__dirname, 'workers/target/scala-2.13');
+  const workersSjs =
+    isProduction
+      ? path.resolve(workersScalaClassesDir, 'workers-opt')
+      : path.resolve(workersScalaClassesDir, 'workers-fastopt');
   const rollupPlugins = isProduction ? [] : [visualizer()];
   const common = path.resolve(__dirname, 'common/');
   const webappCommon = path.resolve(common, 'src/main/webapp/');
@@ -61,6 +66,10 @@ module.exports = ({ command, mode }) => {
         {
           find: '@sjs',
           replacement: sjs,
+        },
+        {
+          find: '@workers',
+          replacement: workersSjs,
         },
         {
           find: '/common',
@@ -134,6 +143,9 @@ module.exports = ({ command, mode }) => {
         plugins: rollupPlugins
       },
       outDir: path.resolve(__dirname, 'heroku/static'),
+    },
+    worker: {
+      format: 'es'
     },
     plugins: [
       isProduction ? null : mkcert.default({ hosts: ['localhost', 'local.lucuma.xyz'] }),

--- a/vite.config.js
+++ b/vite.config.js
@@ -144,9 +144,6 @@ module.exports = ({ command, mode }) => {
       },
       outDir: path.resolve(__dirname, 'heroku/static'),
     },
-    worker: {
-      format: 'es'
-    },
     plugins: [
       isProduction ? null : mkcert.default({ hosts: ['localhost', 'local.lucuma.xyz'] }),
       react(),

--- a/workers/src/main/scala/workers/IDBWorker.scala
+++ b/workers/src/main/scala/workers/IDBWorker.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package workers
+
+import cats.effect.IO
+
+import scala.scalajs.js
+import org.scalajs.dom
+
+import js.annotation._
+
+import cats.effect.unsafe.implicits._
+
+@JSExportTopLevel("IDBWorker", moduleID = "worker")
+object IDBWorker {
+
+  @JSExport
+  def runWorker(): Unit = run.unsafeRunAndForget()
+
+  def run: IO[Unit] = IO {
+    val self = dom.DedicatedWorkerGlobalScope.self
+    self.onmessage = (msg: dom.MessageEvent) => {
+      println(s"Message arrived: ${msg.data}")
+      self.postMessage(90)
+    }
+  }
+}

--- a/workers/src/main/scala/workers/IDBWorker.scala
+++ b/workers/src/main/scala/workers/IDBWorker.scala
@@ -12,6 +12,10 @@ import js.annotation._
 
 import cats.effect.unsafe.implicits._
 
+/**
+  * Sample web worker, extremely simple just accept messages, prints them
+  * and answers a number
+  */
 @JSExportTopLevel("IDBWorker", moduleID = "worker")
 object IDBWorker {
 


### PR DESCRIPTION
This PR setups the infrastructure to create and use web workers. There is no real activity done by them but this is a springboard to start using them

Notes:
* workers will live in a separate module. The main reason is to avoid calling invalid apis in particular dom related apis
* workers will produce a separate scala.js output file from explore but the build takes care of doing them always together
* A wrapper `WebWorkerF` was created to encapsulate the operation
* I added a worker to the `AppContext` to make it available everywhere, maybe it is not the best approach. we can revesit
* I added a sample of how to send/receive messages to the worker