### PR TITLE
Aladin image zooms when changing constraints

### DIFF
--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -55,8 +55,6 @@ object reusability {
   implicit val obsIdSetReuse: Reusability[ObsIdSet]                                   = Reusability.byEq
   implicit val targetIdSetReuse: Reusability[TargetIdSet]                             = Reusability.byEq
   implicit val targetWithIdReuse: Reusability[TargetWithId]                           = Reusability.byEq
-  implicit val asterismReuse: Reusability[Asterism]                                   = Reusability.byEq
-  implicit val targetWithOptIdReuse: Reusability[TargetWithOptId]                     = Reusability.byEq
   implicit val targetWithIdAndObsReuse: Reusability[TargetWithIdAndObs]               = Reusability.byEq
   implicit val targetWithObsReuse: Reusability[TargetWithObs]                         = Reusability.byEq
   implicit val constraintsSummaryReuse: Reusability[ConstraintsSummary]               = Reusability.byEq
@@ -121,4 +119,8 @@ object reusability {
     reusability: Reusability[W]
   ): Reusability[T] =
     reusability.asInstanceOf[Reusability[T]]
+
+  given Reusability[Asterism] = Reusability.byEq[Asterism].logNonReusable
+
+  implicit val targetWithOptIdReuse: Reusability[TargetWithOptId] = Reusability.byEq
 }

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -120,7 +120,9 @@ object reusability {
   ): Reusability[T] =
     reusability.asInstanceOf[Reusability[T]]
 
-  given Reusability[Asterism] = Reusability.byEq[Asterism].logNonReusable
+  given Reusability[Asterism] = Reusability.byEq[Asterism]
 
