### PR TITLE
Vite plugin take 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: npm install --force
-        run: npm install --force
+      - name: npm install
+        run: npm install
 
       - name: Check that workflows are up to date
         run: sbt -v -J-Xmx6g 'project ${{ matrix.project }}' '++${{ matrix.scala }}' 'project /' githubWorkflowCheck
@@ -144,8 +144,8 @@ jobs:
       - name: Stage
         run: sbt -v -J-Xmx6g '++${{ matrix.scala }}' stage
 
-      - name: npm install --force
-        run: npm install --force
+      - name: npm install
+        run: npm install
 
       - name: Build application
         env:
@@ -234,8 +234,8 @@ jobs:
       - name: Stage
         run: sbt -v -J-Xmx6g '++${{ matrix.scala }}' stage
 
-      - name: npm install --force
-        run: npm install --force
+      - name: npm install
+        run: npm install
 
       - name: Build application
         env:
@@ -268,8 +268,8 @@ jobs:
           node-version: 16
           cache: npm
 
-      - name: npm install --force
-        run: npm install --force
+      - name: npm install
+        run: npm install
 
       - name: Setup and expand vars dark
         run: |

--- a/build.mjs
+++ b/build.mjs
@@ -1,11 +1,16 @@
-const path = require("path")
-const fs = require("fs")
-const process = require("process")
-const { build } = require("vite")
-const { minify } = require("terser")
-const humanFormat = require("human-format")
-const brotliSize = require("brotli-size")
-const config = require("./vite.config.js")
+import path from "path"
+import { fileURLToPath } from 'url';
+import fs from "fs"
+import process from "process"
+import { build } from "vite"
+import { minify } from "terser"
+import humanFormat from "human-format"
+import brotliSize from "brotli-size"
+import config from "./vite.config.mjs"
+
+const __filename = fileURLToPath(import.meta.url);
+
+const __dirname = path.dirname(__filename);
 
 const outDir = path.resolve(__dirname, "heroku/static")
 const terserOptions =  {

--- a/build.mjs
+++ b/build.mjs
@@ -1,58 +1,82 @@
-import path from "path"
+import path from 'path';
 import { fileURLToPath } from 'url';
-import fs from "fs"
-import process from "process"
-import { build } from "vite"
-import { minify } from "terser"
-import humanFormat from "human-format"
-import brotliSize from "brotli-size"
-import config from "./vite.config.mjs"
+import fs from 'fs';
+import process from 'process';
+import { build } from 'vite';
+import { minify } from 'terser';
+import humanFormat from 'human-format';
+import brotliSize from 'brotli-size';
+import config from './vite.config.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 
 const __dirname = path.dirname(__filename);
 
-const outDir = path.resolve(__dirname, "heroku/static")
-const terserOptions =  {
+const outDir = path.resolve(__dirname, 'heroku/static');
+const terserOptions = {
   sourceMap: false,
   nameCache: {},
   format: {
     comments: false,
-    ecma: 2015
+    ecma: 2015,
   },
   mangle: {
     properties: {
       debug: false,
-      reserved: ['$classData', 'main', 'toString', 'constructor', 'length', 'call', 'apply', 'NaN', 'Infinity', 'undefined'],
+      reserved: [
+        '$classData',
+        'main',
+        'toString',
+        'constructor',
+        'length',
+        'call',
+        'apply',
+        'NaN',
+        'Infinity',
+        'undefined',
+      ],
       // Basically, every root package except Lcrystal and Lexplore. For some reason it breaks dynamic import of the help system.
-      regex: /^(\$m_|.*__f_|.*__F\d?_|.*__O_|.*Ljava|.*Lcats|.*Ljapgolly|.*Lfs2|.*Lorg|.*Lcom|.*Lio|.*Leu|.*Lclue|.*Llucuma|.*Lreact)/,
-    }
-  }
-}
+      regex:
+        /^(\$m_|.*__f_|.*__F\d?_|.*__O_|.*Ljava|.*Lcats|.*Ljapgolly|.*Lfs2|.*Lorg|.*Lcom|.*Lio|.*Leu|.*Lclue|.*Llucuma|.*Lreact)/,
+    },
+  },
+};
 
