### PR TITLE
Support target import of csv files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -235,6 +235,7 @@ lazy val commonJsLibSettings = commonLibSettings ++ Seq(
   libraryDependencies ++=
     ClueScalaJS.value ++
       Http4sDom.value ++
+      FS2Dom.value ++
       Log4Cats.value ++
       ScalaJSReact.value ++
       ScalaJSDom.value ++

--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -227,8 +227,8 @@ object Icons {
   val faFileCirclePlus: FAIcon = js.native
 
   @js.native
-  @JSImport("@fortawesome/pro-light-svg-icons", "faFileImport")
-  val faFileImport: FAIcon = js.native
+  @JSImport("@fortawesome/pro-light-svg-icons", "faFileArrowUp")
+  val faFileArrowUp: FAIcon = js.native
 
   @js.native
   @JSImport("@fortawesome/pro-thin-svg-icons", "faArrowUpRightAndArrowDownLeftFromCenter")
@@ -300,7 +300,7 @@ object Icons {
     faThinSliders,
     faCircleSmall,
     faBahai,
-    faFileImport,
+    faFileArrowUp,
     faFileCirclePlus,
     faExpandDiagonal,
     faContractDiagonal,
@@ -362,7 +362,7 @@ object Icons {
   val CircleSmall         = FontAwesomeIcon(faCircleSmall)
   val Bahai               = FontAwesomeIcon(faBahai)
   val FileCirclePlus      = FontAwesomeIcon(faFileCirclePlus)
-  val FileImport          = FontAwesomeIcon(faFileImport)
+  val FileArrowUp         = FontAwesomeIcon(faFileArrowUp)
   val ExpandDiagonal      = FontAwesomeIcon(faExpandDiagonal)
   val ContractDiagonal    = FontAwesomeIcon(faContractDiagonal)
   val Clone               = FontAwesomeIcon(faClone)

--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -227,6 +227,10 @@ object Icons {
   val faFileCirclePlus: FAIcon = js.native
 
   @js.native
+  @JSImport("@fortawesome/pro-light-svg-icons", "faFileImport")
+  val faFileImport: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-thin-svg-icons", "faArrowUpRightAndArrowDownLeftFromCenter")
   val faExpandDiagonal: FAIcon = js.native
 
@@ -296,6 +300,7 @@ object Icons {
     faThinSliders,
     faCircleSmall,
     faBahai,
+    faFileImport,
     faFileCirclePlus,
     faExpandDiagonal,
     faContractDiagonal,
@@ -357,6 +362,7 @@ object Icons {
   val CircleSmall         = FontAwesomeIcon(faCircleSmall)
   val Bahai               = FontAwesomeIcon(faBahai)
   val FileCirclePlus      = FontAwesomeIcon(faFileCirclePlus)
+  val FileImport          = FontAwesomeIcon(faFileImport)
   val ExpandDiagonal      = FontAwesomeIcon(faExpandDiagonal)
   val ContractDiagonal    = FontAwesomeIcon(faContractDiagonal)
   val Clone               = FontAwesomeIcon(faClone)

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -308,7 +308,7 @@ object ExploreStyles {
   val StepGuided: Css = Css("step-guided")
 
   val ExploreForm: Css          = Css("explore-form")
-  val TargetImportForm: Css          = Css("explore-target-import--form")
+  val TargetImportForm: Css     = Css("explore-target-import-form")
   val SkipToNext: Css           = Css("explore-skip-to-next")
   val SeqGenParametersForm: Css = Css("seq-gen-parameters-form")
 

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -442,4 +442,6 @@ object ExploreStyles {
   // See `clearInputIcon` in `explore.utils.package`
   val ClearableInputIcon: Css         = Css("clearable-input-icon")
   val ClearableInputPaddingReset: Css = Css("clearable-input-padding-reset")
+
+  val SummaryTableToolbar: Css = Css("summary-table-toolbar")
 }

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -308,6 +308,7 @@ object ExploreStyles {
   val StepGuided: Css = Css("step-guided")
 
   val ExploreForm: Css          = Css("explore-form")
+  val TargetImportForm: Css          = Css("explore-target-import--form")
   val SkipToNext: Css           = Css("explore-skip-to-next")
   val SeqGenParametersForm: Css = Css("seq-gen-parameters-form")
 

--- a/common/src/main/webapp/sass/explore-primereact.scss
+++ b/common/src/main/webapp/sass/explore-primereact.scss
@@ -22,10 +22,6 @@
   &.pl-dialog-small {
     max-width: 95%;
 
-    .p-dialog-header {
-      padding: 0.5rem;
-    }
-
     @media (min-width: common.$tablet-responsive-cutoff) {
       max-width: 760px;
     }

--- a/common/src/main/webapp/sass/explore-primereact.scss
+++ b/common/src/main/webapp/sass/explore-primereact.scss
@@ -22,6 +22,10 @@
   &.pl-dialog-small {
     max-width: 95%;
 
+    .p-dialog-header {
+      padding: 0.5rem;
+    }
+
     @media (min-width: common.$tablet-responsive-cutoff) {
       max-width: 760px;
     }

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -19,12 +19,14 @@
   gap: 0.5em;
   align-items: baseline;
 
-  label {
-    font-size: smaller;
+  label.p-button.pl-compact {
+    padding: 0.4em 0.5em;
+    margin-right: 0.25em;
+    // font-size: smaller;
   }
 
   .p-button.p-button-sm {
-    padding: 0.3rem;
+    // padding: 0.3rem;
     max-width: 4rem;
 
     & svg.p-button-icon:not(.fa-trash-can) {

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -585,3 +585,28 @@ table.explore-border-table {
   }
 }
 
+// ----
+// Target import dialog
+// ----
+.explore-target-import-form {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-width: 20vw;
+
+  .p-progress-spinner {
+    height: 4rem;
+    width: 4rem;
+    margin: 0.5rem 2rem;
+  }
+
+  div {
+    display: flex;
+    flex-direction: column;
+    margin-right: 2rem;
+  }
+
+  svg.fa-check {
+    color: var(--explore-accent-color);
+  }
+}

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -22,11 +22,9 @@
   label.p-button.pl-compact {
     padding: 0.4em 0.5em;
     margin-right: 0.25em;
-    // font-size: smaller;
   }
 
   .p-button.p-button-sm {
-    // padding: 0.3rem;
     max-width: 4rem;
 
     & svg.p-button-icon:not(.fa-trash-can) {
@@ -575,7 +573,7 @@ table.explore-border-table {
 // Toolbar over summary tables
 // ------
 .summary-table-toolbar {
-  padding: 0.25rem 0.25rem;
+  padding: 0.25rem;
 }
 
 

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -569,3 +569,17 @@ table.explore-border-table {
   }
 }
 
+// -----
+// Toolbar over summary tables
+// ------
+.summary-table-toolbar {
+  padding: 0.25rem 0.25rem;
+}
+
+
+.p-button.p-fileupload {
+  + input[type="file"] {
+    display: none;
+  }
+}
+

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -19,8 +19,8 @@
   gap: 0.5em;
   align-items: baseline;
 
-  label.p-button.pl-compact {
-    padding: 0.4em 0.5em;
+  .p-button.pl-compact {
+    padding: 0.3929em;
     margin-right: 0.25em;
   }
 

--- a/explore/src/main/scala/explore/config/TargetImportPopup.scala
+++ b/explore/src/main/scala/explore/config/TargetImportPopup.scala
@@ -128,7 +128,7 @@ object TargetImportPopup:
             ProgressSpinner(strokeWidth = "5").unless(state.value.done),
             Icons.Checkmark.size(IconSize.X4).when(state.value.done),
             <.div(
-              <.span(s"Importing ${state.value.loaded.headOption.foldMap(_.name.value)}")
+              <.span(s"Importing ${state.value.loaded.length}")
                 .unless(state.value.done),
               <.span(s"Imported ${state.value.loaded.length} targets").when(state.value.done),
               <.span(s"Import errors: ${state.value.targetErrors}")

--- a/explore/src/main/scala/explore/config/TargetImportPopup.scala
+++ b/explore/src/main/scala/explore/config/TargetImportPopup.scala
@@ -1,0 +1,110 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targets
+
+import crystal.react.View
+import cats.*
+import cats.syntax.all.*
+import cats.effect.*
+import cats.effect.syntax.all.*
+import clue.TransactionalClient
+import crystal.react.reuse.*
+import explore.Icons
+import crystal.react.implicits.*
+import fs2.*
+import fs2.text
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import explore.model.AppContext
+import explore.components.ui.ExploreStyles
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.ui.syntax.all.*
+import lucuma.ui.syntax.all.given
+import react.common.ReactFnProps
+import react.primereact.Button
+import react.primereact.Dialog
+import react.primereact.DialogPosition
+import react.primereact.ProgressSpinner
+import org.scalajs.dom.{File => DOMFile}
+import lucuma.schemas.ObservationDB
+import queries.common.TargetQueriesGQL.*
+import queries.schemas.odb.ODBConversions.*
+import lucuma.catalog.csv.TargetImport
+import org.typelevel.log4cats.Logger
+
+case class TargetImportPopup(
+  programId: Program.Id,
+  files:     View[List[DOMFile]]
+) extends ReactFnProps(TargetImportPopup.component)
+
+object TargetImportPopup:
+  private type Props = TargetImportPopup
+
+  given Reusability[DOMFile] = Reusability.by(_.name)
+
+  def importTargets[F[_]: Spawn: Logger](
+    programId:     Program.Id,
+    s:             Stream[F, Byte],
+    currentTarget: Option[Target] => F[Unit]
+  )(using TransactionalClient[F, ObservationDB]) =
+    s
+      .through(text.utf8.decode)
+      .through(TargetImport.csv2targets)
+      .evalMap {
+        case Left(a)       => Applicative[F].unit
+        case Right(target) =>
+          Logger[F].info(s"create $target") *>
+            currentTarget(target.some).start *>
+            CreateTargetMutation
+              .execute(target.toCreateTargetInput(programId))
+              .map(_.createTarget.target.id)
+              .void
+      }
+
+  private val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      .useContext(AppContext.ctx)
+      .useState(none[Target])
+      .useEffectWithDepsBy((props, _, _) => props.files.get) {
+        (props, ctx, currentTarget) => files =>
+          import ctx.given
+
+          files
+            .traverse(f =>
+              importTargets[IO](props.programId,
+                                dom.readReadableStream(IO(f.stream())),
+                                currentTarget.setState(_).to[IO]
+              ).compile.toList
+            )
+            .void
+      }
+      .render { (props, _, currentTarget) =>
+        Dialog(
+          footer = Button(size = Button.Size.Small,
+                          icon = Icons.Close,
+                          label = "Close",
+                          disabled = props.files.get.isEmpty,
+                          onClick = props.files.set(Nil)
+          ),
+          //   .withMods(^.key := "input-cancel"),
+          position = DialogPosition.Top,
+          visible = props.files.get.nonEmpty,
+          clazz = ExploreStyles.Dialog.Small,
+          dismissableMask = true,
+          resizable = false,
+          onHide = props.files.set(Nil),
+          header = "Import Targets"
+          //   <.div(s"${props.obsId}: ${props.title}"),
+          //   props.subtitle.map(subtitle => <.div(ExploreStyles.SequenceObsSutitle, subtitle))
+          // )
+        )(
+          <.div(ExploreStyles.TargetImportForm)(
+            ProgressSpinner(),
+            s"Importing ${currentTarget.value.foldMap(_.name.value)}"
+            // ProgressBar(value = 10)
+          )
+        )
+      }

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -61,9 +61,9 @@ import react.draggable.Axis
 import react.gridlayout.*
 import react.hotkeys.*
 import react.hotkeys.hooks.*
+import react.primereact.PrimeStyles
 import react.primereact.Toast
 import react.primereact.hooks.all.*
-import react.primereact.PrimeStyles
 import react.resizable.*
 import react.resizeDetector.*
 import react.resizeDetector.hooks.*

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -63,6 +63,7 @@ import react.hotkeys.*
 import react.hotkeys.hooks.*
 import react.primereact.Toast
 import react.primereact.hooks.all.*
+import react.primereact.PrimeStyles
 import react.resizable.*
 import react.resizeDetector.*
 import react.resizeDetector.hooks.*
@@ -240,19 +241,46 @@ object TargetTabContents:
         )
       )(^.href := ctx.pageUrl(AppTab.Targets, props.programId, Focused.None), Icons.ChevronLeft)
 
+    def onTextChange(e: ReactEventFromInput): Callback =
+      Callback(org.scalajs.dom.window.console.log(e.target.files(0)))
+
     /**
      * Render the summary table.
      */
     def renderSummary: VdomNode =
-      Tile("targetSummary".refined, "Target Summary", backButton.some)(renderInTitle =>
-        TargetSummaryTable(
-          props.userId,
-          props.programId,
-          targetMap,
-          selectObservationAndTarget(props.expandedIds) _,
-          selectTarget _,
-          renderInTitle
-        ): VdomNode
+      <.div(
+        Tile(
+          "targetSummary".refined,
+          "Target Summary",
+          backButton.some,
+          control = _ =>
+            Option(
+              <.div(
+                // ExploreStyles.SummaryTableToolbar,
+                <.label(PrimeStyles.ButtonSmall,
+                        PrimeStyles.ButtonIcon,
+                        ^.cls     := "p-button p-fileupload",
+                        ^.htmlFor := "target-import",
+                        Icons.FileImport
+                ),
+                <.input(^.tpe     := "file",
+                        ^.onChange ==> onTextChange,
+                        ^.id      := "target-import",
+                        ^.name    := "file",
+                        ^.accept  := ".csv"
+                )
+              )
+            )
+        )(renderInTitle =>
+          TargetSummaryTable(
+            props.userId,
+            props.programId,
+            targetMap,
+            selectObservationAndTarget(props.expandedIds) _,
+            selectTarget _,
+            renderInTitle
+          ): VdomNode
+        )
       )
 
     val coreWidth  = resize.width.getOrElse(0) - treeWidth

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -61,7 +61,6 @@ import react.draggable.Axis
 import react.gridlayout.*
 import react.hotkeys.*
 import react.hotkeys.hooks.*
-import react.primereact.PrimeStyles
 import react.primereact.Toast
 import react.primereact.hooks.all.*
 import react.resizable.*

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -241,9 +241,6 @@ object TargetTabContents:
         )
       )(^.href := ctx.pageUrl(AppTab.Targets, props.programId, Focused.None), Icons.ChevronLeft)
 
-    def onTextChange(e: ReactEventFromInput): Callback =
-      Callback(org.scalajs.dom.window.console.log(e.target.files(0)))
-
     /**
      * Render the summary table.
      */
@@ -252,25 +249,7 @@ object TargetTabContents:
         Tile(
           "targetSummary".refined,
           "Target Summary",
-          backButton.some,
-          control = _ =>
-            Option(
-              <.div(
-                // ExploreStyles.SummaryTableToolbar,
-                <.label(PrimeStyles.ButtonSmall,
-                        PrimeStyles.ButtonIcon,
-                        ^.cls     := "p-button p-fileupload",
-                        ^.htmlFor := "target-import",
-                        Icons.FileImport
-                ),
-                <.input(^.tpe     := "file",
-                        ^.onChange ==> onTextChange,
-                        ^.id      := "target-import",
-                        ^.name    := "file",
-                        ^.accept  := ".csv"
-                )
-              )
-            )
+          backButton.some
         )(renderInTitle =>
           TargetSummaryTable(
             props.userId,

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -204,10 +204,9 @@ object TargetSummaryTable extends TableHooks:
             React.Fragment(
               <.div(
                 ExploreStyles.TableSelectionToolbar,
-                <.label(PrimeStyles.ButtonSmall,
-                        ^.cls     := "pl-compact p-component p-button p-fileupload",
+                <.label(^.cls     := "pl-compact p-component p-button p-fileupload",
                         ^.htmlFor := "target-import",
-                        Icons.FileImport
+                        Icons.FileArrowUp
                 ),
                 <.input(^.tpe     := "file",
                         ^.onChange ==> onTextChange,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -18,6 +18,7 @@ object Settings {
     val disciplineMUnit  = "1.0.9"
     val fs2              = "3.3.0"
     val fs2Data          = "1.6.0"
+    val fs2Dom           = "0.0-9abbf5e-SNAPSHOT"
     val geminiLocales    = "0.7.0"
     val http4s           = "0.23.16"
     val http4sDom        = "0.2.3"
@@ -144,6 +145,12 @@ object Settings {
       deps(
         "co.fs2" %%% "fs2-node"
       )(fs2)
+    )
+
+    val FS2Dom = Def.setting(
+      Seq(
+        "com.armanbilge" %%% "fs2-dom" % fs2Dom
+      )
     )
 
     val GeminiLocales = Def.setting(


### PR DESCRIPTION
This is the first PR to support target import. This lets you open a csv file with name/ra/dec columns and import the targets.

In future updates we'll support importing brightnesses, etc

The current API only accepts adding targets one by one thus this gets very slow when adding, e.g. 1000 targets but it is very usable for a few hundreds.

https://user-images.githubusercontent.com/3615303/198096928-9b57cd51-d37e-4e3c-8729-9ea914e78b0b.mp4