-  implicit val targetWithOptIdReuse: Reusability[TargetWithOptId] = Reusability.byEq
+  given Reusability[TargetWithOptId] = Reusability.byEq
+
+  given Reusability[UserGlobalPreferences] = Reusability.byEq
 }

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -283,12 +283,11 @@ object AladinCell extends ModelOptics {
               _ => true,
               o =>
                 // Don't save if the change is less than 1 arcse
-                (o._2.fovRA.toMicroarcseconds - newFov.x.toMicroarcseconds).abs < 1e7 ||
-                  (o._2.fovDec.toMicroarcseconds - newFov.y.toMicroarcseconds).abs < 1e7
+                o._2.fov.isDifferentEnough(newFov)
             )
             if (newFov.x.toMicroarcseconds === 0L) Callback.empty
             else {
-              fovView.set(newFov) *>
+              fovView.set(newFov).unless_(ignore) *>
                 TargetPreferences
                   .updateAladinPreferences[IO](props.uid, props.tid, newFov.x.some, newFov.y.some)
                   .unlessA(ignore)

--- a/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -33,7 +33,7 @@ case class AladinToolbar(
   current:           Coordinates,
   agsState:          AgsState,
   selectedGuideStar: Option[AgsAnalysis],
-  center:            View[Boolean],
+  center:            View[CenterTargetTrigger],
   agsOverlay:        Visible
 ) extends ReactFnProps(AladinToolbar.component)
 
@@ -91,7 +91,10 @@ object AladinToolbar {
         <.div(
           ExploreStyles.AladinCenterButton,
           <.span(
-            Button(size = Mini, icon = true, onClick = props.center.set(true))(
+            Button(size = Mini,
+                   icon = true,
+                   onClick = props.center.set(CenterTargetTrigger.Trigger)
+            )(
               Icons.Bullseye
                 .transform(Transform(size = 24))
                 .clazz(ExploreStyles.Accented)

--- a/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinToolbar.scala
@@ -3,18 +3,18 @@
 
 package explore.targeteditor
 
-import cats.syntax.all._
+import cats.syntax.all.*
 import crystal.react.View
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.model.enums.AgsState
 import explore.model.enums.Visible
-import explore.model.formats._
-import japgolly.scalajs.react._
-import japgolly.scalajs.react.vdom.html_<^._
+import explore.model.formats.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.ags.AgsAnalysis
 import lucuma.ags.GuideStarCandidate
-import lucuma.core.math._
+import lucuma.core.math.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import react.aladin.Fov
@@ -23,10 +23,10 @@ import react.fa.Transform
 import react.floatingui.Placement
 import react.floatingui.syntax.*
 import react.semanticui.elements.button.Button
-import react.semanticui.elements.label._
-import react.semanticui.shorthand._
+import react.semanticui.elements.label.*
+import react.semanticui.shorthand.*
 import react.semanticui.sizes.Small
-import react.semanticui.sizes._
+import react.semanticui.sizes.*
 
 case class AladinToolbar(
   fov:               Fov,

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -23,6 +23,7 @@ import explore.model.SiderealTargetWithId
 import explore.model.TargetWithId
 import explore.model.TargetWithOptId
 import explore.model.reusability.*
+import explore.model.reusability.given
 import explore.optics.*
 import explore.optics.all.*
 import explore.targets.TargetSelectionPopup

--- a/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
@@ -29,7 +29,6 @@ import lucuma.core.math.dimensional.*
 import lucuma.core.math.units.*
 import lucuma.core.model.EmissionLine
 import lucuma.core.util.Enumerated
-import lucuma.core.util.NewType
 import lucuma.core.validation.*
 import lucuma.refined.*
 import lucuma.ui.forms.EnumViewSelect
@@ -47,9 +46,6 @@ import reactST.reactTable.mod.SortingRule
 
 import scala.collection.immutable.SortedMap
 import scala.math.BigDecimal.RoundingMode
-
-object AddDisabled extends NewType[Boolean]
-type AddDisabled = AddDisabled.Type
 
 sealed trait EmissionLineEditor[T] {
   val emissionLines: View[SortedMap[Wavelength, EmissionLine[T]]]

--- a/explore/src/main/scala/explore/targeteditor/TargetTable.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetTable.scala
@@ -19,6 +19,7 @@ import explore.model.Asterism
 import explore.model.ObsIdSet
 import explore.model.SiderealTargetWithId
 import explore.model.reusability.*
+import explore.model.reusability.given
 import explore.targets.TargetColumns
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*

--- a/explore/src/main/scala/explore/targeteditor/package.scala
+++ b/explore/src/main/scala/explore/targeteditor/package.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targeteditor
+
+import explore.model.TargetVisualOptions
+import lucuma.core.util.NewType
+import react.aladin.Fov
+
+extension (options: TargetVisualOptions) inline def fov: Fov = Fov(options.fovRA, options.fovDec)
+
+extension (fov: Fov)
+  def isDifferentEnough(newFov: Fov): Boolean =
+    (fov.x.toMicroarcseconds - newFov.x.toMicroarcseconds).abs < 1e7 ||
+      (fov.y.toMicroarcseconds - newFov.y.toMicroarcseconds).abs < 1e7
+
+object SettingsMenuState extends NewType[Boolean]:
+  inline def Open: SettingsMenuState   = SettingsMenuState(true)
+  inline def Closed: SettingsMenuState = SettingsMenuState(false)
+  extension (s: SettingsMenuState)
+    def flip: SettingsMenuState = if (s.value) SettingsMenuState.Closed else SettingsMenuState.Open
+
+type SettingsMenuState = SettingsMenuState.Type
+
+object CenterTargetTrigger extends NewType[Boolean]:
+  inline def Trigger: CenterTargetTrigger = CenterTargetTrigger(true)
+  inline def Idle: CenterTargetTrigger    = CenterTargetTrigger(false)
+
+type CenterTargetTrigger = CenterTargetTrigger.Type
+
+object AddDisabled extends NewType[Boolean]
+type AddDisabled = AddDisabled.Type

--- a/explore/src/main/scala/explore/visualization/package.scala
+++ b/explore/src/main/scala/explore/visualization/package.scala
@@ -10,7 +10,7 @@ import lucuma.core.util.NewType
 import org.locationtech.jts.geom.Geometry
 import react.aladin.Fov
 
-import scala.math._
+import scala.math.*
 
 // The values on the geometry are in microarcseconds
 // They are fairly large and break is some browsers


### PR DESCRIPTION
There is a cycle with Aladin where you ask it to use a fov (x) and it sends you back what fov is actually using (y). They don't always match but we need to get the real value to react to zoom changes. The small differences add up to produce undesired zoom when e.g. resizing. Surprisingly this is more evident for Linux users.

This PR essentially skip recording very small fov changes.
Also it was noticed that the aladin window would flash in certain cases because of unnecessary re renderings.
To solve these `Reusability` was reintroduced.
I tested this quite a bit but there maybe some regression in certain cases