### PR TITLE
Apply observation to a target

### DIFF
--- a/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -261,6 +261,32 @@ object ObsQueries:
         )
       }
 
+  def applyObservation[F[_]: Async](
+    obsId:    Observation.Id,
+    targetId: Target.Id
+  )(using TransactionalClient[F, ObservationDB]): F[ObsSummaryWithTitleAndConstraints] =
+    CloneObservationMutation
+      .execute[F](
+        CloneObservationInput(
+          observationId = obsId,
+          SET = ObservationPropertiesInput(targetEnvironment =
+            TargetEnvironmentInput(asterism = List(targetId).assign).assign
+          ).assign
+        )
+      )
+      .map { o =>
+        val newObs = o.cloneObservation.newObservation
+        ObsSummaryWithTitleAndConstraints(
+          newObs.id,
+          newObs.title,
+          newObs.subtitle,
+          newObs.constraintSet,
+          newObs.status,
+          newObs.activeStatus,
+          newObs.plannedTime.execution
+        )
+      }
+
   def deleteObservation[F[_]: Async](
     obsId: Observation.Id
   )(using TransactionalClient[F, ObservationDB]): F[Unit] =

--- a/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -3,8 +3,10 @@
 
 package queries.schemas.odb
 
+import cats.Eq
 import cats.effect.Async
 import cats.implicits.*
+import cats.derived.*
 import clue.TransactionalClient
 import clue.data.syntax.*
 import crystal.Pot
@@ -98,7 +100,7 @@ object ObsQueries:
     observations:     ObservationList,
     constraintGroups: ConstraintsList,
     targetMap:        SortedMap[Target.Id, TargetSummary]
-  )
+  ) derives Eq
 
   object ObsSummariesWithConstraints {
     val observations     = Focus[ObsSummariesWithConstraints](_.observations)

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -26,17 +26,18 @@ import workers.WebWorkerF
 import workers.WorkerClient
 
 case class AppContext[F[_]](
-  version:       NonEmptyString,
-  clients:       GraphQLClients[F],
-  workerClients: WorkerClients[F],
-  sso:           SSOClient[F],
-  pageUrl:       (AppTab, Program.Id, Focused) => String,
-  setPageVia:    (AppTab, Program.Id, Focused, SetRouteVia) => Callback,
-  environment:   ExecutionEnvironment
+  version:          NonEmptyString,
+  clients:          GraphQLClients[F],
+  workerClients:    WorkerClients[F],
+  sso:              SSOClient[F],
+  pageUrl:          (AppTab, Program.Id, Focused) => String,
+  setPageVia:       (AppTab, Program.Id, Focused, SetRouteVia) => Callback,
+  environment:      ExecutionEnvironment,
+  exploreClipboard: Ref[F, LocalClipboard]
 )(using
-  val F:         Applicative[F],
-  val logger:    Logger[F],
-  val P:         Parallel[F]
+  val F:            Applicative[F],
+  val logger:       Logger[F],
+  val P:            Parallel[F]
 ):
   def pushPage(appTab: AppTab, programId: Program.Id, focused: Focused): Callback =
     setPageVia(appTab, programId, focused, SetRouteVia.HistoryPush)
@@ -61,7 +62,8 @@ object AppContext:
     reconnectionStrategy: WebSocketReconnectionStrategy,
     pageUrl:              (AppTab, Program.Id, Focused) => String,
     setPageVia:           (AppTab, Program.Id, Focused, SetRouteVia) => Callback,
-    workerClients:        WorkerClients[F]
+    workerClients:        WorkerClients[F],
+    exploreClipboard:     Ref[F, LocalClipboard]
   ): F[AppContext[F]] =
     for {
       clients <-
@@ -75,7 +77,8 @@ object AppContext:
       SSOClient(config.sso),
       pageUrl,
       setPageVia,
-      config.environment
+      config.environment,
+      exploreClipboard
     )
 
   given [F[_]]: Reusability[AppContext[F]] = Reusability.always

--- a/common/src/main/scala/explore/model/LocalClipboard.scala
+++ b/common/src/main/scala/explore/model/LocalClipboard.scala
@@ -1,0 +1,12 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import lucuma.core.model.Observation
+
+sealed trait LocalClipboard
+
+object LocalClipboard:
+  case object Empty                                extends LocalClipboard
+  case class CopiedObservation(id: Observation.Id) extends LocalClipboard

