### PR TITLE
Quick fix for brightness units pulldown menu hidden

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1347,69 +1347,94 @@ html {
   padding: 1em;
 }
 
+// This selector is never matched after the new table transistion. But, the table doesn't
+// seem to be shown on small screens?
 // https://css-tricks.com/responsive-data-tables/
-.tile-xs-width .explore-brightnesses-container .ui.ui.ui.ui.table:not(.unstackable) {
-  tfoot {
-    display: block;
-  }
+// .tile-xs-width .explore-brightnesses-container .ui.ui.ui.ui.table:not(.unstackable) {
+//   tfoot {
+//     display: block;
+//   }
 
-  td {
-    /* Behave  like a "row" */
-    position: relative;
-    padding-left: 40%;
-    padding-right: 0.5em;
-  }
+//   td {
+//     /* Behave  like a "row" */
+//     position: relative;
+//     padding-left: 40%;
+//     padding-right: 0.5em;
+//   }
 
-  td::before {
-    /* Now like a table header */
-    position: absolute;
+//   td::before {
+//     /* Now like a table header */
+//     position: absolute;
 
-    /* Top/left values mimic padding */
-    top: 6px;
-    left: 6px;
-    width: 45%;
-    padding-left: 0.25em;
-    white-space: nowrap;
-  }
+//     /* Top/left values mimic padding */
+//     top: 6px;
+//     left: 6px;
+//     width: 45%;
+//     padding-left: 0.25em;
+//     white-space: nowrap;
+//   }
 
-  td:first-child::before {
-    font-weight: normal;
-  }
+//   td:first-child::before {
+//     font-weight: normal;
+//   }
 
-  // It is a bit unfortunate that we have to hardcode the column names here
-  td:nth-of-type(1)::before {
-    content: 'Value';
-  }
+//   // It is a bit unfortunate that we have to hardcode the column names here
+//   td:nth-of-type(1)::before {
+//     content: 'Value';
+//   }
 
-  td:nth-of-type(2)::before {
-    content: 'Band';
-  }
+//   td:nth-of-type(2)::before {
+//     content: 'Band';
+//   }
 
-  td:nth-of-type(3)::before {
-    content: 'System';
-  }
+//   td:nth-of-type(3)::before {
+//     content: 'System';
+//   }
 
-  td:nth-of-type(4)::before {
-    content: '';
-  }
+//   td:nth-of-type(4)::before {
+//     content: '';
+//   }
 
-  // Align the trash button
-  td:last-child button {
-    margin-left: auto;
-  }
-}
+//   // Align the trash button
+//   td:last-child button {
+//     margin-left: auto;
+//   }
+// }
 
