### PR TITLE
Separate toInput extensions again

### DIFF
--- a/common-queries/src/main/scala/queries/schemas/itc/ITCConversions.scala
+++ b/common-queries/src/main/scala/queries/schemas/itc/ITCConversions.scala
@@ -29,7 +29,7 @@ import eu.timepit.refined.types.numeric.PosLong
 import eu.timepit.refined.types.numeric.NonNegBigDecimal
 
 // There is a lot of duplication here with the odb.conversions package
-object conversions:
+trait ITCConversions:
   type SpectroscopyModeInput = ITC.Types.SpectroscopyModeInput
   val SpectroscopyModeInput = ITC.Types.SpectroscopyModeInput
   type GmosNorthFpuInput = ITC.Types.GmosNorthFpuInput
@@ -223,3 +223,5 @@ object conversions:
       case r: GmosSouthSpectroscopyRow =>
         InstrumentModesInput(gmosS = r.toGmosSITCInput).some
       case _                           => none
+
+object ITCConversions extends ITCConversions

--- a/common-queries/src/main/scala/queries/schemas/odb/ODBConversions.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ODBConversions.scala
@@ -23,14 +23,11 @@ import lucuma.schemas.ObservationDB.Types.*
 
 import scala.collection.immutable.SortedMap
 import scala.annotation.targetName
-import explore.model.ScienceModeBasic
-import explore.model.ScienceModeAdvanced
-import explore.model.ScienceMode
 
 case class WidthUpsertInput(user: User.Id, section: ResizableSection, width: Int)
 
 // TODO Move to lucuma-schemas
-object conversions:
+trait ODBConversions:
   extension (id: Observation.Id)
     def toWhereObservation: WhereObservation =
       WhereObservation(id = WhereOrderObservationId(EQ = id.assign).assign)
@@ -366,69 +363,4 @@ object conversions:
         ).assign
       )
 
-  extension (b: ScienceModeBasic.GmosNorthLongSlit)
-    def toInput: GmosNorthLongSlitBasicConfigInput =
-      GmosNorthLongSlitBasicConfigInput(b.grating.assign, b.filter.orUnassign, b.fpu.assign)
-
-  extension (b: ScienceModeBasic.GmosSouthLongSlit)
-    def toInput: GmosSouthLongSlitBasicConfigInput =
-      GmosSouthLongSlitBasicConfigInput(b.grating.assign, b.filter.orUnassign, b.fpu.assign)
-
-  extension [A](o: Offset.Component[A])
-    def toInput: OffsetComponentInput =
-      OffsetComponentInput(microarcseconds = o.toAngle.toMicroarcseconds.assign)
-
-  extension (a: ScienceModeAdvanced.GmosNorthLongSlit)
-    def toInput: GmosNorthLongSlitAdvancedConfigInput =
-      GmosNorthLongSlitAdvancedConfigInput(
-        a.overrideWavelength.map(_.toInput).orUnassign,
-        a.overrideGrating.orUnassign,
-        a.overrideFilter.orUnassign,
-        a.overrideFpu.orUnassign,
-        a.overrideExposureTimeMode.map(_.toInput).orUnassign,
-        a.explicitXBin.orUnassign,
-        a.explicitYBin.orUnassign,
-        a.explicitAmpReadMode.orUnassign,
-        a.explicitAmpGain.orUnassign,
-        a.explicitRoi.orUnassign,
-        a.explicitWavelengthDithers
-          .map(_.toList.map(_.value))
-          .orUnassign,
-        a.explicitSpatialOffsets.map(_.toList.map(_.toInput)).orUnassign
-      )
-
-  extension (a: ScienceModeAdvanced.GmosSouthLongSlit)
-    def toInput: GmosSouthLongSlitAdvancedConfigInput =
-      GmosSouthLongSlitAdvancedConfigInput(
-        a.overrideWavelength.map(_.toInput).orUnassign,
-        a.overrideGrating.orUnassign,
-        a.overrideFilter.orUnassign,
-        a.overrideFpu.orUnassign,
-        a.overrideExposureTimeMode.map(_.toInput).orUnassign,
-        a.explicitXBin.orUnassign,
-        a.explicitYBin.orUnassign,
-        a.explicitAmpReadMode.orUnassign,
-        a.explicitAmpGain.orUnassign,
-        a.explicitRoi.orUnassign,
-        a.explicitWavelengthDithers
-          .map(_.toList.map(_.value))
-          .orUnassign,
-        a.explicitSpatialOffsets.map(_.toList.map(_.toInput)).orUnassign
-      )
-
-  extension (b: ScienceMode)
-    def toInput: ScienceModeInput = b match
-      case ScienceMode.GmosNorthLongSlit(basic, advanced) =>
-        ScienceModeInput(
-          gmosNorthLongSlit = GmosNorthLongSlitInput(
-            basic = basic.toInput.assign,
-            advanced = advanced.toInput.assign
-          ).assign
-        )
-      case ScienceMode.GmosSouthLongSlit(basic, advanced) =>
-        ScienceModeInput(
-          gmosSouthLongSlit = GmosSouthLongSlitInput(
-            basic = basic.toInput.assign,
-            advanced = advanced.toInput.assign
-          ).assign
-        )
+object ODBConversions extends ODBConversions

