### PR TITLE
Update lucuma-ui and make changes for ViewLike and convert some controls

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -455,6 +455,5 @@ object ExploreStyles {
   val TimingWindowRepeatEditor: Css             = Css("timing-window-repeat-editor")
   val TimingWindowRepeatEditorAlternatives: Css = Css("timing-window-repeat-editor-alternatives")
   val TimingWindowRepeatEditorNTimes: Css       = Css("timing-window-repeat-editor-n-times")
-  val TimingWindowNTimesField: Css              = Css("timing-window-n-times-field")
   val TimingWindowsHeader: Css                  = Css("timing-windows-header")
 }

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1090,6 +1090,7 @@ div.partner-split-total {
   margin-bottom: 0;
 }
 
+// There is already an anolog to this in explore.scss
 .warning-label-mixin() {
   color: var(--warning-text-color);
   background-color: var(--warning-background-color);
@@ -1311,21 +1312,7 @@ html {
   }
 }
 
-.explore-shared-edit-warning {
-  .warning-label-mixin();
-
-  padding: 0.4em;
-
-  .checkbox {
-    padding-left: 2em;
-  }
-}
-
 .tile-xs-width {
-  .explore-shared-edit-warning {
-    display: none;
-  }
-
   // TODO: This will require some work when we change the undo buttons to primereact.
   // For very small tables make the undo buttons remove the text
   .explore-buttons-undo-label {
@@ -1365,7 +1352,7 @@ html {
 
 .explore-target-summary-select {
   left: 0;
-  width: 70px;
+  width: 70px !important;
 
   .p-button {
     width: 55px;

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -13,6 +13,12 @@ $tree-section-width: 300px;
   }
 }
 
+// There is still an analog to this in style.less
+@mixin warning-label-mixin {
+  color: var(--warning-text-color);
+  background-color: var(--warning-background-color);
+}
+
 .p-inputgroup.explore-warning-input {
   box-shadow: -0 0 2px 1px var(--warning-background-color);
 }
@@ -343,6 +349,25 @@ $tree-section-width: 300px;
   .p-button {
     margin-left: 5px;
     flex-shrink: 0;
+  }
+}
+
+// ------
+// Asterism Editor
+// ------
+
+.explore-shared-edit-warning {
+  @include warning-label-mixin;
+
+  padding: 0.4em;
+
+  .pl-radiobutton-with-label {
+    padding-left: 2em;
+
+    .p-radiobutton .p-radiobutton-box.p-highlight {
+      border-color: black;
+      background-color: black;
+    }
   }
 }
 
@@ -1234,6 +1259,10 @@ table.explore-border-table {
     padding: 0.5em;
     font-size: smaller;
 
+    .p-inputgroup input {
+      font-size: 96%;
+    }
+
     span {
       display: inline-block;
     }
@@ -1258,14 +1287,19 @@ table.explore-border-table {
         margin-right: 0.5em;
       }
 
-      .field {
+      .pl-form-field {
         margin-right: 0.5em;
+        width: 9ch;
 
-        .ui.input {
-          width: 9ch;
-        }
+        // .ui.input {
+        //   width: 9ch;
+        // }
       }
     }
+
+    // .timing-window-n-times-field {
+    //   width: 7em;
+    // }
 
     .timing-window-repeat-editor-alternatives {
       display: flex;

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1290,16 +1290,8 @@ table.explore-border-table {
       .pl-form-field {
         margin-right: 0.5em;
         width: 9ch;
-
-        // .ui.input {
-        //   width: 9ch;
-        // }
       }
     }
-
-    // .timing-window-n-times-field {
-    //   width: 7em;
-    // }
 
     .timing-window-repeat-editor-alternatives {
       display: flex;

--- a/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
@@ -73,6 +73,7 @@ import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.FormLabel
 import lucuma.ui.primereact.LucumaStyles
 import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given

--- a/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -37,6 +37,7 @@ import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.EnumDropdownView
 import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.FormLabel
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given

--- a/explore/src/main/scala/explore/programs/ProgramTable.scala
+++ b/explore/src/main/scala/explore/programs/ProgramTable.scala
@@ -32,6 +32,7 @@ import lucuma.react.table.*
 import lucuma.refined.*
 import lucuma.schemas.ObservationDB
 import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given

--- a/explore/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
+++ b/explore/src/main/scala/explore/proposal/PartnerSplitsEditor.scala
@@ -23,6 +23,7 @@ import lucuma.react.table.*
 import lucuma.refined.*
 import lucuma.ui.input.*
 import lucuma.ui.primereact.FormInputTextView
+import lucuma.ui.primereact.given
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.table.*

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -53,8 +53,8 @@ import lucuma.core.model.SiderealTracking
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.refined.*
-import lucuma.ui.primereact.SliderView
 import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -502,7 +502,7 @@ object AladinCell extends ModelOptics with AladinCommon:
                       .asView
                       .map(view =>
                         CheckboxView(
-                          id = "ags-overlay".refined,
+                          id = "ags-candidates".refined,
                           value = view,
                           label = "Show Catalog"
                         )

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -41,8 +41,10 @@ import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.util.NewType
+import lucuma.refined.*
 import lucuma.schemas.ObservationDB
 import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -134,7 +136,7 @@ object AsterismEditor {
       .withHooks[Props]
       .useContext(AppContext.ctx)
       .useStateView(AreAdding(false))
-      .useState(EditScope.CurrentOnly)
+      .useStateView(EditScope.CurrentOnly)
       .useEffectWithDepsBy((props, _, _, _) => (props.asterism.get, props.currentTarget)) {
         (props, _, _, _) => (asterism, oTargetId) =>
           // if the selected targetId is None, or not in the asterism, select the first target (if any)
@@ -227,22 +229,15 @@ object AsterismEditor {
                       <.div(
                         ExploreStyles.SharedEditWarning,
                         s"${t.name.value} is in ${otherObsCount} other observation$plural. Edits here should apply to:",
-                        Checkbox(
-                          name = "editScope",
-                          label =
-                            if (props.obsIds.size === 1) "only this observation"
-                            else "only the current observations",
-                          value = 0,
-                          checked = editScope.value === EditScope.CurrentOnly,
-                          onChange = (_: Boolean) => editScope.setState(EditScope.CurrentOnly)
-                        ),
-                        Checkbox(
-                          name = "editScope",
-                          label = "all observations of this target",
-                          value = 1,
-                          checked = editScope.value === EditScope.AllInstances,
-                          onChange = (_: Boolean) => editScope.setState(EditScope.AllInstances)
-                        )
+                        BooleanRadioButtons(
+                          view = editScope.as(EditScope.value),
+                          idBase = "editscope".refined,
+                          name = "editScope".refined,
+                          trueLabel = "all observations of this target".refined,
+                          falseLabel =
+                            if (props.obsIds.size === 1) "only this observation".refined
+                            else "only the current observations".refined,
+                        ).toFalseTrueFragment
                       ).when(otherObsCount > 0),
                       props.asterism.mapValue(asterism =>
                         SiderealTargetEditor(
@@ -257,7 +252,7 @@ object AsterismEditor {
                           props.searching,
                           onClone = onCloneTarget(targetId, props.asterism, props.setTarget) _,
                           obsIdSubset =
-                            if (otherObsCount > 0 && editScope.value === EditScope.CurrentOnly)
+                            if (otherObsCount > 0 && editScope.get === EditScope.CurrentOnly)
                               props.obsIds.some
                             else none,
                           fullScreen = fullScreen

--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -29,6 +29,7 @@ import lucuma.react.table.*
 import lucuma.refined.*
 import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -117,7 +118,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 _._2.zoom(Measure.unitsTagged[BigDecimal, Brightness[T]]),
                 "Units",
                 cell =>
-                  EnumDropdownView[Units Of Brightness[T]](
+                  EnumDropdownView(
                     id = NonEmptyString.unsafeFrom(s"brightnessUnits_${cell.row.id}"),
                     value = cell.value,
                     disabled = disabled,

--- a/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/EmissionLineEditor.scala
@@ -35,6 +35,7 @@ import lucuma.react.table.*
 import lucuma.refined.*
 import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given

--- a/explore/src/main/scala/explore/targeteditor/RVInput.scala
+++ b/explore/src/main/scala/explore/targeteditor/RVInput.scala
@@ -25,6 +25,7 @@ import lucuma.ui.primereact.EnumDropdownView
 import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.FormLabel
 import lucuma.ui.primereact.LucumaStyles
+import lucuma.ui.primereact.given
 import lucuma.ui.syntax.all.given
 import react.common.ReactFnProps
 

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -20,6 +20,7 @@ import lucuma.core.validation.InputValidSplitEpi
 import lucuma.refined.*
 import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.LucumaStyles
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -54,6 +54,7 @@ import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.LucumaStyles
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given

--- a/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
@@ -24,6 +24,7 @@ import lucuma.ui.primereact.EnumDropdown
 import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.FormLabel
 import lucuma.ui.primereact.LucumaStyles
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.given
 import queries.schemas.*

--- a/explore/src/main/scala/explore/targeteditor/SpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SpectralDefinitionEditor.scala
@@ -55,6 +55,7 @@ import lucuma.ui.primereact.EnumDropdownView
 import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.FormLabel
 import lucuma.ui.primereact.LucumaStyles
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger

--- a/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
@@ -32,6 +32,7 @@ import lucuma.core.util.NewType
 import lucuma.refined.*
 import lucuma.ui.forms.FormInputEV
 import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
     val lucumaRefined    = "0.1.1"
     val lucumaSchemas    = "0.37.6"
     val lucumaSSO        = "0.4.3"
-    val lucumaUI         = "0.56.2"
+    val lucumaUI         = "0.58.0"
     val monocle          = "3.1.0"
     val mouse            = "1.2.1"
     val mUnit            = "0.7.29"


### PR DESCRIPTION
In addition to the changes for ViewLike, the PR:

- Changes the inputs in the timing window edit form to use primereact. This required the viewlike changes because `ViewOpt` is involved.
- On the shared target edit warning, switches out the checkboxes for radiobuttons since only one can be selected.