### PR TITLE
Fix redrawing of charts upon resizing

### DIFF
--- a/common/src/main/scala/explore/components/ResponsiveComponent.scala
+++ b/common/src/main/scala/explore/components/ResponsiveComponent.scala
@@ -12,7 +12,7 @@ import react.common.Css
 import react.common.ReactFnPropsWithChildren
 import react.resizeDetector.hooks._
 
-final case class ResponsiveComponent(
+case class ResponsiveComponent(
   widthBreakpoints:  List[(Int, Css)],
   heightBreakpoints: List[(Int, Css)] = Nil,
   clazz:             Css = Css.Empty

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -26,7 +26,7 @@ import react.semanticui.elements.button.Button
 import scalajs.js
 import scalajs.js.|
 
-final case class Tile(
+case class Tile(
   id:                Tile.TileId,
   title:             String,
   back:              Option[VdomNode] = None,

--- a/common/src/main/scala/explore/components/TileController.scala
+++ b/common/src/main/scala/explore/components/TileController.scala
@@ -37,15 +37,15 @@ import scala.concurrent.duration._
 import scala.scalajs.js.JSConverters._
 import scala.scalajs.js.|
 
-final case class TileController(
-  userId:           Option[User.Id],
-  gridWidth:        Int,
-  defaultLayout:    LayoutsMap,
-  layoutMap:        LayoutsMap,
-  tiles:            List[Tile],
-  section:          GridLayoutSection,
-  clazz:            Option[Css] = None
-)(implicit val ctx: AppContextIO)
+case class TileController(
+  userId:        Option[User.Id],
+  gridWidth:     Int,
+  defaultLayout: LayoutsMap,
+  layoutMap:     LayoutsMap,
+  tiles:         List[Tile],
+  section:       GridLayoutSection,
+  clazz:         Option[Css] = None
+)(using val ctx: AppContextIO)
     extends ReactFnProps[TileController](TileController.component)
 
 object TileController {
@@ -74,7 +74,7 @@ object TileController {
       .headOption
 
     val h = k.map(layoutItemHeight.get)
-    if (h === Some(1)) TileSizeState.Minimized else TileSizeState.Normal
+    if (h.exists(_ === 1)) TileSizeState.Minimized else TileSizeState.Normal
   }
 
   val allTiles: Traversal[LayoutsMap, LayoutItem] =

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -163,6 +163,8 @@ object ExploreStyles {
   val ItcPlotDescription: Css   = Css("itc-plot-description")
   val ItcPlotBody: Css          = Css("itc-plot-body")
   val ItcPlotControls: Css      = Css("itc-plot-controls")
+  val ItcPlotWrapper: Css       = Css("itc-plot-wrapper")
+  val ItcTileBody: Css          = Css("explore-itc-tile-body")
 
   val AladinContainerColumn: Css  = Css("aladin-container-column")
   val AladinContainerBody: Css    = Css("aladin-container-body")

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -981,10 +981,6 @@ tfoot {
   }
 }
 
-.itc-plot-section {
-  .plot-section();
-}
-
 .elevation-plot-controls {
   display: flex;
   justify-content: space-around;

--- a/common/src/main/webapp/sass/charts.scss
+++ b/common/src/main/webapp/sass/charts.scss
@@ -129,16 +129,25 @@ See https://github.com/highcharts/highcharts/issues/13320 */
   }
 }
 
+.explore-itc-tile-body {
+  display: flex;
+}
+
 .itc-plot-section {
+  background-color: var(--plot-background-color);
+  color: var(--plot-text-color);
   display: grid;
+  width: 100%;
+  overflow: hidden;
+  min-height: 0;
   grid-template:
-    'description plot' 1fr
-    'description plot-controls' / minmax(min-content, 1fr) 3fr;
+    'description plot' minmax(0, 1fr) // minmax is required to properly shrink
+    'description plot-controls' / minmax(min-content, 1fr) minmax(0, 3fr);
 }
 
 .itc-plot-body {
   grid-area: plot;
-  align-self: stretch;
+  width: 100%;
   background-color: var(--plot-background-color);
 }
 

--- a/explore/src/main/scala/explore/itc/ItcSpectroscopyPlot.scala
+++ b/explore/src/main/scala/explore/itc/ItcSpectroscopyPlot.scala
@@ -25,7 +25,7 @@ import lucuma.core.util.Enumerated
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import react.common.ReactFnProps
-import react.highcharts.Chart
+import react.highcharts.ResizingChart
 import react.resizeDetector.hooks._
 import react.semanticui.collections.form.Form
 import react.semanticui.elements.button.Button
@@ -125,7 +125,7 @@ object ItcSpectroscopyPlot {
               .setYAxis(0)
               .setData(
                 series.data
-                  .map(p => (p(0), p(1)): Chart.Data)
+                  .map(p => (p(0), p(1)): ResizingChart.Data)
                   .toJSArray
               )
               .setClassName(chartClassName)
@@ -195,27 +195,31 @@ object ItcSpectroscopyPlot {
         itcChartOptions
           .get(props.chartType)
           .map { opt =>
-            Chart(opt,
-                  onCreate = c =>
-                    c.showLoadingCB.when_(loading) *>
-                      props.error
-                        .map(e => c.showLoadingCB(e).unless_(loading))
-                        .orEmpty
+            ResizingChart(
+              opt,
+              onCreate = c =>
+                Callback(c.reflow()) *>
+                  c.showLoadingCB.when_(loading) *>
+                  props.error
+                    .map(e => c.showLoadingCB(e).unless_(loading))
+                    .orEmpty,
+              wrapperCss = ExploreStyles.ItcPlotWrapper
             )
               .withKey(s"$props-$resize")
               .when(resize.height.isDefined)
           }
           .getOrElse(
-            Chart(emptyChartOptions(height),
-                  onCreate = c =>
-                    c.showLoadingCB.when_(loading) *>
-                      props.error
-                        .map(e => c.showLoadingCB(e).unless_(loading))
-                        .orEmpty
+            ResizingChart(emptyChartOptions(height),
+                          onCreate = c =>
+                            c.showLoadingCB.when_(loading) *>
+                              props.error
+                                .map(e => c.showLoadingCB(e).unless_(loading))
+                                .orEmpty
             )
               .withKey(s"$props-$resize")
               .when(resize.height.isDefined)
           )
-      ).withRef(resize.ref)
+      )
+        .withRef(resize.ref)
     }
 }

--- a/explore/src/main/scala/explore/itc/ResizingChart.scala
+++ b/explore/src/main/scala/explore/itc/ResizingChart.scala
@@ -1,0 +1,122 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.highcharts
+
+import cats.syntax.all.*
+import gpp.highcharts.anon.TypeofHighcharts
+import gpp.highcharts.anon.TypeofHighchartsAST
+import gpp.highcharts.mod.Chart_
+import gpp.highcharts.mod.HTMLDOMElement
+import gpp.highcharts.mod.Options
+import gpp.highcharts.mod.PointOptionsObject
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.ui.syntax.all.given
+import org.scalajs.dom.html
+import react.common.ReactFnProps
+import react.common.ReactProps
+import react.common.style.Css
+import react.resizeDetector.UseResizeDetectorProps
+import react.resizeDetector.hooks.*
+
+import scala.scalajs.js
+import scala.scalajs.js.|
+
+case class ResizingChart(
+  options:    Options,
+  onCreate:   Chart_ => Callback = _ => Callback.empty,
+  wrapperCss: Css = Css.Empty,
+  highcharts: TypeofHighchartsAST = Highcharts
+) extends ReactFnProps(ResizingChart.component)
+
+object ResizingChart {
+  type Props = ResizingChart
+
+  type Data =
+    Double |
+      scala.scalajs.js.Tuple2[
+        Double | String,
+        Double | Null
+      ] | Null | PointOptionsObject
+
+  val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      // ref to the chart div
+      .useRefToVdom[html.Element]
+      // ref to the chart
+      .useRef(none[Chart_])
+      // Build the chart and setuup the destroy
+      .useEffectOnMountBy((props, containerRef, graphRef) =>
+        containerRef.foreach { element =>
+          props.highcharts.chart(
+            element.asInstanceOf[HTMLDOMElement],
+            props.options,
+            c => (graphRef.set(Some(c)) *> props.onCreate(c)).runNow()
+          )
+          ()
+        } *>
+          // We need to destroy at unmount or we'll leak memory
+          CallbackTo(graphRef.foreach(_.foreach(_.destroy())))
+      )
+      // On resize do a reflow
+      .useResizeDetectorBy((_, _, graphRef) =>
+        // Reflow on resize to adapt to the size
+        UseResizeDetectorProps(onResize = (_, _) => graphRef.foreach(_.foreach(c => c.reflow())))
+      )
+      .render { (props, containerRef, _, resize) =>
+        // Unfortunately we need two divs to have two references setup
+        <.div(props.wrapperCss, <.div().withRef(containerRef)).withRef(resize.ref)
+      }
+}
+
+case class Chart(
+  options:    Options,
+  onCreate:   Chart_ => Callback = _ => Callback.empty,
+  highcharts: TypeofHighchartsAST = Highcharts
+) extends ReactProps(Chart.component)
+
+object Chart {
+  type Props = Chart
+
+  type Data =
+    Double |
+      scala.scalajs.js.Tuple2[
+        Double | String,
+        Double | Null
+      ] | Null | PointOptionsObject
+
+  class Backend($ : BackendScope[Props, Unit]) {
+    private val containerRef = Ref[html.Element]
+    private val graphRef     = Ref[Chart_]
+
+    def render(props: Props) =
+      <.div.withRef(containerRef)
+
+    def destroy(): Callback =
+      graphRef.foreach(_.destroy())
+
+    def refresh(props: Props): Callback =
+      containerRef.foreach { element =>
+        val result = props.highcharts.chart(
+          element.asInstanceOf[HTMLDOMElement],
+          props.options,
+          c => (props.onCreate(c) *> graphRef.set(Some(c))).runNow()
+        )
+        ()
+      }
+  }
+
+  // We are purposefully not updating the chart on each rerender.
+  // To update the chart either:
+  //  A) Call the refresh method via a Ref; or
+  //  B) Remount with a different key.
+  val component =
+    ScalaComponent
+      .builder[Props]
+      .renderBackend[Backend]
+      .componentDidMount($ => $.backend.refresh($.props))
+      .componentWillUnmount($ => $.backend.destroy())
+      .build
+}

--- a/explore/src/main/scala/explore/tabs/ItcTile.scala
+++ b/explore/src/main/scala/explore/tabs/ItcTile.scala
@@ -3,8 +3,10 @@
 
 package explore.tabs
 
+import cats.syntax.all.*
 import explore.common.ObsQueries._
 import explore.components.Tile
+import explore.components.ui.ExploreStyles
 import explore.implicits._
 import explore.itc.ItcGraphPanel
 import explore.model.ScienceMode
@@ -23,5 +25,6 @@ object ItcTile:
     Tile(
       ObsTabTilesIds.ItcId.id,
       s"ITC",
-      canMinimize = true
+      canMinimize = true,
+      bodyClass = ExploreStyles.ItcTileBody.some
     )(_ => ItcGraphPanel(scienceMode, spectroscopyRequirements, scienceData, itcExposureTime))

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotNight.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotNight.scala
@@ -26,7 +26,7 @@ import lucuma.core.util.Enumerated
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import react.common.ReactFnProps
-import react.highcharts.Chart
+import react.highcharts.ResizingChart
 import react.moon.MoonPhase
 import react.resizeDetector.hooks._
 
@@ -73,16 +73,16 @@ object ElevationPlotNight {
     }
 
   protected case class SeriesData(
-    targetAltitude:   List[Chart.Data],
-    skyBrightness:    List[Chart.Data],
-    parallacticAngle: List[Chart.Data],
-    moonAltitude:     List[Chart.Data]
+    targetAltitude:   List[ResizingChart.Data],
+    skyBrightness:    List[ResizingChart.Data],
+    parallacticAngle: List[ResizingChart.Data],
+    moonAltitude:     List[ResizingChart.Data]
   )
 
   private enum ElevationSeries(
     val name:  String,
     val yAxis: Int,
-    val data:  SeriesData => List[Chart.Data]
+    val data:  SeriesData => List[ResizingChart.Data]
   ) derives Eq:
     case Elevation        extends ElevationSeries("Elevation", 0, _.targetAltitude)
     case ParallacticAngle extends ElevationSeries("Parallactic Angle", 1, _.parallacticAngle)
@@ -178,12 +178,12 @@ object ElevationPlotNight {
           .map { case (instant, results) =>
             val millisSinceEpoch = instant.toEpochMilli.toDouble
 
-            def point(value: Double): Chart.Data =
+            def point(value: Double): ResizingChart.Data =
               PointOptionsObject(js.undefined)
                 .setX(millisSinceEpoch)
                 .setY(value)
 
-            def pointWithAirmass(value: Double, airmass: Double): Chart.Data =
+            def pointWithAirmass(value: Double, airmass: Double): ResizingChart.Data =
               point(value).asInstanceOf[PointOptionsWithAirmass].setAirMass(airmass)
 
             (pointWithAirmass(results.altitude.toAngle.toSignedDoubleDegrees, results.airmass),
@@ -391,7 +391,7 @@ object ElevationPlotNight {
 
         <.div(
           // Include the size in the key
-          Chart(options).withKey(s"$props-$resize").when(resize.height.isDefined),
+          ResizingChart(options).withKey(s"$props-$resize").when(resize.height.isDefined),
           <.div(ExploreStyles.MoonPhase)(
             <.span(
               MoonPhase(phase = moonPhase,

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotSemester.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotSemester.scala
@@ -31,7 +31,7 @@ import lucuma.ui.reusability._
 import lucuma.ui.syntax.all.given
 import react.common.GenericComponentPAF2VdomNode
 import react.common.ReactFnProps
-import react.highcharts.Chart
+import react.highcharts.ResizingChart
 import react.resizeDetector.hooks._
 import spire.math.Bounded
 
@@ -213,7 +213,7 @@ object ElevationPlotSemester {
           )
 
         <.div(
-          Chart(options, c => chartOpt.setState(c.some))
+          ResizingChart(options, c => chartOpt.setState(c.some))
             .withKey(s"$props")
             .when(resize.height.isDefined)
         ).withRef(resize.ref)


### PR DESCRIPTION
For a while we've noticed that resizing the tiles with charts leads to artifacts on correctly drawing the plots often getting larger than the tile and thus showing scrollbars

This PR fixes this with 3 changes
* New `ResizingChart` component that calls `chart.reflow()` upon changing the size (to be moved to lucuma-ui)
* Css changes to better follow the tile size
* A bit unrelated but charts need cleanup or we start accumulating memory used on the charts

[sc-1367]