### PR TITLE
Switch to fewest modules linking in dev.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -252,8 +252,8 @@ lazy val esModule = Seq(
   Compile / fastLinkJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
   Compile / fullLinkJS / scalaJSLinkerConfig ~= { _.withSourceMap(false) },
   Compile / fastLinkJS / scalaJSLinkerConfig ~= (_.withModuleSplitStyle(
-    // If the browser is too slow for the SmallModulesFor switch to ModuleSplitStyle.FewestModules
-    ModuleSplitStyle.SmallModulesFor(List("explore"))
+    // Linking with smaller modules seems to take way longer.
+    ModuleSplitStyle.FewestModules
   )),
   Compile / fullLinkJS / scalaJSLinkerConfig ~= (_.withModuleSplitStyle(
     ModuleSplitStyle.FewestModules


### PR DESCRIPTION
Linking in dev with fewest modules will make HMR unfeasible, but it seems to speed up the fast linker considerably, with times of 7s when making a small change in code, vs 90s we had with smallest-modules-for.