### PR TITLE
Switch facade for hotkeys and setup some shortcuts

### DIFF
--- a/common/src/main/scala/react/hotkeys/hooks.scala
+++ b/common/src/main/scala/react/hotkeys/hooks.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.hotkeys
+
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.TopNode
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters.*
+
+object HooksApiExt {
+
+  private def hook: CustomHook[UseHotkeysProps, Ref] =
+    CustomHook[UseHotkeysProps]
+      .buildReturning { pos =>
+        use.useHotkeys(pos)
+      }
+
+  sealed class Primary[Ctx, Step <: HooksApi.AbstractStep](api: HooksApi.Primary[Ctx, Step]) {
+
+    final def useHotkeys(pos: UseHotkeysProps)(using
+      step:                   Step
+    ): step.Next[Ref] =
+      useHotkeysBy(_ => pos)
+
+    final def useHotkeysBy(pos: Ctx => UseHotkeysProps)(using
+      step:                     Step
+    ): step.Next[Ref] =
+      api.customBy(ctx => hook(pos(ctx)))
+
+  }
+
+  final class Secondary[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ) extends Primary[Ctx, Step](api) {
+
+    def useHotkeysBy(pos: CtxFn[UseHotkeysProps])(using
+      step:               Step
+    ): step.Next[Ref] =
+      useHotkeysBy(step.squash(pos)(_))
+
+  }
+}
+
+trait HooksApiExt {
+  import HooksApiExt._
+  import scala.language.implicitConversions
+
+  implicit def hooksExtHotkeys1[Ctx, Step <: HooksApi.AbstractStep](
+    api: HooksApi.Primary[Ctx, Step]
+  ): Primary[Ctx, Step] =
+    new Primary(api)
+
+  implicit def hooksExtHotkeys2[Ctx, CtxFn[_], Step <: HooksApi.SubsequentStep[Ctx, CtxFn]](
+    api: HooksApi.Secondary[Ctx, CtxFn, Step]
+  ): Secondary[Ctx, CtxFn, Step] =
+    new Secondary(api)
+}
+
+object hooks extends HooksApiExt

