### PR TITLE
Disable dynamic loading for help

### DIFF
--- a/common/src/main/scala/explore/components/HelpIcon.scala
+++ b/common/src/main/scala/explore/components/HelpIcon.scala
@@ -22,7 +22,7 @@ import scala.scalajs.js
 final case class HelpIcon(id: Help.Id, clazz: js.UndefOr[Css] = js.undefined)
     extends ReactFnProps[HelpIcon](HelpIcon.component)
 
-object HelpIcon {
+object HelpIcon:
   type Props = HelpIcon
 
   type HelpId = NonEmptyString
@@ -41,4 +41,3 @@ object HelpIcon {
       )
     }
   }
-}

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -13,7 +13,7 @@ import explore.model._
 import explore.syntax.ui.*
 import explore.syntax.ui.given
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.extra.router._
+import japgolly.scalajs.react.extra.router.ResolutionWithProps
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -27,12 +27,12 @@ import react.semanticui.modules.sidebar.SidebarPusher
 import react.semanticui.modules.sidebar.SidebarWidth
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation.JSExportTopLevel
 
 final case class ExploreLayout(
-  c:        RouterCtl[Page],
-  r:        ResolutionWithProps[Page, View[RootModel]]
+  resolution: ResolutionWithProps[Page, View[RootModel]]
 )(
-  val view: View[RootModel]
+  val view:   View[RootModel]
 ) extends ReactFnProps[ExploreLayout](ExploreLayout.component)
 
 object ExploreLayout {
@@ -46,7 +46,7 @@ object ExploreLayout {
           onLogout: IO[Unit]
         ) =>
           AppCtx.using { implicit ctx =>
-            val routingInfo = RoutingInfo.from(props.r.page)
+            val routingInfo = RoutingInfo.from(props.resolution.page)
 
             HelpCtx.usingView { helpCtx =>
               val helpView = helpCtx.zoom(HelpContext.displayedHelp)
@@ -63,11 +63,7 @@ object ExploreLayout {
                   )(
                     helpView.get
                       .map { h =>
-                        // Lazy load the React component for help
-                        val prom = js.dynamicImport {
-                          new HelpLoader().loadHelp(helpCtx.get, h)
-                        }
-                        React.Suspense(<.div("Loading"), AsyncCallback.fromJsPromise(prom))
+                        HelpBody(helpCtx.get, h)
                       }
                       .when(helpView.get.isDefined)
                   ),
@@ -87,7 +83,7 @@ object ExploreLayout {
                       ),
                       <.div(
                         ExploreStyles.MainBody,
-                        props.r.renderP(props.view)
+                        props.resolution.renderP(props.view)
                       )
                     )
                   )(
@@ -96,7 +92,7 @@ object ExploreLayout {
                 )
               )
             }
-          }: VdomNode
+          }
       )
     }
 

--- a/explore/src/main/scala/explore/HelpBody.scala
+++ b/explore/src/main/scala/explore/HelpBody.scala
@@ -50,13 +50,6 @@ final case class HelpBody(base: HelpContext, helpId: Help.Id)(implicit val ctx: 
     .withQueryParam("message", s"Update $helpId")
 }
 
-// This is a sort of facade to get dynamic loading boundaries right
-// You'd be tempted to put this inside HelpBody but it will make it load HelpBody as part of the main bundle
-class HelpLoader {
-  def loadHelp(helpCtx: HelpContext, h: Help.Id)(implicit ctx: AppContextIO): VdomElement =
-    HelpBody(helpCtx, h)
-}
-
 object HelpBody {
   type Props = HelpBody
 

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -197,7 +197,7 @@ object Routing {
       val configuration =
         rules
           .notFound(redirectToPage(NoProgramPage)(SetRouteVia.HistoryPush))
-          .renderWithP(layout)
+          .renderWithP((_, resolution) => ExploreLayout(resolution))
       // .logToConsole
 
       // Only link and run this in dev mode. Works since calling `verify` trigger verification immediately.
@@ -239,9 +239,4 @@ object Routing {
       configuration
     }
 
-  private def layout(
-    c: RouterCtl[Page],
-    r: ResolutionWithProps[Page, View[RootModel]]
-  ): View[RootModel] => VdomElement =
-    ExploreLayout(c, r)
 }


### PR DESCRIPTION
The help is broken since we switched to scala 3. Traced to
https://github.com/lampepfl/dotty/issues/15701

We'll do static loading