### PR TITLE
Interim solution to store the obstime locally

### DIFF
--- a/common/src/main/scala/explore/model/ExploreLocalPreferences.scala
+++ b/common/src/main/scala/explore/model/ExploreLocalPreferences.scala
@@ -10,16 +10,25 @@ import io.circe.Decoder
 import io.circe.Encoder
 import io.circe.HCursor
 import io.circe.Json
+import io.circe.KeyDecoder
+import io.circe.KeyEncoder
+import io.circe.generic.semiauto._
 import io.circe.parser.decode
 import io.circe.syntax._
 import log4cats.loglevel.LogLevelLogger
+import lucuma.core.math.Angle
+import lucuma.core.model.Observation
 import lucuma.core.util.Enumerated
 import monocle.Focus
 import org.scalajs.dom.window
 import typings.loglevel.mod.LogLevelDesc
 
+// FIXME: Temporarily store the obsConfiguration per obs
 // Preferences stored at the browser level
-case class ExploreLocalPreferences(level: LogLevelDesc)
+case class ExploreLocalPreferences(
+  level:             LogLevelDesc,
+  obsConfigurations: Map[Observation.Id, ObsConfiguration]
+)
 
 object ExploreLocalPreferences {
   implicit val levelEnumerated: Enumerated[LogLevelDesc] =
@@ -41,14 +50,16 @@ object ExploreLocalPreferences {
         else "SILENT"
     }
 
-  val Default = ExploreLocalPreferences(LogLevelLogger.Level.INFO)
+  val Default = ExploreLocalPreferences(LogLevelLogger.Level.INFO, Map.empty)
 
-  val StorageKey = "ExplorePreferences"
-  val LevelKey   = "logLevel"
+  val StorageKey   = "ExplorePreferences"
+  val LevelKey     = "logLevel"
+  val ObsConfigKey = "obsConfig"
 
   val level = Focus[ExploreLocalPreferences](_.level)
 
-  implicit val eqExploreLocalpreferences: Eq[ExploreLocalPreferences] = Eq.by(_.level)
+  implicit val eqExploreLocalpreferences: Eq[ExploreLocalPreferences] =
+    Eq.by(p => (p.level, p.obsConfigurations))
 
   implicit class LevelOps(val l: LogLevelDesc) extends AnyVal {
     def value: String =
@@ -71,15 +82,84 @@ object ExploreLocalPreferences {
 
   implicit val encoder: Encoder[ExploreLocalPreferences] = new Encoder[ExploreLocalPreferences] {
     final def apply(a: ExploreLocalPreferences): Json = Json.obj(
-      (LevelKey, Json.fromString(a.level.value))
+      (LevelKey, Json.fromString(a.level.value)),
+      (ObsConfigKey, (a.obsConfigurations).asJson)
     )
   }
+
+  implicit val oidKeyDecoder: KeyDecoder[Observation.Id] = new KeyDecoder[Observation.Id] {
+    override def apply(key: String): Option[Observation.Id] = Observation.Id.parse(key)
+  }
+
+  implicit val oidKeyEncoder: KeyEncoder[Observation.Id] = new KeyEncoder[Observation.Id] {
+    override def apply(foo: Observation.Id): String = foo.show
+
+  }
+
+  implicit val decodeAngle: Decoder[Angle] = new Decoder[Angle] {
+    final def apply(c: HCursor): Decoder.Result[Angle] =
+      for {
+        angle <- c.downField("angle").as[Long]
+      } yield Angle.fromMicroarcseconds(angle)
+  }
+
+  implicit val encodeAngle: Encoder[Angle] = new Encoder[Angle] {
+    final def apply(a: Angle): Json = Json.obj(("angle", Json.fromLong(a.toMicroarcseconds)))
+  }
+
+  implicit val decodePAFixed: Decoder[PosAngle.Fixed] =
+    Decoder.forProduct1("fixed")(PosAngle.Fixed.apply)
+
+  implicit val encodePAFixed: Encoder[PosAngle.Fixed] =
+    Encoder.forProduct1("fixed")(_.angle)
+
+  implicit val decodePAAllowFlip: Decoder[PosAngle.AllowFlip] =
+    Decoder.forProduct1("allowFlip")(PosAngle.AllowFlip.apply)
+
+  implicit val encodePAAllowFlip: Encoder[PosAngle.AllowFlip] =
+    Encoder.forProduct1("allowFlip")(_.angle)
+
+  implicit val decodePAParallacticOverride: Decoder[PosAngle.ParallacticOverride] =
+    Decoder.forProduct1("parallacticOverride")(PosAngle.ParallacticOverride.apply)
+
+  implicit val encodePAParallcticOverride: Encoder[PosAngle.ParallacticOverride] =
+    Encoder.forProduct1("parallacticOverride")(_.angle)
+
+  implicit val encodePAAverageParallactic: Encoder[PosAngle.AverageParallactic.type] =
+    deriveEncoder[PosAngle.AverageParallactic.type]
+
+  implicit val decodePAAverageParallactic: Decoder[PosAngle.AverageParallactic.type] =
+    deriveDecoder[PosAngle.AverageParallactic.type]
+
+  implicit val decodePAUnconstrained: Decoder[PosAngle.Unconstrained.type] =
+    deriveDecoder[PosAngle.Unconstrained.type]
+
+  implicit val encodePAUnconstrained: Encoder[PosAngle.Unconstrained.type] =
+    deriveEncoder[PosAngle.Unconstrained.type]
+
+  implicit val decodePosAngle: Decoder[PosAngle] =
+    List[Decoder[PosAngle]](
+      Decoder[PosAngle.Fixed].widen,
+      Decoder[PosAngle.AllowFlip].widen,
+      Decoder[PosAngle.AverageParallactic.type].widen,
+      Decoder[PosAngle.ParallacticOverride].widen,
+      Decoder[PosAngle.Unconstrained.type].widen
+    ).reduceLeft(_ or _)
+
+  implicit val encodePosAngle: Encoder[PosAngle] = deriveEncoder[PosAngle]
+
+  implicit val deConf: Decoder[ObsConfiguration] =
+    Decoder.forProduct2("posAngle", "obsTime")(ObsConfiguration.apply)
+
+  implicit val encConf: Encoder[ObsConfiguration] =
+    Encoder.forProduct2("posAngle", "obsTime")(u => (u.posAngle, u.obsInstant))
 
   implicit val decoder: Decoder[ExploreLocalPreferences] = new Decoder[ExploreLocalPreferences] {
     final def apply(c: HCursor): Decoder.Result[ExploreLocalPreferences] =
       for {
         l <- c.downField(LevelKey).as[Option[String]]
-      } yield ExploreLocalPreferences(levelFromString(l.orEmpty))
+        o <- c.downField(ObsConfigKey).as[Map[Observation.Id, ObsConfiguration]]
+      } yield ExploreLocalPreferences(levelFromString(l.orEmpty), o)
   }
 
   // Preferences at the browser level (unlike those stored in heroku)
@@ -99,6 +179,35 @@ object ExploreLocalPreferences {
       for {
         ls <- Option(window.localStorage)
         _  <- Option(ls.setItem(StorageKey, p.asJson.spaces2))
+      } yield ()
+    }
+    .handleError(_ => ().some)
+    .void
+
+  // DELETEME
+  def storeObsConfig[F[_]: Sync](id: Observation.Id, conf: ObsConfiguration): F[Unit] = Sync[F]
+    .delay {
+      for {
+        ls <- Option(window.localStorage)
+        d  <- Option(ls.getItem(StorageKey)).orElse(Some(Default.asJson.spaces2))
+        p  <-
+          decode[ExploreLocalPreferences](d).toOption.map(c =>
+            c.copy(obsConfigurations = c.obsConfigurations + (id -> conf))
+          )
+        _  <- Option(ls.setItem(StorageKey, p.asJson.spaces2))
+      } yield ()
+    }
+    .handleError { u => println(u); ().some }
+    .void
+
+  // DELETEME
+  def cleanObsConfig[F[_]: Sync]: F[Unit] = Sync[F]
+    .delay {
+      for {
+        ls <- Option(window.localStorage)
+        d  <- Option(ls.getItem(StorageKey)).orElse(Some(Default.asJson.spaces2))
+        p  <- decode[ExploreLocalPreferences](d).toOption
+        _  <- Option(ls.setItem(StorageKey, p.copy(obsConfigurations = Map.empty).asJson.spaces2))
       } yield ()
     }
     .handleError(_ => ().some)

--- a/common/src/test/scala/explore/model/arb/ArbExploreLocalPreferences.scala
+++ b/common/src/test/scala/explore/model/arb/ArbExploreLocalPreferences.scala
@@ -5,7 +5,10 @@ package explore.model.arb
 
 import explore.model.ExploreLocalPreferences
 import explore.model.ExploreLocalPreferences._
+import explore.model.ObsConfiguration
 import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
+import lucuma.core.model.Observation
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalacheck.Cogen
@@ -13,15 +16,18 @@ import org.scalacheck.Cogen._
 import typings.loglevel.mod.LogLevelDesc
 
 trait ArbExploreLocalPreferences {
+  import ArbObsConfiguration._
 
   implicit val localPreferencesArb = Arbitrary[ExploreLocalPreferences] {
     for {
       level <- arbitrary[LogLevelDesc]
-    } yield ExploreLocalPreferences(level)
+      obs   <- arbitrary[Map[Observation.Id, ObsConfiguration]]
+    } yield ExploreLocalPreferences(level, obs)
   }
 
   implicit def localPreferencesCogen: Cogen[ExploreLocalPreferences] =
-    Cogen[String].contramap(_.level.toString)
+    Cogen[(String, List[(Observation.Id, ObsConfiguration)])]
+      .contramap(x => (x.level.toString, x.obsConfigurations.toList))
 }
 
 object ArbExploreLocalPreferences extends ArbExploreLocalPreferences

--- a/common/src/test/scala/explore/model/arb/ArbObsConfiguration.scala
+++ b/common/src/test/scala/explore/model/arb/ArbObsConfiguration.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import explore.model.ObsConfiguration
+import explore.model.PosAngle
+import explore.model.arb.ArbPosAngle._
+import java.time.Instant
+import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbGid._
+import lucuma.core.arb.ArbTime._
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+import org.scalacheck.Cogen._
+
+trait ArbObsConfiguration {
+
+  implicit val obsConfigurationArb = Arbitrary[ObsConfiguration] {
+    for {
+      pa <- arbitrary[PosAngle]
+      ot <- arbitrary[Instant]
+    } yield ObsConfiguration(pa, ot)
+  }
+
+  implicit def obsConfigurationCogen: Cogen[ObsConfiguration] =
+    Cogen[(PosAngle, Instant)].contramap(x => (x.posAngle, x.obsInstant))
+}
+
+object ArbObsConfiguration extends ArbObsConfiguration

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -204,7 +204,7 @@ object ExploreMain extends IOApp.Simple {
       dispatcher <- Dispatcher[IO]
       worker     <- WebWorkerF[IO](WebWorkers.TestWorker(), dispatcher)
       prefs      <- Resource.eval(ExploreLocalPreferences.loadPreferences[IO])
-      l          <- Resource.eval(setupLogger[IO](prefs))
+      l          <- { println(prefs); Resource.eval(setupLogger[IO](prefs)) }
       _          <- Resource.eval(buildPage(dispatcher, worker, prefs)(l))
     } yield ()).useForever
   }

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -185,6 +185,12 @@ object TopBar {
                       )(
                         Checkbox(label = "Dark/Light", checked = currentTheme === Theme.Dark)
                       )
+                        .when(appCtx.environment === ExecutionEnvironment.Development),
+                      // DELETME
+                      DropdownItem(text = "Reset Local Obs",
+                                   icon = Icons.SkullCrossBones.fixedWidth(),
+                                   onClick = ExploreLocalPreferences.cleanObsConfig[IO].runAsync
+                      )
                         .when(appCtx.environment === ExecutionEnvironment.Development)
                     )
                   )


### PR DESCRIPTION
While we don't have obs time or pos angle in the API doing demos is a bit hard. This PR stores them locally so each obs gets its own time

Note this is temporal as whenever they get out of sync with db reboots the saved values need to be cleared. A facility for  doing so was added to the top menu