### PR TITLE
Store the aladin fov x/y independently

### DIFF
--- a/common-graphql/src/main/resources/graphql/schemas/UserPreferencesDB.graphql
+++ b/common-graphql/src/main/resources/graphql/schemas/UserPreferencesDB.graphql
@@ -1,4 +1,3 @@
-
 """whether this query should be cached (Hasura Cloud only)"""
 directive @cached(
   """measured in seconds"""
@@ -1574,6 +1573,8 @@ type lucuma_target_preferences {
   agsCandidates: Boolean!
   agsOverlay: Boolean!
   fov: bigint!
+  fovDec: bigint!
+  fovRA: bigint!
   fullScreen: Boolean!
 
   """An object relationship"""
@@ -1639,6 +1640,8 @@ input lucuma_target_preferences_arr_rel_insert_input {
 """aggregate avg on columns"""
 type lucuma_target_preferences_avg_fields {
   fov: Float
+  fovDec: Float
+  fovRA: Float
   viewOffsetP: Float
   viewOffsetQ: Float
 }
@@ -1648,6 +1651,8 @@ order by avg() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_avg_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }
@@ -1662,6 +1667,8 @@ input lucuma_target_preferences_bool_exp {
   agsCandidates: Boolean_comparison_exp
   agsOverlay: Boolean_comparison_exp
   fov: bigint_comparison_exp
+  fovDec: bigint_comparison_exp
+  fovRA: bigint_comparison_exp
   fullScreen: Boolean_comparison_exp
   lucuma_target: lucuma_target_bool_exp
   target_id: String_comparison_exp
@@ -1685,6 +1692,8 @@ input type for incrementing numeric columns in table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_inc_input {
   fov: bigint
+  fovDec: bigint
+  fovRA: bigint
   viewOffsetP: bigint
   viewOffsetQ: bigint
 }
@@ -1696,6 +1705,8 @@ input lucuma_target_preferences_insert_input {
   agsCandidates: Boolean
   agsOverlay: Boolean
   fov: bigint
+  fovDec: bigint
+  fovRA: bigint
   fullScreen: Boolean
   lucuma_target: lucuma_target_obj_rel_insert_input
   target_id: String
@@ -1707,6 +1718,8 @@ input lucuma_target_preferences_insert_input {
 """aggregate max on columns"""
 type lucuma_target_preferences_max_fields {
   fov: bigint
+  fovDec: bigint
+  fovRA: bigint
   target_id: String
   user_id: String
   viewOffsetP: bigint
@@ -1718,6 +1731,8 @@ order by max() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_max_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   target_id: order_by
   user_id: order_by
   viewOffsetP: order_by
@@ -1727,6 +1742,8 @@ input lucuma_target_preferences_max_order_by {
 """aggregate min on columns"""
 type lucuma_target_preferences_min_fields {
   fov: bigint
+  fovDec: bigint
+  fovRA: bigint
   target_id: String
   user_id: String
   viewOffsetP: bigint
@@ -1738,6 +1755,8 @@ order by min() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_min_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   target_id: order_by
   user_id: order_by
   viewOffsetP: order_by
@@ -1769,6 +1788,8 @@ input lucuma_target_preferences_order_by {
   agsCandidates: order_by
   agsOverlay: order_by
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   fullScreen: order_by
   lucuma_target: lucuma_target_order_by
   target_id: order_by
@@ -1797,6 +1818,12 @@ enum lucuma_target_preferences_select_column {
   fov
 
   """column name"""
+  fovDec
+
+  """column name"""
+  fovRA
+
+  """column name"""
   fullScreen
 
   """column name"""
@@ -1819,6 +1846,8 @@ input lucuma_target_preferences_set_input {
   agsCandidates: Boolean
   agsOverlay: Boolean
   fov: bigint
+  fovDec: bigint
+  fovRA: bigint
   fullScreen: Boolean
   target_id: String
   user_id: String
@@ -1829,6 +1858,8 @@ input lucuma_target_preferences_set_input {
 """aggregate stddev on columns"""
 type lucuma_target_preferences_stddev_fields {
   fov: Float
+  fovDec: Float
+  fovRA: Float
   viewOffsetP: Float
   viewOffsetQ: Float
 }
@@ -1838,6 +1869,8 @@ order by stddev() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_stddev_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }
@@ -1845,6 +1878,8 @@ input lucuma_target_preferences_stddev_order_by {
 """aggregate stddev_pop on columns"""
 type lucuma_target_preferences_stddev_pop_fields {
   fov: Float
+  fovDec: Float
+  fovRA: Float
   viewOffsetP: Float
   viewOffsetQ: Float
 }
@@ -1854,6 +1889,8 @@ order by stddev_pop() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_stddev_pop_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }
@@ -1861,6 +1898,8 @@ input lucuma_target_preferences_stddev_pop_order_by {
 """aggregate stddev_samp on columns"""
 type lucuma_target_preferences_stddev_samp_fields {
   fov: Float
+  fovDec: Float
+  fovRA: Float
   viewOffsetP: Float
   viewOffsetQ: Float
 }
@@ -1870,6 +1909,8 @@ order by stddev_samp() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_stddev_samp_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }
@@ -1890,6 +1931,8 @@ input lucuma_target_preferences_stream_cursor_value_input {
   agsCandidates: Boolean
   agsOverlay: Boolean
   fov: bigint
+  fovDec: bigint
+  fovRA: bigint
   fullScreen: Boolean
   target_id: String
   user_id: String
@@ -1900,6 +1943,8 @@ input lucuma_target_preferences_stream_cursor_value_input {
 """aggregate sum on columns"""
 type lucuma_target_preferences_sum_fields {
   fov: bigint
+  fovDec: bigint
+  fovRA: bigint
   viewOffsetP: bigint
   viewOffsetQ: bigint
 }
@@ -1909,6 +1954,8 @@ order by sum() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_sum_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }
@@ -1925,6 +1972,12 @@ enum lucuma_target_preferences_update_column {
 
   """column name"""
   fov
+
+  """column name"""
+  fovDec
+
+  """column name"""
+  fovRA
 
   """column name"""
   fullScreen
@@ -1954,6 +2007,8 @@ input lucuma_target_preferences_updates {
 """aggregate var_pop on columns"""
 type lucuma_target_preferences_var_pop_fields {
   fov: Float
+  fovDec: Float
+  fovRA: Float
   viewOffsetP: Float
   viewOffsetQ: Float
 }
@@ -1963,6 +2018,8 @@ order by var_pop() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_var_pop_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }
@@ -1970,6 +2027,8 @@ input lucuma_target_preferences_var_pop_order_by {
 """aggregate var_samp on columns"""
 type lucuma_target_preferences_var_samp_fields {
   fov: Float
+  fovDec: Float
+  fovRA: Float
   viewOffsetP: Float
   viewOffsetQ: Float
 }
@@ -1979,6 +2038,8 @@ order by var_samp() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_var_samp_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }
@@ -1986,6 +2047,8 @@ input lucuma_target_preferences_var_samp_order_by {
 """aggregate variance on columns"""
 type lucuma_target_preferences_variance_fields {
   fov: Float
+  fovDec: Float
+  fovRA: Float
   viewOffsetP: Float
   viewOffsetQ: Float
 }
@@ -1995,6 +2058,8 @@ order by variance() on columns of table "lucuma_target_preferences"
 """
 input lucuma_target_preferences_variance_order_by {
   fov: order_by
+  fovDec: order_by
+  fovRA: order_by
   viewOffsetP: order_by
   viewOffsetQ: order_by
 }

--- a/common-graphql/src/main/scala/queries/common/UserPreferencesQueriesGQL.scala
+++ b/common-graphql/src/main/scala/queries/common/UserPreferencesQueriesGQL.scala
@@ -113,7 +113,8 @@ object UserPreferencesQueriesGQL {
     val document = """
       query target_preferences($user_id: String! = "", $targetId: String! = "") {
         lucuma_target_preferences_by_pk(target_id: $targetId, user_id: $user_id) {
-          fov
+          fovRA
+          fovDec
           viewOffsetP
           viewOffsetQ
           agsCandidates

--- a/common/src/main/public/development.conf.json
+++ b/common/src/main/public/development.conf.json
@@ -1,7 +1,7 @@
 {
   "environment": "DEVELOPMENT",
   "odbURI": "wss://lucuma-odb-development.herokuapp.com/ws",
-  "preferencesDBURI": "wss://user-prefs-development.herokuapp.com/v1/graphql",
+  "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-development.herokuapp.com/itc",
   "sso": {
     "uri": "https://sso.gpp.lucuma.xyz",

--- a/common/src/main/public/development.conf.json
+++ b/common/src/main/public/development.conf.json
@@ -1,7 +1,7 @@
 {
   "environment": "DEVELOPMENT",
   "odbURI": "wss://lucuma-odb-development.herokuapp.com/ws",
-  "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
+  "preferencesDBURI": "wss://user-prefs-development.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-development.herokuapp.com/itc",
   "sso": {
     "uri": "https://sso.gpp.lucuma.xyz",

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -366,7 +366,7 @@ object AladinContainer {
                     showReticle = false,
                     showLayersControl = false,
                     target = baseCoordinatesForAladin,
-                    fov = props.options.fovAngle,
+                    fov = props.options.fovDec,
                     showGotoControl = false,
                     showZoomControl = false,
                     showFullscreenControl = false,

--- a/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -28,19 +28,19 @@ import react.semanticui.shorthand._
 import react.semanticui.sizes.Small
 import react.semanticui.sizes._
 
-final case class AladinToolbar(
+case class AladinToolbar(
   fov:               Fov,
   current:           Coordinates,
   agsState:          AgsState,
   selectedGuideStar: Option[AgsAnalysis],
   center:            View[Boolean],
   agsOverlay:        Visible
-) extends ReactFnProps[AladinToolbar](AladinToolbar.component)
+) extends ReactFnProps(AladinToolbar.component)
 
 object AladinToolbar {
-  type Props = AladinToolbar
+  private type Props = AladinToolbar
 
-  val component =
+  private val component =
     ScalaFnComponent[Props] { props =>
       val usableGuideStar = props.selectedGuideStar.forall(_.isUsable)
 

--- a/explore/src/main/scala/explore/visualization/ScienceSVGTarget.scala
+++ b/explore/src/main/scala/explore/visualization/ScienceSVGTarget.scala
@@ -110,7 +110,7 @@ object CrossTarget {
         val heightPaddingFactor = 1.05
         val widthPaddingFactor  = 1.2
 
-        val pf = p.sx.min(p.sy).min(0.04)
+        val pf = p.sx.max(p.sy)
 
         val (textWidth, textHeight) = textDomSize(tooltip)
         val tooltipWidth            = textWidth / pf

--- a/explore/src/main/scala/explore/visualization/TargetsOverlay.scala
+++ b/explore/src/main/scala/explore/visualization/TargetsOverlay.scala
@@ -134,9 +134,6 @@ object TargetsOverlay {
         val (viewBoxX, viewBoxY, viewBoxW, viewBoxH) =
           calculateViewBox(x, y, w, h, p.fov, p.screenOffset)
 
-        val sx = p.width / (viewBoxW - viewBoxX)
-        val sy = p.height / (viewBoxH - viewBoxY)
-
         val svg = <.svg(
           JtsSvg,
           ^.untypedRef := svgRef,
@@ -186,6 +183,9 @@ object TargetsOverlay {
                       SVGTarget.ScienceTarget(_, css, selectedCss, sidePx, title, selected)
                     ) =>
                   val pointCss = ExploreStyles.CrosshairTarget |+| css
+                  val sx       = p.width / (viewBoxW - viewBoxX).abs
+                  val sy       = p.height / (viewBoxH - viewBoxY).abs
+
                   CrossTarget(Option(svgRef.raw.current).map(_.asInstanceOf[SVG]),
                               offP,
                               offQ,

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetVisualOptions.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbTargetVisualOptions.scala
@@ -5,33 +5,33 @@ package explore.model.arb
 
 import explore.model.TargetVisualOptions
 import explore.model.enums.Visible
-import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbEnumerated.*
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
-import lucuma.core.math.arb.ArbAngle._
-import lucuma.core.math.arb.ArbOffset._
+import lucuma.core.math.arb.ArbAngle.*
+import lucuma.core.math.arb.ArbOffset.*
 import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary._
+import org.scalacheck.Arbitrary.*
 import org.scalacheck.Cogen
-import org.scalacheck.Cogen._
+import org.scalacheck.Cogen.*
 
-trait ArbTargetVisualOptions {
+trait ArbTargetVisualOptions:
 
-  implicit val targetVisualOptionsArb: Arbitrary[TargetVisualOptions] =
+  given Arbitrary[TargetVisualOptions] =
     Arbitrary[TargetVisualOptions] {
       for {
-        fa <- arbitrary[Angle]
-        vo <- arbitrary[Offset]
-        a  <- arbitrary[Visible]
-        o  <- arbitrary[Visible]
-        f  <- arbitrary[Boolean]
-      } yield TargetVisualOptions(fa, vo, a, o, f)
+        fra  <- arbitrary[Angle]
+        fdec <- arbitrary[Angle]
+        vo   <- arbitrary[Offset]
+        a    <- arbitrary[Visible]
+        o    <- arbitrary[Visible]
+        f    <- arbitrary[Boolean]
+      } yield TargetVisualOptions(fra, fdec, vo, a, o, f)
     }
 
-  implicit val targetVisualOptionsCogen: Cogen[TargetVisualOptions] =
-    Cogen[(Angle, Offset, Visible, Visible, Boolean)].contramap(c =>
-      (c.fovAngle, c.viewOffset, c.agsCandidates, c.agsOverlay, c.fullScreen)
+  given Cogen[TargetVisualOptions] =
+    Cogen[(Angle, Angle, Offset, Visible, Visible, Boolean)].contramap(c =>
+      (c.fovRA, c.fovDec, c.viewOffset, c.agsCandidates, c.agsOverlay, c.fullScreen)
     )
-}
 
 object ArbTargetVisualOptions extends ArbTargetVisualOptions

--- a/model-tests/jvm/src/test/scala/explore/modes/ModesSuite.scala
+++ b/model-tests/jvm/src/test/scala/explore/modes/ModesSuite.scala
@@ -5,24 +5,24 @@ package explore.modes
 
 import cats.effect.IO
 import cats.effect.Resource
-import cats.syntax.all._
-import coulomb._
+import cats.syntax.all.*
+import coulomb.*
 import coulomb.conversion.spire.*
 import coulomb.ops.algebra.cats.quantity.given
 import coulomb.ops.algebra.spire.all.given
 import coulomb.policy.spire.standard.given
 import coulomb.syntax.*
-import coulomb.units.time._
-import eu.timepit.refined._
-import eu.timepit.refined.auto._
-import eu.timepit.refined.numeric._
+import coulomb.units.time.*
+import eu.timepit.refined.*
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.numeric.*
 import fs2.io.file.Path
 import lucuma.core.enums.FocalPlane
 import lucuma.core.enums.ImageQuality
 import lucuma.core.math.Angle
 import lucuma.core.math.Wavelength
-import lucuma.core.math.units._
-import lucuma.refined._
+import lucuma.core.math.units.*
+import lucuma.refined.*
 import munit.CatsEffectSuite
 import spire.math.Rational
 

--- a/model-tests/shared/src/test/scala/explore/model/ModelSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/ModelSuite.scala
@@ -3,15 +3,14 @@
 
 package explore.model
 
-import cats.kernel.laws.discipline._
-import explore.model.arb.all._
+import cats.kernel.laws.discipline.*
+import explore.model.arb.all.*
+import explore.model.arb.all.given
 import explore.model.enums.AppTab
-import lucuma.core.util.arb.ArbEnumerated._
+import lucuma.core.util.arb.ArbEnumerated.*
 import munit.DisciplineSuite
 
-class ModelSuite extends DisciplineSuite {
+class ModelSuite extends DisciplineSuite:
   checkAll("Eq[TargetVisualOptions]", EqTests[TargetVisualOptions].eqv)
   checkAll("Eq[SideButton]", EqTests[AppTab].eqv)
   checkAll("Eq[UserVault]", EqTests[UserVault].eqv)
-
-}

--- a/model/shared/src/main/scala/explore/model/TargetVisualOptions.scala
+++ b/model/shared/src/main/scala/explore/model/TargetVisualOptions.scala
@@ -3,30 +3,35 @@
 
 package explore.model
 
-import cats._
+import cats.Eq
+import cats.derived.*
 import explore.model.enums.Visible
 import lucuma.core.math.Angle
 import lucuma.core.math.Offset
 import monocle.Focus
 
-final case class TargetVisualOptions(
-  fovAngle:      Angle,
+case class TargetVisualOptions(
+  fovRA:         Angle,
+  fovDec:        Angle,
   viewOffset:    Offset,
   agsCandidates: Visible,
   agsOverlay:    Visible,
   fullScreen:    Boolean
-)
+) derives Eq
 
-object TargetVisualOptions {
-  val fovAngle      = Focus[TargetVisualOptions](_.fovAngle)
+object TargetVisualOptions:
+  val fovRA         = Focus[TargetVisualOptions](_.fovRA)
+  val fovDec        = Focus[TargetVisualOptions](_.fovDec)
   val viewOffset    = Focus[TargetVisualOptions](_.viewOffset)
   val agsCandidates = Focus[TargetVisualOptions](_.agsCandidates)
   val agsOverlay    = Focus[TargetVisualOptions](_.agsOverlay)
   val fullScreen    = Focus[TargetVisualOptions](_.fullScreen)
 
   val Default =
-    TargetVisualOptions(Constants.InitialFov, Offset.Zero, Visible.Hidden, Visible.Hidden, false)
-
-  implicit val targetVisualOptionsEq: Eq[TargetVisualOptions] =
-    Eq.by(x => (x.fovAngle, x.viewOffset, x.agsCandidates, x.agsOverlay, x.fullScreen))
-}
+    TargetVisualOptions(Constants.InitialFov,
+                        Constants.InitialFov,
+                        Offset.Zero,
+                        Visible.Hidden,
+                        Visible.Hidden,
+                        false
+    )


### PR DESCRIPTION
It was requested to store the field of view of ra/dec independently instead of assuming it is a square
This PR adds this, it is a bit bigger because we are also storing fov on the user preferences