### PR TITLE
Don't draw probe outline

### DIFF
--- a/common/src/main/webapp/sass/visualization.scss
+++ b/common/src/main/webapp/sass/visualization.scss
@@ -51,7 +51,6 @@ $brightness: var(--aladin-image-brightness);
 
   .gmos-probe-arm {
     stroke: hsl(0deg 67.9% 41.6%);
-    outline: 1px solid red;
   }
 
   .gmos-patrol-field {


### PR DESCRIPTION
Oddly I don't see it in chrome or safari but at least one user sees it on safari