-.explore-brightnesses-units-dropdown .ui.dropdown {
+.explore-brightnesses-units-dropdown.p-dropdown {
   white-space: nowrap;
+  width: 100%;
 }
 
 .explore-brightnesses-delete-button-wrapper {
   display: flex;
   justify-content: center;
 
-  .ui.button.delete-button {
-    padding: 0.4em 0;
+  .p-button.delete-button {
+    padding: 0;
   }
+}
+
+// TODO: Temporary until the entire sidereal target editor is converted to primereact
+.explore-brightnesses-wrapper .explore-brightnesses-container {
+  // Because even the brightnesses tabler is embedded in a SUI Form, the SUI CSS os overriding 
+  // the primereact CSS.
+  .p-inputgroup.pl-form-field input {
+    font-family: "Lato", "Helvetica Neue", Arial, Helvetica, sans-serif;
+    font-size: 1rem;
+    color: rgba(255, 255, 255, 0.87);
+    background: #121212;
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #383838;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
+    appearance: none;
+    border-radius: 4px;
+  }
+
+  // Need to do some theme work on the dropdowns.
+ .p-dropdown .p-dropdown-trigger-icon {
+  font-size: .929em;
+ } 
 }
 
 .explore-brightnesses-footer {
@@ -1420,7 +1445,7 @@ html {
   background-color: var(--table-footer-background);
 }
 
-.ui.button.explore-brightnesses-add-button {
+.p-button.explore-brightnesses-add-button {
   margin-left: 5px;
 }
 

--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -27,17 +27,15 @@ import lucuma.core.util.Enumerated
 import lucuma.react.syntax.*
 import lucuma.react.table.*
 import lucuma.refined.*
-import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.*
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.table.*
 import monocle.Focus
 import react.common.ReactFnProps
-import react.semanticui.elements.button.Button
-import react.semanticui.sizes.*
+import react.primereact.Button
 import reactST.{tanstackTableCore => raw}
 
 import scala.collection.immutable.SortedMap
@@ -102,7 +100,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 _._2.zoom(Measure.valueTagged[BigDecimal, Brightness[T]]),
                 "Value",
                 cell =>
-                  FormInputEV[View, BigDecimal](
+                  FormInputTextView(
                     id = NonEmptyString.unsafeFrom(s"brightnessValue_${cell.row.id}"),
                     value = cell.value,
                     validFormat = ExploreModelValidators.brightnessValidWedge,
@@ -119,10 +117,10 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 _._2.zoom(Measure.unitsTagged[BigDecimal, Brightness[T]]),
                 "Units",
                 cell =>
-                  EnumViewSelect[View, Units Of Brightness[T]](
+                  EnumDropdownView[Units Of Brightness[T]](
                     id = NonEmptyString.unsafeFrom(s"brightnessUnits_${cell.row.id}"),
                     value = cell.value,
-                    compact = true,
+                    // compact = true,
                     disabled = disabled,
                     clazz = ExploreStyles.BrightnessesTableUnitsDropdown
                   ),
@@ -137,11 +135,12 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 cell =>
                   <.div(ExploreStyles.BrightnessesTableDeletButtonWrapper)(
                     Button(
-                      size = Small,
+                      icon = Icons.Trash,
                       clazz = ExploreStyles.DeleteButton,
+                      text = true,
                       disabled = disabled,
                       onClick = brightnesses.mod(_ - cell.value)
-                    )(Icons.Trash)
+                    ).small
                   ),
                 size = 20.toPx,
                 minSize = 20.toPx,
@@ -179,23 +178,21 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                   )
 
                 React.Fragment(
-                  EnumViewSelect(
-                    id = "NEW_BAND",
+                  EnumDropdownView(
+                    id = "NEW_BAND".refined,
                     value = bandView,
                     exclude = state.get.usedBands,
-                    upward = true,
-                    clazz = ExploreStyles.FlatFormField,
+                    // upward = true,
+                    clazz = ExploreStyles.FlatFormField, // TODO: Look at this CSS
                     disabled = props.disabled
                   ),
                   Button(
-                    size = Mini,
-                    compact = true,
+                    icon = Icons.New,
                     onClick = addBrightness,
-                    clazz = ExploreStyles.BrightnessAddButton,
-                    disabled = props.disabled
-                  )(
-                    Icons.New
-                  )
+                    clazz = ExploreStyles.BrightnessAddButton, // TODO: Look at this CSS
+                    disabled = props.disabled,
+                    severity = Button.Severity.Secondary
+                  ).mini.compact
                 )
               }
               .whenDefined


### PR DESCRIPTION
I did a quick fix for the problem of the brightness units dropdown dropping down behind the table rows. But it's a bit of an ugly hack, so I don't know if we want to use. I'm just thinking it would be nice if it worked in the demo this week...

I set out to convert the whole target editor to primereact, but I wasn't going to have time to finish it. So, I rigged some temporary CSS to make it work. The rows are still slightly taller than the old table.
<img width="510" alt="image" src="https://user-images.githubusercontent.com/6035943/201548515-4ef72c1c-dce1-4ebe-9beb-da565e3bf191.png">

