### PR TITLE
Prevent duplicate target search results.

### DIFF
--- a/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
@@ -272,7 +272,13 @@ object TargetSelectionPopup {
             )
           )(
             ^.autoComplete.off,
-            ^.onSubmit ==> (e => e.preventDefaultCB >> search(inputValue.get).runAsync)
+            ^.onSubmit ==> (e =>
+              e.preventDefaultCB >>
+                singleEffect
+                  .submit(search(inputValue.get))
+                  .runAsync
+                  .whenA(!searching.value)
+            )
           )
         )
     }


### PR DESCRIPTION
Pressing <ENTER> to submit the target selection form would not cancel the "start search after the user hasn't typed for 700ms" effect, resulting in both search processes running simultaneously and duplicate results.