### PR TITLE
Select the first available target for the elevation plot

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -214,9 +214,14 @@ object ObsTabTiles {
 
         val constraintsSelector = makeConstraintsSelector(props.constraintGroups, obsViewPot)
 
+        // first target of the obs. We can use it in case there is no target focus
+        val firstTarget = props.targetMap.collect {
+          case (tid, ts) if props.focusedObs.forall(o => ts.obsIds.contains(o)) => tid
+        }.headOption
+
         val skyPlotTile =
           ElevationPlotTile.elevationPlotTile(props.userId,
-                                              props.focusedTarget,
+                                              props.focusedTarget.orElse(firstTarget),
                                               scienceMode,
                                               targetCoords,
                                               vizTime


### PR DESCRIPTION
This is a small fix where the elevation plot is not show if the selection is focused on the obs though there are available targets