### PR TITLE
Convert SiderealTargetEditor to primereact

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -238,10 +238,8 @@ object ExploreStyles {
   val TargetAladinCell: Css         = Css("target-aladin-cell")
   val TargetAladin: Css             = Css("aladin-target")
   val TargetAladinDisableMouse: Css = Css("aladin-target-disable-mouse")
-  val TargetRaDecMinWidth: Css      = Css("target-ra-dec-min-width")
   val TargetForm: Css               = Css("target-form")
   val TargetProperMotionForm: Css   = Css("target-proper-motion-form")
-  val SearchForm: Css               = Css("target-search-form")
   val TargetRVControls: Css         = Css("target-rv-controls")
   val CatalogueForm: Css            = Css("catalogue-form")
 
@@ -286,7 +284,6 @@ object ExploreStyles {
   val BrightnessesTableFooter: Css             = Css("explore-brightnesses-footer")
   val BrightnessesTableUnitsDropdown: Css      = Css("explore-brightnesses-units-dropdown")
   val BrightnessesTableDeletButtonWrapper: Css = Css("explore-brightnesses-delete-button-wrapper")
-  val BrightnessAddButton: Css                 = Css("explore-brightnesses-add-button")
   val EmptyTreeContent: Css                    = Css("explore-empty-tree-content")
 
   // This is rendered without React, so we include SUI classes.
@@ -403,8 +400,6 @@ object ExploreStyles {
   val TargetSearchAladin: Css             = Css("aladin-search-target")
   val TargetSearchPreviewPlaceholder: Css = Css("explore-target-search-preview-placeholder")
   val TargetSearchResults: Css            = Css("explore-target-search-results")
-
-  val NewEmissionLineWavelength: Css = Css("explore-new-emissionline-wavelength")
 
   // Aladin Target classes
   val ScienceTarget: Css           = Css("science-target")

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1149,60 +1149,6 @@ html {
   padding: 1em;
 }
 
-// This selector is never matched after the new table transistion. But, the table doesn't
-// seem to be shown on small screens?
-// https://css-tricks.com/responsive-data-tables/
-// .tile-xs-width .explore-brightnesses-container .ui.ui.ui.ui.table:not(.unstackable) {
-//   tfoot {
-//     display: block;
-//   }
-
-//   td {
-//     /* Behave  like a "row" */
-//     position: relative;
-//     padding-left: 40%;
-//     padding-right: 0.5em;
-//   }
-
-//   td::before {
-//     /* Now like a table header */
-//     position: absolute;
-
-//     /* Top/left values mimic padding */
-//     top: 6px;
-//     left: 6px;
-//     width: 45%;
-//     padding-left: 0.25em;
-//     white-space: nowrap;
-//   }
-
-//   td:first-child::before {
-//     font-weight: normal;
-//   }
-
-//   // It is a bit unfortunate that we have to hardcode the column names here
-//   td:nth-of-type(1)::before {
-//     content: 'Value';
-//   }
-
-//   td:nth-of-type(2)::before {
-//     content: 'Band';
-//   }
-
-//   td:nth-of-type(3)::before {
-//     content: 'System';
-//   }
-
-//   td:nth-of-type(4)::before {
-//     content: '';
-//   }
-
-//   // Align the trash button
-//   td:last-child button {
-//     margin-left: auto;
-//   }
-// }
-
 .obs-badge-header {
   display: flex;
   align-items: center;
@@ -1377,6 +1323,12 @@ html {
 
 .tile-xs-width {
   .explore-shared-edit-warning {
+    display: none;
+  }
+
+  // TODO: This will require some work when we change the undo buttons to primereact.
+  // For very small tables make the undo buttons remove the text
+  .explore-buttons-undo-label {
     display: none;
   }
 }

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -63,12 +63,6 @@ a {
   color: var(--site-link-color);
 }
 
-.explore-new-emissionline-wavelength {
-  .ui.input {
-    padding: 0 0.5em;
-  }
-}
-
 // Mixins
 //
 .full-height-width {
@@ -551,66 +545,6 @@ tfoot {
   height: 100%;
 }
 
-.target-tile-body {
-  display: flex;
-  flex-direction: column;
-
-  >div {
-    flex-grow: 1;
-    display: flex;
-    flex-direction: column;
-  }
-}
-
-.target-tile-editor {
-  flex-grow: 2;
-  display: flex;
-  flex-direction: column;
-}
-
-.expanded-aladin() {
-  grid-template-areas: 'aladin';
-  grid-template-columns: 1fr;
-
-  .explore-title-undo-buttons {
-    display: none;
-  }
-
-  .target-form {
-    display: none;
-  }
-
-  .target-proper-motion-form {
-    display: none;
-  }
-
-  .target-source-profile-editor {
-    display: none;
-  }
-}
-
-.aladin-full-screen {
-
-  .explore-shared-edit-warning,
-  .target-asterism-table {
-    display: none;
-  }
-
-  >div .target-grid {
-    .expanded-aladin();
-  }
-
-}
-
-.explore-form.target-source-profile-editor {
-  align-self: stretch;
-  grid-template-rows: repeat(3, auto) 1fr;
-
-  &.gaussian {
-    grid-template-rows: repeat(4, auto) 1fr;
-  }
-}
-
 .obs-tree {
   display: flex;
   flex-direction: column;
@@ -930,11 +864,6 @@ tfoot {
     'fov    agsstatus guidestar curr   center';
 }
 
-.aladin-search-icon {
-  align-self: center;
-  margin-left: 0.5em;
-}
-
 .moon-phase {
   position: absolute;
   top: 5px;
@@ -985,28 +914,6 @@ tfoot {
   width: 100%;
 }
 
-.target-form {
-  grid-template-columns: [label] minmax(100px, 10%) [field] 1fr;
-  justify-items: stretch;
-}
-
-.target-search-form {
-  grid-column: 1 / span 2;
-  display: grid;
-  grid-template-columns: [label] minmax(100px, 10%) [field] minmax(calc(100% - 100px - 0.3em),
-      calc(90% - 0.3em));
-  grid-gap: 0.3em;
-
-  .field {
-    margin-bottom: 0 !important;
-  }
-
-  .ui.input {
-    display: grid;
-    grid-template-columns: [input] calc(100% - 20px) [svg] 20px;
-  }
-}
-
 .target-brightness-cell {
   .form {
     height: 100%;
@@ -1018,23 +925,8 @@ tfoot {
   outline: 3px solid pink !important;
 }
 
-.target-rv-controls {
-  justify-self: stretch;
-
-  .explore-grow-1 {
-    margin-left: 0.3em !important;
-  }
-}
-
 .catalogue-form {
   height: max-content; // keep it from expanding to fill cell
-}
-
-// for the ra and dec inputs expand
-.target-ra-dec-min-width {
-  .ui.input {
-    width: 100%;
-  }
 }
 
 .error-label-mixin() {
@@ -1147,98 +1039,6 @@ div.partner-split-total {
   }
 }
 
-.explore-brightnesses-wrapper {
-  grid-column: 1 / -1;
-  justify-self: stretch;
-  align-self: stretch;
-}
-
-.explore-brightnesses-container {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.target-grid {
-  display: grid;
-  grid-gap: 0.5em;
-  grid-row-gap: 0.3em;
-  padding: 0.5em;
-  height: 100%;
-
-  .explore-title-undo-buttons {
-    grid-area: undo;
-  }
-
-  .target-aladin-cell {
-    grid-area: aladin;
-  }
-
-  .target-form {
-    grid-area: coordinates;
-  }
-
-  .target-proper-motion-form {
-    grid-area: proper-motion;
-  }
-
-  .target-source-profile-editor {
-    grid-area: source-profile;
-  }
-}
-
-.tile-xl-width,
-.tile-lg-width,
-.tile-md-width,
-.tile-sm-width {
-  .target-grid {
-    grid-template-columns: 1fr 2fr;
-    grid-template-rows: min-content min-content min-content 1fr;
-    grid-template-areas:
-      'undo           aladin'
-      'coordinates    aladin'
-      'proper-motion  aladin'
-      'source-profile aladin';
-  }
-
-  .target-aladin-cell {
-    grid-row: span 4;
-  }
-}
-
-// For very small tables hide the headers and add fake "header" to the left of the row
-.tile-xs-width {
-
-  // For very small tables make the undo buttons remove the text
-  .explore-buttons-undo-label {
-    display: none;
-  }
-
-  .target-grid {
-    .expanded-aladin();
-  }
-
-  .explore-brightnesses-container {
-
-    .ui.table,
-    thead,
-    tbody,
-    th,
-    td,
-    tr {
-      // SUI already has an !important
-      display: block !important;
-    }
-
-    // Hide table headers (but not display: none;, for accessibility)
-    thead tr {
-      position: absolute;
-      top: -9999px;
-      left: -9999px;
-    }
-  }
-}
-
 // position all fields relative so that error labels position properly.
 .ui .field {
   position: relative;
@@ -1262,13 +1062,15 @@ div.partner-split-total {
 .ui.button.blended-button {
   border: none;
   background-color: transparent;
-  box-shadow: none;
-
+  box-shadow: none;n
   &:hover {
     outline: 1px var(--site-border-color) solid;
   }
 }
 
+// TODO: This was also used in the brightness tables, but is no longer needed. 
+// When the obs badge is converted to primereact, this may be able to go away, or
+// be made specific to the obs badge
 .ui.button.delete-button {
   padding: 0;
   margin: 0;
@@ -1347,82 +1149,59 @@ html {
   padding: 1em;
 }
 
+// This selector is never matched after the new table transistion. But, the table doesn't
+// seem to be shown on small screens?
 // https://css-tricks.com/responsive-data-tables/
-.tile-xs-width .explore-brightnesses-container .ui.ui.ui.ui.table:not(.unstackable) {
-  tfoot {
-    display: block;
-  }
+// .tile-xs-width .explore-brightnesses-container .ui.ui.ui.ui.table:not(.unstackable) {
+//   tfoot {
+//     display: block;
+//   }
 
-  td {
-    /* Behave  like a "row" */
-    position: relative;
-    padding-left: 40%;
-    padding-right: 0.5em;
-  }
+//   td {
+//     /* Behave  like a "row" */
+//     position: relative;
+//     padding-left: 40%;
+//     padding-right: 0.5em;
+//   }
 
-  td::before {
-    /* Now like a table header */
-    position: absolute;
+//   td::before {
+//     /* Now like a table header */
+//     position: absolute;
 
-    /* Top/left values mimic padding */
-    top: 6px;
-    left: 6px;
-    width: 45%;
-    padding-left: 0.25em;
-    white-space: nowrap;
-  }
+//     /* Top/left values mimic padding */
+//     top: 6px;
+//     left: 6px;
+//     width: 45%;
+//     padding-left: 0.25em;
+//     white-space: nowrap;
+//   }
 
-  td:first-child::before {
-    font-weight: normal;
-  }
+//   td:first-child::before {
+//     font-weight: normal;
+//   }
 
-  // It is a bit unfortunate that we have to hardcode the column names here
-  td:nth-of-type(1)::before {
-    content: 'Value';
-  }
+//   // It is a bit unfortunate that we have to hardcode the column names here
+//   td:nth-of-type(1)::before {
+//     content: 'Value';
+//   }
 
-  td:nth-of-type(2)::before {
-    content: 'Band';
-  }
+//   td:nth-of-type(2)::before {
+//     content: 'Band';
+//   }
 
-  td:nth-of-type(3)::before {
-    content: 'System';
-  }
+//   td:nth-of-type(3)::before {
+//     content: 'System';
+//   }
 
-  td:nth-of-type(4)::before {
-    content: '';
-  }
+//   td:nth-of-type(4)::before {
+//     content: '';
+//   }
 
-  // Align the trash button
-  td:last-child button {
-    margin-left: auto;
-  }
-}
-
-.explore-brightnesses-units-dropdown .ui.dropdown {
-  white-space: nowrap;
-}
-
-.explore-brightnesses-delete-button-wrapper {
-  display: flex;
-  justify-content: center;
-
-  .ui.button.delete-button {
-    padding: 0.4em 0;
-  }
-}
-
-.explore-brightnesses-footer {
-  display: flex;
-  justify-content: flex-start;
-  padding: 0.2em;
-  border-top: 0.2px solid var(--under-tab-border-color);
-  background-color: var(--table-footer-background);
-}
-
-.ui.button.explore-brightnesses-add-button {
-  margin-left: 5px;
-}
+//   // Align the trash button
+//   td:last-child button {
+//     margin-left: auto;
+//   }
+// }
 
 .obs-badge-header {
   display: flex;

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -233,16 +233,15 @@ $tree-section-width: 300px;
   }
 }
 
-@mixin expanded-aladin {
-  grid-template-areas: 'aladin';
-  grid-template-columns: 1fr;
+@mixin hide-hidden-target-cells($all) {
+  @if $all {
+    .explore-title-undo-buttons {
+      display: none;
+    }
 
-  .explore-title-undo-buttons {
-    display: none;
-  }
-
-  .target-form {
-    display: none;
+    .target-form {
+      display: none;
+    }
   }
 
   .target-proper-motion-form {
@@ -259,13 +258,12 @@ $tree-section-width: 300px;
 .tile-md-width,
 .tile-sm-width {
   .target-grid {
-    grid-template-columns: 1fr 2fr;
-    grid-template-rows: min-content min-content min-content 1fr;
-    grid-template-areas:
-      'undo           aladin'
-      'coordinates    aladin'
-      'proper-motion  aladin'
-      'source-profile aladin';
+    grid-template:
+      'undo           aladin' min-content
+      'coordinates    aladin' min-content
+      'proper-motion  aladin' min-content
+      'source-profile aladin' 1fr
+      / 1fr 2fr;
   }
 
   .target-aladin-cell {
@@ -274,38 +272,15 @@ $tree-section-width: 300px;
 }
 
 .tile-xs-width {
-  
-  // undo buttons are not show in xs tiles, only aladin
-  // For very small tables make the undo buttons remove the text
-  // .explore-buttons-undo-label {
-  //   display: none;
-  // }
-  
   .target-grid {
-    @include expanded-aladin;
+    @include hide-hidden-target-cells(false);
+
+    grid-template:
+      'undo' min-content
+      'coordinates' min-content
+      'aladin' 1fr
+      / 1fr
   }
-  
-  // brightness are not even displayed in xs tiles.
-  // For very small tables hide the headers and add fake "header" to the left of the row
-  // .explore-brightnesses-container {
-
-  //   .ui.table,
-  //   thead,
-  //   tbody,
-  //   th,
-  //   td,
-  //   tr {
-  //     // SUI already has an !important
-  //     display: block !important;
-  //   }
-
-  //   // Hide table headers (but not display: none;, for accessibility)
-  //   thead tr {
-  //     position: absolute;
-  //     top: -9999px;
-  //     left: -9999px;
-  //   }
-  // }
 }
 
 .target-tile-body {
@@ -326,16 +301,18 @@ $tree-section-width: 300px;
 }
 
 .aladin-full-screen {
-
   .explore-shared-edit-warning,
   .target-asterism-table {
     display: none;
   }
 
   >div .target-grid {
-    @include expanded-aladin;
-  }
+    @include hide-hidden-target-cells(true);
 
+    grid-template: 
+      'aladin' 1fr
+      / 1fr;
+  }
 }
 
 .pl-form-column.target-source-profile-editor {

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -13,6 +13,10 @@ $tree-section-width: 300px;
   }
 }
 
+.p-inputgroup.explore-warning-input {
+  box-shadow: -0 0 2px 1px var(--warning-background-color);
+}
+
 // -----
 // Table toolbar
 // -----
@@ -157,7 +161,212 @@ $tree-section-width: 300px;
       display: unset;
     }
   }
+}
 
+// ------
+// Sidereal Target Editor
+// ------
+.explore-brightnesses-wrapper {
+  grid-column: 1 / -1;
+  justify-self: stretch;
+  align-self: stretch;
+}
+
+.explore-brightnesses-container {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.explore-brightnesses-units-dropdown.p-dropdown {
+  white-space: nowrap;
+  width: 100%;
+}
+
+.explore-brightnesses-delete-button-wrapper {
+  display: flex;
+  justify-content: center;
+
+  .p-button.delete-button {
+    padding: 0;
+    flex-shrink: 0;
+  }
+}
+
+.target-grid {
+  display: grid;
+  grid-gap: 0.5em;
+  grid-row-gap: 0.3em;
+  padding: 0.5em;
+  height: 100%;
+
+  .explore-title-undo-buttons {
+    grid-area: undo;
+  }
+
+  .target-aladin-cell {
+    grid-area: aladin;
+  }
+
+  .target-form {
+    grid-area: coordinates;
+  }
+
+  .target-proper-motion-form {
+    grid-area: proper-motion;
+
+    .p-inputgroup>span:first-of-type {
+      width: 4em;
+    }
+  }
+
+  .target-source-profile-editor {
+    grid-area: source-profile;
+  }
+}
+
+.target-rv-controls {
+  justify-self: stretch;
+
+  .explore-grow-1 {
+    margin-left: 0.3em !important;
+  }
+}
+
+@mixin expanded-aladin {
+  grid-template-areas: 'aladin';
+  grid-template-columns: 1fr;
+
+  .explore-title-undo-buttons {
+    display: none;
+  }
+
+  .target-form {
+    display: none;
+  }
+
+  .target-proper-motion-form {
+    display: none;
+  }
+
+  .target-source-profile-editor {
+    display: none;
+  }
+}
+
+.tile-xl-width,
+.tile-lg-width,
+.tile-md-width,
+.tile-sm-width {
+  .target-grid {
+    grid-template-columns: 1fr 2fr;
+    grid-template-rows: min-content min-content min-content 1fr;
+    grid-template-areas:
+      'undo           aladin'
+      'coordinates    aladin'
+      'proper-motion  aladin'
+      'source-profile aladin';
+  }
+
+  .target-aladin-cell {
+    grid-row: span 4;
+  }
+}
+
+.tile-xs-width {
+  
+  // undo buttons are not show in xs tiles, only aladin
+  // For very small tables make the undo buttons remove the text
+  // .explore-buttons-undo-label {
+  //   display: none;
+  // }
+  
+  .target-grid {
+    @include expanded-aladin;
+  }
+  
+  // brightness are not even displayed in xs tiles.
+  // For very small tables hide the headers and add fake "header" to the left of the row
+  // .explore-brightnesses-container {
+
+  //   .ui.table,
+  //   thead,
+  //   tbody,
+  //   th,
+  //   td,
+  //   tr {
+  //     // SUI already has an !important
+  //     display: block !important;
+  //   }
+
+  //   // Hide table headers (but not display: none;, for accessibility)
+  //   thead tr {
+  //     position: absolute;
+  //     top: -9999px;
+  //     left: -9999px;
+  //   }
+  // }
+}
+
+.target-tile-body {
+  display: flex;
+  flex-direction: column;
+
+  >div {
+    flex-grow: 1;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.target-tile-editor {
+  flex-grow: 2;
+  display: flex;
+  flex-direction: column;
+}
+
+.aladin-full-screen {
+
+  .explore-shared-edit-warning,
+  .target-asterism-table {
+    display: none;
+  }
+
+  >div .target-grid {
+    @include expanded-aladin;
+  }
+
+}
+
+.pl-form-column.target-source-profile-editor {
+  align-self: stretch;
+  grid-template-rows: repeat(3, auto) 1fr;
+
+  &.gaussian {
+    grid-template-rows: repeat(4, auto) 1fr;
+  }
+}
+
+.explore-brightnesses-footer {
+  display: flex;
+  justify-content: flex-start;
+  padding: 0.2em;
+  border-top: 0.2px solid var(--under-tab-border-color);
+  background-color: var(--table-footer-background);
+
+  .pl-form-field-label {
+    flex-shrink: 0;
+  }
+
+  .pl-form-field {
+    margin-left: 5px;
+    width: 15em;
+  }
+
+  .p-button {
+    margin-left: 5px;
+    flex-shrink: 0;
+  }
 }
 
 // ------

--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -27,17 +27,15 @@ import lucuma.core.util.Enumerated
 import lucuma.react.syntax.*
 import lucuma.react.table.*
 import lucuma.refined.*
-import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.*
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.table.*
 import monocle.Focus
 import react.common.ReactFnProps
-import react.semanticui.elements.button.Button
-import react.semanticui.sizes.*
+import react.primereact.Button
 import reactST.{tanstackTableCore => raw}
 
 import scala.collection.immutable.SortedMap
@@ -102,7 +100,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 _._2.zoom(Measure.valueTagged[BigDecimal, Brightness[T]]),
                 "Value",
                 cell =>
-                  FormInputEV[View, BigDecimal](
+                  FormInputTextView(
                     id = NonEmptyString.unsafeFrom(s"brightnessValue_${cell.row.id}"),
                     value = cell.value,
                     validFormat = ExploreModelValidators.brightnessValidWedge,
@@ -119,10 +117,9 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 _._2.zoom(Measure.unitsTagged[BigDecimal, Brightness[T]]),
                 "Units",
                 cell =>
-                  EnumViewSelect[View, Units Of Brightness[T]](
+                  EnumDropdownView[Units Of Brightness[T]](
                     id = NonEmptyString.unsafeFrom(s"brightnessUnits_${cell.row.id}"),
                     value = cell.value,
-                    compact = true,
                     disabled = disabled,
                     clazz = ExploreStyles.BrightnessesTableUnitsDropdown
                   ),
@@ -137,11 +134,12 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 cell =>
                   <.div(ExploreStyles.BrightnessesTableDeletButtonWrapper)(
                     Button(
-                      size = Small,
+                      icon = Icons.Trash,
                       clazz = ExploreStyles.DeleteButton,
+                      text = true,
                       disabled = disabled,
                       onClick = brightnesses.mod(_ - cell.value)
-                    )(Icons.Trash)
+                    ).small
                   ),
                 size = 20.toPx,
                 minSize = 20.toPx,
@@ -179,23 +177,19 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                   )
 
                 React.Fragment(
-                  EnumViewSelect(
-                    id = "NEW_BAND",
+                  EnumDropdownView(
+                    id = "NEW_BAND".refined,
                     value = bandView,
                     exclude = state.get.usedBands,
-                    upward = true,
-                    clazz = ExploreStyles.FlatFormField,
+                    clazz = ExploreStyles.FlatFormField, // TODO: Look at this CSS
                     disabled = props.disabled
                   ),
                   Button(
-                    size = Mini,
-                    compact = true,
+                    icon = Icons.New,
                     onClick = addBrightness,
-                    clazz = ExploreStyles.BrightnessAddButton,
-                    disabled = props.disabled
-                  )(
-                    Icons.New
-                  )
+                    disabled = props.disabled,
+                    severity = Button.Severity.Secondary
+                  ).mini.compact
                 )
               }
               .whenDefined

--- a/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
@@ -33,16 +33,14 @@ import lucuma.core.validation.*
 import lucuma.react.syntax.*
 import lucuma.react.table.*
 import lucuma.refined.*
-import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.*
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.table.*
 import react.common.ReactFnProps
-import react.semanticui.elements.button.Button
-import react.semanticui.sizes.*
+import react.primereact.Button
 import reactST.{tanstackTableCore => raw}
 
 import scala.collection.immutable.SortedMap
@@ -93,7 +91,7 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
             _._2.zoom(EmissionLine.lineWidth[T]).stripQuantity,
             "Width (km/s)",
             cell =>
-              FormInputEV[View, PosBigDecimal](
+              FormInputTextView(
                 id = NonEmptyString.unsafeFrom(s"lineWidth_${cell.row.id}"),
                 value = cell.value,
                 validFormat = InputValidSplitEpi.posBigDecimal,
@@ -111,7 +109,7 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
             ),
             "Brightness",
             cell =>
-              FormInputEV[View, PosBigDecimal](
+              FormInputTextView(
                 id = NonEmptyString.unsafeFrom(s"lineValue_${cell.row.id}"),
                 value = cell.value,
                 validFormat = InputValidSplitEpi.posBigDecimalWithScientificNotation,
@@ -129,10 +127,9 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
             ),
             "Units",
             cell =>
-              EnumViewSelect[View, Units Of LineFlux[T]](
-                id = s"lineUnits_${cell.row.id}",
+              EnumDropdownView(
+                id = NonEmptyString.unsafeFrom(s"lineUnits_${cell.row.id}"),
                 value = cell.value,
-                compact = true,
                 disabled = disabled,
                 clazz = ExploreStyles.BrightnessesTableUnitsDropdown
               ),
@@ -148,11 +145,12 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
               <.div(
                 ExploreStyles.BrightnessesTableDeletButtonWrapper,
                 Button(
-                  size = Small,
+                  icon = Icons.Trash,
                   clazz = ExploreStyles.DeleteButton,
+                  text = true,
                   disabled = disabled,
                   onClick = emissionLines.mod(_ - cell.value)
-                )(Icons.Trash)
+                ).small
               ),
             size = 20.toPx,
             minSize = 20.toPx,
@@ -197,29 +195,25 @@ sealed abstract class EmissionLineEditorBuilder[T, Props <: EmissionLineEditor[T
       val footer =
         <.div(
           ExploreStyles.BrightnessesTableFooter,
-          "New line λ: ",
-          FormInputEV[View, Option[Wavelength]](
+          FormInputTextView(
             id = "newWavelength".refined,
             value = newWavelength,
+            label = "New line λ:",
             validFormat = InputValidSplitEpi.fromFormat(formatWavelengthMicron).optional,
             changeAuditor = ChangeAuditor
               .fromFormat(formatWavelengthMicron)
               .decimal(3.refined)
               .allow(List("0", "0.").contains)
               .optional,
-            onTextChange = s => addDisabled.set(AddDisabled(s.isEmpty)),
-            clazz = ExploreStyles.NewEmissionLineWavelength
+            onTextChange = (s: String) => addDisabled.set(AddDisabled(s.isEmpty)),
+            postAddons = List("μm")
           ),
-          "μm",
           Button(
-            size = Mini,
-            compact = true,
+            icon = Icons.New,
             onClick = addLine,
-            clazz = ExploreStyles.BrightnessAddButton,
+            severity = Button.Severity.Secondary,
             disabled = props.disabled || addDisabled.get.value
-          )(
-            Icons.New
-          )
+          ).mini.compact
         )
 
       <.div(ExploreStyles.ExploreTable |+| ExploreStyles.BrightnessesContainer)(

--- a/explore/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/explore/src/main/scala/explore/targeteditor/RVInput.scala
@@ -20,12 +20,13 @@ import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
 import lucuma.core.validation.*
 import lucuma.refined.*
-import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.EnumDropdownView
+import lucuma.ui.primereact.FormInputTextView
+import lucuma.ui.primereact.FormLabel
+import lucuma.ui.primereact.LucumaStyles
 import lucuma.ui.syntax.all.given
 import react.common.ReactFnProps
-import react.semanticui.elements.label.LabelPointing
 
 case class RVInput(
   rv:       View[Option[RadialVelocity]],
@@ -44,70 +45,66 @@ object RVInput {
     given Enumerated[RVView] = Enumerated.from(RVView.RV, RVView.Z, RVView.CZ).withTag(_.tag)
     given Display[RVView]    = Display.byShortName(_.tag.value)
 
-  private def units(rvView: RVView, v: Option[RadialVelocity]) = rvView match {
-    case RVView.Z              =>
-      <.div(requiredForITC.unless(v.nonEmpty))
-    case RVView.CZ | RVView.RV =>
-      <.div(ExploreStyles.UnitsLabel, "km/s", requiredForITC.unless(v.nonEmpty))
-  }
+  private def addons(rvView: RVView, v: Option[RadialVelocity]): List[TagMod] =
+    val l: List[TagMod] = if (v.isEmpty) List(requiredForITC) else List.empty
+    rvView match {
+      case RVView.Z              =>
+        l
+      case RVView.CZ | RVView.RV =>
+        "km/s" :: l
+    }
 
   protected val component =
     ScalaFnComponent
       .withHooks[Props]
       .useStateView[RVView](RVView.RV)
       .render { (props, rvView) =>
-        val errorCss = ExploreStyles.InputErrorTooltip
 
-        val baseCss = ExploreStyles.Grow(1.refined) |+| ExploreStyles.WarningInput.when_(
-          props.rv.get.isEmpty
-        )
+        val baseCss = ExploreStyles.Grow(1.refined) |+|
+          ExploreStyles.WarningInput.when_(props.rv.get.isEmpty)
 
         val input = rvView.get match {
           case RVView.Z  =>
-            FormInputEV(
+            FormInputTextView(
               id = rvView.get.tag,
               value = props.rv.zoom(rvToRedshiftGet)(rvToRedshiftMod),
-              errorClazz = errorCss,
-              errorPointing = LabelPointing.Below,
               validFormat =
                 InputValidSplitEpi.fromFormat(formatZ, "Must be a number".refined).optional,
               changeAuditor = ChangeAuditor.fromFormat(formatZ).decimal(9.refined).optional,
-              clazz = baseCss,
-              disabled = props.disabled
+              groupClass = baseCss,
+              disabled = props.disabled,
+              postAddons = addons(rvView.get, props.rv.get)
             )
           case RVView.CZ =>
-            FormInputEV(
+            FormInputTextView(
               id = rvView.get.tag,
               value = props.rv.zoom(rvToARVGet)(rvToARVMod),
-              errorClazz = errorCss,
-              errorPointing = LabelPointing.Below,
               validFormat =
                 InputValidSplitEpi.fromFormat(formatCZ, "Must be a number".refined).optional,
               changeAuditor = ChangeAuditor.fromFormat(formatCZ).decimal(10.refined).optional,
-              clazz = baseCss,
-              disabled = props.disabled
+              groupClass = baseCss,
+              disabled = props.disabled,
+              postAddons = addons(rvView.get, props.rv.get)
             )
           case RVView.RV =>
-            FormInputEV(
+            FormInputTextView(
               id = rvView.get.tag,
               value = props.rv,
-              errorClazz = errorCss,
-              errorPointing = LabelPointing.Below,
               validFormat =
                 InputValidSplitEpi.fromFormat(formatRV, "Must be a number".refined).optional,
               changeAuditor = ChangeAuditor.fromFormat(formatRV).decimal(3.refined).optional,
-              clazz = baseCss,
-              disabled = props.disabled
+              groupClass = baseCss,
+              disabled = props.disabled,
+              postAddons = addons(rvView.get, props.rv.get)
             )
         }
         React.Fragment(
-          <.label(rvView.get.tag.value, ExploreStyles.SkipToNext),
+          FormLabel(htmlFor = "rv-view".refined)(rvView.get.tag.value),
           <.div(
-            ExploreStyles.FlexContainer |+| ExploreStyles.TargetRVControls,
-            EnumViewSelect(id = "view", value = rvView, disabled = props.disabled),
+            ExploreStyles.FlexContainer |+| ExploreStyles.TargetRVControls |+| LucumaStyles.FormField,
+            EnumDropdownView(id = "rv-view".refined, value = rvView, disabled = props.disabled),
             input
-          ),
-          units(rvView.get, props.rv.get)
+          )
         )
       }
 }

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -70,7 +70,6 @@ object SearchForm {
         _ => // Auto-select name field on new targets.
           // Accessing dom elements by id is not ideal in React, but passing a ref to the <input> element of a
           // Form.Input is a bit convoluted. We should reevaluate when and if we switch to another component library.
-          // TODO: I don't think this even works.
           CallbackTo(
             Option(dom.document.getElementById("search"))
               .foldMap(node =>

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -52,6 +52,8 @@ import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Types.*
 import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.FormInputTextView
+import lucuma.ui.primereact.LucumaStyles
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -59,9 +61,6 @@ import lucuma.utils.*
 import queries.common.TargetQueriesGQL
 import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
-import react.semanticui.collections.form.Form
-import react.semanticui.elements.label.LabelPointing
-import react.semanticui.sizes.Small
 
 import java.time.Instant
 
@@ -315,7 +314,7 @@ object SiderealTargetEditor {
                   props.fullScreen
                 )
               )(vizTime),
-              <.div(ExploreStyles.Grid, ExploreStyles.Compact, ExploreStyles.TargetForm)(
+              <.div(LucumaStyles.FormColumnVeryCompact, ExploreStyles.TargetForm)(
                 // Keep the search field and the coords always together
                 SearchForm(
                   tid,
@@ -327,85 +326,68 @@ object SiderealTargetEditor {
                   props.searching,
                   searchAndSet(allView)
                 ),
-                <.label("RA",
-                        HelpIcon("target/main/coordinates.md".refined),
-                        ExploreStyles.SkipToNext
-                ),
-                FormInputEV(
+                FormInputTextView(
                   id = "ra".refined,
                   value = coordsRAView,
+                  label = React.Fragment("RA", HelpIcon("target/main/coordinates.md".refined)),
+                  disabled = disabled,
                   validFormat = MathValidators.truncatedRA,
-                  changeAuditor = ChangeAuditor.truncatedRA,
-                  clazz = ExploreStyles.TargetRaDecMinWidth,
-                  errorPointing = LabelPointing.Below,
-                  errorClazz = ExploreStyles.InputErrorTooltip,
-                  disabled = disabled
+                  changeAuditor = ChangeAuditor.truncatedRA
                 ),
-                <.label("Dec",
-                        HelpIcon("target/main/coordinates.md".refined),
-                        ExploreStyles.SkipToNext
-                ),
-                FormInputEV(
+                FormInputTextView(
                   id = "dec".refined,
                   value = coordsDecView,
+                  label = React.Fragment("Dec", HelpIcon("target/main/coordinates.md".refined)),
+                  disabled = disabled,
                   validFormat = MathValidators.truncatedDec,
-                  changeAuditor = ChangeAuditor.truncatedDec,
-                  clazz = ExploreStyles.TargetRaDecMinWidth,
-                  errorPointing = LabelPointing.Below,
-                  errorClazz = ExploreStyles.InputErrorTooltip,
-                  disabled = disabled
+                  changeAuditor = ChangeAuditor.truncatedDec
                 )
               ),
-              Form(as = <.div, size = Small)(
-                ExploreStyles.Grid,
-                ExploreStyles.Compact,
-                ExploreStyles.ExploreForm,
+              <.div(
+                LucumaStyles.FormColumnVeryCompact,
                 ExploreStyles.TargetProperMotionForm,
-                <.label("Epoch",
-                        HelpIcon("target/main/epoch.md".refined),
-                        ExploreStyles.SkipToNext
-                ),
-                InputWithUnits(
+                FormInputTextView(
                   id = "epoch".refined,
                   value = epochView,
+                  label = React.Fragment("Epoch", HelpIcon("target/main/epoch.md".refined)),
+                  disabled = disabled,
                   validFormat = MathValidators.epochNoScheme,
                   changeAuditor = ChangeAuditor.maxLength(8.refined).decimal(3.refined).denyNeg,
-                  units = "years",
-                  disabled = disabled
+                  postAddons = List("years")
                 ),
-                <.label("µ RA", ExploreStyles.SkipToNext),
-                InputWithUnits(
+                FormInputTextView(
                   id = "raPM".refined,
                   value = properMotionRAView,
+                  label = "µ RA",
+                  disabled = disabled,
                   validFormat = ExploreModelValidators.pmRAValidWedge.optional,
                   changeAuditor = ChangeAuditor.bigDecimal(3.refined).optional,
-                  units = "mas/y",
-                  disabled = disabled
+                  postAddons = List("mas/y")
                 ),
-                <.label("µ Dec", ExploreStyles.SkipToNext),
-                InputWithUnits(
+                FormInputTextView(
                   id = "raDec".refined,
                   value = properMotionDecView,
+                  label = "µ Dec",
+                  disabled = disabled,
                   validFormat = ExploreModelValidators.pmDecValidWedge.optional,
                   changeAuditor = ChangeAuditor.bigDecimal(3.refined).optional,
-                  units = "mas/y",
-                  disabled = disabled
+                  postAddons = List("mas/y")
                 ),
-                <.label("Parallax", ExploreStyles.SkipToNext),
-                InputWithUnits(
+                FormInputTextView(
                   id = "parallax".refined,
                   value = parallaxView,
+                  label = "Parallax",
+                  disabled = disabled,
                   validFormat = ExploreModelValidators.pxValidWedge.optional,
                   changeAuditor = ChangeAuditor.bigDecimal(3.refined).optional,
-                  units = "mas",
-                  disabled = disabled
+                  postAddons = List("mas")
                 ),
                 RVInput(radialVelocityView, disabled)
               ),
-              Form(as = <.div, size = Small)(
+              <.div(
                 ExploreStyles.Grid,
                 ExploreStyles.Compact,
-                ExploreStyles.ExploreForm,
+                LucumaStyles.FormColumnVeryCompact,
                 ExploreStyles.TargetSourceProfileEditor,
                 ExploreStyles.Gaussian
                   .when(SourceProfile.gaussian.getOption(sourceProfileAligner.get).isDefined)

--- a/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
@@ -8,7 +8,6 @@ import clue.data.syntax.*
 import eu.timepit.refined.auto.*
 import explore.common.*
 import explore.components.HelpIcon
-import explore.components.InputWithUnits
 import explore.components.ui.ExploreStyles
 import explore.model.AppContext
 import explore.model.enums.SourceProfileType
@@ -20,8 +19,11 @@ import lucuma.core.model.SourceProfile
 import lucuma.core.model.SourceProfile.*
 import lucuma.refined.*
 import lucuma.schemas.ObservationDB.Types.*
-import lucuma.ui.forms.EnumSelect
 import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.EnumDropdown
+import lucuma.ui.primereact.FormInputTextView
+import lucuma.ui.primereact.FormLabel
+import lucuma.ui.primereact.LucumaStyles
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.given
 import queries.schemas.*
@@ -50,16 +52,16 @@ object SourceProfileEditor:
           )
 
         React.Fragment(
-          <.label(
+          FormLabel(htmlFor = "profile-type".refined)(
             "Profile",
-            HelpIcon("target/main/target-profile.md".refined),
-            ExploreStyles.SkipToNext
+            HelpIcon("target/main/target-profile.md".refined)
           ),
-          EnumSelect[SourceProfileType](
-            value = SourceProfileType.fromSourceProfile(props.sourceProfile.get).some,
-            onChange = sp => props.sourceProfile.view(_.toInput).mod(sp.convert)
+          EnumDropdown[SourceProfileType](
+            id = "profile-type".refined,
+            value = SourceProfileType.fromSourceProfile(props.sourceProfile.get),
+            onChange = sp => props.sourceProfile.view(_.toInput).mod(sp.convert),
+            clazz = LucumaStyles.FormField
           ),
-          <.span,
           props.sourceProfile
             .zoomOpt(
               SourceProfile.point.andThen(Point.spectralDefinition),
@@ -79,18 +81,18 @@ object SourceProfileEditor:
           gaussianAlignerOpt
             .map(gaussianAligner =>
               React.Fragment(
-                <.label("FWHM", ExploreStyles.SkipToNext),
-                InputWithUnits(                             // FWHM is positive arcsec accepting decimals
+                FormInputTextView(                          // FWHM is positive arcsec accepting decimals
                   id = "fwhm".refined,
                   value = gaussianAligner
                     .zoom(Gaussian.fwhm, GaussianInput.fwhm.modify)
                     .view(_.toInput.assign),
+                  label = "FWHM",
                   validFormat = MathValidators.angleArcSec, // THIS IS ARCSEC AND NOT SIGNED!
                   changeAuditor = ChangeAuditor
                     .fromInputValidSplitEpi(MathValidators.angleArcSec)
                     .denyNeg
                     .allowEmpty,
-                  units = "arcsec"
+                  postAddons = List("arcsec")
                 ),
                 IntegratedSpectralDefinitionEditor(
                   gaussianAligner.zoom(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
     val lucumaRefined    = "0.1.1"
     val lucumaSchemas    = "0.37.6"
     val lucumaSSO        = "0.4.3"
-    val lucumaUI         = "0.56.1"
+    val lucumaUI         = "0.56.2"
     val monocle          = "3.1.0"
     val mouse            = "1.2.1"
     val mUnit            = "0.7.29"


### PR DESCRIPTION
Some images of the converted sidereal target editor.  See comments in the PR.

Note: The `Epoch` field and the ones below it used to be indented further than the `Name`, `RA` and `Dec` fields. Carlos said he thought that just fell out of the structure of the HTML and wasn't intentional or necessary. This indentation could be restored if desired.

With bands:
<img width="527" alt="image" src="https://user-images.githubusercontent.com/6035943/203597517-23bd2b89-1bc4-4e1c-93ec-3ca09a6ac29c.png">

With emission lines:
<img width="527" alt="image" src="https://user-images.githubusercontent.com/6035943/203597785-85d6120c-6f32-45ab-b2ba-be2c3b50dedd.png">