-var i = 1
+var i = 1;
 function runTerserOn(fileName, length) {
-  process.stdout.write(`Minifying ${i++}/${length}: ${fileName}...`)
-  const absolute = path.join(outDir, fileName)
-  const original = fs.readFileSync(absolute, "utf8")
-  minify(original, terserOptions).then( minified => {
-    fs.writeFileSync(absolute, minified.code, "utf8")
-    const fromSize = original.length
-    const toSize = minified.code.length
-    const ratio = (toSize / fromSize) * 100
-    const fromBrotli = brotliSize.sync(original)
-    const toBrotli = brotliSize.sync(minified.code)
-    const brotliRatio = (toBrotli / fromBrotli) * 100
-    process.stdout.write(` ${humanFormat.bytes(fromSize, { prefix: 'Ki' })} --> ${humanFormat.bytes(toSize, { prefix: 'Ki' })} (${ratio.toFixed(2)}%)` +
-                          ` / brotli: ${humanFormat.bytes(fromBrotli, { prefix: 'Ki' })} --> ${humanFormat.bytes(toBrotli, { prefix: 'Ki' })} (${brotliRatio.toFixed(2)}%) \n`)
-  })
+  process.stdout.write(`Minifying ${i++}/${length}: ${fileName}...`);
+  const absolute = path.join(outDir, fileName);
+  const original = fs.readFileSync(absolute, 'utf8');
+  minify(original, terserOptions).then((minified) => {
+    fs.writeFileSync(absolute, minified.code, 'utf8');
+    const fromSize = original.length;
+    const toSize = minified.code.length;
+    const ratio = (toSize / fromSize) * 100;
+    const fromBrotli = brotliSize.sync(original);
+    const toBrotli = brotliSize.sync(minified.code);
+    const brotliRatio = (toBrotli / fromBrotli) * 100;
+    process.stdout.write(
+      ` ${humanFormat.bytes(fromSize, {
+        prefix: 'Ki',
+      })} --> ${humanFormat.bytes(toSize, { prefix: 'Ki' })} (${ratio.toFixed(
+        2
+      )}%)` +
+        ` / brotli: ${humanFormat.bytes(fromBrotli, {
+          prefix: 'Ki',
+        })} --> ${humanFormat.bytes(toBrotli, {
+          prefix: 'Ki',
+        })} (${brotliRatio.toFixed(2)}%) \n`
+    );
+  });
 }
 
-;(async () => {
-  const rollupOutput = await build(config)
-  const jsChunks = rollupOutput.output.map(chunk => chunk.fileName).filter(fileName => fileName.endsWith(".js"))
+(async () => {
+  const rollupOutput = await build(config);
+  const jsChunks = rollupOutput.output
+    .map((chunk) => chunk.fileName)
+    .filter((fileName) => fileName.endsWith('.js'));
 
   for (const fileName of jsChunks) {
-    await runTerserOn(fileName, jsChunks.length)
+    await runTerserOn(fileName, jsChunks.length);
   }
-})()
+})();

--- a/build.sbt
+++ b/build.sbt
@@ -293,8 +293,8 @@ lazy val sbtStage = WorkflowStep.Sbt(List("stage"), name = Some("Stage"))
 
 // https://stackoverflow.com/a/55610612
 lazy val npmInstall = WorkflowStep.Run(
-  List("npm install --force"),
-  name = Some("npm install --force")
+  List("npm install"),
+  name = Some("npm install")
 )
 
 lazy val npmBuild = WorkflowStep.Run(

--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,8 @@ ThisBuild / ScalafixConfig / bspEnabled.withRank(KeyRanks.Invisible) := false
 ThisBuild / evictionErrorLevel := Level.Info
 ThisBuild / resolvers ++= Resolver.sonatypeOssRepos("snapshots")
 
+ThisBuild / coverageEnabled    := false
+
 addCommandAlias(
   "quickTest",
   "modelTestsJVM/test"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "explore",
       "dependencies": {
         "@cquiroz/aladin-lite": "0.7.6",
         "@cquiroz/react-moon": "2.0.2",
@@ -67,7 +68,7 @@
         "stylelint-config-standard-scss": "^5.0.0",
         "terser": "5.15.0",
         "vite": "3.1.3",
-        "vite-plugin-fonts": "^0.2.2",
+        "vite-plugin-fonts": "^0.6.0",
         "vite-plugin-mkcert": "^1.8.1",
         "vite-plugin-pwa": "^0.12.8"
       }
@@ -9371,12 +9372,15 @@
       }
     },
     "node_modules/vite-plugin-fonts": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-fonts/-/vite-plugin-fonts-0.2.2.tgz",