--- a/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -32,13 +32,13 @@ import monocle.Focus
 import monocle.Getter
 import monocle.Lens
 import queries.common.ObsQueriesGQL.*
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 
 import java.time.Instant
 import scala.collection.immutable.SortedMap
 import lucuma.core.model.ExposureTimeMode.FixedExposure
 
-object ObsQueries {
+object ObsQueries:
   type ObservationList = KeyedIndexedList[Observation.Id, ObsSummaryWithTitleConstraintsAndConf]
   type ConstraintsList = SortedMap[ObsIdSet, ConstraintGroup]
 
@@ -278,4 +278,3 @@ object ObsQueries {
         UndeleteObservationsInput(WHERE = obsId.toWhereObservation.assign)
       )
       .void
-}

--- a/common/src/main/scala/explore/common/AsterismQueries.scala
+++ b/common/src/main/scala/explore/common/AsterismQueries.scala
@@ -23,7 +23,7 @@ import monocle.Focus
 import monocle.Getter
 import queries.common.AsterismQueriesGQL.*
 import queries.common.ObsQueriesGQL.*
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet

--- a/common/src/main/scala/explore/common/ConstraintsQueries.scala
+++ b/common/src/main/scala/explore/common/ConstraintsQueries.scala
@@ -20,8 +20,7 @@ import lucuma.schemas.ObservationDB.Types.*
 import monocle.Lens
 import org.typelevel.log4cats.Logger
 import queries.common.ObsQueriesGQL.*
