### PR TITLE
Use new css device units

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -14,50 +14,11 @@
 
 @gridSpace: 5px;
 @minHeight: 2.85714286em; // TODO: Calculate this on less
-@resizeHandleWidth: 5px; // Width of the tree resize handle
 
 // media queries cutoff
 @tablet-responsive-cutoff: 992px;
 @mobile-responsive-cutoff: 670px;
 
-// Full viewport settings taken from https://dev.to/lennythedev/css-gotcha-how-to-fill-page-with-a-div-270j
-
-html,
-body {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-body {
-  overflow: hidden;
-  position: fixed;
-  min-height: 100vh;
-
-  /* mobile viewport bug fix */
-  min-height: -webkit-fill-available;
-  width: 100vw;
-  scrollbar-width: thin;
-  scrollbar-color: var(--scrollbar-background);
-}
-
-*::-webkit-scrollbar {
-  width: 0.8em !important;
-}
-
-*::-webkit-scrollbar-track {
-  background: var(--scrollbar-background) !important;
-}
-
-*::-webkit-scrollbar-thumb {
-  background: var(--scrollbar-background-thumb) !important;
-  border: 1px solid var(--scrollbar-background);
-
-  &:active,
-  &:hover {
-    background: var(--scrollbar-background-thumb-hover) !important;
-  }
-}
 
 a {
   color: var(--site-link-color);
@@ -203,22 +164,6 @@ body.light-theme {
 
 tfoot {
   background-color: var(--table-footer-background);
-}
-
-/* Avoid Chrome to see Safari hack */
-@supports (-webkit-touch-callout: none) {
-  .main-grid {
-    /* The hack for Safari */
-    height: -webkit-fill-available;
-  }
-}
-
-.main-body {
-  grid-area: body;
-  max-width: 100vw;
-  overflow: hidden;
-  display: grid;
-  justify-items: stretch;
 }
 
 .main-title {
@@ -524,21 +469,6 @@ tfoot {
   justify-content: center;
   align-items: center;
   height: 100%;
-}
-
-// Vertical handle to resize the tree
-.resize-handle {
-  width: @resizeHandleWidth;
-  height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  user-select: none;
-  cursor: ew-resize;
-  position: relative;
-  margin-left: -@resizeHandleWidth;
-  background: black;
-  z-index: 1;
 }
 
 .maingrid {
@@ -1063,7 +993,7 @@ div.partner-split-total {
   }
 }
 
-// TODO: This was also used in the brightness tables, but is no longer needed. 
+// TODO: This was also used in the brightness tables, but is no longer needed.
 // When the obs badge is converted to primereact, this may be able to go away, or
 // be made specific to the obs badge
 .ui.button.delete-button {

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -2,6 +2,49 @@
 
 $tree-section-width: 300px;
 
+// Scrollbar
+*::-webkit-scrollbar {
+  width: 0.8em !important;
+}
+
+*::-webkit-scrollbar-track {
+  background: var(--scrollbar-background) !important;
+}
+
+*::-webkit-scrollbar-thumb {
+  background: var(--scrollbar-background-thumb) !important;
+  border: 1px solid var(--scrollbar-background);
+
+  &:active,
+  &:hover {
+    background: var(--scrollbar-background-thumb-hover) !important;
+  }
+}
+
+*::-webkit-scrollbar-corner {
+  background: var(--control-background-color);
+}
+
+// Full viewport settings taken from https://dev.to/lennythedev/css-gotcha-how-to-fill-page-with-a-div-270j
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  overflow: hidden;
+  position: fixed;
+  min-height: 100svh;
+
+  /* mobile viewport bug fix */
+  /* stylelint-disable-next-line value-no-vendor-prefix */
+  min-height: -webkit-fill-available;
+  width: 100svw;
+}
+
 @mixin small-tile-title {
   display: flex;
   gap: 1em;
@@ -949,7 +992,7 @@ table.explore-border-table {
     /* stylelint-disable-next-line selector-class-pattern */
     span > svg.svg-inline--fa {
       padding-right: 0.5em;
-    } 
+    }
 
     .explore-prompt-toast {
       display: flex;
@@ -1027,25 +1070,45 @@ table.explore-border-table {
 // ----------
 // Main grid
 // ----------
-  .main-grid {
-    $top-bottom-space: 42px;
+.main-grid {
+  $top-bottom-space: 42px;
 
-    display: grid;
-    height: 100vh;
-    width: 100%;
-    overflow: hidden;
+  display: grid;
+  height: 100vh;
+  height: 100svh;
+  width: 100%;
+  overflow: hidden;
+  grid-template:
+    'header' $top-bottom-space
+    'body' minmax(calc(100% - $top-bottom-space - $top-bottom-space), 1fr)
+    'sidebar' #{$top-bottom-space} / 1fr;
+
+  @media (min-width: common.$tablet-responsive-cutoff) {
     grid-template:
-      'header' $top-bottom-space
-      'body' minmax(calc(100% - $top-bottom-space - $top-bottom-space), 1fr)
-      'sidebar' #{$top-bottom-space} / 1fr;
-
-    @media (min-width: common.$tablet-responsive-cutoff) {
-      grid-template:
-        'header header' $top-bottom-space
-        'sidebar body' minmax(calc(100% - $top-bottom-space), 1fr) / 50px auto;
-    }
+      'header header' $top-bottom-space
+      'sidebar body' minmax(calc(100% - $top-bottom-space), 1fr) / 50px auto;
   }
+}
 
+
+// --------------------
+// Main grid definition
+// --------------------
+@supports (-webkit-touch-callout: none) {
+  .main-grid {
+    /* The hack for Safari */
+    /* stylelint-disable-next-line value-no-vendor-prefix */
+    height: -webkit-fill-available;
+  }
+}
+
+.main-body {
+  grid-area: body;
+  max-width: 100svw;
+  overflow: hidden;
+  display: grid;
+  justify-items: stretch;
+}
 
 // ------------
 // Two panel pages

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -37,12 +37,12 @@ body {
 body {
   overflow: hidden;
   position: fixed;
-  min-height: 100svh;
+  min-height: 100dvh;
 
   /* mobile viewport bug fix */
   /* stylelint-disable-next-line value-no-vendor-prefix */
   min-height: -webkit-fill-available;
-  width: 100svw;
+  width: 100dvw;
 }
 
 @mixin small-tile-title {
@@ -1075,7 +1075,7 @@ table.explore-border-table {
 
   display: grid;
   height: 100vh;
-  height: 100svh;
+  height: 100dvh;
   width: 100%;
   overflow: hidden;
   grid-template:


### PR DESCRIPTION
Starting in chrome 108 new dynamic device css units are supported
https://web.dev/viewport-units/

This PR uses them instead of the old non dynamic ones. This produces a better result putting the side tabs in position and should allow us to target more devices