-      "integrity": "sha512-fhzhsrTiuzlDjSO6g5sV5EVIIvbb8lmsaIY6eUTBM4lcF55x40UBpHrcyvNwIhQG211g0lu83XC7oZlkmvdkMA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-fonts/-/vite-plugin-fonts-0.6.0.tgz",
+      "integrity": "sha512-dV6nnLEju8k5EmvlBH6egxkVZ+rgc5zWsJr9+cNRXBMEDnpRGHcZPI260UEDNg2yB99wSTNER2eduEvZFbMIGw==",
       "dev": true,
+      "dependencies": {
+        "fast-glob": "^3.2.11"
+      },
       "peerDependencies": {
-        "vite": "^2.0.0"
+        "vite": "^2.0.0 || ^3.0.0"
       }
     },
     "node_modules/vite-plugin-mkcert": {
@@ -16518,11 +16522,13 @@
       }
     },
     "vite-plugin-fonts": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-fonts/-/vite-plugin-fonts-0.2.2.tgz",
-      "integrity": "sha512-fhzhsrTiuzlDjSO6g5sV5EVIIvbb8lmsaIY6eUTBM4lcF55x40UBpHrcyvNwIhQG211g0lu83XC7oZlkmvdkMA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-fonts/-/vite-plugin-fonts-0.6.0.tgz",
+      "integrity": "sha512-dV6nnLEju8k5EmvlBH6egxkVZ+rgc5zWsJr9+cNRXBMEDnpRGHcZPI260UEDNg2yB99wSTNER2eduEvZFbMIGw==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "fast-glob": "^3.2.11"
+      }
     },
     "vite-plugin-mkcert": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "stylelint-config-standard-scss": "^5.0.0",
     "terser": "5.15.0",
     "vite": "3.1.3",
-    "vite-plugin-fonts": "^0.2.2",
+    "vite-plugin-fonts": "^0.6.0",
     "vite-plugin-mkcert": "^1.8.1",
     "vite-plugin-pwa": "^0.12.8"
   },
@@ -71,7 +71,7 @@
     "fix-dark": "sed '/^[\\.\\}\\@]/d;/^[[:blank:]]*\\..*/d;/\\/\\/.*/d' common/src/main/webapp/less/variables-dark.less > vars.css;trap \"rm vars.css\" EXIT;npx stylelint --fix common/src/main/webapp/sass",
     "lint-light": "sed '/^[\\.\\}\\@]/d;/^[[:blank:]]*\\..*/d;/\\/\\/.*/d' common/src/main/webapp/less/variables-light.less > vars.css;trap \"rm vars.css\" EXIT;npx stylelint common/src/main/webapp/sass",
     "fix-light": "sed '/^[\\.\\}\\@]/d;/^[[:blank:]]*\\..*/d;/\\/\\/.*/d' common/src/main/webapp/less/variables-light.less > vars.css;trap \"rm vars.css\" EXIT;npx stylelint --fix common/src/main/webapp/sass",
