### PR TITLE
Double initialization sync for workers.

### DIFF
--- a/model/shared/src/main/scala/workers/WorkerMessage.scala
+++ b/model/shared/src/main/scala/workers/WorkerMessage.scala
@@ -19,12 +19,13 @@ private type Pickled = Pickled.Type
 private object WorkerMessage:
   sealed trait FromClient
   object FromClient:
+    case object ClientReady                                 extends FromClient
     case class Start(id: WorkerProcessId, payload: Pickled) extends FromClient
     case class End(id: WorkerProcessId)                     extends FromClient
 
   sealed trait FromServer
   object FromServer:
-    case object Ready                                             extends FromServer
+    case object ServerReady                                       extends FromServer
     case class Data(id: WorkerProcessId, payload: Pickled)        extends FromServer
     case class Complete(id: WorkerProcessId)                      extends FromServer
     case class Error(id: WorkerProcessId, error: WorkerException) extends FromServer
@@ -33,13 +34,15 @@ private object WorkerMessage:
 
   private given Pickler[Pickled] = transformPickler(Pickled.apply)(_.value)
 
+  private given Pickler[FromClient.ClientReady.type] = generatePickler
+
   private given Pickler[FromClient.Start] = generatePickler
 
   private given Pickler[FromClient.End] = generatePickler
 
   given Pickler[FromClient] = generatePickler
 
-  private given Pickler[FromServer.Ready.type] = generatePickler
+  private given Pickler[FromServer.ServerReady.type] = generatePickler
 
   private given Pickler[FromServer.Data] = generatePickler
 


### PR DESCRIPTION
There's a race condition between initializing workers and initializing their clients. By "initialize" I mean that the "onmessage" listener is executed.

In a previous PR we added a message for the server to notify the client when it's initialized and logic for the client to wait for that message before sending requests to the server.

However, the client may not be initialized when the server sends its ready message, so now we add another "client ready" message for the client to request the "server ready" message from the server.

The server therefore sends the "server ready" message twice: once as an answer to the "client ready" request, and once as soon the server is initialized. The first one may not happen if the server misses the "client ready" message. This way we make sure that the client gets at least one "server ready" message.