-import queries.schemas.odb.conversions.*
-
+import queries.schemas.odb.ODBConversions.*
 object ConstraintsQueries:
   case class UndoView(
     obsIds:  List[Observation.Id],

--- a/common/src/main/scala/explore/common/ProgramQueries.scala
+++ b/common/src/main/scala/explore/common/ProgramQueries.scala
@@ -17,7 +17,7 @@ import lucuma.ui.reusability.*
 import monocle.Focus
 import monocle.Lens
 import queries.common.ProgramQueriesGQL.*
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 
 object ProgramQueries:
   case class ProgramInfo(id: Program.Id, name: Option[NonEmptyString], deleted: Boolean)

--- a/common/src/main/scala/explore/common/ScienceConversions.scala
+++ b/common/src/main/scala/explore/common/ScienceConversions.scala
@@ -1,0 +1,82 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.common
+
+import clue.data.syntax.*
+import explore.model.ScienceMode
+import explore.model.ScienceModeAdvanced
+import explore.model.ScienceModeBasic
+import lucuma.core.math.*
+import lucuma.schemas.ObservationDB.Types.*
+import queries.schemas.odb.ODBConversions
+
+trait ScienceConversions extends ODBConversions:
+  extension (b: ScienceModeBasic.GmosNorthLongSlit)
+    def toInput: GmosNorthLongSlitBasicConfigInput =
+      GmosNorthLongSlitBasicConfigInput(b.grating.assign, b.filter.orUnassign, b.fpu.assign)
+
+  extension (b: ScienceModeBasic.GmosSouthLongSlit)
+    def toInput: GmosSouthLongSlitBasicConfigInput =
+      GmosSouthLongSlitBasicConfigInput(b.grating.assign, b.filter.orUnassign, b.fpu.assign)
+
+  extension [A](o: Offset.Component[A])
+    def toInput: OffsetComponentInput =
+      OffsetComponentInput(microarcseconds = o.toAngle.toMicroarcseconds.assign)
+
+  extension (a: ScienceModeAdvanced.GmosNorthLongSlit)
+    def toInput: GmosNorthLongSlitAdvancedConfigInput =
+      GmosNorthLongSlitAdvancedConfigInput(
+        a.overrideWavelength.map(_.toInput).orUnassign,
+        a.overrideGrating.orUnassign,
+        a.overrideFilter.orUnassign,
+        a.overrideFpu.orUnassign,
+        a.overrideExposureTimeMode.map(_.toInput).orUnassign,
+        a.explicitXBin.orUnassign,
+        a.explicitYBin.orUnassign,
+        a.explicitAmpReadMode.orUnassign,
+        a.explicitAmpGain.orUnassign,
+        a.explicitRoi.orUnassign,
+        a.explicitWavelengthDithers
+          .map(_.toList.map(_.value))
+          .orUnassign,
+        a.explicitSpatialOffsets.map(_.toList.map(_.toInput)).orUnassign
+      )
+
+  extension (a: ScienceModeAdvanced.GmosSouthLongSlit)
+    def toInput: GmosSouthLongSlitAdvancedConfigInput =
+      GmosSouthLongSlitAdvancedConfigInput(
+        a.overrideWavelength.map(_.toInput).orUnassign,
+        a.overrideGrating.orUnassign,
+        a.overrideFilter.orUnassign,
+        a.overrideFpu.orUnassign,
+        a.overrideExposureTimeMode.map(_.toInput).orUnassign,
+        a.explicitXBin.orUnassign,
+        a.explicitYBin.orUnassign,
+        a.explicitAmpReadMode.orUnassign,
+        a.explicitAmpGain.orUnassign,
+        a.explicitRoi.orUnassign,
+        a.explicitWavelengthDithers
+          .map(_.toList.map(_.value))
+          .orUnassign,
+        a.explicitSpatialOffsets.map(_.toList.map(_.toInput)).orUnassign
+      )
+
+  extension (b: ScienceMode)
+    def toInput: ScienceModeInput = b match
+      case ScienceMode.GmosNorthLongSlit(basic, advanced) =>
+        ScienceModeInput(
+          gmosNorthLongSlit = GmosNorthLongSlitInput(
+            basic = basic.toInput.assign,
+            advanced = advanced.toInput.assign
+          ).assign
+        )
+      case ScienceMode.GmosSouthLongSlit(basic, advanced) =>
+        ScienceModeInput(
+          gmosSouthLongSlit = GmosSouthLongSlitInput(
+            basic = basic.toInput.assign,
+            advanced = advanced.toInput.assign
+          ).assign
+        )
+
+object ScienceConversions extends ScienceConversions

--- a/common/src/main/scala/explore/common/ScienceQueries.scala
+++ b/common/src/main/scala/explore/common/ScienceQueries.scala
@@ -23,8 +23,8 @@ import lucuma.schemas.ObservationDB.Types.*
 import monocle.Lens
 import org.typelevel.log4cats.Logger
 import queries.common.ObsQueriesGQL.*
+import queries.schemas.odb.ODBConversions.*
 import queries.schemas.odb.ObsQueries.*
-import queries.schemas.odb.conversions.*
 
 object ScienceQueries:
 

--- a/common/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/common/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -35,14 +35,14 @@ import queries.schemas.UserPreferencesDB.Enums.*
 import queries.schemas.UserPreferencesDB.Scalars.*
 import queries.schemas.UserPreferencesDB.Types.LucumaObservationInsertInput
 import queries.schemas.UserPreferencesDB.Types.*
+import queries.schemas.odb.ODBConversions.*
 import queries.schemas.odb.WidthUpsertInput
-import queries.schemas.odb.conversions.*
 import react.gridlayout.{BreakpointName => _, _}
 import reactST.highcharts.highchartsStrings.chart_
 
 import scala.collection.immutable.SortedMap
 
-object UserPreferencesQueries {
+object UserPreferencesQueries:
 
   implicit class UserWidthsCreationOps(val self: UserWidthsCreation.type) extends AnyVal {
     import self.*
@@ -365,5 +365,3 @@ object UserPreferencesQueries {
         w.user.toString.assign,
         w.width.assign
       )
-
-}

--- a/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
@@ -25,6 +25,7 @@ import eu.timepit.refined.types.numeric.PosInt
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.Icons
 import explore.common.Aligner
+import explore.common.ScienceConversions.*
 import explore.common.ScienceQueries.*
 import explore.components.HelpIcon
 import explore.components.InputWithUnits
@@ -80,7 +81,6 @@ import monocle.Lens
 import mouse.boolean.*
 import org.typelevel.log4cats.Logger
 import queries.schemas.odb.ObsQueries.*
-import queries.schemas.odb.conversions.*
 import react.common.Css
 import react.common.ReactFnProps
 import react.fa.IconSize

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -18,6 +18,7 @@ import eu.timepit.refined.auto.*
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.*
 import explore.common.Aligner
+import explore.common.ScienceConversions.*
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
@@ -47,7 +48,6 @@ import lucuma.ui.syntax.all.given
 import org.http4s.syntax.all.*
 import queries.common.ObsQueriesGQL
 import queries.schemas.odb.ObsQueries.*
-import queries.schemas.odb.conversions.*
 import react.common.ReactFnProps
 
 case class ConfigurationPanel(

--- a/explore/src/main/scala/explore/config/SequenceEditor.scala
+++ b/explore/src/main/scala/explore/config/SequenceEditor.scala
@@ -11,7 +11,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
 import lucuma.ui.syntax.all.given
 import queries.common.ManualSequenceGQL.*
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 
 case class SequenceEditor(programId: Program.Id) extends ReactFnProps(SequenceEditor.component)

--- a/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
+++ b/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
@@ -55,7 +55,7 @@ import lucuma.ui.syntax.all.given
 import monocle.Focus
 import monocle.Lens
 import queries.common.UserPreferencesQueriesGQL.*
-import queries.schemas.itc.conversions.*
+import queries.schemas.itc.ITCConversions.*
 import queries.schemas.odb.ObsQueries.*
 import react.common.ReactFnProps
 

--- a/explore/src/main/scala/explore/itc/ItcPanelProps.scala
+++ b/explore/src/main/scala/explore/itc/ItcPanelProps.scala
@@ -25,7 +25,7 @@ import explore.modes.GmosSouthSpectroscopyRow
 import explore.modes.InstrumentRow
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ExposureTimeMode
-import queries.schemas.itc.conversions.*
+import queries.schemas.itc.ITCConversions.*
 import queries.schemas.odb.ObsQueries.*
 import react.common.ReactFnProps
 import workers.WorkerClient

--- a/explore/src/main/scala/explore/itc/ItcPanelTitle.scala
+++ b/explore/src/main/scala/explore/itc/ItcPanelTitle.scala
@@ -30,7 +30,7 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.given
-import queries.schemas.itc.conversions.*
+import queries.schemas.itc.ITCConversions.*
 import queries.schemas.odb.ObsQueries.*
 import react.common.ReactFnProps
 import react.floatingui.syntax.*

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -33,7 +33,7 @@ import lucuma.ui.syntax.all.given
 import mouse.boolean.*
 import org.typelevel.log4cats.Logger
 import queries.common.TargetQueriesGQL
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 import react.beautifuldnd.*
 import react.common.ReactFnProps
 import react.fa.FontAwesomeIcon

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsListActions.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsListActions.scala
@@ -22,7 +22,7 @@ import lucuma.core.model.Target
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Types.*
 import queries.common.TargetQueriesGQL
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 
 import scala.annotation.unused
 import scala.collection.immutable.SortedSet

--- a/explore/src/main/scala/explore/observationtree/ObsListActions.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsListActions.scala
@@ -20,8 +20,8 @@ import lucuma.schemas.ObservationDB.Types.*
 import monocle.Focus
 import monocle.Iso
 import queries.common.ObsQueriesGQL.*
+import queries.schemas.odb.ODBConversions.*
 import queries.schemas.odb.ObsQueries
-import queries.schemas.odb.conversions.*
 
 trait ObsListActions {
   protected val obsListMod =

--- a/explore/src/main/scala/explore/proposal/ProposalEditor.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalEditor.scala
@@ -53,7 +53,7 @@ import lucuma.ui.syntax.all.given
 import monocle.Iso
 import org.typelevel.log4cats.Logger
 import queries.common.ProgramQueriesGQL
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 import react.semanticui.collections.form.*
 import react.semanticui.elements.label.Label

--- a/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -32,7 +32,7 @@ import monocle.Focus
 import monocle.Lens
 import org.typelevel.log4cats.Logger
 import queries.common.ProgramQueriesGQL.*
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.image.Image

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -18,7 +18,7 @@ import lucuma.core.model.Observation
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
-import queries.schemas.itc.conversions.*
+import queries.schemas.itc.ITCConversions.*
 import queries.schemas.odb.ObsQueries.*
 
 object ConfigurationTile {

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -47,8 +47,8 @@ import monocle.Lens
 import monocle.std.option.some
 import org.typelevel.log4cats.Logger
 import queries.common.TargetQueriesGQL.*
+import queries.schemas.odb.ODBConversions.*
 import queries.schemas.odb.ObsQueries
-import queries.schemas.odb.conversions.*
 import react.common.ReactFnProps
 import react.semanticui.elements.button.*
 import react.semanticui.modules.checkbox.*

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -56,7 +56,7 @@ import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.utils.*
 import queries.common.TargetQueriesGQL
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 import react.semanticui.collections.form.Form
 import react.semanticui.elements.label.LabelPointing

--- a/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
@@ -25,7 +25,7 @@ import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.given
 import queries.schemas.*
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 
 case class SourceProfileEditor(

--- a/explore/src/main/scala/explore/targeteditor/SpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SpectralDefinitionEditor.scala
@@ -57,7 +57,7 @@ import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
-import queries.schemas.odb.conversions.*
+import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 import react.semanticui.elements.label.LabelPointing
 

--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -25,13 +25,13 @@ import lucuma.refined.*
 import org.typelevel.log4cats.Logger
 import queries.common.ITCQueriesGQL.*
 import queries.schemas.ITC
-import queries.schemas.itc.conversions.*
+import queries.schemas.itc.ITCConversions.*
 import workers.*
 
 import java.util.UUID
 import scala.concurrent.duration.*
 //
-object ITCGraphRequests {
+object ITCGraphRequests:
   // Picklers for generated types not in the model.
   private given Pickler[SpectroscopyGraphITCQuery.Data.SpectroscopyGraph.Ccds]   = generatePickler
   private given Pickler[SpectroscopyGraphITCQuery.Data.SpectroscopyGraph.Charts] =
@@ -115,5 +115,3 @@ object ITCGraphRequests {
             }.sequence.void
           }
     }.orEmpty
-
-}

--- a/workers/src/main/scala/workers/itc/ITCRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCRequests.scala
@@ -32,13 +32,13 @@ import org.scalajs.dom
 import org.typelevel.log4cats.Logger
 import queries.common.ITCQueriesGQL.*
 import queries.schemas.ITC
-import queries.schemas.itc.conversions.*
+import queries.schemas.itc.ITCConversions.*
 import workers.*
 
 import java.util.UUID
 import scala.concurrent.duration.*
 
-object ITCRequests {
+object ITCRequests:
   // Copied from https://gist.github.com/gvolpe/44e2263f9068efe298a1f30390de6d22
   def parTraverseN[F[_]: Concurrent: Parallel, G[_]: Traverse, A, B](
     n:  Long,
@@ -142,5 +142,3 @@ object ITCRequests {
       cache.eval(cacheableRequest).apply(params).flatMap(_.map(callback).orEmpty)
     }.void
   }
-
-}


### PR DESCRIPTION
Due to the way extension methods work, I joined all the `toInput` methods in the last PR since I couldn't get it to compile if kept separate.

See https://github.com/lampepfl/dotty/issues/15691#issuecomment-1186560928

However, it is desirable to have separately defined `toInput` methods for model classes (which we will move to `lucuma-schemas`) and for classes defined here. This PR separates them again using the suggestion from the above link to compose extension collections.