-    "build": "node --unhandled-rejections=strict build.js",
+    "build": "node --unhandled-rejections=strict build.mjs",
     "serve": "vite preview"
   },
   "browserslist": [

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,7 +4,7 @@ import { visualizer } from 'rollup-plugin-visualizer';
 import path from 'path';
 import fs from 'fs';
 import mkcert from 'vite-plugin-mkcert';
-import { VitePluginFonts } from 'vite-plugin-fonts'
+import { VitePluginFonts } from 'vite-plugin-fonts';
 import { VitePWA } from 'vite-plugin-pwa';
 
 const fontImport = VitePluginFonts({
@@ -52,7 +52,10 @@ const itcCache = ({ name, pattern }) => ({
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
-  const scalaClassesDir = path.resolve(__dirname, 'explore/target/scala-3.2.1-RC2');
+  const scalaClassesDir = path.resolve(
+    __dirname,
+    'explore/target/scala-3.2.1-RC2'
+  );
   const isProduction = mode == 'production';
   const sjs = isProduction
     ? path.resolve(scalaClassesDir, 'explore-opt')
@@ -179,7 +182,7 @@ export default defineConfig(({ command, mode }) => {
       outDir: path.resolve(__dirname, 'heroku/static'),
     },
     worker: {
-      format: 'es' // We need this for workers to be able to do dynamic imports.
+      format: 'es', // We need this for workers to be able to do dynamic imports.
     },
     plugins: [
       mkcert({ hosts: ['localhost', 'local.lucuma.xyz'] }),
@@ -199,13 +202,15 @@ export default defineConfig(({ command, mode }) => {
               name: 'aladin-images',
             }),
             itcCache({
-              pattern: /^https:\/\/(itc-staging.lucuma.xyz|itc.gpp.gemini.edu)\/itc/,
+              pattern:
+                /^https:\/\/(itc-staging.lucuma.xyz|itc.gpp.gemini.edu)\/itc/,
               name: 'itc-cache',
             }),
             itcCache({
-              pattern: /^https:\/\/cors-proxy.(lucuma.xyz|gpp.gemini.edu)\/http:\/\/aladin.unistra.fr\/java\/nph-aladin.*/,
+              pattern:
+                /^https:\/\/cors-proxy.(lucuma.xyz|gpp.gemini.edu)\/http:\/\/aladin.unistra.fr\/java\/nph-aladin.*/,
               name: 'cors-cache',
-            })
+            }),
           ],
         },
       }),

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,13 +1,13 @@
-const { defineConfig } = require('vite');
-const react = require('@vitejs/plugin-react');
-const { visualizer } = require('rollup-plugin-visualizer');
-const path = require('path');
-const fs = require('fs');
-const ViteFonts = require('vite-plugin-fonts');
-const mkcert = require('vite-plugin-mkcert');
-const { VitePWA } = require('vite-plugin-pwa');
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { visualizer } from 'rollup-plugin-visualizer';
+import path from 'path';
+import fs from 'fs';
+import mkcert from 'vite-plugin-mkcert';
+import { VitePluginFonts } from 'vite-plugin-fonts'
+import { VitePWA } from 'vite-plugin-pwa';
 
-const fontImport = ViteFonts.Plugin({
+const fontImport = VitePluginFonts({
   google: {
     families: [
       {
@@ -51,7 +51,7 @@ const itcCache = ({ name, pattern }) => ({
 });
 
 // https://vitejs.dev/config/
-module.exports = ({ command, mode }) => {
+export default defineConfig(({ command, mode }) => {
   const scalaClassesDir = path.resolve(__dirname, 'explore/target/scala-3.2.1-RC2');
   const isProduction = mode == 'production';
   const sjs = isProduction
@@ -182,7 +182,7 @@ module.exports = ({ command, mode }) => {
       format: 'es' // We need this for workers to be able to do dynamic imports.
     },
     plugins: [
-      mkcert.default({ hosts: ['localhost', 'local.lucuma.xyz'] }),
+      mkcert({ hosts: ['localhost', 'local.lucuma.xyz'] }),
       react(),
       fontImport,
       VitePWA({
@@ -211,4 +211,4 @@ module.exports = ({ command, mode }) => {
       }),
     ],
   };
-};
+});


### PR DESCRIPTION
This PR transform build.js and vite config to ES modules to let us upgrade vite-plugin-font and avoid having to do `npm install --force`