### PR TITLE
Move Add Target back to the tree from the summary table

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1296,6 +1296,7 @@ html {
 
 .explore-button-summary {
   width: 100%;
+  justify-content: center;
 }
 
 .ui.labeled.icon.button.verycompact {

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -143,7 +143,6 @@ object AsterismGroupObsList:
     adding.async.set(AddingTarget(true)) >>
       TargetQueriesGQL.CreateTargetMutation
         .execute(EmptySiderealTarget.toCreateTargetInput(programId))
-        // .void
         .flatMap { data =>
           val targetId = data.createTarget.target.id
 

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -169,7 +169,9 @@ object TargetTabContents extends TwoPanels:
         props.focused,
         selectedView.set(SelectedPanel.Summary),
         props.expandedIds,
-        undoCtx
+        undoCtx,
+        toastRef,
+        selectTargetOrSummary _
       )
 
     def findAsterismGroup(

--- a/explore/src/main/scala/explore/targets/TargetAddDeleteActions.scala
+++ b/explore/src/main/scala/explore/targets/TargetAddDeleteActions.scala
@@ -22,7 +22,7 @@ import lucuma.schemas.ObservationDB.Types.*
 import queries.common.TargetQueriesGQL
 import queries.schemas.odb.ODBConversions.*
 
-object TargetSummaryActions {
+object TargetAddDeleteActions {
   private def singleTargetGetter(
     targetId: Target.Id
   ): AsterismGroupsWithObs => Option[TargetWithObs] = _.targetsWithObs.get(targetId)
@@ -121,7 +121,7 @@ object TargetSummaryActions {
       onRestore = (_, lotwo) =>
         lotwo.sequence.fold(
           remoteDeleteTargets(targetIds, programId) >> setSummary >>
-            postMessage(s"Re-deleted ${targetIds.length} target(s)")
+            postMessage(s"Deleted ${targetIds.length} target(s)")
         )(_ =>
           remoteUndeleteTargets(targetIds, programId) >> setSummary >>
             postMessage(s"Restored ${targetIds.length} target(s)")


### PR DESCRIPTION
In a conversation with @andrewwstephens, he indicated he would like the `+ Sidereal` button moved back to it's original location. He also wanted it renamed to `+ Tgt`. Apparently his plan for when we support non-sidereal targets is that the user will select which type they want after clicking the button. 
<img width="681" alt="image" src="https://user-images.githubusercontent.com/6035943/206262457-d9fbbd63-d13e-4d7c-add8-98d2d2670e7e.png">
