### PR TITLE
Fix for ExploreModelValidators test

### DIFF
--- a/model-tests/shared/src/test/scala/explore/model/ExploreModelValidatorsSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/ExploreModelValidatorsSuite.scala
@@ -20,12 +20,11 @@ import org.scalacheck.Arbitrary.*
 import org.scalacheck.Gen
 
 final class ExploreModelValidatorsSuite extends DisciplineSuite:
-
   // Scala.js seems to have trouble formatting BigDecimals with very high absolute scale or precision.
   // We therefore use these bounded arbitraries.
   // TODO: This is duplicated in `InputValidSplitEpiInstancesSuite` in lucuma-core.
   // We should move it to the testkit there and reuse it here.
-  implicit lazy val arbBigDecimalLimitedPrecision: Arbitrary[BigDecimal] =
+  given Arbitrary[BigDecimal] =
     Arbitrary(
       org.scalacheck.Arbitrary.arbBigDecimal.arbitrary.suchThat(x =>
         x.scale.abs < 100 && x.precision <= 15

--- a/model/shared/src/main/scala/explore/model/ExploreModelValidators.scala
+++ b/model/shared/src/main/scala/explore/model/ExploreModelValidators.scala
@@ -23,6 +23,7 @@ import lucuma.core.math.validation.MathValidators
 import lucuma.core.optics.Format
 import lucuma.core.optics.ValidSplitEpi
 import lucuma.core.optics.ValidWedge
+import lucuma.core.syntax.string.*
 import lucuma.core.validation.*
 import lucuma.refined.*
 import lucuma.utils.*
@@ -30,7 +31,7 @@ import lucuma.utils.*
 import scala.util.Try
 
 object ExploreModelValidators:
-  val i = ValidSplitEpi
+  private val i = ValidSplitEpi
     .forRefined[String, BigDecimal, HourRange]("Invalid hour value")
 
   val brightnessValidWedge: InputValidWedge[BigDecimal] =
@@ -71,13 +72,18 @@ object ExploreModelValidators:
           .toErrorsValidWedge
       )
 
+  private val bdPattern = """"-?(?:\\d+(?:\\.\\d+)?|\\.\\d+)""".r
+
   // Strips non-significant zeros on `reverseGet`
-  val compactDecimalString: Format[String, String] =
+  private val compactDecimalString: Format[String, String] =
     Format(
       _.some,
       s =>
-        try BigDecimal(s).bigDecimal.stripTrailingZeros.toPlainString
-        catch { case _ => s }
+        if (bdPattern.matches(s)) {
+          s.parseBigDecimalOption
+            .map(_.bigDecimal.stripTrailingZeros.toPlainString)
+            .getOrElse(s)
+        } else s
     )
 
   val compactDecimalStringValidWedge: InputValidWedge[String] =


### PR DESCRIPTION
It seems BigDecimal can parse digits in other locales, e.g. the number 1 in tibetan: `༡`

To fix it this is verifying that the string matches a regex for US numbers