--- a/common/src/main/scala/explore/model/newtypes.scala
+++ b/common/src/main/scala/explore/model/newtypes.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import lucuma.core.util.NewType
+
+object LoadingState extends NewType[Boolean]:
+  inline def Loading: LoadingState = LoadingState(true)
+  inline def Done: LoadingState    = LoadingState(false)
+
+type LoadingState = LoadingState.Type
+
+object AladinFullScreen extends NewType[Boolean]:
+  inline def FullScreen: AladinFullScreen = AladinFullScreen(true)
+  inline def Normal: AladinFullScreen     = AladinFullScreen(false)
+  extension (s: AladinFullScreen)
+    def flip: AladinFullScreen =
+      if (s.value) AladinFullScreen.Normal else AladinFullScreen.FullScreen
+
+type AladinFullScreen = AladinFullScreen.Type

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -30,6 +30,7 @@ import lucuma.core.model.Target
 import lucuma.core.util.NewType
 import lucuma.schemas.ObservationDB.Enums.Existence
 import lucuma.ui.reusability.*
+import queries.schemas.odb.ObsQueries.ObsSummariesWithConstraints
 import queries.schemas.odb.ObsQueries.SpectroscopyRequirementsData
 
 import scala.collection.immutable.SortedMap
@@ -124,4 +125,6 @@ object reusability {
   given Reusability[TargetWithOptId] = Reusability.byEq
 
   given Reusability[UserGlobalPreferences] = Reusability.byEq
+
+  given Reusability[ObsSummariesWithConstraints] = Reusability.byEq
 }

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -16,6 +16,7 @@ import crystal.react.reuse.*
 import eu.timepit.refined.*
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.BuildInfo
+import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.model.enums.ExecutionEnvironment
 import explore.model.enums.ExecutionEnvironment.Development
@@ -29,8 +30,10 @@ import lucuma.ui.utils.versionDateFormatter
 import lucuma.ui.utils.versionDateTimeFormatter
 import org.http4s.Uri
 import org.scalajs.dom
+import react.fa.IconSize
 import react.semanticui.collections.message.Message
 import react.semanticui.elements.loader.Loader
+import react.toastify.*
 
 import java.time.Instant
 import scala.scalajs.js
