### PR TITLE
Better responsivness for the obs time editor

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -310,7 +310,6 @@ object ExploreStyles {
   val ObsConfigurationForm: Css         = Css("explore-obs-configuration-form")
   val ObsInstantTileTitle: Css          = Css("explore-obs-instant-tile-title")
   val ObsConfigurationObsPA: Css        = Css("explore-obs-configuration-pa")
-  val ObsConfigurationObsTime: Css      = Css("explore-obs-configuration-time")
   val ConfigurationGrid: Css            = Css("explore-configuration-grid")
   val BasicConfigurationGrid: Css       = Css("explore-basic-configuration-grid")
   val BasicConfigurationForm: Css       = Css("explore-basic-configuration-form")

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -36,6 +36,10 @@ import java.time.Instant
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters.*
 
+val canvasWidth  = VdomAttr("width")
+val canvasHeight = VdomAttr("height")
+val dataAbbrv    = VdomAttr("data-abbrv")
+
 def toggleReusabilityOverlay[F[_]: Sync](): F[Unit] =
   Sync[F]
     .delay(

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -17,6 +17,10 @@
 @minHeight: 2.85714286em; // TODO: Calculate this on less
 @resizeHandleWidth: 5px; // Width of the tree resize handle
 
+// media queries cutoff
+@tablet-responsive-cutoff: 992px;
+@mobile-responsive-cutoff: 670px;
+
 // Full viewport settings taken from https://dev.to/lennythedev/css-gotcha-how-to-fill-page-with-a-div-270j
 
 html,
@@ -226,7 +230,7 @@ tfoot {
     'body'
     'sidebar';
 
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     grid-template-columns: 50px auto;
     grid-template-rows: @topBottom minmax(calc(100% - @topBottom), 1fr);
     grid-template-areas:
@@ -358,13 +362,14 @@ tfoot {
 .ui.button.tile-back-button {
   margin-right: 0;
 
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     display: none;
   }
 }
 
 .explore-tile-control {
   margin-right: auto;
+  flex-grow: 3;
 }
 
 .main-header>.ui.tabular.menu .item {
@@ -391,7 +396,7 @@ tfoot {
 .sidetabs-divider {
   display: none;
 
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     display: block;
   }
 }
@@ -400,7 +405,7 @@ tfoot {
 .sidetabs-body {
   display: flex;
 
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     height: 100%;
     display: block;
     overflow: hidden;
@@ -411,7 +416,7 @@ tfoot {
   height: 100%;
   display: none;
 
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     display: inherit;
   }
 }
@@ -684,7 +689,7 @@ tfoot {
 .tree-body {
   .full-height-width();
 
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     width:~'calc(100% - @{resizeHandleWidth})';
   }
 }
@@ -1234,10 +1239,6 @@ tfoot {
   z-index: 2000;
   width: 100%;
 }
-
-// The Target Position layout
-@target-grid-responsive-cutoff: 992px;
-@mobile-responsive-cutoff: 670px;
 
 .target-form {
   grid-template-columns: [label] minmax(100px, 10%) [field] 1fr;
@@ -2176,6 +2177,13 @@ html {
 
 .explore-title-select-columns {
   text-align: right;
+  display: none;
+}
+
+@media (min-width: @mobile-responsive-cutoff) {
+  .explore-title-select-columns {
+    display: inline;
+  }
 }
 
 .explore-select-columns {
@@ -2285,12 +2293,6 @@ html {
   grid-area: table;
 }
 
-.react-datepicker-wrapper() {
-  width: unset;
-  padding-left: 0.3em;
-  padding-right: 0.3em;
-}
-
 .explore-obs-configuration-form {
   grid-area: obs-props;
   display: flex;
@@ -2317,22 +2319,6 @@ html {
 .explore-advanced-configuration-buttons {
   grid-area: buttons;
   justify-self: end;
-}
-
-.explore-obs-instant-tile-title {
-  display: flex;
-  justify-self: center;
-  justify-content: end;
-  flex-grow: 3;
-
-  .react-datepicker-wrapper {
-    .react-datepicker-wrapper();
-  }
-}
-
-.explore-obs-configuration-time {
-  display: flex;
-  align-items: center;
 }
 
 .explore-basic-configuration-form {

--- a/common/src/main/webapp/less/verticalbuttons.less
+++ b/common/src/main/webapp/less/verticalbuttons.less
@@ -2,7 +2,7 @@
 // See:
 // https://stackoverflow.com/questions/16301625/rotated-elements-in-css-that-affect-their-parents-height-correctly
 .vertical-button {
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     // In an ideal world this would do the trick but chrome doesn't support this
     // writing-mode: vertical-rl;
     margin-top: -50%;
@@ -13,13 +13,13 @@
 }
 
 .rotation-wrapper-outer {
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     display: table;
   }
 }
 
 .rotation-wrapper-inner {
-  @media (min-width: @target-grid-responsive-cutoff) {
+  @media (min-width: @tablet-responsive-cutoff) {
     padding: 52% 0;
     height: 0;
   }

--- a/common/src/main/webapp/sass/charts.scss
+++ b/common/src/main/webapp/sass/charts.scss
@@ -217,17 +217,6 @@ $description-column-count: 2;
   font-size: smaller;
 }
 
-.explore-itc-tile-title {
-  display: flex;
-  gap: 1em;
-  font-size: 0.92em;
-  align-items: baseline;
-
-  label {
-    font-weight: bold;
-  }
-}
-
 .highcharts-reset-zoom {
   fill: var(--button-background-color-semi);
   stroke: var(--site-border-color);

--- a/common/src/main/webapp/sass/datepicker.scss
+++ b/common/src/main/webapp/sass/datepicker.scss
@@ -14,5 +14,22 @@
   color: var(--form-input-color);
   text-shadow: 1px 1px 1px rgb(0 0 0 / 30%);
   font-weight: bold;
+
+  // FIXME Taken from SUI input
+  margin: 0;
+  outline: none;
+  line-height: 1.2143em;
+  padding: 0.25em 0.4286em;
+  font-size: 1em;
+  border: 1px solid var(--site-border-color);
+  border-radius: 0.2857rem;
+  box-shadow: 0 0 0 0 transparent inset;
+  transition: color 0.1s ease, border-color 0.1s ease;
+
+  &:focus {
+    color: var(--form-input-focus-color);
+    border-color: var(--form-input-focus-border-color);
+    box-shadow: var(--form-input-focus-box-shadow);
+  }
 }
 

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1,0 +1,87 @@
+// media queries cutoff
+$tablet-responsive-cutoff: 992px;
+$mobile-responsive-cutoff: 670px;
+
+@mixin small-tile-title {
+  display: flex;
+  gap: 1em;
+  font-size: 0.92em;
+  align-items: baseline;
+
+  label {
+    font-weight: bold;
+  }
+}
+
+.explore-itc-tile-title {
+  @include small-tile-title;
+}
+
+@mixin react-datepicker-wrapper {
+  width: unset;
+  padding-left: 0.3em;
+  padding-right: 0.3em;
+}
+
+.explore-obs-instant-tile-title {
+  @include small-tile-title;
+
+  justify-content: center;
+  flex-grow: 0;
+
+  & .react-datepicker-wrapper {
+    @include react-datepicker-wrapper;
+  }
+
+  label:first-child {
+    max-width: 5ch;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  label:last-child {
+    display: none;
+  }
+
+  label[data-abbrv]::after {
+    content: attr(data-abbrv);
+  }
+
+  label[data-abbrv] > span{
+    display: none;
+  }
+
+  @media (min-width: $tablet-responsive-cutoff) {
+    label:first-child {
+      max-width: unset;
+    }
+
+    label[data-abbrv]::after {
+      content: "";
+    }
+
+    label[data-abbrv] > span{
+      display: unset;
+    }
+
+    label:last-child {
+      display: inline;
+    }
+  }
+
+  @media (min-width: $mobile-responsive-cutoff) {
+    label:first-child {
+      display: unset;
+    }
+  }
+
+  /* stylelint-disable-next-line selector-class-pattern */
+  & .react-datepicker__input-container input {
+    text-shadow: unset;
+    font-weight: unset;
+    font-size: smaller;
+  }
+
+}
+

--- a/explore/src/main/scala/explore/config/VizTimeEditor.scala
+++ b/explore/src/main/scala/explore/config/VizTimeEditor.scala
@@ -3,64 +3,43 @@
 
 package explore.config
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import crystal.Pot
 import crystal.react.View
-import eu.timepit.refined.auto._
+import eu.timepit.refined.auto.*
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
-import explore.utils._
-import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.html_<^._
+import explore.utils.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.refined.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import react.common.ReactFnProps
-import react.datepicker._
-import react.semanticui.collections.form.Form
-import react.semanticui.sizes._
+import react.datepicker.*
+import react.semanticui.sizes.*
 
 import java.time.Instant
 
 import scalajs.js
 import scalajs.js.|
 
-final case class VizTimeEditor(vizTimeView: Pot[View[Option[Instant]]])
-    extends ReactFnProps[VizTimeEditor](VizTimeEditor.component)
+case class VizTimeEditor(vizTimeView: Pot[View[Option[Instant]]])
+    extends ReactFnProps(VizTimeEditor.component)
 
 object VizTimeEditor {
-  type Props = VizTimeEditor
+  private type Props = VizTimeEditor
 
   // TODO Move these to react-datetime
-  implicit class InstantOps(val instant: Instant) extends AnyVal {
+  extension (instant: Instant)
     // DatePicker only works in local timezone, so we trick it by adding the timezone offset.
     // See https://github.com/Hacker0x01/react-datepicker/issues/1787
     def toDatePickerJsDate: js.Date =
       new js.Date(instant.toEpochMilli.toDouble + (new js.Date()).getTimezoneOffset() * 60000)
-  }
 
-  object InstantBuilder {
-    // DatePicker only works in local timezone, so we trick it by adding the timezone offset.
-    // See https://github.com/Hacker0x01/react-datepicker/issues/1787
-    def fromDatePickerJsDate(jsDate: js.Date): Instant =
-      Instant.ofEpochMilli((jsDate.getTime() - jsDate.getTimezoneOffset() * 60000).toLong)
-  }
-
-  implicit class JSUndefOrNullOrTuple2DateTimeOps[A](
-    val value: js.UndefOr[DateOrRange]
-  ) extends AnyVal {
-    def toEitherOpt2: Option[Either[(A, A), A]] =
-      value.toOption
-        .flatMap(valueOrNull => Option(valueOrNull.asInstanceOf[A | js.Tuple2[A, A]]))
-        .map { valueOrTuple =>
-          if (js.Array.isArray(valueOrTuple))
-            Left(valueOrTuple.asInstanceOf[js.Tuple2[A, A]])
-          else
-            Right(valueOrTuple.asInstanceOf[A])
-        }
-
-    def fromDatePickerToInstantEitherOpt(implicit
-      ev: A <:< js.Date
+  extension [A](value: js.UndefOr[DateOrRange])
+    def fromDatePickerToInstantEitherOpt(using
+      A <:< js.Date
     ): Option[Either[(Instant, Instant), Instant]] =
       value.toEitherOpt.map { (e: Either[(js.Date, js.Date), js.Date]) =>
         e match {
@@ -71,35 +50,40 @@ object VizTimeEditor {
         }
       }.widen
 
-    def fromDatePickerToInstantOpt(implicit ev: A <:< js.Date): Option[Instant] =
+    def fromDatePickerToInstantOpt(using ev: A <:< js.Date): Option[Instant] =
       fromDatePickerToInstantEitherOpt.flatMap(_.toOption)
+
+  object InstantBuilder {
+    // DatePicker only works in local timezone, so we trick it by adding the timezone offset.
+    // See https://github.com/Hacker0x01/react-datepicker/issues/1787
+    def fromDatePickerJsDate(jsDate: js.Date): Instant =
+      Instant.ofEpochMilli((jsDate.getTime() - jsDate.getTimezoneOffset() * 60000).toLong)
   }
 
-  val component =
+  private val component =
     ScalaFnComponent[Props] { p =>
       <.div(
-        ExploreStyles.ObsConfigurationObsTime,
-        Form(size = Small)(
-          ExploreStyles.Compact,
-          ExploreStyles.ObsInstantTileTitle,
-          potRender[View[Option[Instant]]](
-            pendingRender = EmptyVdom,
-            valueRender = instant =>
-              React.Fragment(
-                <.label("Observation time", HelpIcon("configuration/obstime.md".refined)),
-                Datepicker(onChange =
-                  (newValue, _) =>
-                    newValue.fromDatePickerToInstantOpt.foldMap { i =>
-                      instant.set(i.some)
-                    }
-                )
-                  .showTimeInput(true)
-                  .selected(instant.get.getOrElse(Instant.now).toDatePickerJsDate)
-                  .dateFormat("yyyy-MM-dd HH:mm"),
-                "UTC"
+        ExploreStyles.ObsInstantTileTitle,
+        potRender[View[Option[Instant]]](
+          pendingRender = EmptyVdom,
+          valueRender = instant =>
+            React.Fragment(
+              <.label(dataAbbrv := "Time",
+                      <.span("Observation time"),
+                      HelpIcon("configuration/obstime.md".refined)
+              ),
+              Datepicker(onChange =
+                (newValue, _) =>
+                  newValue.fromDatePickerToInstantOpt.foldMap { i =>
+                    instant.set(i.some)
+                  }
               )
-          )(p.vizTimeView)
-        )
+                .showTimeInput(true)
+                .selected(instant.get.getOrElse(Instant.now).toDatePickerJsDate)
+                .dateFormat("yyyy-MM-dd HH:mm"),
+              <.label("UTC")
+            )
+        )(p.vizTimeView)
       )
     }
 

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -61,7 +61,7 @@ object AsterismEditorTile {
       ObsQueries.updateVisualizationTime[IO](obsId.toList, t).runAsync
     })
 
-    val control: VdomNode = VizTimeEditor(vizTimeView)
+    def control: VdomNode = <.div(VizTimeEditor(vizTimeView))
 
     Tile(
       ObsTabTilesIds.TargetId.id,

--- a/explore/src/main/scala/explore/visualization/TargetsOverlay.scala
+++ b/explore/src/main/scala/explore/visualization/TargetsOverlay.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
 import explore.components.ui.ExploreStyles
+import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.svg_<^.*
 import lucuma.core.math.Coordinates
@@ -98,9 +99,7 @@ object TargetsOverlay {
   val JtsTargets = Css("overlay-all-targets")
   val JtsGuides  = Css("viz-guides")
 
-  val canvasWidth  = VdomAttr("width")
-  val canvasHeight = VdomAttr("height")
-  val component    =
+  val component =
     ScalaFnComponent
       .withHooks[Props]
       .useRefToVdom[SVG] // svg

--- a/explore/src/main/webapp/main.jsx
+++ b/explore/src/main/webapp/main.jsx
@@ -5,6 +5,7 @@ import "/common/sass/tooltips.scss";
 import "/common/less/vendor/aladin.less";
 import "/common/sass/charts.scss";
 import "/common/sass/datepicker.scss";
+import "/common/sass/explore.scss";
 import "/common/less/vendor/react-reflex.less";
 import "github-markdown-css/github-markdown-light.css";
 import "react-circular-progressbar/dist/styles.css";


### PR DESCRIPTION
These are just small improvements to the obs time editor, especially when we have reduced screen sizes

I also created a new `explore.scss` to start migrating the styles in less

Before
![image](https://user-images.githubusercontent.com/3615303/191976624-e52289de-668d-43f8-99b0-9477f9afed18.png)

After
![Explore 2022-09-23 10-53-55](https://user-images.githubusercontent.com/3615303/191976682-f82a0d97-8665-4b60-842e-ad5960516be6.png)

