### PR TITLE
Visualization fixes

### DIFF
--- a/common/src/main/webapp/sass/visualization.scss
+++ b/common/src/main/webapp/sass/visualization.scss
@@ -15,7 +15,7 @@
 .visualization-overlay-svg {
   position: absolute;
   pointer-events: none; // let aladin get pointer events
-  z-index: 30;
+  z-index: 40;
 
   .viz-polygon {
     stroke: gray;
@@ -93,7 +93,7 @@
 .targets-overlay-svg {
   pointer-events: none; // let aladin get pointer events
   position: absolute;
-  z-index: 140;
+  z-index: 30;
 
   circle,
   line {

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -11,6 +11,7 @@ import explore.model.ObsConfiguration
 import explore.model.TargetVisualOptions
 import explore.model.enums.Visible
 import explore.model.reusability._
+import explore.visualization._
 import japgolly.scalajs.react.Reusability._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.feature.ReactFragment

--- a/explore/src/main/scala/explore/visualization/package.scala
+++ b/explore/src/main/scala/explore/visualization/package.scala
@@ -4,10 +4,11 @@
 package explore
 
 import cats.Semigroup
-import org.locationtech.jts.geom.Geometry
-import scala.math._
 import lucuma.core.math.Offset
+import org.locationtech.jts.geom.Geometry
 import react.aladin.Fov
+
+import scala.math._
 
 package object visualization {
   // The values on the geometry are in microarcseconds

--- a/explore/src/main/scala/explore/visualization/package.scala
+++ b/explore/src/main/scala/explore/visualization/package.scala
@@ -1,0 +1,56 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore
+
+import cats.Semigroup
+import org.locationtech.jts.geom.Geometry
+import scala.math._
+import lucuma.core.math.Offset
+import react.aladin.Fov
+
+package object visualization {
+  // The values on the geometry are in microarcseconds
+  // They are fairly large and break is some browsers
+  // We apply a scaling factor uniformil
+  val scale: Double => Double = (v: Double) => rint(v / 1000)
+
+  val geometryUnionSemigroup: Semigroup[Geometry] =
+    Semigroup.instance(_.union(_))
+
+  implicit class OffsetOps(val offset: Offset) extends AnyVal {
+    def micros: (Double, Double) = {
+      // Offset amount
+      val offP =
+        Offset.P.signedDecimalArcseconds.get(offset.p).toDouble * 1e6
+
+      val offQ =
+        Offset.Q.signedDecimalArcseconds.get(offset.q).toDouble * 1e6
+      (offP, offQ)
+    }
+  }
+
+  def calculateViewBox(
+    x:            Double,
+    y:            Double,
+    w:            Double,
+    h:            Double,
+    fov:          Fov,
+    screenOffset: Offset
+  ): String = {
+    // Shift factors on x/y, basically the percentage shifted on x/y
+    val px           = abs(x / w) - 0.5
+    val py           = abs(y / h) - 0.5
+    // scaling factors on x/y
+    val sx           = fov.x.toMicroarcseconds / w
+    val sy           = fov.y.toMicroarcseconds / h
+    // Offset amount
+    val (offP, offQ) = screenOffset.micros
+
+    val viewBoxX = scale(x + px * w) * sx + scale(offP)
+    val viewBoxY = scale(y + py * h) * sy + scale(offQ)
+    val viewBoxW = scale(w) * sx
+    val viewBoxH = scale(h) * sy
+    s"$viewBoxX $viewBoxY $viewBoxW $viewBoxH"
+  }
+}


### PR DESCRIPTION
This PR  abstracts some common code and fixes two bugs:
*  Use the proper fov or else we get bad scaling of the svgs
* Display the base coordinates cross even if there are no ags candidates