@@ -144,9 +147,20 @@ def forceAssign[T, S](mod: Endo[Input[S]] => Endo[T])(base: S): Endo[S] => Endo[
  * `ExploreStyles.Grow(1), so you may need to add that, too.
  */
 def clearInputIcon[EV[_], A](
-  view:        EV[Option[A]]
-)(implicit ev: ExternalValue[EV]): js.UndefOr[VdomNode] =
+  view:     EV[Option[A]]
+)(using ev: ExternalValue[EV]): js.UndefOr[VdomNode] =
   ev.get(view)
     .flatten
     .map(_ => <.i(ExploreStyles.ClearableInputIcon, ^.onClick --> ev.set(view)(None)))
     .orUndefined
+
+def info(text: String) = Callback(
+  toast(
+    <.div(
+      ExploreStyles.ExploreToastGrid,
+      Icons.Info.size(IconSize.LG),
+      text
+    ),
+    ToastOptions(autoClose = 1500, hideProgressBar = true)
+  )
+)

--- a/common/src/main/scala/react/toastify/package.scala
+++ b/common/src/main/scala/react/toastify/package.scala
@@ -98,17 +98,19 @@ package toastify {
     var closeButton: Boolean                    = js.native
     var closeOnClick: Boolean                   = js.native
     var theme: js.UndefOr[String]               = js.native
+    var hideProgressBar: js.UndefOr[Boolean]    = js.native
   }
 
   object ToastOptions {
     def apply(
-      toastId:      js.UndefOr[String] = js.undefined,
-      position:     js.UndefOr[Position] = js.undefined,
-      onClose:      js.UndefOr[Callback] = js.undefined,
-      autoClose:    js.UndefOr[Boolean | Double] = js.undefined,
-      closeButton:  js.UndefOr[Boolean] = js.undefined,
-      closeOnClick: js.UndefOr[Boolean] = js.undefined,
-      theme:        js.UndefOr[Theme] = js.undefined
+      toastId:         js.UndefOr[String] = js.undefined,
+      position:        js.UndefOr[Position] = js.undefined,
+      onClose:         js.UndefOr[Callback] = js.undefined,
+      autoClose:       js.UndefOr[Boolean | Double] = js.undefined,
+      closeButton:     js.UndefOr[Boolean] = js.undefined,
+      closeOnClick:    js.UndefOr[Boolean] = js.undefined,
+      theme:           js.UndefOr[Theme] = js.undefined,
+      hideProgressBar: js.UndefOr[Boolean] = js.undefined
     ): ToastOptions = {
       val p = (new js.Object).asInstanceOf[ToastOptions]
       toastId.foreach(q => p.toastId = q)
@@ -118,6 +120,7 @@ package toastify {
       closeButton.foreach(q => p.closeButton = q)
       closeOnClick.foreach(q => p.closeOnClick = q)
       theme.foreach(v => p.theme = v.undefToJs)
+      hideProgressBar.foreach(v => p.hideProgressBar = v)
       p
     }
   }

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -8,6 +8,7 @@ import cats.effect.IO
 import cats.effect.IOApp
 import cats.effect.Resource
 import cats.effect.Sync
+import cats.effect.Ref
 import cats.effect.std.Dispatcher
 import cats.syntax.all.*
 import clue.WebSocketReconnectionStrategy
@@ -56,6 +57,7 @@ import scala.concurrent.duration.*
 import scala.scalajs.js
 
 import js.annotation.*
+import explore.model.LocalClipboard
 
 @JSExportTopLevel("Explore")
 object ExploreMain extends IOApp.Simple {
@@ -165,13 +167,15 @@ object ExploreMain extends IOApp.Simple {
         appConfig            <- fetchConfig[IO]
         _                    <- Logger[IO].info(s"Git Commit: [${utils.gitHash.getOrElse("NONE")}]")
         _                    <- Logger[IO].info(s"Config: ${appConfig.show}")
+        clipboard            <- Ref.of[IO, LocalClipboard](LocalClipboard.Empty)
         ctx                  <-
           AppContext.from[IO](
             appConfig,
             reconnectionStrategy,
             pageUrl,
             setPageVia,
-            workerClients
+            workerClients,
+            clipboard
           )
         _                    <- setupReusabilityOverlay(appConfig.environment)
         r                    <- (ctx.sso.whoami, setupDOM[IO], showEnvironment[IO](appConfig.environment)).parTupled

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -6,9 +6,9 @@ package explore
 import cats.effect.Async
 import cats.effect.IO
 import cats.effect.IOApp
+import cats.effect.Ref
 import cats.effect.Resource
 import cats.effect.Sync
-import cats.effect.Ref
 import cats.effect.std.Dispatcher
 import cats.syntax.all.*
 import clue.WebSocketReconnectionStrategy
@@ -27,6 +27,7 @@ import explore.model.AppContext
 import explore.model.ExploreLocalPreferences
 import explore.model.Focused
 import explore.model.Help
+import explore.model.LocalClipboard
 import explore.model.RootModel
 import explore.model.RoutingInfo
 import explore.model.UserVault
@@ -57,7 +58,6 @@ import scala.concurrent.duration.*
 import scala.scalajs.js
 
 import js.annotation.*
-import explore.model.LocalClipboard
 
 @JSExportTopLevel("Explore")
 object ExploreMain extends IOApp.Simple {

--- a/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
+++ b/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
@@ -24,6 +24,7 @@ import explore.components.ui.ExploreStyles
 import explore.config.ExposureTimeModeType.FixedExposure
 import explore.events.*
 import explore.model.AppContext
+import explore.model.LoadingState
 import explore.model.ScienceMode
 import explore.model.ScienceModeAdvanced
 import explore.model.ScienceModeBasic
@@ -92,7 +93,7 @@ object ItcGraphPanel:
       .useContext(AppContext.ctx)
       .useState(Pot.pending[Map[ItcTarget, ItcChartResult]])
       // loading
-      .useState(PlotLoading.Done)
+      .useState(LoadingState.Done)
       // Request ITC graph data
       .useEffectWithDepsBy((props, _, _, _) => props.queryProps) {
         (props, ctx, charts, loading) => _ =>
@@ -104,11 +105,11 @@ object ItcGraphPanel:
                 charts.modStateAsync {
                   case Pot.Ready(r) => Pot.Ready(r + (m.target -> m))
                   case u            => Pot.Ready(Map(m.target -> m))
-                } *> loading.setState(PlotLoading.Done).to[IO],
+                } *> loading.setState(LoadingState.Done).to[IO],
               (charts.setState(
                 Pot.error(new RuntimeException("Not enough information to calculate the ITC graph"))
-              ) *> loading.setState(PlotLoading.Done)).to[IO],
-              loading.setState(PlotLoading.Loading).to[IO]
+              ) *> loading.setState(LoadingState.Done)).to[IO],
+              loading.setState(LoadingState.Loading).to[IO]
             )
             .runAsyncAndForget
       }

--- a/explore/src/main/scala/explore/itc/ItcSpectroscopyPlot.scala
+++ b/explore/src/main/scala/explore/itc/ItcSpectroscopyPlot.scala
@@ -9,6 +9,7 @@ import crystal.Pot
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
 import explore.highcharts.*
+import explore.model.LoadingState
 import explore.model.enums.ItcChartType
 import explore.model.enums.ItcSeriesType
 import explore.model.itc.ItcCcd
@@ -50,7 +51,7 @@ case class ItcSpectroscopyPlot(
   chartType:       ItcChartType,
   targetName:      Option[String],
   signalToNoiseAt: Option[Wavelength],
-  loading:         PlotLoading,
+  loading:         LoadingState,
   details:         PlotDetails
 ) extends ReactFnProps(ItcSpectroscopyPlot.component)
 
@@ -60,7 +61,7 @@ object ItcSpectroscopyPlot {
   private def chartOptions(
     chart:           ItcChart,
     targetName:      Option[String],
-    loading:         PlotLoading,
+    loading:         LoadingState,
     details:         PlotDetails,
     signalToNoiseAt: Option[Wavelength],
     maxSNWavelength: Option[Wavelength],
@@ -126,7 +127,7 @@ object ItcSpectroscopyPlot {
           .setHeight(height)
           .clazz(
             ExploreStyles.ItcPlotChart |+|
-              ExploreStyles.ItcPlotLoading.when_(loading.boolValue)
+              ExploreStyles.ItcPlotLoading.when_(loading.value)
           )
       )
       .setTitle(TitleOptions().setText(chartTitle))
@@ -218,7 +219,7 @@ object ItcSpectroscopyPlot {
     .withHooks[Props]
     .useResizeDetector()
     .render { (props, resize) =>
-      val loading = props.loading.boolValue
+      val loading = props.loading.value
 
       val series: List[ItcChart] =
         props.charts.filterNot(_ => loading).foldMap(_.toList)

--- a/explore/src/main/scala/explore/itc/package.scala
+++ b/explore/src/main/scala/explore/itc/package.scala
@@ -28,16 +28,6 @@ def requiredForITC: TagMod =
     <.span(^.cls := "fa-layers-text fa-inverse", "ITC")
   ).withTooltip("Required for ITC")
 
-opaque type PlotLoading = Boolean
-
-object PlotLoading:
-  val Loading: PlotLoading = true
-  val Done: PlotLoading    = false
-
-  inline def apply(b: Boolean): PlotLoading = b
-
-extension (p: PlotLoading) inline def boolValue: Boolean = p
-
 def formatDuration(seconds: Long): String =
   if (seconds < 60)
     s"$seconds sec"

--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -28,3 +28,16 @@ val GoToTargets     = Shortcut("t")
 val GoToProposals   = Shortcut("r")
 val GoToConstraints = Shortcut("c")
 val GoToOverview    = Shortcut("w")
+val GoToSummary     = Shortcut("s")
+
+val CopyAlt1 = Shortcut("y")
+val CopyAlt2 = Shortcut("ctrl+c")
+val CopyAlt3 = Shortcut("cmd+c")
+
+val CopyKeys = List(CopyAlt1, CopyAlt2, CopyAlt3)
+
+val PasteAlt1 = Shortcut("p")
+val PasteAlt2 = Shortcut("ctrl+v")
+val PasteAlt3 = Shortcut("cmd+v")
+
+val PasteKeys = List(PasteAlt1, PasteAlt2, PasteAlt3)

--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -30,6 +30,9 @@ val GoToConstraints = Shortcut("c")
 val GoToOverview    = Shortcut("w")
 val GoToSummary     = Shortcut("s")
 
+val Down = Shortcut("j")
+val Up   = Shortcut("k")
+
 val CopyAlt1 = Shortcut("y")
 val CopyAlt2 = Shortcut("ctrl+c")
 val CopyAlt3 = Shortcut("cmd+c")

--- a/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintSetTabContents.scala
@@ -25,11 +25,14 @@ import explore.model.reusability.*
 import explore.observationtree.ConstraintGroupObsList
 import explore.optics.*
 import explore.optics.all.*
+import explore.shortcuts.*
+import explore.shortcuts.given
 import explore.syntax.ui.*
 import explore.undo.*
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.callback.CallbackCatsEffect.*
+import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Program
@@ -48,6 +51,8 @@ import queries.schemas.UserPreferencesDB
 import react.common.ReactFnProps
 import react.draggable.Axis
 import react.fa.*
+import react.hotkeys.*
+import react.hotkeys.hooks.*
 import react.resizable.*
 import react.resizeDetector.*
 import react.resizeDetector.hooks.*
@@ -243,6 +248,14 @@ object ConstraintSetTabContents extends TwoResizablePanels:
     ScalaFnComponent
       .withHooks[Props]
       .useContext(AppContext.ctx)
+      .useGlobalHotkeysWithDepsBy((props, ctx) => props.programId) { (props, ctx) => pid =>
+        import ctx.given
+
+        def callbacks: ShortcutCallbacks = { case GoToSummary =>
+          ctx.setPageVia(AppTab.Constraints, pid, Focused.None, SetRouteVia.HistoryPush)
+        }
+        UseHotkeysProps(GoToSummary.value, callbacks)
+      }
       .useStateView(TwoPanelState.initial(SelectedPanel.Uninitialized))
       .useEffectOnMountBy((props, ctx, state) =>
         import ctx.given

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -54,6 +54,10 @@ import react.resizeDetector.hooks.*
 import react.semanticui.elements.button.Button
 import react.semanticui.elements.button.Button.ButtonProps
 import react.semanticui.sizes.*
+import react.hotkeys.*
+import react.hotkeys.hooks.*
+import explore.shortcuts.*
+import explore.shortcuts.given
 
 import scala.concurrent.duration.*
 
@@ -293,6 +297,17 @@ object ObsTabContents extends TwoResizablePanels:
           .reRunOnResourceSignals(
             ProgramObservationsEditSubscription.subscribe[IO](props.programId)
           )
+      }
+      .useGlobalHotkeysWithDepsBy((props, ctx, _, _, _, _, _, _) => props.focusedObs) {
+        (props, ctx, _, _, _, _, _, _) => obs =>
+          import ctx.given
+
+          def callbacks: ShortcutCallbacks = { case CopyAlt1 | CopyAlt2 | CopyAlt3 =>
+            obs
+              .map(id => ctx.exploreClipboard.set(LocalClipboard.CopiedObservation(id)).runAsync)
+              .getOrEmpty
+          }
+          UseHotkeysProps(CopyKeys.toHotKeys, callbacks)
       }
       .render {
         (

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -8,6 +8,7 @@ import cats.syntax.all.*
 import crystal.react.View
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
+import explore.model.AladinFullScreen
 import explore.model.Asterism
 import explore.model.util.*
 import explore.targeteditor.SiderealTargetEditor
@@ -32,7 +33,7 @@ object SiderealTargetEditorTile {
     undoStacks: View[UndoStacks[IO, Target.Sidereal]],
     searching:  View[Set[Target.Id]],
     title:      String,
-    fullScreen: View[Boolean],
+    fullScreen: View[AladinFullScreen],
     backButton: Option[VdomNode] = none
   ) =
     Tile(ObsTabTilesIds.TargetId.id,
@@ -43,7 +44,7 @@ object SiderealTargetEditorTile {
     ) { (renderInTitle: Tile.RenderInTitle) =>
       val asterism = target.widen[Target].zoom(Asterism.oneTarget(targetId).reverse.asLens)
       <.div(
-        ExploreStyles.AladinFullScreen.when(fullScreen.get),
+        ExploreStyles.AladinFullScreen.when(fullScreen.get.value),
         <.div(
           ExploreStyles.TargetTileEditor,
           userId.map(uid =>

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -19,6 +19,7 @@ import explore.Icons
 import explore.common.UserPreferencesQueries.*
 import explore.components.ui.ExploreStyles
 import explore.events.*
+import explore.model.AladinFullScreen
 import explore.model.AladinMouseScroll
 import explore.model.AppContext
 import explore.model.Asterism
@@ -71,7 +72,7 @@ case class AladinCell(
   tid:        Target.Id,
   obsConf:    ObsConfiguration,
   asterism:   Asterism,
-  fullScreen: View[Boolean]
+  fullScreen: View[AladinFullScreen]
 ) extends ReactFnProps(AladinCell.component)
 
 object AladinCell extends ModelOptics:
@@ -341,7 +342,7 @@ object AladinCell extends ModelOptics:
               prefsSetter(_.flip, identity, identity)
 
           def fullScreenSetter: Callback =
-            props.fullScreen.mod(!_) *>
+            props.fullScreen.mod(_.flip) *>
               fullScreenView.mod(!_) *>
               prefsSetter(identity, identity, !_)
 
@@ -360,7 +361,7 @@ object AladinCell extends ModelOptics:
                 props.asterism,
                 props.obsConf,
                 u.aladinMouseScroll,
-                t.copy(fullScreen = props.fullScreen.get),
+                t.copy(fullScreen = props.fullScreen.get.value),
                 coordinatesSetter,
                 fovSetter.reuseAlways,
                 offsetSetter.reuseAlways,
@@ -398,8 +399,8 @@ object AladinCell extends ModelOptics:
               ExploreStyles.AladinContainerColumn,
               Button(size = Small, icon = true, onClick = fullScreenSetter)(
                 ExploreStyles.AladinFullScreenButton,
-                Icons.ExpandDiagonal.unless(props.fullScreen.get),
-                Icons.ContractDiagonal.when(props.fullScreen.get)
+                Icons.ExpandDiagonal.unless(props.fullScreen.get.value),
+                Icons.ContractDiagonal.when(props.fullScreen.get.value)
               ),
               <.div(
                 ExploreStyles.AladinToolbox,

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -15,6 +15,7 @@ import explore.common.AsterismQueries
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.config.VizTimeEditor
+import explore.model.AladinFullScreen
 import explore.model.AppContext
 import explore.model.Asterism
 import explore.model.ObsIdSet
@@ -145,7 +146,7 @@ object AsterismEditor {
           }
       }
       // full screen aladin
-      .useStateView(false)
+      .useStateView(AladinFullScreen.Normal)
       .render { (props, ctx, adding, editScope, fullScreen) =>
         import ctx.given
 
@@ -166,7 +167,7 @@ object AsterismEditor {
         val vizTime = props.potVizTime.toOption.flatMap(_.get)
 
         <.div(
-          ExploreStyles.AladinFullScreen.when(fullScreen.get),
+          ExploreStyles.AladinFullScreen.when(fullScreen.get.value),
           props.renderInTitle(
             TargetSelectionPopup(
               props.programId,

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -20,6 +20,7 @@ import explore.components.InputWithUnits
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
+import explore.model.AladinFullScreen
 import explore.model.AppContext
 import explore.model.Asterism
 import explore.model.ExploreModelValidators
@@ -85,7 +86,7 @@ case class SiderealTargetEditor(
   obsIdSubset:   Option[ObsIdSet] = None,
   onClone:       TargetWithId => Callback = _ => Callback.empty,
   renderInTitle: Option[Tile.RenderInTitle] = none,
-  fullScreen:    View[Boolean]
+  fullScreen:    View[AladinFullScreen]
 ) extends ReactFnProps(SiderealTargetEditor.component)
 
 object SiderealTargetEditor {

--- a/explore/src/main/scala/explore/targeteditor/TargetTable.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetTable.scala
@@ -15,6 +15,7 @@ import explore.Icons
 import explore.common.AsterismQueries
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
+import explore.model.AladinFullScreen
 import explore.model.AppContext
 import explore.model.Asterism
 import explore.model.ObsIdSet
@@ -54,7 +55,7 @@ case class TargetTable(
   selectedTarget: View[Option[Target.Id]],
   vizTime:        Option[Instant],
   renderInTitle:  Tile.RenderInTitle,
-  fullScreen:     Boolean
+  fullScreen:     AladinFullScreen
 ) extends ReactFnProps(TargetTable.component)
 
 object TargetTable {
@@ -173,7 +174,7 @@ object TargetTable {
                       )
                     }
                 )
-              ).unless(props.fullScreen)
+              ).unless(props.fullScreen.value)
             )
           ),
           if (rows.isEmpty) {

--- a/model/shared/src/main/scala/explore/model/itc/package.scala
+++ b/model/shared/src/main/scala/explore/model/itc/package.scala
@@ -17,7 +17,6 @@ import lucuma.core.math.Wavelength
 import lucuma.core.model.NonNegDuration
 import lucuma.core.model.implicits.*
 import lucuma.core.util.Enumerated
-import lucuma.core.util.NewType
 import lucuma.schemas.decoders.given
 
 import scala.concurrent.duration.*


### PR DESCRIPTION
Initial version of the ability to copy paste observations into other targets
It sets up some shortcuts to do the operation
There are a few things missing though:
* No undo support
* After the obs is cloned it takes a while for the UI to update
* not possible to copy/paste across browser tabs

Despite the shortcomings it is good for testing