--- a/common/src/main/scala/react/hotkeys/package.scala
+++ b/common/src/main/scala/react/hotkeys/package.scala
@@ -20,9 +20,7 @@ type HotkeysCallback = Callback | (HotkeysEvent => Callback)
 @js.native
 trait Options extends js.Object {
   var enabled: js.UndefOr[Boolean]                 = js.native
-  // filter?: (event: KeyboardEvent) => boolean;
   var filterPreventDefault: js.UndefOr[Boolean]    = js.native
-  // enableOnTags?: AvailableTags[];
   var enableOnContentEditable: js.UndefOr[Boolean] = js.native
   var splitKey: js.UndefOr[String]                 = js.native
   var keyup: js.UndefOr[Boolean]                   = js.native

--- a/common/src/main/scala/react/hotkeys/package.scala
+++ b/common/src/main/scala/react/hotkeys/package.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package react.hotkeys
+
+import cats.syntax.all.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.TopNode
+import org.scalajs.dom
+import org.scalajs.dom.html
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters._
+import scala.scalajs.js.annotation.JSImport
+import scala.scalajs.js.|
+
+type Ref             = Ref.Simple[dom.Element]
+type HotkeysCallback = Callback | (HotkeysEvent => Callback)
+
+@js.native
+trait Options extends js.Object {
+  var enabled: js.UndefOr[Boolean]                 = js.native
+  // filter?: (event: KeyboardEvent) => boolean;
+  var filterPreventDefault: js.UndefOr[Boolean]    = js.native
+  // enableOnTags?: AvailableTags[];
+  var enableOnContentEditable: js.UndefOr[Boolean] = js.native
+  var splitKey: js.UndefOr[String]                 = js.native
+  var keyup: js.UndefOr[Boolean]                   = js.native
+  var keydown: js.UndefOr[Boolean]                 = js.native
+}
+
+object Options {
+
+  def apply(
+    enabled: js.UndefOr[Boolean] = js.undefined
+  ): Options =
+    val p = js.Dynamic.literal().asInstanceOf[Options]
+    p.enabled.foreach(o => p.enabled = o)
+    p
+}
+
+@js.native
+trait HotkeysEvent extends js.Object {
+  var key: String
+}
+
+@js.native
+trait UseHotkeysProps extends js.Object {
+  var keys: String = js.native
+
+  var callback: js.Function2[js.Any, HotkeysEvent, Unit] = js.native
+
+  var options: js.UndefOr[Options] = js.native
+
+  var deps: js.UndefOr[js.Array[js.Any]] = js.native
+}
+
+object UseHotkeysProps {
+
+  def apply(
+    keys:     String,
+    callback: HotkeysCallback,
+    options:  js.UndefOr[Options] = js.undefined
+  ): UseHotkeysProps =
+    val p = js.Dynamic.literal().asInstanceOf[UseHotkeysProps]
+    p.keys = keys
+    p.callback = (_, h) =>
+      callback match
+        case c: Callback                   => c.runNow()
+        case c: (HotkeysEvent => Callback) => c(h).runNow()
+    options.foreach(o => p.options = o)
+    p
+}
+
+object use {
+  @JSImport("react-hotkeys-hook", JSImport.Namespace)
+  @js.native
+  val ^ : js.Any = js.native
+
+  inline def useHotkeys[N <: TopNode](
+    props: UseHotkeysProps
+  ): Ref = {
+    val r = ^.asInstanceOf[js.Dynamic]
+      .applyDynamic("useHotkeys")(props.keys, props.callback)
+    Ref.fromJs(r.asInstanceOf[facade.React.RefHandle[dom.Element | Null]])
+  }
+}

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -10,10 +10,14 @@ import crystal.react.implicits.*
 import explore.components.state.IfLogged
 import explore.components.ui.ExploreStyles
 import explore.model.*
+import explore.model.enums.AppTab
+import explore.shortcuts.*
+import explore.shortcuts.given
 import explore.syntax.ui.*
 import explore.syntax.ui.given
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.ResolutionWithProps
+import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -29,10 +33,6 @@ import react.semanticui.modules.sidebar.SidebarWidth
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExportTopLevel
-import explore.model.enums.AppTab
-import explore.shortcuts.*
-import explore.shortcuts.given
-import japgolly.scalajs.react.extra.router.SetRouteVia
 
 case class ExploreLayout(
   resolution: ResolutionWithProps[Page, View[RootModel]]

--- a/explore/src/main/scala/explore/HelpBody.scala
+++ b/explore/src/main/scala/explore/HelpBody.scala
@@ -21,6 +21,7 @@ import org.http4s.*
 import org.http4s.dom.FetchClientBuilder
 import react.common.ReactFnProps
 import react.hotkeys.*
+import react.hotkeys.hooks.*
 import react.markdown.ReactMarkdown
 import react.markdown.RehypePlugin
 import react.markdown.RemarkPlugin
@@ -69,7 +70,8 @@ object HelpBody:
       .useEffectOnMountBy { (props, _, state) =>
         load(props.url).flatMap(v => state.set(Pot.fromTry(v)).to[IO])
       }
-      .render { (props, helpCtx, state) =>
+      .useHotkeysBy((_, helpCtx, _) => UseHotkeysProps("esc", helpCtx.displayedHelp.set(none)))
+      .render { (props, helpCtx, state, _) =>
         val imageConv = (s: Uri) => props.baseUrl.addPath(s.path)
 
         val helpView = helpCtx.displayedHelp
@@ -80,9 +82,6 @@ object HelpBody:
 
         <.div(
           ExploreStyles.HelpSidebar,
-          GlobalHotKeys(keyMap = KeyMap("CLOSE_HELP" -> "ESC"),
-                        handlers = Handlers("CLOSE_HELP" -> helpView.set(none))
-          ),
           <.div(
             ExploreStyles.HelpTitle,
             <.h4(ExploreStyles.HelpTitleLabel, "Help"),

--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -4,11 +4,12 @@
 package explore.shortcuts
 
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.refined.*
 import japgolly.scalajs.react.Callback
-import react.hotkeys.HotkeysEvent
-import react.hotkeys.HotkeysCallback
 import lucuma.core.util.NewType
+import lucuma.refined.*
+import react.hotkeys.HotkeysCallback
+import react.hotkeys.HotkeysEvent
+
 import scala.scalajs.js.|
 
 object Shortcut extends NewType[String]

--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.shortcuts
+
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.refined.*
+import japgolly.scalajs.react.Callback
+import react.hotkeys.HotkeysEvent
+import react.hotkeys.HotkeysCallback
+import lucuma.core.util.NewType
+import scala.scalajs.js.|
+
+object Shortcut extends NewType[String]
+type Shortcut = Shortcut.Type
+
+extension (shortcuts: List[Shortcut]) def toHotKeys: String = shortcuts.mkString(",")
+
+type ShortcutCallbacks = PartialFunction[Shortcut, Callback]
+
+given Conversion[PartialFunction[Shortcut, Callback], HotkeysCallback] with
+  def apply(p: PartialFunction[Shortcut, Callback]): HotkeysCallback =
+    (e: HotkeysEvent) => p.applyOrElse(Shortcut(e.key), _ => Callback.empty)
+
+val GoToObs         = Shortcut("o")
+val GoToTargets     = Shortcut("t")
+val GoToProposals   = Shortcut("r")
+val GoToConstraints = Shortcut("c")
+val GoToOverview    = Shortcut("w")
+
+val all: List[Shortcut] =
+  List(GoToObs, GoToTargets, GoToProposals, GoToConstraints, GoToOverview)

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -46,9 +46,9 @@ import queries.schemas.odb.ObsQueries.*
 import react.common.ReactFnProps
 import react.draggable.Axis
 import react.gridlayout.*
-import react.resizable.*
 import react.hotkeys.*
 import react.hotkeys.hooks.*
+import react.resizable.*
 import react.resizeDetector.*
 import react.resizeDetector.hooks.*
 import react.semanticui.elements.button.Button

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -47,6 +47,8 @@ import react.common.ReactFnProps
 import react.draggable.Axis
 import react.gridlayout.*
 import react.resizable.*
+import react.hotkeys.*
+import react.hotkeys.hooks.*
 import react.resizeDetector.*
 import react.resizeDetector.hooks.*
 import react.semanticui.elements.button.Button

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "react-dom": "17.0.2",
         "react-draggable": "4.4.5",
         "react-grid-layout": "1.3.4",
-        "react-hotkeys": "^2.0.0",
+        "react-hotkeys-hook": "^3.4.7",
         "react-is": "17.0.2",
         "react-markdown": "^8.0.3",
         "react-reflex": "4.0.9",
@@ -4685,6 +4685,11 @@
         "node": ">=10"
       }
     },
+    "node_modules/hotkeys-js": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.4.tgz",
+      "integrity": "sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q=="
+    },
     "node_modules/html-tags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
@@ -7328,15 +7333,16 @@
         "react-dom": ">= 16.3.0"
       }
     },
-    "node_modules/react-hotkeys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
-      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
+    "node_modules/react-hotkeys-hook": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.7.tgz",
+      "integrity": "sha512-+bbPmhPAl6ns9VkXkNNyxlmCAIyDAcWbB76O4I0ntr3uWCRuIQf/aRLartUahe9chVMPj+OEzzfk3CQSjclUEQ==",
       "dependencies": {
-        "prop-types": "^15.6.1"
+        "hotkeys-js": "3.9.4"
       },
       "peerDependencies": {
-        "react": ">= 0.14.0"
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
       }
     },
     "node_modules/react-is": {
@@ -13295,6 +13301,11 @@
         "lru-cache": "^6.0.0"
       }
     },
