### PR TITLE
Allow disabling scroll to zoom in aladin

### DIFF
--- a/USERPREFS.md
+++ b/USERPREFS.md
@@ -1,0 +1,41 @@
+# User preferences
+
+explore stores a set of user preferences outside of the main odb api server. It is reserved
+for settings which would only impact the UI, e.g. zoom of the aladin display, range of plots, etc.
+In general, anything that is of no interest to the API users can go to the user prefs database
+
+For the user preferences db we are using hasura to provide an automatic graphql api for simple
+odb tables.
+
+This is not considered critical and we would take the freedom of deleting the preferences if it
+makes the transition simpler.
+
+## Environments
+We have three environments with a respective db and heroku app:
+* development
+* staging
+* production
+
+## Copy the database
+To copy the database between instances you can create a backup on the postgress page under the
+durability tab. From there pick the backup id you want to copy and then upload to the destination
+environment with the command:
+
+```
+heroku pg:backups:restore {original_env}::{backup_id} {DATABASE_URL} --app {new_env}
+```
+
+Where:
+
+    * original_env is the name of the environment you are pulling the backup from
+    * backup_id is the ID of the backup, found on the Durability tab of the Heroku Postgres database page
+    * DATABASE_URL is the env var that Heroku generated for the new database
+    * new_env is the new application ID that has the DATABASE_URL attached to it
+
+
+## Update hasura
+Checkout the original code from:
+https://git.heroku.com/user-prefs-staging.git
+
+then push this via git to the url of each environment
+

