### PR TITLE
Generic cache for workers

### DIFF
--- a/HEROKU.md
+++ b/HEROKU.md
@@ -6,7 +6,7 @@ Since the runtime application consists only of static files, we use https://gith
 
 Originally, we were running the build Heroku, which then served the output assets with said buildpack. (Description of this process is detailed below in case we resume it in the future).
 
-Currently, we are *not* performing builds in Heroku though. This is because Heroku always runs builds in a `performance-m` dyno, which provisions 2.5Gb of memory, which is not enough in our case. We are building in GitHub actions instead (which provide 7Gb of memory) and then deploying the result to Heroku (all this is in `heroku.yml`). This works, but we lose the ability to deploy review apps, at least with the press of a button in the Heroku pipeline.
+Currently, we are *not* performing builds in Heroku though. This is because Heroku always runs builds in a `performance-m` dyno, which provisions 2.5Gb of memory, which is not enough in our case. We are building in GitHub actions instead (which provide 7Gb of memory) and then deploying the result to Heroku (all this is in `ci.yml`). This works, but we lose the ability to deploy review apps, at least with the press of a button in the Heroku pipeline.
 
 In this setup, none of these Heroku configuration files mentioned below are being used: `/system.properties`, `/package.json`, `/static.json` (there's one being used in `/explore/.../resources/static`). In `app.json`, the `environments/test` section is used since we still run CI in Heroku, but the rest of the file is ignored.
 

--- a/build.sbt
+++ b/build.sbt
@@ -235,6 +235,7 @@ lazy val commonJsLibSettings = commonLibSettings ++ Seq(
       Http4sDom.value ++
       Log4Cats.value ++
       LucumaUI.value ++
+      ScalaJSDom.value ++
       ScalaJSReact.value ++
       In(Test)(
         ScalaJSReactTest.value

--- a/model/shared/src/main/scala/explore/model/boopickle/CommonPicklers.scala
+++ b/model/shared/src/main/scala/explore/model/boopickle/CommonPicklers.scala
@@ -27,6 +27,7 @@ import lucuma.core.math.Epoch
 import lucuma.core.math.HourAngle
 import lucuma.core.math.Offset
 import lucuma.core.math.Parallax
+import lucuma.core.math.Place
 import lucuma.core.math.ProperMotion
 import lucuma.core.math.RadialVelocity
 import lucuma.core.math.RightAscension
@@ -43,7 +44,9 @@ import org.http4s.Uri
 
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 import java.time.Year
+import java.time.ZoneId
 
 trait CommonPicklers {
   given picklerRefined[A: Pickler, B](using Validate[A, B]): Pickler[A Refined B] =
@@ -159,8 +162,13 @@ trait CommonPicklers {
 
   given Pickler[ConstraintSet] = generatePickler
 
+  given Pickler[LocalDate] =
+    transformPickler[LocalDate, (Int, Int, Int)]((year, month, dayOfMonth) =>
+      LocalDate.of(year, month, dayOfMonth)
+    )(d => (d.getYear, d.getMonthValue, d.getDayOfMonth))
+
   given Pickler[Instant] =
-    transformPickler[Instant, (Long, Long)]((epochSecond: Long, nanoOfSecond: Long) =>
+    transformPickler[Instant, (Long, Long)]((epochSecond, nanoOfSecond) =>
       Instant.ofEpochSecond(epochSecond, nanoOfSecond)
     )(i => (i.getEpochSecond, i.getNano))
 
@@ -173,10 +181,15 @@ trait CommonPicklers {
   given Pickler[Year] =
     transformPickler(Year.of)(_.getValue)
 
+  given Pickler[ZoneId] =
+    transformPickler(ZoneId.of)(_.getId)
+
   given Pickler[Uri] =
     transformPickler(Uri.unsafeFromString)(_.toString)
 
   given Pickler[Semester] = generatePickler
+
+  given Pickler[Place] = generatePickler
 }
 
 object CommonPicklers extends CommonPicklers

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -39,6 +39,7 @@ object Settings {
     val pprint                = "0.7.3"
     val reactAladin           = "0.25.1"
     val refinedAlgebraVersion = "0.1.0"
+    val scalaJsDom            = "2.3.0"
     val scalaJsReact          = "2.1.1"
     val webAppUtil            = "2.0.0-RC7"
   }
@@ -306,6 +307,12 @@ object Settings {
 
     val RefinedAlgebra = Def.setting(
       Seq("edu.gemini" %%% "refined-algebra" % refinedAlgebraVersion)
+    )
+
+    val ScalaJSDom = Def.setting(
+      deps(
+        "org.scala-js" %%% "scalajs-dom"
+      )(scalaJsDom)
     )
 
     val ScalaJSReact = Def.setting(

--- a/workers/src/main/scala/workers/Cache.scala
+++ b/workers/src/main/scala/workers/Cache.scala
@@ -1,0 +1,146 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package workers
+
+import boopickle.DefaultBasic.*
+import boopickle.Pickler
+import cats.effect.kernel.Async
+import cats.effect.kernel.Sync
+import cats.syntax.all.*
+import explore.model.boopickle.Boopickle.*
+import japgolly.scalajs.react.callback.*
+import japgolly.webapputil.indexeddb.IndexedDb
+import japgolly.webapputil.indexeddb.IndexedDb.Database
+import japgolly.webapputil.indexeddb.IndexedDbKey
+import japgolly.webapputil.indexeddb.KeyCodec
+import japgolly.webapputil.indexeddb.ObjectStoreDef
+import japgolly.webapputil.indexeddb.ValueCodec
+import org.scalajs.dom
+import org.scalajs.dom.CacheStorage
+import org.scalajs.dom.IDBFactory
+import org.scalajs.dom.{Cache => JsCache}
+
+import java.time.Instant
+import java.util.Base64
+import scala.scalajs.js.typedarray.Int8Array
+
+import scalajs.js
+import scalajs.js.JSConverters.*
+
+/**
+ * Cacheable computation.
+ */
+case class Cacheable[F[_], I, O](name: String, version: Int, invoke: I => F[O])
+
+/**
+ * Generic cache interface.
+ */
+sealed trait Cache[F[_]]:
+  def eval[I: Pickler, O: Pickler](computation: Cacheable[F, I, O]): I => F[O]
+
+/**
+ * `NoCache` is used when, for some reason, a cache could not be initialized.
+ */
+case class NoCache[F[_]]() extends Cache[F]:
+  def eval[I: Pickler, O: Pickler](computation: Cacheable[F, I, O]): I => F[O] =
+    computation.invoke
+
+/**
+ * Cache backed up by an Indexed DB store.
+ */
+case class IDBCache[F[_]](
+  cacheDB: IndexedDb.Database,
+  store:   ObjectStoreDef.Sync[Pickled, Pickled]
+)(using
+  F:       Async[F]
+) extends Cache[F]:
+  override def eval[I: Pickler, O: Pickler](computation: Cacheable[F, I, O]): I => F[O] = { input =>
+    val pickledInput: Pickled = Pickled(asBytes((computation.name, computation.version, input)))
+
+    // F.delay(println(s"CACHED EVAL $input")) >>
+    cacheDB
+      .get(store)(pickledInput)
+      .toF
+      // .flatTap(pickled => F.delay(println(pickled.fold("CACHE MISS")(_ => "CACHE HIT"))))
+      .flatMap(
+        _.fold(
+          computation
+            .invoke(input)
+            .flatTap(output => cacheDB.put(store)(pickledInput, Pickled(asBytes(output))).toF)
+        )(pickledOutput => F.pure(fromBytes[O](pickledOutput.value)).rethrow)
+      )
+    // .flatTap(o => F.delay(println(s"CACHED RESULT $o")))
+  }
+
+/**
+ * Cache backed up by a JS `Cache`.
+ */
+case class JsCacheCache[F[_]: PromiseConverter](cache: JsCache)(using F: Sync[F]) extends Cache[F]:
+  def eval[I: Pickler, O: Pickler](computation: Cacheable[F, I, O]): I => F[O] = { input =>
+    val pickledInput: Array[Byte] = asBytes(input)
+    val base64Input: String       = Base64.getEncoder.encode(pickledInput).map(_.toChar).mkString
+    val stringInput: String       =
+      s"http://request/${computation.name}/v${computation.version}?$base64Input"
+
+    PromiseConverter[F]
+      .convert(cache.`match`(stringInput))
+      // .flatTap(pickled => F.delay(println(pickled.fold("CACHE MISS")(_ => "CACHE HIT"))))
+      .flatMap(
+        _.fold(
+          computation
+            .invoke(input)
+            .flatTap(output =>
+              PromiseConverter[F].convert(
+                cache.put(stringInput, new dom.Response(asTypedArray(output)))
+              )
+            )
+        )(response =>
+          PromiseConverter[F]
+            .convert(response.arrayBuffer())
+            .flatMap(ab => F.pure(fromTypedArray[O](new Int8Array(ab))).rethrow)
+        )
+      )
+  }
+
+object Cache:
+  def withIDB[F[_]: Async](dbFactory: Option[IDBFactory], dbName: String): F[Cache[F]] =
+    dbFactory.fold(Sync[F].delay(NoCache[F]())) { factory =>
+      val storeName: String = s"$dbName-store"
+
+      val DBVersion: Int = 1
+
+      val store: ObjectStoreDef.Sync[Pickled, Pickled] = ObjectStoreDef.Sync(
+        storeName,
+        KeyCodec[Pickled](
+          i => IndexedDbKey.fromJs(i.value.toJSArray),
+          k => CallbackTo(Pickled(k.asJs.asInstanceOf[js.Array[Byte]].toArray))
+        ),
+        ValueCodec[Pickled](
+          o =>
+            CallbackTo(Instant.now) >>= (i =>
+              CallbackTo(js.Tuple3(o.value.toJSArray, i.getEpochSecond.toInt, i.getNano))
+            ),
+          v => CallbackTo(Pickled(v.asInstanceOf[js.Tuple3[js.Array[Byte], Int, Int]]._1.toArray))
+        )
+      )
+
+      IndexedDb(factory)
+        .open(IndexedDb.DatabaseName(storeName), DBVersion)(
+          IndexedDb.OpenCallbacks(upgradeNeeded =
+            _.createObjectStore(store, createdInDbVer = DBVersion)
+          )
+        )
+        .toF
+        .map(db => IDBCache[F](db, store))
+    }
+
+  def withJsCache[F[_]: Async: PromiseConverter](
+    cacheStorage: Option[CacheStorage],
+    cacheName:    String
+  ): F[Cache[F]] =
+    cacheStorage.fold(Sync[F].delay(NoCache[F]())) { caches =>
+      PromiseConverter[F]
+        .convert(caches.open(cacheName))
+        .map(cache => JsCacheCache(cache))
+    }

--- a/workers/src/main/scala/workers/PlotServer.scala
+++ b/workers/src/main/scala/workers/PlotServer.scala
@@ -3,33 +3,45 @@
 
 package workers
 
+import boopickle.DefaultBasic.*
 import cats.Eval
 import cats.effect.IO
 import cats.effect.IOApp
 import cats.effect.unsafe.implicits.given
 import cats.syntax.all.given
 import explore.events.PlotMessage
+import explore.model.boopickle.CommonPicklers.given
 import lucuma.core.enums.Site
 import lucuma.core.enums.TwilightType
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Declination
+import lucuma.core.math.Place
+import lucuma.core.math.skycalc.ImprovedSkyCalc
+import lucuma.core.math.skycalc.ImprovedSkyCalc.apply
+import lucuma.core.math.skycalc.SkyCalcResults
 import lucuma.core.math.skycalc.solver.ElevationSolver
 import lucuma.core.math.skycalc.solver.Samples
 import lucuma.core.model.Semester
 import lucuma.core.model.TwilightBoundedNight
 import lucuma.core.syntax.boundedInterval.given
 import lucuma.core.syntax.time.given
+import lucuma.core.util.Enumerated
+import org.scalajs.dom
 import org.typelevel.cats.time.given
 import org.typelevel.log4cats.Logger
 import spire.math.Bounded
+import spire.math.extras.interval.IntervalSeq
 
 import java.time.Duration
 import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalTime
 import scala.ContextFunction1
 import scala.collection.immutable.TreeMap
 import scala.scalajs.js.annotation.JSExport
 import scala.scalajs.js.annotation.JSExportTopLevel
+
+import scalajs.js
 
 @JSExportTopLevel("PlotServer", moduleID = "exploreworkers")
 object PlotServer extends WorkerServer[IO, PlotMessage.Request] {
@@ -41,58 +53,86 @@ object PlotServer extends WorkerServer[IO, PlotMessage.Request] {
 
   private val MinTargetElevation = Declination.fromDoubleDegrees(30.0).get
 
-  private final case class SemesterPlotCalc(semester: Semester, site: Site) {
+  private val skyCalcForSite: Map[Site, ImprovedSkyCalc] =
+    Enumerated[Site].all.map(s => s -> ImprovedSkyCalc(s.place)).toMap
 
-    def samples(
-      coordsForInstant: Instant => Coordinates,
-      dayRate:          Long
-    ): Samples[Duration] = {
-      val results = Samples
-        .atFixedRate(
-          Bounded.unsafeOpenUpper(
-            semester.start.atSite(site).toInstant,
-            semester.end.atSite(site).toInstant
-          ),
-          SampleRate
-        )(coordsForInstant)
-        .toSkyCalResultsAt(site.place)
+  private val CacheVersion: Int = 1
 
-      val targetVisible = ElevationSolver(MinTargetElevation, Declination.Max).solve(results) _
+  private given Pickler[SkyCalcResults] = generatePickler
 
-      Samples.fromMap(
-        Iterator
-          .iterate(semester.start.localDate)(_.plusDays(dayRate))
-          .takeWhile(_ <= semester.end.localDate)
-          .map { date =>
+  private final case class SemesterPlotCalc(semester: Semester, site: Site, cache: Cache[IO])(using
+    Logger[IO]
+  ) {
+
+    def siderealVisibility(
+      skyCalcSamples: Samples[SkyCalcResults]
+    ): Cacheable[IO, (Site, LocalDate, Coordinates), (Instant, Duration)] = {
+      val targetVisible: Bounded[Instant] => IntervalSeq[Instant] =
+        ElevationSolver(MinTargetElevation, Declination.Max).solve(skyCalcSamples) _
+
+      Cacheable(
+        "siderealVisibility",
+        CacheVersion,
+        (site, date, _) =>
+          IO {
             val instant = date.atTime(LocalTime.MIDNIGHT).atZone(site.timezone).toInstant
-            instant -> Eval.later {
+            instant -> {
               val night     = TwilightBoundedNight
                 .fromTwilightTypeAndSiteAndLocalDateUnsafe(TwilightType.Nautical, site, date)
               val intervals = targetVisible(night.interval)
               intervals.duration
             }
           }
-          .to(TreeMap)
       )
+    }
+
+    def siderealSamples(coords: Coordinates, dayRate: Long): fs2.Stream[IO, (Instant, Duration)] = {
+      val skyCalcSamples = Samples
+        .atFixedRate(
+          Bounded.unsafeOpenUpper(
+            semester.start.atSite(site).toInstant,
+            semester.end.atSite(site).toInstant
+          ),
+          SampleRate
+        )(_ => coords)
+        .toSkyCalResultsAt(site.place)
+
+      val visibilityCalc = siderealVisibility(skyCalcSamples)
+
+      fs2.Stream
+        .fromIterator[IO](
+          Iterator
+            .iterate(semester.start.localDate)(_.plusDays(dayRate))
+            .takeWhile(_ <= semester.end.localDate),
+          1
+        )
+        .evalMap { date =>
+          cache
+            .eval(visibilityCalc)
+            .apply(site, date, coords)
+        }
     }
   }
 
-  override protected val handler: Logger[IO] ?=> IO[Invocation => IO[Unit]] = IO { invocation =>
-    invocation.data match {
-      case PlotMessage.RequestSemesterSidereal(semester, site, coords, dayRate) =>
-        fs2.Stream
-          .fromIterator[IO](
-            SemesterPlotCalc(semester, site).samples(_ => coords, dayRate).iterator,
-            1
-          )
-          .evalMap { case (instant, visibilityDuration) =>
-            invocation.respond(
-              PlotMessage.SemesterPoint(instant.toEpochMilli, visibilityDuration.toMillis)
-            )
-          }
-          .compile
-          .drain
-    }
-  }
+  override protected val handler: Logger[IO] ?=> IO[Invocation => IO[Unit]] =
+    for
+      self  <- IO(dom.DedicatedWorkerGlobalScope.self)
+      cache <- Cache.withJsCache[IO](self.caches.toOption, "explore-plots")
+    // cache <- Cache.withIDB[IO](self.indexedDB.toOption, "explore-plots")
+    yield invocation =>
+      invocation.data match {
+        case PlotMessage.RequestSemesterSidereal(semester, site, coords, dayRate) =>
+          Logger[IO].info("HELLO!") >>
+            SemesterPlotCalc(semester, site, cache)
+              .siderealSamples(coords, dayRate)
+              .evalMap { case (instant, visibilityDuration) =>
+                invocation.respond(
+                  PlotMessage.SemesterPoint(instant.toEpochMilli, visibilityDuration.toMillis)
+                )
+              }
+              .compile
+              .drain
+              .handleErrorWith(t => Logger[IO].error(t)("ERROR!!!"))
+      }
 
 }

--- a/workers/src/main/scala/workers/WorkerServer.scala
+++ b/workers/src/main/scala/workers/WorkerServer.scala
@@ -117,7 +117,7 @@ trait WorkerServer[F[_]: Async, T: Pickler](using Monoid[F[Unit]]):
   protected def runInternal(dispatcher: Dispatcher[F])(using Logger[F]): F[Unit] =
     for {
       self         <- F.delay(dom.DedicatedWorkerGlobalScope.self)
-      handlerFn    <- handler(self)
+      handlerFn    <- handler
       cancelTokens <- Ref[F].of(Map.empty[WorkerProcessId, F[Unit]])
       _            <- Logger[F].debug("Mounting")
       _            <- mount(self, handlerFn, cancelTokens)(dispatcher)

--- a/workers/src/main/scala/workers/package.scala
+++ b/workers/src/main/scala/workers/package.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package workers
+
+import cats.effect.Async
+import cats.effect.IO
+import cats.~>
+import japgolly.scalajs.react.callback.AsyncCallback
+import japgolly.scalajs.react.callback.Callback
+
+import scalajs.js
+
+// Copied and generalized from CallbackCatsEffect
+// Move all of these somewhere else?
+class AsyncCallbackToF[F[_]](dispatch: Callback => Unit)(using F: Async[F])
+    extends (AsyncCallback ~> F) {
+  override def apply[A](f: AsyncCallback[A]): F[A] =
+    F.async[A](k =>
+      F.delay {
+        val s = new AsyncCallback.State
+        val g = f.underlyingRepr(s)
+        val d = g(t => Callback(k(t.toEither)))
+        dispatch(d)
+        s.cancelCallback.map(x => F.delay(x.runNow()))
+      }
+    )
+}
+
+extension [A](self: AsyncCallback[A])
+  def toF[F[_]](using Async[F]): F[A] =
+    new AsyncCallbackToF(_.async.toCallback.runNow())(self)
+
+trait PromiseConverter[F[_]]:
+  def convert[A](promise: => js.Promise[A]): F[A]
+
+object PromiseConverter:
+  def apply[F[_]](using ev: PromiseConverter[F]) = ev
+
+given PromiseConverter[IO] = new PromiseConverter[IO] {
+  inline def convert[A](promise: => js.Promise[A]): IO[A] = IO.fromPromise(IO(promise))
+}


### PR DESCRIPTION
This PR implements a generic cache, mainly geared towards workers, which can be backed up by either:
- An Indexed DB store; or
- A browser `Cache` (https://developer.mozilla.org/en-US/docs/Web/API/Cache)

No eviction is implemented yet for either method.

I plan to implement eviction for Indexed DB, for which I plant to resort to a cursor. Cursors are not implemented in the IDB layer we are using (https://github.com/japgolly/webapp-util) so we have to do this through the low-level facade.

For the `Cache`, it's a bit more tricky. Even though the cache stores a timestamp for each entry, there's no way to access it via the API. Furthermore, we cannot open a cursor, forcing us to load all keys into memory to do expired eviction.

I'm opening the PR as draft nonetheless so we can discuss advantages/disadvantages of each approach.
