### PR TITLE
Allow observation creation on target tab

### DIFF
--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -171,7 +171,8 @@ object TargetTabContents extends TwoPanels:
         props.expandedIds,
         undoCtx,
         toastRef,
-        selectTargetOrSummary _
+        selectTargetOrSummary _,
+        selectedTargetIds.get
       )
 
     def findAsterismGroup(

--- a/explore/src/main/scala/explore/targets/ObservationInsertAction.scala
+++ b/explore/src/main/scala/explore/targets/ObservationInsertAction.scala
@@ -1,0 +1,91 @@
+// Copyright (c) 2016-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targets
+
+import cats.Order.*
+import cats.effect.IO
+import cats.syntax.all.*
+import clue.TransactionalClient
+import crystal.react.View
+import crystal.react.implicits.*
+import explore.common.AsterismQueries.*
+import explore.model.ObsIdSet
+import explore.model.ObsSummaryWithConstraintsAndConf
+import explore.model.syntax.all.*
+import explore.undo.*
+import lucuma.core.model.Observation
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.ObservationDB.Types.*
+import queries.schemas.odb.ODBConversions.*
+import queries.schemas.odb.ObsQueries
+
+import scala.collection.immutable.SortedSet
+
+object ObservationInsertAction {
+  private def getter(
+    obsId: Observation.Id
+  ): AsterismGroupsWithObs => Option[ObsSummaryWithConstraintsAndConf] = _.observations.get(obsId)
+
+  private def setter(obsId: Observation.Id)(
+    optObs:                 Option[ObsSummaryWithConstraintsAndConf]
+  ): AsterismGroupsWithObs => AsterismGroupsWithObs = agwo =>
+    optObs.fold {
+      // we're undoing - look to see what the current targets are.
+      val targets =
+        agwo.observations
+          .get(obsId)
+          .fold(SortedSet.empty[Target.Id])(o => SortedSet.from(o.scienceTargetIds))
+      agwo.removeObsWithTargets(obsId, targets)
+    } { // do or re-do
+      agwo.insertObs
+    }
+
+  private def updateExpandedIds(
+    obsId:       Observation.Id,
+    agwo:        AsterismGroupsWithObs,
+    optObs:      Option[ObsSummaryWithConstraintsAndConf]
+  )(expandedIds: SortedSet[ObsIdSet]) =
+    // We'll just expand the associated asterism.
+    val setOfOne = ObsIdSet.one(obsId)
+    optObs.fold(
+      // we're deleting, so find in current agwo (it should be there)
+      agwo.asterismGroups
+        .findContainingObsIds(setOfOne)
+        .fold(expandedIds)(grp =>
+          // if there is anything left in the group after removing this obs, expand it
+          grp.obsIds.remove(setOfOne).fold(expandedIds)(expandedIds + _)
+        )
+    )(obs =>
+      // we're doing or re-doing, so find the current group with this asterism
+      agwo.asterismGroups
+        .findWithTargetIds(SortedSet.from(obs.scienceTargetIds))
+        .fold(expandedIds + setOfOne)(grp => expandedIds + (grp.obsIds ++ setOfOne))
+    )
+
+  def insert(
+    obsId:       Observation.Id,
+    expandedIds: View[SortedSet[ObsIdSet]],
+    setPage:     Option[Observation.Id] => IO[Unit],
+    postMessage: String => IO[Unit]
+  )(using
+    TransactionalClient[IO, ObservationDB]
+  ): Action[AsterismGroupsWithObs, Option[ObsSummaryWithConstraintsAndConf]] =
+    Action(getter = getter(obsId), setter = setter(obsId))(
+      onSet = (agwo, optObs) =>
+        expandedIds.mod(updateExpandedIds(obsId, agwo, optObs)).to[IO] >> setPage(obsId.some),
+      onRestore = (agwo, optObs) =>
+        expandedIds.mod(updateExpandedIds(obsId, agwo, optObs)).to[IO] >>
+          optObs.fold(
+            ObsQueries.deleteObservation[IO](obsId) >>
+              setPage(none) >>
+              postMessage(s"Deleted observation $obsId")
+          )(_ =>
+            ObsQueries.undeleteObservation[IO](obsId) >>
+              setPage(obsId.some) >>
+              postMessage(s"Restored observation $obsId")
+          )
+    )
+}

--- a/explore/src/main/scala/explore/targets/ObservationPasteActions.scala
+++ b/explore/src/main/scala/explore/targets/ObservationPasteActions.scala
@@ -39,9 +39,13 @@ object ObservationPasteActions {
     otwol:                       Option[List[ObsSummaryWithConstraintsAndConf]]
   ): AsterismGroupsWithObs => AsterismGroupsWithObs = agwo =>
     otwol.fold {
-      // agwo doesn't contain the observations, so we're deleting.
+      // the Option[List]] is empty, so we're deleting.
       ids.foldLeft(agwo) { case (grps, (obsId, tid)) =>
-        grps.removeObsWithTargets(obsId, SortedSet(tid))
+        // the target list could have been edited, so we'll look for the current list
+        val targetIds = grps.observations
+          .get(obsId)
+          .fold(SortedSet(tid))(o => SortedSet.from(o.scienceTargetIds))
+        grps.removeObsWithTargets(obsId, targetIds)
       }
 
     } {

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -107,6 +107,20 @@ case class ObsSummaryWithTitleAndConstraints(
       none,
       none
     )
+
+  def toConstraintsAndConf(targetIds: Set[Target.Id]) =
+    ObsSummaryWithConstraintsAndConf(
+      id,
+      constraints,
+      status,
+      activeStatus,
+      duration,
+      targetIds,
+      none,
+      none,
+      none,
+      none
+    )
 }
 
 object ObsSummaryWithTitleAndConstraints {


### PR DESCRIPTION
Adds a `+ Obs` button next to the `+ Tgt` button on the target tab. This is part of the workflow @andrewwstephens requested when we discussed target copy/paste. If there are one or more observations selected in the target tree, the same asterism as for that (those) observation(s) is used for the new observation. Otherwise, the targets that are selected in the summary (if any) are used.
<img width="335" alt="image" src="https://user-images.githubusercontent.com/6035943/206805229-4135f857-e335-4cde-9e48-ec347600b9bc.png">
