### PR TITLE
Update highcharts and the accessibility module

### DIFF
--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -113,6 +113,8 @@ object ExploreMain extends IOApp.Simple {
   // To setup the accessibility module we need to call the modules
   // This needs to be done in the right order
   def setupHighCharts[F[_]: Sync]: F[Unit] = Sync[F].delay {
+    // This may seem like a no-op but it is in fact triggering the npm import
+    // Order is important you need to import Highcharts first
     react.highcharts.Highcharts
     explore.highcharts.HighchartsAccesibility
   }

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -110,6 +110,13 @@ object ExploreMain extends IOApp.Simple {
       element.innerHTML = msg
     }
 
+  // To setup the accessibility module we need to call the modules
+  // This needs to be done in the right order
+  def setupHighCharts[F[_]: Sync]: F[Unit] = Sync[F].delay {
+    react.highcharts.Highcharts
+    explore.highcharts.HighchartsAccesibility
+  }
+
   override final def run: IO[Unit] = {
 
     def setupReusabilityOverlay(env: ExecutionEnvironment): IO[Unit] =
@@ -210,6 +217,7 @@ object ExploreMain extends IOApp.Simple {
 
     (for {
       dispatcher       <- Dispatcher[IO]
+      _                <- Resource.eval(setupHighCharts[IO])
       prefs            <- Resource.eval(ExploreLocalPreferences.loadPreferences[IO])
       given Logger[IO] <- Resource.eval(setupLogger[IO](prefs))
       workerClients    <- WorkerClients.build[IO](dispatcher)

--- a/explore/src/main/scala/explore/highcharts.scala
+++ b/explore/src/main/scala/explore/highcharts.scala
@@ -6,4 +6,11 @@ package explore.highcharts
 import gpp.highcharts.mod._
 import japgolly.scalajs.react._
 
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
 extension (c: Chart_) inline def showLoadingCB = CallbackTo(c.showLoading())
+
+@js.native
+@JSImport("highcharts/es-modules/masters/modules/accessibility.src.js", JSImport.Default)
+object HighchartsAccesibility extends js.Object

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "copy-to-clipboard": "3.3.2",
         "fomantic-ui-less": "2.8.8",
         "github-markdown-css": "^5.1.0",
-        "highcharts": "9.3.2",
+        "highcharts": "10.2.0",
         "loglevel": "1.8.0",
         "prop-types": "15.8.1",
         "react": "17.0.2",
@@ -4565,9 +4565,9 @@
       }
     },
     "node_modules/highcharts": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.2.tgz",
-      "integrity": "sha512-I/48gNMvs3hZxZnPRUqLbnlrGZJJ7YPPVr1+fYeZ35p4pSZAOwTmAGbptrjBr7JlF52HmJH9zMbt/I4TPLu9Pg=="
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.0.tgz",
+      "integrity": "sha512-MvLo4dzR2Vo7Y85dsqJ07uabBXSSIRKRRdW4l9IGP55h2jYWNm/m9JBszVVxySH5Lda6g+Ins9NdGppZJpjNCA=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -13115,9 +13115,9 @@
       }
     },
     "highcharts": {
-      "version": "9.3.2",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.2.tgz",
-      "integrity": "sha512-I/48gNMvs3hZxZnPRUqLbnlrGZJJ7YPPVr1+fYeZ35p4pSZAOwTmAGbptrjBr7JlF52HmJH9zMbt/I4TPLu9Pg=="
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-10.2.0.tgz",
+      "integrity": "sha512-MvLo4dzR2Vo7Y85dsqJ07uabBXSSIRKRRdW4l9IGP55h2jYWNm/m9JBszVVxySH5Lda6g+Ins9NdGppZJpjNCA=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "copy-to-clipboard": "3.3.2",
     "fomantic-ui-less": "2.8.8",
     "github-markdown-css": "^5.1.0",
-    "highcharts": "9.3.2",
+    "highcharts": "10.2.0",
     "loglevel": "1.8.0",
     "prop-types": "15.8.1",
     "react": "17.0.2",


### PR DESCRIPTION
We have a pending highcharts update to version 10.
Among other changes on version it produced a big warning if you have the accessibility module disabled

This could be avoided but perhaps we can try using the module

This PR adds the code to add the accessibility module. Let's see how big it gets