### PR TITLE
Switch to Tooltips using floating-ui

### DIFF
--- a/common/src/main/scala/explore/components/ConnectionsStatus.scala
+++ b/common/src/main/scala/explore/components/ConnectionsStatus.scala
@@ -17,11 +17,11 @@ import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import react.common.ReactFnProps
+import react.floatingui.*
 import react.semanticui.elements.icon._
-import react.semanticui.modules.popup._
 import react.semanticui.views.item.Item
 
-final case class ConnectionsStatus()(implicit val ctx: AppContextIO)
+case class ConnectionsStatus()(using val ctx: AppContextIO)
     extends ReactFnProps[ConnectionsStatus](ConnectionsStatus.component)
 
 object ConnectionsStatus {
@@ -43,11 +43,10 @@ object ConnectionsStatus {
 
     if (show) {
       Item(clazz = ExploreStyles.ConnectionIcon)(
-        Popup(
-          header = s"$name Connection Status",
-          content = message,
-          position = PopupPosition.BottomRight,
-          trigger = Icons.CircleSmall.clazz(clazz)
+        Tooltip(
+          tooltip = message,
+          placement = Placement.Bottom,
+          trigger = <.span(Icons.CircleSmall.clazz(clazz))
         )
       )
     } else <.span()

--- a/common/src/main/scala/react/floatingui/Tooltip.scala
+++ b/common/src/main/scala/react/floatingui/Tooltip.scala
@@ -26,12 +26,12 @@ import js.annotation._
  * Tooltip base on floating ui see: https://floating-ui.com/docs/react-dom
  */
 case class Tooltip(trigger: VdomTag, tooltip: VdomNode, placement: Placement = Placement.Top)
-    extends ReactFnProps[Tooltip](Tooltip.component)
+    extends ReactFnProps(Tooltip.component)
 
 object Tooltip {
-  type Props = Tooltip
+  private type Props = Tooltip
 
-  val component =
+  private val component =
     ScalaFnComponent
       .withHooks[Props]
       .useState(false) // isOpen

--- a/common/src/main/scala/react/floatingui/Tooltip.scala
+++ b/common/src/main/scala/react/floatingui/Tooltip.scala
@@ -1,0 +1,135 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.floatingui
+
+import cats.syntax.all.*
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.feature.ReactFragment
+import japgolly.scalajs.react.vdom.TagOf
+import japgolly.scalajs.react.vdom.html_<^._
+import lucuma.ui.syntax.all.*
+import lucuma.ui.syntax.all.given
+import org.scalajs.dom
+import org.scalajs.dom.html
+import react.common.ReactFnProps
+import react.common.Style
+import react.floatingui.hooks._
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSExportTopLevel
+import scala.scalajs.js.|
+
+import js.annotation._
+
+/**
+ * Tooltip base on floating ui see: https://floating-ui.com/docs/react-dom
+ */
+case class Tooltip(trigger: VdomTag, tooltip: VdomNode, placement: Placement = Placement.Top)
+    extends ReactFnProps[Tooltip](Tooltip.component)
+
+object Tooltip {
+  type Props = Tooltip
+
+  val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      .useState(false) // isOpen
+      .useRefToVdom[dom.HTMLElement] // arrow
+      .useFloatingBy { (props, open, arrow) =>
+        UseFloatingProps(
+          placement = props.placement,
+          open = open.value,
+          onOpenChange = open.setState,
+          middleware = List(
+            middleware.flip(),
+            middleware.shift(ShiftOptions(padding = 5)),
+            middleware.offset(4),
+            middleware.arrow(ArrowElement(arrow.raw))
+          )
+        )
+      }
+      .useInteractionsBy { (_, _, _, h) =>
+        List(middleware.useHover(h.context))
+      }
+      .render { (props, open, arrow, floating, _) =>
+        val display: Map[String, String | Int] =
+          if (open.value) Map.empty[String, String | Int]
+          else Map[String, String | Int]("display" -> "none")
+
+        val style = (floating.x.toOption, floating.y.toOption) match {
+          case (Some(x), Some(y)) =>
+            Style(
+              Map(
+                "position" -> floating.strategy,
+                "left"     -> s"${x}px",
+                "top"      -> s"${y}px"
+              ) ++ display
+            )
+          case _                  =>
+            Style(
+              Map(
+                "position" -> floating.strategy,
+                "left"     -> "0",
+                "top"      -> "0"
+              ) ++ display
+            )
+        }
+
+        val arrowOpt                                 = floating.middlewareData.arrow.toOption
+        val arrowStyleMap: Map[String, String | Int] =
+          (arrowOpt.flatMap(_.x.toOption), arrowOpt.flatMap(_.y.toOption)) match {
+            case (Some(x), Some(y)) =>
+              Map("left" -> s"${x}px", "top" -> s"${y}px", "right" -> "", "bottom" -> "")
+            case (Some(x), None)    =>
+              Map("left" -> s"${x}px", "top" -> s"", "right" -> "", "bottom" -> "")
+            case (None, Some(y))    =>
+              Map("left" -> "", "top" -> s"${y}px", "right" -> "", "bottom" -> "")
+            case _                  => Map.empty
+          }
+
+        val arrowShift  = "-4px"
+        val arrowBorder = "var(--tooltip-border-width)"
+
+        val placementStyle: Map[String, String | Int] =
+          Placement.fromString(floating.placement) match {
+            case Some(Placement.Top) | Some(Placement.TopStart) | Some(Placement.TopEnd)          =>
+              Map("bottom"              -> arrowShift,
+                  "border-right-width"  -> arrowBorder,
+                  "border-bottom-width" -> arrowBorder
+              )
+            case Some(Placement.Bottom) | Some(Placement.BottomStart) | Some(Placement.BottomEnd) =>
+              Map("top"               -> arrowShift,
+                  "border-left-width" -> arrowBorder,
+                  "border-top-width"  -> arrowBorder
+              )
+            case Some(Placement.Left) | Some(Placement.LeftStart) | Some(Placement.LeftEnd)       =>
+              Map("right"              -> arrowShift,
+                  "border-right-width" -> arrowBorder,
+                  "border-top-width"   -> arrowBorder
+              )
+            case Some(Placement.Right) | Some(Placement.RightStart) | Some(Placement.RightEnd)    =>
+              Map("left"                -> arrowShift,
+                  "border-left-width"   -> arrowBorder,
+                  "border-bottom-width" -> arrowBorder
+              )
+            case _                                                                                => Map.empty
+          }
+
+        val arrowStyle =
+          arrowOpt.fold(Style(display))(_ => Style(display ++ arrowStyleMap ++ placementStyle))
+        ReactFragment(
+          props.trigger(^.untypedRef := floating.reference),
+          if (open.value)
+            <.div(
+              ^.untypedRef := floating.floating,
+              ^.cls        := "tooltip",
+              ^.style      := style.toJsObject,
+              props.tooltip,
+              <.div(^.cls := "arrow", ^.untypedRef := arrow, ^.style := arrowStyle.toJsObject)
+            )
+          else
+            EmptyVdom
+        )
+      }
+}

--- a/common/src/main/scala/react/floatingui/hooks.scala
+++ b/common/src/main/scala/react/floatingui/hooks.scala
@@ -1,0 +1,85 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.floatingui
+
+import japgolly.scalajs.react._
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters._
+import scala.scalajs.js.|
+
+@js.native
+trait ElementProps extends js.Object
+
+type ElementPropsList = List[ElementProps]
+
+object HooksApiExt {
+  val floatingHook =
+    CustomHook[UseFloatingProps]
+      .buildReturning { pos =>
+        use.useFloating(pos)
+      }
+
+  val interactionsHook =
+    CustomHook[ElementPropsList]
+      .buildReturning { ctx =>
+        use.useInteractions(ctx.toJSArray)
+      }
+
+  sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+    final def useFloating(pos: UseFloatingProps = UseFloatingProps())(implicit
+      step:                    Step
+    ): step.Next[UseFloatingReturn] =
+      useFloatingBy(_ => pos)
+
+    final def useFloatingBy(pos: Ctx => UseFloatingProps)(implicit
+      step:                      Step
+    ): step.Next[UseFloatingReturn] =
+      api.customBy(ctx => floatingHook(pos(ctx)))
+
+    final def useInteractions(pos: ElementPropsList)(implicit
+      step:                        Step
+    ): step.Next[UseFloatingReturn] =
+      useInteractionsBy(_ => pos)
+
+    final def useInteractionsBy(pos: Ctx => ElementPropsList)(implicit
+      step:                          Step
+    ): step.Next[UseFloatingReturn] =
+      api.customBy(ctx => interactionsHook(pos(ctx)))
+  }
+
+  final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ) extends Primary[Ctx, Step](api) {
+
+    def useFloatingBy(pos: CtxFn[UseFloatingProps])(implicit
+      step:                Step
+    ): step.Next[UseFloatingReturn] =
+      useFloatingBy(step.squash(pos)(_))
+
+    def useInteractionsBy(pos: CtxFn[ElementPropsList])(implicit
+      step:                    Step
+    ): step.Next[UseFloatingReturn] =
+      useInteractionsBy(step.squash(pos)(_))
+
+  }
+}
+
+trait HooksApiExt {
+  import HooksApiExt._
+  import scala.language.implicitConversions
+
+  implicit def hooksExtFloating1[Ctx, Step <: HooksApi.AbstractStep](
+    api: HooksApi.Primary[Ctx, Step]
+  ): Primary[Ctx, Step] =
+    new Primary(api)
+
+  implicit def hooksExtFloating2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ): Secondary[Ctx, CtxFn, Step] =
+    new Secondary(api)
+}
+
+object hooks extends HooksApiExt

--- a/common/src/main/scala/react/floatingui/hooks.scala
+++ b/common/src/main/scala/react/floatingui/hooks.scala
@@ -15,13 +15,13 @@ trait ElementProps extends js.Object
 type ElementPropsList = List[ElementProps]
 
 object HooksApiExt {
-  val floatingHook =
+  private val floatingHook =
     CustomHook[UseFloatingProps]
       .buildReturning { pos =>
         use.useFloating(pos)
       }
 
-  val interactionsHook =
+  private val interactionsHook =
     CustomHook[ElementPropsList]
       .buildReturning { ctx =>
         use.useInteractions(ctx.toJSArray)

--- a/common/src/main/scala/react/floatingui/package.scala
+++ b/common/src/main/scala/react/floatingui/package.scala
@@ -1,0 +1,249 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.floatingui
+
+import cats.syntax.all.*
+import japgolly.scalajs.react._
+import japgolly.scalajs.react.facade.React
+import japgolly.scalajs.react.vdom.TopNode
+import org.scalajs.dom
+import org.scalajs.dom.html
+import react.common.EnumValue
+import react.common.syntax.callback.*
+import react.common.syntax.enumValue.*
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters._
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.|
+
+enum Side:
+  case Top, Right, Bottom, Left
+
+enum Alignment:
+  case Start, End
+
+enum Strategy:
+  case Absolute, Fixed
+
+enum AlignedPlacement:
+  case TopStart, TopEnd, RightStart, RightEnd, BottomStart, BottomEnd, LeftStart, LeftEnd
+
+enum Placement: // Side | AlignedPlacement
+  case Top, Right, Bottom, Left, TopStart, TopEnd, RightStart, RightEnd, BottomStart, BottomEnd,
+    LeftStart, LeftEnd
+
+object Placement:
+  def fromString(s: String): Option[Placement] = s match {
+    case "top"          => Placement.Top.some
+    case "right"        => Placement.Right.some
+    case "bottom"       => Placement.Bottom.some
+    case "left"         => Placement.Left.some
+    case "top-start"    => Placement.TopStart.some
+    case "top-end"      => Placement.TopEnd.some
+    case "right-start"  => Placement.RightStart.some
+    case "right-end"    => Placement.RightEnd.some
+    case "botton-start" => Placement.BottomStart.some
+    case "bottom-end"   => Placement.BottomEnd.some
+    case "left-start"   => Placement.LeftStart.some
+    case "left-end"     => Placement.LeftEnd.some
+    case _              => none
+  }
+
+given EnumValue[Strategy]  = EnumValue.toLowerCaseString[Strategy]
+given EnumValue[Placement] = EnumValue.instance {
+  case Placement.Top         => "top"
+  case Placement.Right       => "right"
+  case Placement.Bottom      => "bottom"
+  case Placement.Left        => "left"
+  case Placement.TopStart    => "top-start"
+  case Placement.TopEnd      => "top-end"
+  case Placement.RightStart  => "right-start"
+  case Placement.RightEnd    => "right-end"
+  case Placement.BottomStart => "botton-start"
+  case Placement.BottomEnd   => "bottom-end"
+  case Placement.LeftStart   => "left-start"
+  case Placement.LeftEnd     => "left-end"
+}
+
+type Middleware = js.Object
+
+@js.native
+trait UseFloatingReturn extends js.Object {
+
+  var context: FloatingContext               = js.native
+  var middlewareData: MiddlewareData         = js.native
+  var placement: String                      = js.native
+  val reference: facade.React.RefFn[TopNode] = js.native
+  val floating: facade.React.RefFn[TopNode]  = js.native
+  val strategy: String                       = js.native
+
+  val x: js.UndefOr[Double] = js.native
+  val y: js.UndefOr[Double] = js.native
+
+}
+
+@js.native
+trait ArrowCoords extends js.Object {
+
+  var centerOffset: Double = js.native
+
+  var x: js.UndefOr[Double] = js.native
+
+  var y: js.UndefOr[Double] = js.native
+}
+
+@js.native
+trait MiddlewareData extends js.Object {
+
+  var arrow: js.UndefOr[ArrowCoords] = js.native
+
+}
+
+@js.native
+trait UseFloatingProps extends js.Object {
+
+  var middleware: js.UndefOr[js.Array[Middleware]] = js.native
+
+  var onOpenChange: js.UndefOr[js.Function1[Boolean, Unit]] = js.native
+
+  var open: js.UndefOr[Boolean] = js.native
+
+  var placement: js.UndefOr[String] = js.native
+
+  var strategy: js.UndefOr[String] = js.native
+}
+
+object UseFloatingProps {
+
+  inline def apply(
+    placement:    js.UndefOr[Placement] = js.undefined,
+    strategy:     js.UndefOr[Strategy] = js.undefined,
+    open:         js.UndefOr[Boolean] = js.undefined,
+    onOpenChange: js.UndefOr[Boolean => Callback] = js.undefined,
+    middleware:   List[Middleware] = Nil
+  ): UseFloatingProps =
+    val p = js.Dynamic.literal().asInstanceOf[UseFloatingProps]
+    strategy.foreach(s => p.strategy = s.toJs)
+    placement.foreach(s => p.placement = s.toJs)
+    open.foreach(s => p.open = s)
+    onOpenChange.foreach(s => p.onOpenChange = s.toJs)
+    p.middleware = middleware.toJSArray
+    p
+
+}
+
+type Padding = Double //| SideObject
+
+@js.native
+trait ShiftOptions extends js.Object {
+  var padding: js.UndefOr[Padding] = js.native
+}
+
+object ShiftOptions {
+
+  inline def apply(
+    padding: js.UndefOr[Padding] = js.undefined
+  ): ShiftOptions =
+    val p = js.Dynamic.literal().asInstanceOf[ShiftOptions]
+    padding.foreach(s => p.padding = s)
+    p
+}
+
+type OffsetValue = Double //| AlignmentAxis
+
+type OffsetOptions = OffsetValue //| OffsetFunction
+
+@js.native
+trait FloatingContext extends UseFloatingReturn {
+  var open: Boolean = js.native
+}
+
+@js.native
+trait ArrowElement extends js.Object:
+
+  var element: js.Any = js.native
+
+  var padding: js.UndefOr[Padding] = js.native
+
+object ArrowElement:
+
+  inline def apply(element: facade.React.RefHandle[TopNode | Null]): ArrowElement = {
+    val o = js.Dynamic.literal.asInstanceOf[ArrowElement]
+    Option(element.current)
+      .flatMap(_.domToHtml)
+      .fold(o.element = element)(o.element = _)
+    o
+  }
+  inline def apply(element: html.Element): ArrowElement                           = {
+    val __obj = js.Dynamic.literal(element = element.asInstanceOf[js.Any])
+    __obj.asInstanceOf[ArrowElement]
+  }
+
+object middleware {
+
+  @JSImport("@floating-ui/react-dom-interactions", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+
+  /**
+   * Positions an inner element of the floating element such that it is centered to the reference
+   * element.
+   * @see
+   *   https://floating-ui.com/docs/arrow
+   */
+  inline def arrow(options: ArrowElement): Middleware = ^.asInstanceOf[js.Dynamic]
+    .applyDynamic("arrow")(options.asInstanceOf[js.Any])
+    .asInstanceOf[Middleware]
+
+  /**
+   * Changes the placement of the floating element to one that will fit if the initially specified
+   * `placement` does not.
+   * @see
+   *   https://floating-ui.com/docs/flip
+   */
+  inline def flip(): Middleware                       =
+    ^.asInstanceOf[js.Dynamic].applyDynamic("flip")().asInstanceOf[Middleware]
+  //
+  inline def offset(): Middleware                     =
+    ^.asInstanceOf[js.Dynamic].applyDynamic("offset")().asInstanceOf[Middleware]
+  inline def offset(value: OffsetOptions): Middleware = ^.asInstanceOf[js.Dynamic]
+    .applyDynamic("offset")(value.asInstanceOf[js.Any])
+    .asInstanceOf[Middleware]
+
+  /**
+   * Shifts the floating element in order to keep it in view when it will overflow a clipping
+   * boundary.
+   * @see
+   *   https://floating-ui.com/docs/shift
+   */
+  inline def shift(): Middleware                      =
+    ^.asInstanceOf[js.Dynamic].applyDynamic("shift")().asInstanceOf[Middleware]
+  inline def shift(options: ShiftOptions): Middleware = ^.asInstanceOf[js.Dynamic]
+    .applyDynamic("shift")(options.asInstanceOf[js.Any])
+    .asInstanceOf[Middleware]
+
+  inline def useHover(context: FloatingContext): ElementProps =
+    ^.asInstanceOf[js.Dynamic]
+      .applyDynamic("useHover")(context.asInstanceOf[js.Any])
+      .asInstanceOf[ElementProps]
+}
+
+object use {
+  @JSImport("@floating-ui/react-dom-interactions", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+
+  inline def useFloating(): UseFloatingReturn =
+    ^.asInstanceOf[js.Dynamic].applyDynamic("useFloating")().asInstanceOf[UseFloatingReturn]
+  inline def useFloating(
+    props: UseFloatingProps
+  ): UseFloatingReturn =
+    ^.asInstanceOf[js.Dynamic].applyDynamic("useFloating")(props).asInstanceOf[UseFloatingReturn]
+
+  inline def useInteractions(propsList: js.Array[ElementProps | Unit]): UseFloatingReturn =
+    ^.asInstanceOf[js.Dynamic]
+      .applyDynamic("useInteractions")(propsList.asInstanceOf[js.Any])
+      .asInstanceOf[UseFloatingReturn]
+}

--- a/common/src/main/webapp/less/variables-dark.less
+++ b/common/src/main/webapp/less/variables-dark.less
@@ -200,6 +200,10 @@
   );
   --ags-icon-color: hsla(60, 100%, 50%, 80%);
   --ags-good-iq-color: hsl(120, 60.7%, 33.9%, 80%);
+  --tooltip-background-color: var(--color-background-light-3);
+  --tooltip-border-color: var(--color-background-light-50);
+  --tooltip-border-width: 1px;
+  --tooltip-z-index: 150;
 }
 
 .site-dark() {

--- a/common/src/main/webapp/less/variables-light.less
+++ b/common/src/main/webapp/less/variables-light.less
@@ -85,6 +85,10 @@
   );
   --ags-icon-color: hsla(60, 100%, 50%, 80%);
   --ags-good-iq-color: hsl(120, 60.7%, 33.9%, 80%);
+  --tooltip-background-color: var(--color-background-light-3);
+  --tooltip-border-color: var(--color-background-light-50);
+  --tooltip-border-width: 1px;
+  --tooltip-z-index: 150;
 }
 
 .site-light() {

--- a/common/src/main/webapp/sass/tooltips.scss
+++ b/common/src/main/webapp/sass/tooltips.scss
@@ -1,0 +1,38 @@
+
+@keyframes append-animate {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+@mixin common-tooltip {
+  position: absolute;
+  background-color: var(--tooltip-background-color);
+  z-index: var(--tooltip-z-index);
+	animation: append-animate 180ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.tooltip {
+  @include common-tooltip;
+
+  border: var(--tooltip-border-width) solid var(--tooltip-border-color);
+  border-radius: 3px;
+  padding: 0.7em;
+  font-size: smaller;
+  display: inline;
+  min-width: 100px;
+  max-width: 300px;
+}
+
+.arrow {
+  @include common-tooltip;
+
+  border: 0 solid var(--tooltip-border-color);
+  width: 8px;
+  height: 8px;
+  transform: rotate(45deg);
+}

--- a/common/src/main/webapp/theme/semantic.less
+++ b/common/src/main/webapp/theme/semantic.less
@@ -130,9 +130,9 @@
 & {
   @import "fomantic-ui-less/definitions/modules/nag";
 }
-& {
-  @import "fomantic-ui-less/definitions/modules/popup";
-}
+// & {
+//   @import "fomantic-ui-less/definitions/modules/popup";
+// }
 & {
   @import "fomantic-ui-less/definitions/modules/progress";
 }

--- a/common/src/main/webapp/theme/semantic.less
+++ b/common/src/main/webapp/theme/semantic.less
@@ -127,9 +127,10 @@
 & {
   @import "fomantic-ui-less/definitions/modules/modal";
 }
-& {
-  @import "fomantic-ui-less/definitions/modules/nag";
-}
+// Nag and popup are not used
+// & {
+//   @import "fomantic-ui-less/definitions/modules/nag";
+// }
 // & {
 //   @import "fomantic-ui-less/definitions/modules/popup";
 // }

--- a/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
@@ -71,10 +71,10 @@ import mouse.boolean.*
 import queries.schemas.implicits.*
 import react.common.ReactFnProps
 import react.fa.IconSize
+import react.floatingui.Tooltip
 import react.semanticui.collections.form.Form
 import react.semanticui.collections.form.FormInput
 import react.semanticui.elements.button.Button
-import react.semanticui.modules.popup.Popup
 import react.semanticui.shorthand.*
 import react.semanticui.sizes.*
 import spire.math.Bounded
@@ -267,14 +267,15 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
     rows.collectFirstSome(row => findMatrixDataFromRow(basic, advanced, reqsWavelength, row))
 
   private def customized(original: String): VdomNode =
-    Popup(
+    Tooltip(
       trigger = <.span(
         ^.cls := "fa-layers fa-fw",
         Icons.ExclamationDiamond
           .clazz(ExploreStyles.WarningIcon)
           .size(IconSize.X1)
-      )
-    )(s"Customized! Orginal: $original")
+      ),
+      tooltip = <.div("Customized!", <.br, s"Orginal: $original")
+    )
 
   private def customizedUnit(units: String, original: String, isCustom: Boolean): VdomNode =
     if (isCustom) <.span(units, customized(original)) else units

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -57,11 +57,11 @@ import lucuma.utils._
 import react.circularprogressbar.CircularProgressbar
 import react.common.Css
 import react.common.ReactFnProps
+import react.floatingui.*
 import react.semanticui._
 import react.semanticui.collections.table._
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.label.Label
-import react.semanticui.modules.popup.Popup
 import react.virtuoso._
 import react.virtuoso.raw.ListRange
 import reactST.reactTable._
@@ -198,22 +198,33 @@ object SpectroscopyModesTable {
     val content: TagMod = c match {
       case Left(nel)                        =>
         if (nel.exists(_ == ItcQueryProblems.UnsupportedMode))
-          Popup(content = "Mode not supported", trigger = Icons.Ban.color("red"))
+          Tooltip(tooltip = "Mode not supported",
+                  placement = Placement.RightStart,
+                  trigger = <.span(Icons.Ban.color("red"))
+          )
         else {
           val content = nel.collect {
-            case ItcQueryProblems.MissingSignalToNoise => "Set S/N"
-            case ItcQueryProblems.MissingWavelength    => "Set Wavelength"
-            case ItcQueryProblems.MissingTargetInfo    => "Missing target info"
-            case ItcQueryProblems.GenericError(e)      => e
-          }
-          Popup(content = content.mkString_(", "), trigger = Icons.TriangleSolid)
+            case ItcQueryProblems.MissingSignalToNoise => <.span("Set S/N")
+            case ItcQueryProblems.MissingWavelength    => <.span("Set Wavelength")
+            case ItcQueryProblems.MissingTargetInfo    => <.span("Missing target info")
+            case ItcQueryProblems.GenericError(e)      => e.split("\\.").mkTagMod(<.br)
+          }.toList
+
+          Tooltip(tooltip = <.div(content.mkTagMod(<.span)),
+                  placement = Placement.RightEnd,
+                  trigger = <.span(Icons.TriangleSolid)
+          )
         }
       case Right(r: ItcResult.Result)       =>
-        formatDuration(r.duration.toSeconds)
+        Tooltip(
+          trigger = <.span(formatDuration(r.duration.toSeconds)),
+          placement = Placement.RightStart,
+          tooltip = s"${r.exposures} × ${formatDuration(r.exposureTime.toSeconds)}"
+        )
       case Right(ItcResult.Pending)         =>
         Icons.Spinner.spin(true)
       case Right(ItcResult.SourceTooBright) =>
-        Popup(content = "Source too bright", trigger = Icons.SunBright.color("yellow"))
+        Tooltip(tooltip = "Source too bright", trigger = <.span(Icons.SunBright.color("yellow")))
     }
     <.div(ExploreStyles.ITCCell, content)
 

--- a/explore/src/main/scala/explore/itc/package.scala
+++ b/explore/src/main/scala/explore/itc/package.scala
@@ -10,21 +10,22 @@ import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.utils.NewType
 import react.fa.IconSize
-import react.semanticui.modules.popup.Popup
+import react.floatingui.Tooltip
 
 import java.time.Duration
 
 // Icon to indicate a field is required to do ITC calculations
 def requiredForITC: TagMod =
-  Popup(
+  Tooltip(
     trigger = <.span(
       ^.cls := "fa-layers fa-fw",
       Icons.StarExclamation
         .clazz(ExploreStyles.WarningIcon)
         .size(IconSize.X1),
       <.span(^.cls := "fa-layers-text fa-inverse", "ITC")
-    )
-  )("Required for ITC")
+    ),
+    tooltip = "Required for ITC"
+  )
 
 opaque type PlotLoading = Boolean
 

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -26,16 +26,16 @@ import lucuma.ui.forms.EnumViewSelect
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import react.common.ReactFnProps
+import react.floatingui.*
 import react.semanticui.collections.form.FormDropdown
 import react.semanticui.elements.button.Button
 import react.semanticui.modules.checkbox.Checkbox
 import react.semanticui.modules.dropdown.Dropdown
-import react.semanticui.modules.popup.Popup
 import react.semanticui.shorthand._
 import react.semanticui.sizes._
 import react.semanticui.views.card._
 
-final case class ObsBadge(
+case class ObsBadge(
   obs:               ObsSummary, // The layout will depend on the mixins of the ObsSummary.
   selected:          Boolean = false,
   setStatusCB:       Option[ObsStatus => Callback] = none,
@@ -49,7 +49,7 @@ object ObsBadge {
 
   // TODO Make this a component similar to the one in the docs.
   private def renderEnumProgress[A: Enumerated](value: A): VdomNode = {
-    val all = implicitly[Enumerated[A]].all
+    val all = summon[Enumerated[A]].all
     <.progress(^.width := "100%", ^.max := all.length - 1, ^.value := all.indexOf(value))
   }
 
@@ -135,20 +135,22 @@ object ObsBadge {
                   ReactFragment(obs.id.toString)
               },
               props.setActiveStatusCB.map(setActiveStatus =>
-                Popup(
-                  clazz = ExploreStyles.Compact,
-                  content = obs.activeStatus match {
+                Tooltip(
+                  placement = Placement.TopEnd,
+                  tooltip = obs.activeStatus match
                     case ObsActiveStatus.Active   => "Observation is active"
                     case ObsActiveStatus.Inactive => "Observation is not active"
-                  },
-                  trigger = Checkbox(
-                    toggle = true,
-                    checked = obs.activeStatus.toBoolean,
-                    onClickE = (e: ReactEvent, _: Checkbox.CheckboxProps) =>
-                      e.preventDefaultCB >> e.stopPropagationCB >> setActiveStatus(
-                        ObsActiveStatus.FromBoolean.get(!obs.activeStatus.toBoolean)
-                      ),
-                    clazz = ExploreStyles.ObsActiveStatusToggle
+                  ,
+                  trigger = <.span(
+                    Checkbox(
+                      toggle = true,
+                      checked = obs.activeStatus.toBoolean,
+                      onClickE = (e: ReactEvent, _: Checkbox.CheckboxProps) =>
+                        e.preventDefaultCB >> e.stopPropagationCB >> setActiveStatus(
+                          ObsActiveStatus.FromBoolean.get(!obs.activeStatus.toBoolean)
+                        ),
+                      clazz = ExploreStyles.ObsActiveStatusToggle
+                    )
                   )
                 )
               )

--- a/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -19,10 +19,9 @@ import lucuma.ui.syntax.all.given
 import react.aladin.Fov
 import react.common.ReactFnProps
 import react.fa.Transform
+import react.floatingui.*
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.label._
-import react.semanticui.modules.popup.Popup
-import react.semanticui.modules.popup.PopupPosition
 import react.semanticui.shorthand._
 import react.semanticui.sizes.Small
 import react.semanticui.sizes._
@@ -53,20 +52,17 @@ object AladinToolbar {
         ),
         <.div(
           ExploreStyles.AladinGuideStarLoading,
-          Popup(
-            content = "Loading catalog stars..",
-            position = PopupPosition.TopCenter,
-            trigger = Icons.CircleSmall.beat().clazz(ExploreStyles.WarningIcon)
+          Tooltip(
+            trigger = <.span(Icons.CircleSmall.beat().clazz(ExploreStyles.WarningIcon)),
+            tooltip = "Loading catalog stars.."
           ).when(props.agsState === AgsState.LoadingCandidates),
-          Popup(
-            content = "Calculating guide star..",
-            position = PopupPosition.TopCenter,
-            trigger = Icons.CircleSmall.beat().clazz(ExploreStyles.WarningIcon)
+          Tooltip(
+            trigger = <.span(Icons.CircleSmall.beat().clazz(ExploreStyles.WarningIcon)),
+            tooltip = "Calculating guide star.."
           ).when(props.agsState === AgsState.Calculating),
-          Popup(
-            content = "The Catalog isn't responding at the moment - please try again later..",
-            position = PopupPosition.TopCenter,
-            trigger = Icons.CircleSmall.clazz(ExploreStyles.ErrorIcon)
+          Tooltip(
+            trigger = <.span(Icons.CircleSmall.clazz(ExploreStyles.ErrorIcon)),
+            tooltip = "The Catalog isn't responding at the moment - please try again later.."
           ).when(props.agsState === AgsState.Error)
         ),
         <.div(
@@ -86,14 +82,16 @@ object AladinToolbar {
         ),
         <.div(
           ExploreStyles.AladinCenterButton,
-          Popup(
-            content = "Center on target",
-            position = PopupPosition.BottomLeft,
-            trigger = Button(size = Mini, icon = true, onClick = props.center.set(true))(
-              Icons.Bullseye
-                .transform(Transform(size = 24))
-                .clazz(ExploreStyles.Accented)
-            )
+          Tooltip(
+            trigger = <.span(
+              Button(size = Mini, icon = true, onClick = props.center.set(true))(
+                Icons.Bullseye
+                  .transform(Transform(size = 24))
+                  .clazz(ExploreStyles.Accented)
+              )
+            ),
+            tooltip = "Center on target",
+            placement = Placement.BottomEnd
           )
         )
       )

--- a/explore/src/main/webapp/main.jsx
+++ b/explore/src/main/webapp/main.jsx
@@ -1,6 +1,7 @@
 import "/common/theme/semantic.less";
 import "/common/less/style.less";
 import "/common/sass/visualization.scss";
+import "/common/sass/tooltips.scss";
 import "/common/less/vendor/aladin.less";
 import "/common/sass/charts.scss";
 import "/common/sass/datepicker.scss";

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "dependencies": {
         "@cquiroz/aladin-lite": "0.7.6",
+        "@floating-ui/react-dom-interactions": "^0.9.3",
         "@fortawesome/fontawesome-pro": "^6.1.2",
         "@fortawesome/fontawesome-svg-core": "^6.1.2",
         "@fortawesome/pro-duotone-svg-icons": "^6.1.2",
@@ -1795,6 +1796,44 @@
         "node": ">=12"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.1.tgz",
+      "integrity": "sha512-wBDiLUKWU8QNPNOTAFHiIAkBv1KlHauG2AhqjSeh2H+wR8PX+AArXfz8NkRexH5PgMJMmSOS70YS89AbWYh5dA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.0.1"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
+      "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom-interactions": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom-interactions/-/react-dom-interactions-0.9.3.tgz",
+      "integrity": "sha512-oHwFLxySRtmhgwg7ZdWswvDDi+ld4mEtxu6ngOd7mRC5L1Rk6adjSfOBOHDxea+ItAWmds8m6A725sn1HQtUyQ==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^1.0.0",
+        "aria-hidden": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
     "node_modules/@fluentui/react-component-event-listener": {
       "version": "0.63.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
@@ -2576,6 +2615,26 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.1.tgz",
+      "integrity": "sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/array-union": {
@@ -8870,8 +8929,7 @@
     "node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/type-fest": {
       "version": "0.18.1",
@@ -11105,6 +11163,36 @@
       "dev": true,
       "optional": true
     },
+    "@floating-ui/core": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.0.1.tgz",
+      "integrity": "sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA=="
+    },
+    "@floating-ui/dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.0.1.tgz",
+      "integrity": "sha512-wBDiLUKWU8QNPNOTAFHiIAkBv1KlHauG2AhqjSeh2H+wR8PX+AArXfz8NkRexH5PgMJMmSOS70YS89AbWYh5dA==",
+      "requires": {
+        "@floating-ui/core": "^1.0.1"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.0.0.tgz",
+      "integrity": "sha512-uiOalFKPG937UCLm42RxjESTWUVpbbatvlphQAU6bsv+ence6IoVG8JOUZcy8eW81NkU+Idiwvx10WFLmR4MIg==",
+      "requires": {
+        "@floating-ui/dom": "^1.0.0"
+      }
+    },
+    "@floating-ui/react-dom-interactions": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom-interactions/-/react-dom-interactions-0.9.3.tgz",
+      "integrity": "sha512-oHwFLxySRtmhgwg7ZdWswvDDi+ld4mEtxu6ngOd7mRC5L1Rk6adjSfOBOHDxea+ItAWmds8m6A725sn1HQtUyQ==",
+      "requires": {
+        "@floating-ui/react-dom": "^1.0.0",
+        "aria-hidden": "^1.1.3"
+      }
+    },
     "@fluentui/react-component-event-listener": {
       "version": "0.63.1",
       "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
@@ -11718,6 +11806,14 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.1.tgz",
+      "integrity": "sha512-PN344VAf9j1EAi+jyVHOJ8XidQdPVssGco39eNcsGdM4wcsILtxrKLkbuiMfLWYROK1FjRQasMWCBttrhjnr6A==",
+      "requires": {
+        "tslib": "^2.0.0"
       }
     },
     "array-union": {
@@ -16150,8 +16246,7 @@
     "tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "type-fest": {
       "version": "0.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@cquiroz/aladin-lite": "0.7.6",
+    "@floating-ui/react-dom-interactions": "^0.9.3",
     "@fortawesome/fontawesome-pro": "^6.1.2",
     "@fortawesome/fontawesome-svg-core": "^6.1.2",
     "@fortawesome/pro-duotone-svg-icons": "^6.1.2",

--- a/workers/src/main/scala/workers/WorkerServer.scala
+++ b/workers/src/main/scala/workers/WorkerServer.scala
@@ -55,7 +55,7 @@ trait WorkerServer[F[_]: Async, T: Pickler](using Monoid[F[Unit]]):
   private val F = summon[Sync[F]]
 
   protected def setupLogger: F[Logger[F]] = Sync[F].delay {
-    LogLevelLogger.setLevel(LogLevelDesc.INFO)
+    LogLevelLogger.setLevel(LogLevelDesc.DEBUG)
     LogLevelLogger.createForRoot[F]
   }
 


### PR DESCRIPTION
I was never too happy with SUI tooltips as they are kind of ugly and may not place themselves on the right place.

This PR includes a facade to use [floating-ui](https://floating-ui.com/) which is a low-level library to implement thing like tooltips. It doesn't include a Tooltip itsef thus a component is provided.

The tooltip looks better IMHO:
* before
![Explore 2022-08-30 16-54-40(1)](https://user-images.githubusercontent.com/3615303/187576844-2dc637b4-256d-43f8-b51c-f0cdb5341f9d.png)

* after:
![Explore 2022-08-30 16-56-20](https://user-images.githubusercontent.com/3615303/187576881-c5f67531-e792-48ba-aa83-7c9143d09fab.png)

A nice feature is that it can adapt its location depending on the size available as can be seen here:

https://user-images.githubusercontent.com/3615303/187576984-eff7ff82-abd5-4d29-98f1-d9bc391a3340.mp4

