### PR TITLE
Support observation copy paste in targets

### DIFF
--- a/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -264,15 +264,15 @@ object ObsQueries:
       }
 
   def applyObservation[F[_]: Async](
-    obsId:    Observation.Id,
-    targetId: Target.Id
+    obsId:     Observation.Id,
+    targetIds: List[Target.Id]
   )(using TransactionalClient[F, ObservationDB]): F[ObsSummaryWithTitleAndConstraints] =
     CloneObservationMutation
       .execute[F](
         CloneObservationInput(
           observationId = obsId,
           SET = ObservationPropertiesInput(targetEnvironment =
-            TargetEnvironmentInput(asterism = List(targetId).assign).assign
+            TargetEnvironmentInput(asterism = targetIds.assign).assign
           ).assign
         )
       )

--- a/common/src/main/scala/explore/model/LocalClipboard.scala
+++ b/common/src/main/scala/explore/model/LocalClipboard.scala
@@ -8,5 +8,5 @@ import lucuma.core.model.Observation
 sealed trait LocalClipboard
 
 object LocalClipboard:
-  case object Empty                                extends LocalClipboard
-  case class CopiedObservation(id: Observation.Id) extends LocalClipboard
+  case object Empty                             extends LocalClipboard
+  case class CopiedObservations(oids: ObsIdSet) extends LocalClipboard

--- a/common/src/main/webapp/sass/visualization.scss
+++ b/common/src/main/webapp/sass/visualization.scss
@@ -17,7 +17,6 @@
 .aladin-container-body {
   grid-area: aladin;
   position: relative;
-  margin-bottom: 0.2em;
 }
 
 .visualization-display {

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -52,8 +52,6 @@ import react.common.ReactFnProps
 import react.draggable.Axis
 import react.gridlayout.*
 import react.hotkeys.*
-import react.hotkeys.*
-import react.hotkeys.hooks.*
 import react.hotkeys.hooks.*
 import react.resizable.*
 import react.resizeDetector.*
@@ -314,9 +312,10 @@ object ObsTabContents extends TwoResizablePanels:
           case CopyAlt1 | CopyAlt2 | CopyAlt3 =>
             obs
               .map(id =>
-                ctx.exploreClipboard.set(LocalClipboard.CopiedObservation(id)).runAsync *> info(
-                  s"Copied"
-                )
+                ctx.exploreClipboard
+                  .set(LocalClipboard.CopiedObservations(ObsIdSet.one(id)))
+                  .runAsync *>
+                  info(s"Copied obs $id")
               )
               .getOrEmpty
           case Down                           =>

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -603,7 +603,6 @@ object TargetTabContents:
   ): IO[Unit] =
     import ctx.given
     adding.async.set(LoadingState.Loading) >>
-      IO(pprint.pprintln(asterismGroupsWithObs.get.asterismGroups)) *>
       obsIds
         .traverse(obsId =>
           ObsQueries

--- a/model/shared/src/main/scala/explore/model/AsterismGroup.scala
+++ b/model/shared/src/main/scala/explore/model/AsterismGroup.scala
@@ -5,7 +5,7 @@ package explore.model
 
 import cats.Eq
 import cats.Semigroup
-import cats.derived.*
+import cats.syntax.all.*
 import lucuma.core.model.Target
 import monocle.Focus
 import monocle.Lens
@@ -15,7 +15,8 @@ import scala.collection.immutable.SortedSet
 case class AsterismGroup(
   obsIds:    ObsIdSet,
   targetIds: SortedSet[Target.Id]
-) derives Semigroup {
+) {
+
   def addTargetId(targetId: Target.Id): AsterismGroup =
     AsterismGroup.targetIds.modify(_ + targetId)(this)
 
@@ -32,7 +33,10 @@ case class AsterismGroup(
 }
 
 object AsterismGroup {
-  implicit val eqAsterismGroup: Eq[AsterismGroup] = Eq.by(x => (x.obsIds, x.targetIds))
+  given Eq[AsterismGroup] = Eq.by(x => (x.obsIds, x.targetIds))
+
+  given Semigroup[AsterismGroup] =
+    Semigroup.instance((a, b) => AsterismGroup(a.obsIds |+| b.obsIds, a.targetIds |+| b.targetIds))
 
   val obsIds: Lens[AsterismGroup, ObsIdSet] = Focus[AsterismGroup](_.obsIds)
 

--- a/model/shared/src/main/scala/explore/model/AsterismGroup.scala
+++ b/model/shared/src/main/scala/explore/model/AsterismGroup.scala
@@ -4,6 +4,8 @@
 package explore.model
 
 import cats.Eq
+import cats.Semigroup
+import cats.derived.*
 import lucuma.core.model.Target
 import monocle.Focus
 import monocle.Lens
@@ -13,7 +15,7 @@ import scala.collection.immutable.SortedSet
 case class AsterismGroup(
   obsIds:    ObsIdSet,
   targetIds: SortedSet[Target.Id]
-) {
+) derives Semigroup {
   def addTargetId(targetId: Target.Id): AsterismGroup =
     AsterismGroup.targetIds.modify(_ + targetId)(this)
 

--- a/model/shared/src/main/scala/explore/model/ObsIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/ObsIdSet.scala
@@ -5,7 +5,9 @@ package explore.model
 
 import cats.Order
 import cats.Order.*
+import cats.Semigroup
 import cats.data.NonEmptySet
+import cats.derived.*
 import cats.syntax.all.*
 import explore.model.util.NonEmptySetWrapper
 import lucuma.core.model.Observation
@@ -14,10 +16,10 @@ import monocle.Prism
 
 import scala.collection.immutable.SortedSet
 
-case class ObsIdSet(idSet: NonEmptySet[Observation.Id])
+case class ObsIdSet(idSet: NonEmptySet[Observation.Id]) derives Semigroup
 
 object ObsIdSet {
-  implicit val orderObsIdSet: Order[ObsIdSet] = Order.by(_.idSet)
+  given Order[ObsIdSet] = Order.by(_.idSet)
 
   val iso: Iso[ObsIdSet, NonEmptySet[Observation.Id]] =
     Iso[ObsIdSet, NonEmptySet[Observation.Id]](_.idSet)(ObsIdSet.apply)

--- a/model/shared/src/main/scala/explore/model/ObsIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/ObsIdSet.scala
@@ -7,7 +7,6 @@ import cats.Order
 import cats.Order.*
 import cats.Semigroup
 import cats.data.NonEmptySet
-import cats.derived.*
 import cats.syntax.all.*
 import explore.model.util.NonEmptySetWrapper
 import lucuma.core.model.Observation
@@ -16,10 +15,12 @@ import monocle.Prism
 
 import scala.collection.immutable.SortedSet
 
-case class ObsIdSet(idSet: NonEmptySet[Observation.Id]) derives Semigroup
+case class ObsIdSet(idSet: NonEmptySet[Observation.Id])
 
 object ObsIdSet {
   given Order[ObsIdSet] = Order.by(_.idSet)
+
+  given Semigroup[ObsIdSet] = Semigroup.instance((a, b) => ObsIdSet(a.idSet |+| b.idSet))
 
   val iso: Iso[ObsIdSet, NonEmptySet[Observation.Id]] =
     Iso[ObsIdSet, NonEmptySet[Observation.Id]](_.idSet)(ObsIdSet.apply)


### PR DESCRIPTION
This PR includes the following improvements:

* Ability to copy observations directly on the targets tab, you can select individual observations or select all associated with a target
* Pasting n observations will produce n new observations
* You can now paste into an asterism which will be preserved
* The paste operation will be simulated locally for a faster UI