--- a/common-graphql/src/main/resources/graphql/schemas/UserPreferencesDB.graphql
+++ b/common-graphql/src/main/resources/graphql/schemas/UserPreferencesDB.graphql
@@ -1572,7 +1572,7 @@ columns and relationships of "lucuma_target_preferences"
 type lucuma_target_preferences {
   agsCandidates: Boolean!
   agsOverlay: Boolean!
-  fov: bigint!
+  fov: bigint
   fovDec: bigint!
   fovRA: bigint!
   fullScreen: Boolean!
@@ -2182,6 +2182,16 @@ type lucuma_user_mutation_response {
 }
 
 """
+input type for inserting object relation for remote table "lucuma_user"
+"""
+input lucuma_user_obj_rel_insert_input {
+  data: lucuma_user_insert_input!
+
+  """upsert condition"""
+  on_conflict: lucuma_user_on_conflict
+}
+
+"""
 on_conflict condition type for table "lucuma_user"
 """
 input lucuma_user_on_conflict {
@@ -2198,6 +2208,160 @@ input lucuma_user_order_by {
 """primary key columns input for table: lucuma_user"""
 input lucuma_user_pk_columns_input {
   user_id: String!
+}
+
+"""
+columns and relationships of "lucuma_user_preferences"
+"""
+type lucuma_user_preferences {
+  aladinMouseScroll: Boolean!
+
+  """An object relationship"""
+  lucuma_user: lucuma_user!
+  user_id: String!
+}
+
+"""
+aggregated selection of "lucuma_user_preferences"
+"""
+type lucuma_user_preferences_aggregate {
+  aggregate: lucuma_user_preferences_aggregate_fields
+  nodes: [lucuma_user_preferences!]!
+}
+
+"""
+aggregate fields of "lucuma_user_preferences"
+"""
+type lucuma_user_preferences_aggregate_fields {
+  count(columns: [lucuma_user_preferences_select_column!], distinct: Boolean): Int!
+  max: lucuma_user_preferences_max_fields
+  min: lucuma_user_preferences_min_fields
+}
+
+"""
+Boolean expression to filter rows from the table "lucuma_user_preferences". All fields are combined with a logical 'AND'.
+"""
+input lucuma_user_preferences_bool_exp {
+  _and: [lucuma_user_preferences_bool_exp!]
+  _not: lucuma_user_preferences_bool_exp
+  _or: [lucuma_user_preferences_bool_exp!]
+  aladinMouseScroll: Boolean_comparison_exp
+  lucuma_user: lucuma_user_bool_exp
+  user_id: String_comparison_exp
+}
+
+"""
+unique or primary key constraints on table "lucuma_user_preferences"
+"""
+enum lucuma_user_preferences_constraint {
+  """
+  unique or primary key constraint on columns "user_id"
+  """
+  lucuma_user_preferences_pkey
+}
+
+"""
+input type for inserting data into table "lucuma_user_preferences"
+"""
+input lucuma_user_preferences_insert_input {
+  aladinMouseScroll: Boolean
+  lucuma_user: lucuma_user_obj_rel_insert_input
+  user_id: String
+}
+
+"""aggregate max on columns"""
+type lucuma_user_preferences_max_fields {
+  user_id: String
+}
+
+"""aggregate min on columns"""
+type lucuma_user_preferences_min_fields {
+  user_id: String
+}
+
+"""
+response of any mutation on the table "lucuma_user_preferences"
+"""
+type lucuma_user_preferences_mutation_response {
+  """number of rows affected by the mutation"""
+  affected_rows: Int!
+
+  """data from the rows affected by the mutation"""
+  returning: [lucuma_user_preferences!]!
+}
+
+"""
+on_conflict condition type for table "lucuma_user_preferences"
+"""
+input lucuma_user_preferences_on_conflict {
+  constraint: lucuma_user_preferences_constraint!
+  update_columns: [lucuma_user_preferences_update_column!]! = []
+  where: lucuma_user_preferences_bool_exp
+}
+
+"""Ordering options when selecting data from "lucuma_user_preferences"."""
+input lucuma_user_preferences_order_by {
+  aladinMouseScroll: order_by
+  lucuma_user: lucuma_user_order_by
+  user_id: order_by
+}
+
+"""primary key columns input for table: lucuma_user_preferences"""
+input lucuma_user_preferences_pk_columns_input {
+  user_id: String!
+}
+
+"""
+select columns of table "lucuma_user_preferences"
+"""
+enum lucuma_user_preferences_select_column {
+  """column name"""
+  aladinMouseScroll
+
+  """column name"""
+  user_id
+}
+
+"""
+input type for updating data in table "lucuma_user_preferences"
+"""
+input lucuma_user_preferences_set_input {
+  aladinMouseScroll: Boolean
+  user_id: String
+}
+
+"""
+Streaming cursor of the table "lucuma_user_preferences"
+"""
+input lucuma_user_preferences_stream_cursor_input {
+  """Stream column input with initial value"""
+  initial_value: lucuma_user_preferences_stream_cursor_value_input!
+
+  """cursor ordering"""
+  ordering: cursor_ordering
+}
+
+"""Initial value of the column from where the streaming should start"""
+input lucuma_user_preferences_stream_cursor_value_input {
+  aladinMouseScroll: Boolean
+  user_id: String
+}
+
+"""
+update columns of table "lucuma_user_preferences"
+"""
+enum lucuma_user_preferences_update_column {
+  """column name"""
+  aladinMouseScroll
+
+  """column name"""
+  user_id
+}
+
+input lucuma_user_preferences_updates {
+  """sets the columns of the filtered rows to the given values"""
+  _set: lucuma_user_preferences_set_input
+  where: lucuma_user_preferences_bool_exp!
 }
 
 """
@@ -2350,6 +2514,19 @@ type Mutation {
   delete single row from the table: "lucuma_user"
   """
   delete_lucuma_user_by_pk(user_id: String!): lucuma_user
+
+  """
+  delete data from the table: "lucuma_user_preferences"
+  """
+  delete_lucuma_user_preferences(
+    """filter the rows which have to be deleted"""
+    where: lucuma_user_preferences_bool_exp!
+  ): lucuma_user_preferences_mutation_response
+
+  """
+  delete single row from the table: "lucuma_user_preferences"
+  """
+  delete_lucuma_user_preferences_by_pk(user_id: String!): lucuma_user_preferences
 
   """
   insert data into the table: "explore_resizable_width"
@@ -2526,6 +2703,28 @@ type Mutation {
     """upsert condition"""
     on_conflict: lucuma_user_on_conflict
   ): lucuma_user
+
+  """
+  insert data into the table: "lucuma_user_preferences"
+  """
+  insert_lucuma_user_preferences(
+    """the rows to be inserted"""
+    objects: [lucuma_user_preferences_insert_input!]!
+
+    """upsert condition"""
+    on_conflict: lucuma_user_preferences_on_conflict
+  ): lucuma_user_preferences_mutation_response
+
+  """
+  insert a single row into the table: "lucuma_user_preferences"
+  """
+  insert_lucuma_user_preferences_one(
+    """the row to be inserted"""
+    object: lucuma_user_preferences_insert_input!
+
+    """upsert condition"""
+    on_conflict: lucuma_user_preferences_on_conflict
+  ): lucuma_user_preferences
 
   """
   update data of the table: "explore_resizable_width"
@@ -2768,6 +2967,34 @@ type Mutation {
     """updates to execute, in order"""
     updates: [lucuma_user_updates!]!
   ): [lucuma_user_mutation_response]
+
+  """
+  update data of the table: "lucuma_user_preferences"
+  """
+  update_lucuma_user_preferences(
+    """sets the columns of the filtered rows to the given values"""
+    _set: lucuma_user_preferences_set_input
+
+    """filter the rows which have to be updated"""
+    where: lucuma_user_preferences_bool_exp!
+  ): lucuma_user_preferences_mutation_response
+
+  """
+  update single row of the table: "lucuma_user_preferences"
+  """
+  update_lucuma_user_preferences_by_pk(
+    """sets the columns of the filtered rows to the given values"""
+    _set: lucuma_user_preferences_set_input
+    pk_columns: lucuma_user_preferences_pk_columns_input!
+  ): lucuma_user_preferences
+
+  """
+  update multiples rows of table: "lucuma_user_preferences"
+  """
+  update_lucuma_user_preferences_many(
+    """updates to execute, in order"""
+    updates: [lucuma_user_preferences_updates!]!
+  ): [lucuma_user_preferences_mutation_response]
 }
 
 """column ordering options"""
@@ -3135,6 +3362,51 @@ type Query {
 
   """fetch data from the table: "lucuma_user" using primary key columns"""
   lucuma_user_by_pk(user_id: String!): lucuma_user
+
+  """
+  fetch data from the table: "lucuma_user_preferences"
+  """
+  lucuma_user_preferences(
+    """distinct select on columns"""
+    distinct_on: [lucuma_user_preferences_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [lucuma_user_preferences_order_by!]
+
+    """filter the rows returned"""
+    where: lucuma_user_preferences_bool_exp
+  ): [lucuma_user_preferences!]!
+
+  """
+  fetch aggregated fields from the table: "lucuma_user_preferences"
+  """
+  lucuma_user_preferences_aggregate(
+    """distinct select on columns"""
+    distinct_on: [lucuma_user_preferences_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [lucuma_user_preferences_order_by!]
+
+    """filter the rows returned"""
+    where: lucuma_user_preferences_bool_exp
+  ): lucuma_user_preferences_aggregate!
+
+  """
+  fetch data from the table: "lucuma_user_preferences" using primary key columns
+  """
+  lucuma_user_preferences_by_pk(user_id: String!): lucuma_user_preferences
 }
 
 scalar resizable_area
@@ -3613,6 +3885,65 @@ type Subscription {
 
   """fetch data from the table: "lucuma_user" using primary key columns"""
   lucuma_user_by_pk(user_id: String!): lucuma_user
+
+  """
+  fetch data from the table: "lucuma_user_preferences"
+  """
+  lucuma_user_preferences(
+    """distinct select on columns"""
+    distinct_on: [lucuma_user_preferences_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [lucuma_user_preferences_order_by!]
+
+    """filter the rows returned"""
+    where: lucuma_user_preferences_bool_exp
+  ): [lucuma_user_preferences!]!
+
+  """
+  fetch aggregated fields from the table: "lucuma_user_preferences"
+  """
+  lucuma_user_preferences_aggregate(
+    """distinct select on columns"""
+    distinct_on: [lucuma_user_preferences_select_column!]
+
+    """limit the number of rows returned"""
+    limit: Int
+
+    """skip the first n rows. Use only with order_by"""
+    offset: Int
+
+    """sort the rows by one or more columns"""
+    order_by: [lucuma_user_preferences_order_by!]
+
+    """filter the rows returned"""
+    where: lucuma_user_preferences_bool_exp
+  ): lucuma_user_preferences_aggregate!
+
+  """
+  fetch data from the table: "lucuma_user_preferences" using primary key columns
+  """
+  lucuma_user_preferences_by_pk(user_id: String!): lucuma_user_preferences
+
+  """
+  fetch data from the table in a streaming manner : "lucuma_user_preferences"
+  """
+  lucuma_user_preferences_stream(
+    """maximum number of rows returned in a single batch"""
+    batch_size: Int!
+
+    """cursor to stream the results returned by the query"""
+    cursor: [lucuma_user_preferences_stream_cursor_input]!
+
+    """filter the rows returned"""
+    where: lucuma_user_preferences_bool_exp
+  ): [lucuma_user_preferences!]!
 
   """
   fetch data from the table in a streaming manner : "lucuma_user"

--- a/common-graphql/src/main/scala/queries/common/UserPreferencesQueriesGQL.scala
+++ b/common-graphql/src/main/scala/queries/common/UserPreferencesQueriesGQL.scala
@@ -121,6 +121,9 @@ object UserPreferencesQueriesGQL {
           agsOverlay
           fullScreen
         }
+        lucuma_user_preferences_by_pk(user_id: $user_id) {
+          aladinMouseScroll
+        }
       }
     """
   }
@@ -139,6 +142,26 @@ object UserPreferencesQueriesGQL {
   }
 
   @GraphQL
+  trait UserPreferencesUpdateQuery extends GraphQLOperation[UserPreferencesDB] {
+    val document = """
+      mutation user_preferences_upsert($aladinMouseScroll: Boolean = false, $user_id: String = "") {
+        insert_lucuma_user_preferences_one(
+          object: {
+            user_id: $user_id,
+            aladinMouseScroll: $aladinMouseScroll
+          },
+          on_conflict: {
+            constraint: lucuma_user_preferences_pkey,
+            update_columns: aladinMouseScroll
+          }
+        ) {
+          user_id
+        }
+      }
+    """
+  }
+
+  @GraphQL
   trait UserTargetPreferencesUpsert extends GraphQLOperation[UserPreferencesDB] {
     val document =
       """mutation target_preferences_upsert($objects: lucuma_target_insert_input! = {}) {
@@ -149,7 +172,7 @@ object UserPreferencesQueriesGQL {
   }
 
   @GraphQL
-  trait UserTargetPreferencesFovUpdate extends GraphQLOperation[UserPreferencesDB] {
+  trait UserTargetOffsetUpdateQuery extends GraphQLOperation[UserPreferencesDB] {
     val document =
       """ mutation update_target_fov($user_id: String!, $target_id: String!, $viewOffsetP: bigint!, $viewOffsetQ: bigint!) {
         update_lucuma_target_preferences_by_pk(

--- a/common/src/main/public/production.conf.json
+++ b/common/src/main/public/production.conf.json
@@ -1,7 +1,7 @@
 {
   "environment": "PRODUCTION",
   "odbURI": "wss://lucuma-odb.herokuapp.com/ws",
-  "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
+  "preferencesDBURI": "wss://user-prefs.herokuapp.com/v1/graphql",
   "itcURI": "https://itc.gpp.gemini.edu/itc",
   "sso": {
     "uri": "https://sso.gpp.gemini.edu",

--- a/common/src/main/public/staging.conf.json
+++ b/common/src/main/public/staging.conf.json
@@ -1,7 +1,7 @@
 {
   "environment": "STAGING", 
   "odbURI": "wss://odb.gpp.lucuma.xyz/ws",
-  "preferencesDBURI": "wss://userprefs-hasura-staging.herokuapp.com/v1/graphql",
+  "preferencesDBURI": "wss://user-prefs-staging.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-staging.lucuma.xyz/itc",
   "sso": {
     "uri": "https://sso.gpp.lucuma.xyz",

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -234,14 +234,15 @@ object ExploreStyles {
   val AsterismTable: Css  = Css("target-asterism-table")
   val BrightnessCell: Css = Css("target-brightness-cell")
 
-  val TargetAladinCell: Css       = Css("target-aladin-cell")
-  val TargetAladin: Css           = Css("aladin-target")
-  val TargetRaDecMinWidth: Css    = Css("target-ra-dec-min-width")
-  val TargetForm: Css             = Css("target-form")
-  val TargetProperMotionForm: Css = Css("target-proper-motion-form")
-  val SearchForm: Css             = Css("target-search-form")
-  val TargetRVControls: Css       = Css("target-rv-controls")
-  val CatalogueForm: Css          = Css("catalogue-form")
+  val TargetAladinCell: Css         = Css("target-aladin-cell")
+  val TargetAladin: Css             = Css("aladin-target")
+  val TargetAladinDisableMouse: Css = Css("aladin-target-disable-mouse")
+  val TargetRaDecMinWidth: Css      = Css("target-ra-dec-min-width")
+  val TargetForm: Css               = Css("target-form")
+  val TargetProperMotionForm: Css   = Css("target-proper-motion-form")
+  val SearchForm: Css               = Css("target-search-form")
+  val TargetRVControls: Css         = Css("target-rv-controls")
+  val CatalogueForm: Css            = Css("catalogue-form")
 
   // The Constraints tab contents
   val ConstraintsGrid                = Css("constraints-grid")

--- a/common/src/main/webapp/sass/common.scss
+++ b/common/src/main/webapp/sass/common.scss
@@ -1,0 +1,3 @@
+// media queries cutoff
+$tablet-responsive-cutoff: 992px;
+$mobile-responsive-cutoff: 670px;

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1,6 +1,4 @@
-// media queries cutoff
-$tablet-responsive-cutoff: 992px;
-$mobile-responsive-cutoff: 670px;
+@use 'common.scss';
 
 @mixin small-tile-title {
   display: flex;
@@ -55,7 +53,7 @@ $mobile-responsive-cutoff: 670px;
     display: none;
   }
 
-  @media (min-width: $tablet-responsive-cutoff) {
+  @media (min-width: common.$tablet-responsive-cutoff) {
     label:first-child {
       max-width: unset;
     }
@@ -73,7 +71,7 @@ $mobile-responsive-cutoff: 670px;
     }
   }
 
-  @media (min-width: $mobile-responsive-cutoff) {
+  @media (min-width: common.$mobile-responsive-cutoff) {
     label:first-child {
       display: unset;
     }
@@ -131,7 +129,7 @@ $search-preview-margin: 5px;
     margin-bottom: 0.2em;
   }
 
-  @media (min-width: $tablet-responsive-cutoff) {
+  @media (min-width: common.$tablet-responsive-cutoff) {
     min-height: calc($search-preview-width + 2 * $search-preview-margin);
     padding-right: calc(
       $search-preview-width + 3 * $search-preview-margin
@@ -142,7 +140,7 @@ $search-preview-margin: 5px;
 }
 
 .explore-target-search-top {
-  @media (min-width: $tablet-responsive-cutoff) {
+  @media (min-width: common.$tablet-responsive-cutoff) {
     gap: 0.3em;
   }
 }
@@ -155,7 +153,7 @@ $search-preview-margin: 5px;
   min-width: $search-preview-width;
   min-height: $search-preview-height-mobile;
 
-  @media (min-width: $tablet-responsive-cutoff) {
+  @media (min-width: common.$tablet-responsive-cutoff) {
     position: absolute;
     right: 0;
     margin-right: $search-preview-margin;
@@ -209,7 +207,7 @@ $search-preview-margin: 5px;
   display: none;
   margin-left: 0.5em;
 
-  @media (min-width: $mobile-responsive-cutoff) {
+  @media (min-width: common.$mobile-responsive-cutoff) {
     display: block;
   }
 }

--- a/common/src/main/webapp/sass/visualization.scss
+++ b/common/src/main/webapp/sass/visualization.scss
@@ -1,6 +1,21 @@
+$tablet-responsive-cutoff: 992px;
+$mobile-responsive-cutoff: 670px;
+
 .aladin-container {
   overflow: hidden; // Needed to keep the visualization svg inside the component
   outline: none;
+}
+
+.aladin-container {
+  pointer-events: none;
+
+  @media (min-width: $mobile-responsive-cutoff) {
+    pointer-events: initial;
+  }
+}
+
+.aladin-target-disable-mouse {
+  pointer-events: none;
 }
 
 .aladin-container-body {
@@ -255,10 +270,10 @@
 
   .explore-aladin-settings-menu {
     position: absolute;
-    left: 30px;
+    left: 35px;
 
     &.ui.compact.vertical.menu {
-      width: 8rem !important; // in SUI it is important too
+      width: 14em !important; // in SUI it is important too
     }
   }
 }

--- a/common/src/main/webapp/sass/visualization.scss
+++ b/common/src/main/webapp/sass/visualization.scss
@@ -4,9 +4,6 @@ $mobile-responsive-cutoff: 670px;
 .aladin-container {
   overflow: hidden; // Needed to keep the visualization svg inside the component
   outline: none;
-}
-
-.aladin-container {
   pointer-events: none;
 
   @media (min-width: $mobile-responsive-cutoff) {

--- a/common/src/main/webapp/sass/visualization.scss
+++ b/common/src/main/webapp/sass/visualization.scss
@@ -1,12 +1,11 @@
-$tablet-responsive-cutoff: 992px;
-$mobile-responsive-cutoff: 670px;
+@use 'common.scss';
 
 .aladin-container {
   overflow: hidden; // Needed to keep the visualization svg inside the component
   outline: none;
   pointer-events: none;
 
-  @media (min-width: $mobile-responsive-cutoff) {
+  @media (min-width: common.$mobile-responsive-cutoff) {
     pointer-events: initial;
   }
 }

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -75,15 +75,9 @@ case class AladinCell(
 )(using val ctx: AppContextIO)
     extends ReactFnProps(AladinCell.component)
 
-// case class AladinSettings(showMenu: Boolean, showCatalog: Boolean)
-//
-// object AladinSettings {
-//   val Default = AladinSettings(false, false)
-// }
-//
 object SettingsMenuState extends NewType[Boolean]:
-  val Open: SettingsMenuState   = SettingsMenuState(true)
-  val Closed: SettingsMenuState = SettingsMenuState(false)
+  inline def Open: SettingsMenuState   = SettingsMenuState(true)
+  inline def Closed: SettingsMenuState = SettingsMenuState(false)
   extension (s: SettingsMenuState)
     def flip: SettingsMenuState = if (s.value) SettingsMenuState.Closed else SettingsMenuState.Open
 

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -19,10 +19,12 @@ import explore.common.UserPreferencesQueries.*
 import explore.components.ui.ExploreStyles
 import explore.events.*
 import explore.implicits.*
+import explore.model.AladinMouseScroll
 import explore.model.Asterism
 import explore.model.Constants
 import explore.model.ObsConfiguration
 import explore.model.TargetVisualOptions
+import explore.model.UserGlobalPreferences
 import explore.model.WorkerClients.*
 import explore.model.boopickle.Boopickle.*
 import explore.model.boopickle.CatalogPicklers.given
@@ -44,9 +46,11 @@ import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.Target
 import lucuma.core.model.User
+import lucuma.core.util.NewType
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
+import monocle.Focus
 import monocle.Lens
 import org.typelevel.log4cats.Logger
 import queries.common.UserPreferencesQueriesGQL.*
@@ -54,6 +58,7 @@ import react.aladin.Fov
 import react.common.ReactFnProps
 import react.semanticui.collections.menu.*
 import react.semanticui.elements.button.Button
+import react.semanticui.elements.divider.Divider
 import react.semanticui.modules.checkbox.Checkbox
 import react.semanticui.sizes.*
 
@@ -70,11 +75,19 @@ case class AladinCell(
 )(using val ctx: AppContextIO)
     extends ReactFnProps(AladinCell.component)
 
-case class AladinSettings(showMenu: Boolean, showCatalog: Boolean)
+// case class AladinSettings(showMenu: Boolean, showCatalog: Boolean)
+//
+// object AladinSettings {
+//   val Default = AladinSettings(false, false)
+// }
+//
+object SettingsMenuState extends NewType[Boolean]:
+  val Open: SettingsMenuState   = SettingsMenuState(true)
+  val Closed: SettingsMenuState = SettingsMenuState(false)
+  extension (s: SettingsMenuState)
+    def flip: SettingsMenuState = if (s.value) SettingsMenuState.Closed else SettingsMenuState.Open
 
-object AladinSettings {
-  val Default = AladinSettings(false, false)
-}
+type SettingsMenuState = SettingsMenuState.Type
 
 object AladinCell extends ModelOptics {
   private type Props = AladinCell
@@ -96,13 +109,19 @@ object AladinCell extends ModelOptics {
       t => t.copy(fovRA = f.x, fovDec = f.y)
     )
 
+  val targetPrefs: Lens[(UserGlobalPreferences, TargetVisualOptions), TargetVisualOptions] =
+    Focus[(UserGlobalPreferences, TargetVisualOptions)](_._2)
+
+  val userPrefs: Lens[(UserGlobalPreferences, TargetVisualOptions), UserGlobalPreferences] =
+    Focus[(UserGlobalPreferences, TargetVisualOptions)](_._1)
+
   private val component =
     ScalaFnComponent
       .withHooks[Props]
       // mouse coordinates, starts on the base
       .useStateBy(_.asterism.baseTracking.baseCoordinates)
       // target options, will be read from the user preferences
-      .useStateView(Pot.pending[TargetVisualOptions])
+      .useStateView(Pot.pending[(UserGlobalPreferences, TargetVisualOptions)])
       // flag to trigger centering. This is a bit brute force but
       // avoids us needing a ref to a Fn component
       .useStateView(false)
@@ -131,19 +150,9 @@ object AladinCell extends ModelOptics {
 
           TargetPreferences
             .queryWithDefault[IO](props.uid, props.tid, Constants.InitialFov)
-            .flatMap { (fovRA, fovDec, viewOffset, agsCandidates, agsOverlay, fullScreen) =>
+            .flatMap { (up, tp) =>
               options
-                .set(
-                  TargetVisualOptions.Default
-                    .copy(fovRA = fovRA,
-                          fovDec = fovDec,
-                          viewOffset = viewOffset,
-                          agsCandidates = agsCandidates,
-                          agsOverlay = agsOverlay,
-                          fullScreen = fullScreen
-                    )
-                    .ready
-                )
+                .set((up, tp).ready)
                 .to[IO]
             }
       }
@@ -212,7 +221,7 @@ object AladinCell extends ModelOptics {
         }
       }
       // open settings menu
-      .useState(false)
+      .useState(SettingsMenuState.Closed)
       // Reset the selected gs if results change
       .useEffectWithDepsBy((p, _, _, _, _, agsResults, _, _, _) => (agsResults, p.obsConf)) {
         (p, _, _, _, _, agsResults, agsState, selectedIndex, _) => _ =>
@@ -237,23 +246,39 @@ object AladinCell extends ModelOptics {
           import props.given
 
           val agsCandidatesView =
-            options.zoom(Pot.readyPrism.andThen(TargetVisualOptions.agsCandidates))
+            options.zoom(
+              Pot.readyPrism.andThen(targetPrefs).andThen(TargetVisualOptions.agsCandidates)
+            )
 
           val agsOverlayView =
-            options.zoom(Pot.readyPrism.andThen(TargetVisualOptions.agsOverlay))
+            options.zoom(
+              Pot.readyPrism.andThen(targetPrefs).andThen(TargetVisualOptions.agsOverlay)
+            )
 
           val fovView =
-            options.zoom(Pot.readyPrism.andThen(fovLens))
+            options.zoom(Pot.readyPrism.andThen(targetPrefs).andThen(fovLens))
 
           val offsetView =
-            options.zoom(Pot.readyPrism.andThen(TargetVisualOptions.viewOffset))
+            options.zoom(
+              Pot.readyPrism.andThen(targetPrefs).andThen(TargetVisualOptions.viewOffset)
+            )
 
           val fullScreenView =
-            options.zoom(Pot.readyPrism.andThen(TargetVisualOptions.fullScreen))
+            options.zoom(
+              Pot.readyPrism.andThen(targetPrefs).andThen(TargetVisualOptions.fullScreen)
+            )
+
+          val allowMouseZoomView =
+            options.zoom(
+              Pot.readyPrism.andThen(userPrefs).andThen(UserGlobalPreferences.aladinMouseScroll)
+            )
 
           val agsCandidatesShown: Boolean = agsCandidatesView.get.map(_.visible).getOrElse(false)
 
           val agsOverlayShown: Boolean = agsOverlayView.get.map(_.visible).getOrElse(false)
+
+          val allowMouseZoom: AladinMouseScroll =
+            allowMouseZoomView.get.getOrElse(AladinMouseScroll.Allowed)
 
           val coordinatesSetter =
             ((c: Coordinates) => mouseCoords.setState(c)).reuseAlways
@@ -264,8 +289,8 @@ object AladinCell extends ModelOptics {
               _ => true,
               o =>
                 // Don't save if the change is less than 1 arcse
-                (o.fovRA.toMicroarcseconds - newFov.x.toMicroarcseconds).abs < 1e6 &&
-                  (o.fovDec.toMicroarcseconds - newFov.y.toMicroarcseconds).abs < 1e6
+                (o._2.fovRA.toMicroarcseconds - newFov.x.toMicroarcseconds).abs < 1e6 &&
+                  (o._2.fovDec.toMicroarcseconds - newFov.y.toMicroarcseconds).abs < 1e6
             )
             if (newFov.x.toMicroarcseconds === 0L) Callback.empty
             else {
@@ -294,15 +319,15 @@ object AladinCell extends ModelOptics {
               true,
               _ => true,
               o => {
-                val diffP = newOffset.p.toAngle.difference(o.viewOffset.p.toAngle)
-                val diffQ = newOffset.q.toAngle.difference(o.viewOffset.q.toAngle)
+                val diffP = newOffset.p.toAngle.difference(o._2.viewOffset.p.toAngle)
+                val diffQ = newOffset.q.toAngle.difference(o._2.viewOffset.q.toAngle)
                 // Don't save if the change is less than 1 arcse
                 diffP.toMicroarcseconds < 1e6 && diffQ.toMicroarcseconds < 1e6
               }
             )
 
             offsetView.set(newOffset) *>
-              UserTargetPreferencesFovUpdate
+              UserTargetOffsetUpdate
                 .updateViewOffset[IO](props.uid, props.tid, newOffset)
                 .unlessA(ignore)
                 .runAsync
@@ -344,26 +369,32 @@ object AladinCell extends ModelOptics {
               fullScreenView.mod(!_) *>
               prefsSetter(identity, identity, !_)
 
+          def mouseScrollSetter: Callback =
+            allowMouseZoomView.mod(_.flip) *>
+              UserPreferences.storePreferences[IO](props.uid, allowMouseZoom.flip).runAsync
+
           val aladinKey = s"${props.asterism}"
 
           val selectedGuideStar = selectedGSIndex.get.flatMap(agsResults.value.lift)
           val usableGuideStar   = selectedGuideStar.exists(_.isUsable)
 
-          val renderCell: TargetVisualOptions => VdomNode = (t: TargetVisualOptions) =>
-            AladinContainer(
-              props.asterism,
-              props.obsConf,
-              t.copy(fullScreen = props.fullScreen.get),
-              coordinatesSetter,
-              fovSetter.reuseAlways,
-              offsetSetter.reuseAlways,
-              center,
-              selectedGuideStar,
-              agsResults.value
-            ).withKey(aladinKey)
+          val renderCell: ((UserGlobalPreferences, TargetVisualOptions)) => VdomNode =
+            case (u: UserGlobalPreferences, t: TargetVisualOptions) =>
+              AladinContainer(
+                props.asterism,
+                props.obsConf,
+                u.aladinMouseScroll,
+                t.copy(fullScreen = props.fullScreen.get),
+                coordinatesSetter,
+                fovSetter.reuseAlways,
+                offsetSetter.reuseAlways,
+                center,
+                selectedGuideStar,
+                agsResults.value
+              ).withKey(aladinKey)
 
-          val renderToolbar: TargetVisualOptions => VdomNode =
-            (t: TargetVisualOptions) =>
+          val renderToolbar: ((UserGlobalPreferences, TargetVisualOptions)) => VdomNode =
+            case (_: UserGlobalPreferences, t: TargetVisualOptions) =>
               AladinToolbar(Fov(t.fovRA, t.fovDec),
                             mouseCoords.value,
                             agsState.value,
@@ -372,8 +403,8 @@ object AladinCell extends ModelOptics {
                             t.agsOverlay
               ): VdomNode
 
-          val renderAgsOverlay: TargetVisualOptions => VdomNode =
-            (t: TargetVisualOptions) =>
+          val renderAgsOverlay: ((UserGlobalPreferences, TargetVisualOptions)) => VdomNode =
+            case (u: UserGlobalPreferences, t: TargetVisualOptions) =>
               if (t.agsOverlay.visible && usableGuideStar) {
                 <.div(
                   ExploreStyles.AgsOverlay,
@@ -396,9 +427,9 @@ object AladinCell extends ModelOptics {
               ),
               <.div(
                 ExploreStyles.AladinToolbox,
-                Button(size = Small, icon = true, onClick = openSettings.modState(!_))(
+                Button(size = Small, icon = true, onClick = openSettings.modState(_.flip))(
                   ExploreStyles.ButtonOnAladin,
-                  ^.onMouseEnter --> openSettings.setState(true),
+                  ^.onMouseEnter --> openSettings.setState(SettingsMenuState.Open),
                   Icons.ThinSliders
                 ),
                 Menu(vertical = true,
@@ -406,26 +437,37 @@ object AladinCell extends ModelOptics {
                      size = Mini,
                      clazz = ExploreStyles.AladinSettingsMenu
                 )(
-                  ^.onMouseLeave --> openSettings.setState(false),
+                  ^.onMouseLeave --> openSettings.setState(SettingsMenuState.Closed),
                   MenuItem(
                     Checkbox(
                       label = "Show Catalog",
                       checked = agsCandidatesShown,
-                      onChange = (_: Boolean) => openSettings.setState(false) *> candidatesSetter
+                      onChange = (_: Boolean) =>
+                        openSettings.setState(SettingsMenuState.Closed) *> candidatesSetter
                     )
                   ),
                   MenuItem(
                     Checkbox(
                       label = "AGS",
                       checked = agsOverlayShown,
-                      onChange = (_: Boolean) => openSettings.setState(false) *> agsOverlaySetter
+                      onChange = (_: Boolean) =>
+                        openSettings.setState(SettingsMenuState.Closed) *> agsOverlaySetter
+                    )
+                  ),
+                  Divider(fitted = true),
+                  MenuItem(
+                    Checkbox(
+                      label = "Scroll to zoom",
+                      checked = allowMouseZoom.value,
+                      onChange = (_: Boolean) =>
+                        openSettings.setState(SettingsMenuState.Closed) *> mouseScrollSetter
                     )
                   )
-                ).when(openSettings.value)
+                ).when(openSettings.value.value)
               ),
-              potRenderView[TargetVisualOptions](renderCell)(options),
-              potRenderView[TargetVisualOptions](renderToolbar)(options),
-              potRenderView[TargetVisualOptions](renderAgsOverlay)(options)
+              potRenderView[(UserGlobalPreferences, TargetVisualOptions)](renderCell)(options),
+              potRenderView[(UserGlobalPreferences, TargetVisualOptions)](renderToolbar)(options),
+              potRenderView[(UserGlobalPreferences, TargetVisualOptions)](renderAgsOverlay)(options)
             )
           )
       }

--- a/model/shared/src/main/scala/explore/model/UserGlobalPreferences.scala
+++ b/model/shared/src/main/scala/explore/model/UserGlobalPreferences.scala
@@ -1,0 +1,28 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import lucuma.core.util.NewType
+import monocle.Focus
+
+object AladinMouseScroll extends NewType[Boolean]:
+  val Allowed: AladinMouseScroll  = AladinMouseScroll(true)
+  val Disabled: AladinMouseScroll = AladinMouseScroll(false)
+  extension (s: AladinMouseScroll)
+    def flip: AladinMouseScroll =
+      if (s.value) AladinMouseScroll.Disabled else AladinMouseScroll.Allowed
+
+type AladinMouseScroll = AladinMouseScroll.Type
+
+case class UserGlobalPreferences(
+  aladinMouseScroll: AladinMouseScroll
+) derives Eq
+
+object UserGlobalPreferences:
+  val aladinMouseScroll = Focus[UserGlobalPreferences](_.aladinMouseScroll)
+
+  val Default =
+    UserGlobalPreferences(AladinMouseScroll.Allowed)


### PR DESCRIPTION
Mouse interaction with aladin can now be disabled with a global (per user) setting.
interaction is also disabled on mobiles as it is very hard to scroll if you have aladin on the viewport

This also include settings for a separate production user prefs server and a little bit of documentation about user preferences in general