### PR TITLE
Fix spectroscopy matrix rows ids, optimize table rendering

### DIFF
--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -639,7 +639,6 @@ private object SpectroscopyModesTable extends TableHooks:
                 estimateRowHeight = _ => 32.toPx,
                 striped = true,
                 compact = Compact.Very,
-                // getItemKey = idx => rows(idx).id,
                 containerMod = ^.overflow.auto,
                 rowMod = row =>
                   TagMod(

--- a/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
+++ b/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
@@ -13,10 +13,10 @@ trait SpectroscopyModesMatrixPlatform extends SpectroscopyModesMatrixDecoders {
   def loadMatrix[F[_]: Concurrent](s: Stream[F, String]): F[List[SpectroscopyModeRow]] =
     s
       .through(decodeUsingHeaders[NonEmptyList[SpectroscopyModeRow]]())
-      .flatMap(l => Stream(l.toList: _*))
+      // .flatMap(l => Stream(l.toList: _*))
       .compile
       .toList
-      .map(_.zipWithIndex.map { case (row, i) => row.copy(id = i) })
+      .map(_.flatMap(_.toList).zipWithIndex.map { case (row, i) => row.copy(id = i) })
 
   def apply[F[_]: Concurrent](s: Stream[F, String]): F[SpectroscopyModesMatrix] =
     loadMatrix(s).map(SpectroscopyModesMatrix(_))

--- a/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
+++ b/model/js/src/main/scala/explore/modes/SpectroscopyModesMatrixPlatform.scala
@@ -13,10 +13,10 @@ trait SpectroscopyModesMatrixPlatform extends SpectroscopyModesMatrixDecoders {
   def loadMatrix[F[_]: Concurrent](s: Stream[F, String]): F[List[SpectroscopyModeRow]] =
     s
       .through(decodeUsingHeaders[NonEmptyList[SpectroscopyModeRow]]())
-      .map(_.zipWithIndex.map { case (row, i) => row.copy(id = i) })
       .flatMap(l => Stream(l.toList: _*))
       .compile
       .toList
+      .map(_.zipWithIndex.map { case (row, i) => row.copy(id = i) })
 
   def apply[F[_]: Concurrent](s: Stream[F, String]): F[SpectroscopyModesMatrix] =
     loadMatrix(s).map(SpectroscopyModesMatrix(_))

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -366,8 +366,8 @@ trait SpectroscopyModesMatrixDecoders extends Decoders {
       r   <- row.as[PosInt]("resolution")
       sl  <- row.as[ModeSlitSize]("slit length")
       sw  <- row.as[ModeSlitSize]("slit width")
-    } yield fs.map(f =>
-      SpectroscopyModeRow(row.line.foldMap(_.toInt), i, s, f, c, a, min, max, wo, wr, r, sl, sw)
+    } yield fs.map(f => // Ids are assigned later, after list is flattened.
+      SpectroscopyModeRow(0, i, s, f, c, a, min, max, wo, wr, r, sl, sw)
     )
 
 }


### PR DESCRIPTION
Some rows had duplicated ids, which broke sorting.

Also, precompute ITC result summary, storing it in the table row, so it doesn't have to be computed on every render.