+    "hotkeys-js": {
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.9.4.tgz",
+      "integrity": "sha512-2zuLt85Ta+gIyvs4N88pCYskNrxf1TFv3LR9t5mdAZIX8BcgQQ48F2opUptvHa6m8zsy5v/a0i9mWzTrlNWU0Q=="
+    },
     "html-tags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
@@ -15096,12 +15107,12 @@
         "react-resizable": "^3.0.4"
       }
     },
-    "react-hotkeys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-hotkeys/-/react-hotkeys-2.0.0.tgz",
-      "integrity": "sha512-3n3OU8vLX/pfcJrR3xJ1zlww6KS1kEJt0Whxc4FiGV+MJrQ1mYSYI3qS/11d2MJDFm8IhOXMTFQirfu6AVOF6Q==",
+    "react-hotkeys-hook": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-3.4.7.tgz",
+      "integrity": "sha512-+bbPmhPAl6ns9VkXkNNyxlmCAIyDAcWbB76O4I0ntr3uWCRuIQf/aRLartUahe9chVMPj+OEzzfk3CQSjclUEQ==",
       "requires": {
-        "prop-types": "^15.6.1"
+        "hotkeys-js": "3.9.4"
       }
     },
     "react-is": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-dom": "17.0.2",
     "react-draggable": "4.4.5",
     "react-grid-layout": "1.3.4",
-    "react-hotkeys": "^2.0.0",
+    "react-hotkeys-hook": "^3.4.7",
     "react-is": "17.0.2",
     "react-markdown": "^8.0.3",
     "react-reflex": "4.0.9",


### PR DESCRIPTION
`react-hotkeys` is not actively maintained so I'm switching to `react-hook-hotkeys` which is
I added some shortcuts to switch between tabs though I'm not going to promote them yet