### PR TITLE
Cache ITC graphs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ addCommandAlias(
 
 addCommandAlias(
   "fix",
-  "; headerCreateAll; fixImports; scalafmtAll; fixCSS; githubWorkflowGenerate"
+  "; prePR; fixCSS"
 )
 
 ThisBuild / description                := "Explore"

--- a/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
+++ b/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
@@ -14,12 +14,16 @@ import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.itc.ItcCcd
 import explore.model.itc.ItcChart
 import explore.model.itc.ItcChartResult
+import explore.model.itc.ItcGraphRequestParams
 import explore.model.itc.ItcQueryProblems
 import explore.model.itc.ItcRequestParams
 import explore.model.itc.ItcResult
 import explore.model.itc.ItcSeries
 import explore.model.itc.ItcTarget
 import explore.model.itc.YAxis
+import explore.model.itc.remote.ItcChartGroupRemote
+import explore.model.itc.remote.ItcChartRemote
+import explore.model.itc.remote.XAxis
 import explore.modes.InstrumentRow
 import explore.modes.ModeAO
 import explore.modes.ModeSlitSize
@@ -191,6 +195,14 @@ trait ItcPicklers extends CommonPicklers {
   given Pickler[ItcChart] = generatePickler
 
   given Pickler[ItcChartResult] = generatePickler
+
+  given Pickler[ItcGraphRequestParams] = generatePickler
+
+  given Pickler[XAxis] = generatePickler
+
+  given Pickler[ItcChartRemote] = generatePickler
+
+  given Pickler[ItcChartGroupRemote] = generatePickler
 }
 
 object ItcPicklers extends ItcPicklers

--- a/workers/src/main/scala/workers/ItcServer.scala
+++ b/workers/src/main/scala/workers/ItcServer.scala
@@ -109,6 +109,7 @@ object ItcServer extends WorkerServer[IO, ItcMessage.Request] with ItcPicklers {
                 constraint,
                 targets,
                 mode,
+                cache,
                 r => invocation.respond(r)
               )
       }

--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -3,6 +3,7 @@
 
 package explore.itc
 
+import boopickle.DefaultBasic.*
 import cats.*
 import cats.data.*
 import cats.effect.*
@@ -11,6 +12,7 @@ import clue.TransactionalClient
 import clue.data.syntax._
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosInt
+import explore.model.boopickle.ItcPicklers.given
 import explore.model.itc.*
 import explore.model.itc.math.*
 import explore.modes.GmosNorthSpectroscopyRow
@@ -24,15 +26,24 @@ import org.typelevel.log4cats.Logger
 import queries.common.ITCQueriesGQL.*
 import queries.schemas.ITC
 import queries.schemas.itc.implicits.*
+import workers.*
 
 import java.util.UUID
 import scala.concurrent.duration._
 //
 object ITCGraphRequests {
+  // Picklers for generated types not in the model.
+  private given Pickler[SpectroscopyGraphITCQuery.Data.SpectroscopyGraphBeta.Ccds]   = generatePickler
+  private given Pickler[SpectroscopyGraphITCQuery.Data.SpectroscopyGraphBeta.Charts] =
+    generatePickler
+  private given Pickler[SpectroscopyGraphITCQuery.Data.SpectroscopyGraphBeta]        = generatePickler
+  private given Pickler[SpectroscopyGraphITCQuery.Data]                              = generatePickler
+
   private val significantFigures =
-    SignificantFiguresInput(6.refined[Positive].assign,
-                            6.refined[Positive].assign,
-                            3.refined[Positive].assign
+    SignificantFiguresInput(
+      6.refined[Positive].assign,
+      6.refined[Positive].assign,
+      3.refined[Positive].assign
     ).assign
 
   def queryItc[F[_]: Concurrent: Parallel: Logger](
@@ -42,6 +53,7 @@ object ITCGraphRequests {
     constraints:  ConstraintSet,
     targets:      NonEmptyList[ItcTarget],
     mode:         InstrumentRow,
+    cache:        Cache[F],
     callback:     ItcChartResult => F[Unit]
   )(using Monoid[F[Unit]], TransactionalClient[F, ITC]): F[Unit] =
 
@@ -53,14 +65,14 @@ object ITCGraphRequests {
       case _                           =>
         none
 
-    itcRowsParams.map { request =>
-      Logger[F].debug(
-        s"ITC: Request for mode ${request.mode} and target count: ${request.target.length}"
-      ) *>
-        request.target
-          .fproduct(t => selectedBrightness(t.profile, request.wavelength))
-          .collect { case (t, Some(brightness)) =>
-            request.mode.toITCInput.map { mode =>
+    def doRequest(
+      request: ItcGraphRequestParams
+    ): F[List[(ItcTarget, SpectroscopyGraphITCQuery.Data)]] =
+      request.target
+        .fproduct(t => selectedBrightness(t.profile, request.wavelength))
+        .collect { case (t, Some(brightness)) =>
+          request.mode.toITCInput
+            .map(mode =>
               SpectroscopyGraphITCQuery
                 .query(
                   SpectroscopyGraphModeInput(
@@ -75,19 +87,33 @@ object ITCGraphRequests {
                     significantFigures
                   ).assign
                 )
-                .flatMap { r =>
-                  val charts = r.spectroscopyGraphBeta.charts.map(_.toItcChart)
-                  val ccds   = r.spectroscopyGraphBeta.ccds
+                .map(r => t -> r)
+            )
+        }
+        .flatten
+        .sequence
 
-                  (ccds.toNel, charts.toNel)
-                    .mapN((ccds, charts) => ItcChartResult(t, ccds, charts))
-                    .map(callback)
-                    .orEmpty
-                }
-            }.orEmpty
+    // We cache unexpanded results, exactly as received from server.
+    val cacheableRequest = Cacheable(CacheName("itcGraphQuery"), CacheVersion(1), doRequest)
+
+    itcRowsParams.map { request =>
+      Logger[F].debug(
+        s"ITC: Request for mode ${request.mode} and target count: ${request.target.length}"
+      ) *>
+        cache
+          .eval(cacheableRequest)
+          .apply(request)
+          .flatMap {
+            _.map { case (t, r) =>
+              val charts = r.spectroscopyGraphBeta.charts.map(_.toItcChart)
+              val ccds   = r.spectroscopyGraphBeta.ccds
+
+              (ccds.toNel, charts.toNel)
+                .mapN((ccds, charts) => ItcChartResult(t, ccds, charts))
+                .map(callback)
+                .orEmpty
+            }.sequence.void
           }
-          .sequence
-          .void
     }.orEmpty
 
 }


### PR DESCRIPTION
The Cache allows the same store to be used for different computations.

ITC graphs and ITC requests are now being cached in the same store, thus sharing a 30 day eviction policy.
