### PR TITLE
Support allow flip mode

### DIFF
--- a/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -229,6 +229,7 @@ object ObsQueries:
       )
       .void
   }
+
   def createObservation[F[_]: Async](
     programId: Program.Id
   )(using TransactionalClient[F, ObservationDB]): F[ObsSummaryWithTitleAndConstraints] =

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -30,6 +30,7 @@ import explore.model.WorkerClients.*
 import explore.model.boopickle.Boopickle.*
 import explore.model.boopickle.ItcPicklers.given
 import explore.model.boopickle.*
+import explore.model.enums.AgsState
 import explore.model.itc.ItcTarget
 import explore.model.reusability.*
 import explore.model.syntax.scienceModes.*
@@ -51,7 +52,6 @@ import org.http4s.syntax.all.*
 import queries.common.ObsQueriesGQL
 import queries.schemas.odb.ObsQueries.*
 import react.common.ReactFnProps
-import explore.model.enums.AgsState
 
 case class ConfigurationPanel(
   userId:          Option[User.Id],

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -51,6 +51,7 @@ import org.http4s.syntax.all.*
 import queries.common.ObsQueriesGQL
 import queries.schemas.odb.ObsQueries.*
 import react.common.ReactFnProps
+import explore.model.enums.AgsState
 
 case class ConfigurationPanel(
   userId:          Option[User.Id],
@@ -61,6 +62,7 @@ case class ConfigurationPanel(
   constraints:     ConstraintSet,
   itcTargets:      List[ItcTarget],
   baseCoordinates: Option[CoordinatesAtVizTime],
+  agsState:        AgsState,
   renderInTitle:   Tile.RenderInTitle
 ) extends ReactFnProps[ConfigurationPanel](ConfigurationPanel.component)
 
@@ -190,7 +192,7 @@ object ConfigurationPanel:
             <.div(ExploreStyles.TitleUndoButtons)(UndoButtons(props.scienceData))
           ),
           <.div(ExploreStyles.ConfigurationGrid)(
-            ObsConfigurationPanel(props.obsId, posAngleView),
+            ObsConfigurationPanel(props.obsId, posAngleView, props.agsState),
             if (editState.get === ConfigEditState.TableView)
               BasicConfigurationPanel(
                 props.userId,

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -62,7 +62,7 @@ case class ConfigurationPanel(
   constraints:     ConstraintSet,
   itcTargets:      List[ItcTarget],
   baseCoordinates: Option[CoordinatesAtVizTime],
-  agsState:        AgsState,
+  agsState:        View[AgsState],
   renderInTitle:   Tile.RenderInTitle
 ) extends ReactFnProps[ConfigurationPanel](ConfigurationPanel.component)
 

--- a/explore/src/main/scala/explore/config/ObsConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ObsConfigurationPanel.scala
@@ -31,10 +31,12 @@ import react.common.Css
 import react.common.ReactFnProps
 import react.semanticui.collections.form.Form
 import react.semanticui.sizes.*
+import explore.model.enums.AgsState
 
 case class ObsConfigurationPanel(
   obsId:        Observation.Id,
-  posAngleView: View[Option[PosAngleConstraint]]
+  posAngleView: View[Option[PosAngleConstraint]],
+  agsState:     AgsState
 ) extends ReactFnProps(ObsConfigurationPanel.component)
 
 object ObsConfigurationPanel:
@@ -62,6 +64,7 @@ object ObsConfigurationPanel:
       .useContext(AppContext.ctx)
       .render { (props, ctx) =>
         import ctx.given
+        println(props.agsState)
 
         val paView = props.posAngleView
           .withOnMod(c => ObsQueries.updatePosAngle[IO](List(props.obsId), c).runAsync)
@@ -92,6 +95,7 @@ object ObsConfigurationPanel:
               clazz = Css.Empty,
               value = pa,
               units = "° E of N",
+              disabled = !props.agsState.canRecalculate,
               validFormat = MathValidators.truncatedAngleDegrees,
               changeAuditor = ChangeAuditor.bigDecimal(3.refined, 2.refined)
             )
@@ -105,7 +109,8 @@ object ObsConfigurationPanel:
           EnumViewSelect(
             clazz = ExploreStyles.ObsConfigurationObsPA,
             id = "pos-angle-alternative",
-            value = posAngleOptionsView
+            value = posAngleOptionsView,
+            disabled = !props.agsState.canRecalculate
           ),
           fixedView.mapValue(posAngleEditor),
           allowedFlipView.mapValue(posAngleEditor),

--- a/explore/src/main/scala/explore/config/ObsConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ObsConfigurationPanel.scala
@@ -11,6 +11,7 @@ import explore.components.HelpIcon
 import explore.components.InputWithUnits
 import explore.components.ui.ExploreStyles
 import explore.model.AppContext
+import explore.model.enums.AgsState
 import explore.model.enums.PosAngleOptions
 import explore.model.syntax.all.*
 import japgolly.scalajs.react.*
@@ -31,7 +32,6 @@ import react.common.Css
 import react.common.ReactFnProps
 import react.semanticui.collections.form.Form
 import react.semanticui.sizes.*
-import explore.model.enums.AgsState
 
 case class ObsConfigurationPanel(
   obsId:        Observation.Id,

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -36,6 +36,7 @@ import queries.schemas.odb.ObsQueries
 import react.common.ReactFnProps
 
 import java.time.Instant
+import explore.model.enums.AgsState
 
 object AsterismEditorTile:
 
@@ -54,6 +55,7 @@ object AsterismEditorTile:
     undoStacks:      View[Map[Target.Id, UndoStacks[IO, Target.Sidereal]]],
     searching:       View[Set[Target.Id]],
     title:           String,
+    agsState:        Option[View[AgsState]],
     backButton:      Option[VdomNode] = none
   )(using TransactionalClient[IO, ObservationDB], Logger[IO]) = {
 
@@ -89,7 +91,8 @@ object AsterismEditorTile:
             otherObsCount,
             undoStacks,
             searching,
-            renderInTitle
+            renderInTitle,
+            agsState
           )
         )
       }(

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -37,13 +37,14 @@ import react.common.ReactFnProps
 
 import java.time.Instant
 import explore.model.enums.AgsState
+import lucuma.core.model.Observation
 
 object AsterismEditorTile:
 
   def asterismEditorTile(
     userId:          Option[User.Id],
     programId:       Program.Id,
-    obsId:           ObsIdSet,
+    sharedInObsIds:  ObsIdSet,
     potAsterismMode: Pot[(View[Option[Asterism]], Option[ScienceMode])],
     potVizTime:      Pot[View[Option[Instant]]],
     posAngle:        Option[PosAngleConstraint],
@@ -55,13 +56,13 @@ object AsterismEditorTile:
     undoStacks:      View[Map[Target.Id, UndoStacks[IO, Target.Sidereal]]],
     searching:       View[Set[Target.Id]],
     title:           String,
-    agsState:        Option[View[AgsState]],
+    agsState:        Option[(Observation.Id, View[AgsState])],
     backButton:      Option[VdomNode] = none
   )(using TransactionalClient[IO, ObservationDB], Logger[IO]) = {
 
     // Save the time here. this works for the obs and target tabs
     val vizTimeView = potVizTime.map(_.withOnMod { t =>
-      ObsQueries.updateVisualizationTime[IO](obsId.toList, t).runAsync
+      ObsQueries.updateVisualizationTime[IO](sharedInObsIds.toList, t).runAsync
     })
 
     def control: VdomNode = <.div(VizTimeEditor(vizTimeView))
@@ -79,7 +80,7 @@ object AsterismEditorTile:
           AsterismEditor(
             uid,
             programId,
-            obsId,
+            sharedInObsIds,
             asterism,
             potVizTime,
             scienceMode,

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -11,6 +11,7 @@ import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.Tile
 import explore.config.ConfigurationPanel
 import explore.model.CoordinatesAtVizTime
+import explore.model.enums.AgsState
 import explore.undo.*
 import explore.utils.*
 import lucuma.core.math.Coordinates
@@ -21,7 +22,6 @@ import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
 import queries.schemas.itc.ITCConversions.*
 import queries.schemas.odb.ObsQueries.*
-import explore.model.enums.AgsState
 
 object ConfigurationTile {
   def configurationTile(
@@ -30,7 +30,7 @@ object ConfigurationTile {
     obsData:         Pot[(String, Option[NonEmptyString], View[ScienceData])],
     undoStacks:      View[UndoStacks[IO, ScienceData]],
     baseCoordinates: Option[CoordinatesAtVizTime],
-    agsState: AgsState
+    agsState:        AgsState
   )(using Logger[IO]) =
     Tile(
       ObsTabTilesIds.ConfigurationId.id,

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -30,7 +30,7 @@ object ConfigurationTile {
     obsData:         Pot[(String, Option[NonEmptyString], View[ScienceData])],
     undoStacks:      View[UndoStacks[IO, ScienceData]],
     baseCoordinates: Option[CoordinatesAtVizTime],
-    agsState:        AgsState
+    agsState:        View[AgsState]
   )(using Logger[IO]) =
     Tile(
       ObsTabTilesIds.ConfigurationId.id,

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -21,6 +21,7 @@ import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
 import queries.schemas.itc.ITCConversions.*
 import queries.schemas.odb.ObsQueries.*
+import explore.model.enums.AgsState
 
 object ConfigurationTile {
   def configurationTile(
@@ -28,7 +29,8 @@ object ConfigurationTile {
     obsId:           Observation.Id,
     obsData:         Pot[(String, Option[NonEmptyString], View[ScienceData])],
     undoStacks:      View[UndoStacks[IO, ScienceData]],
-    baseCoordinates: Option[CoordinatesAtVizTime]
+    baseCoordinates: Option[CoordinatesAtVizTime],
+    agsState: AgsState
   )(using Logger[IO]) =
     Tile(
       ObsTabTilesIds.ConfigurationId.id,
@@ -46,6 +48,7 @@ object ConfigurationTile {
             scienceData.get.constraints,
             scienceData.get.itcTargets,
             baseCoordinates,
+            agsState,
             renderInTitle
           )
       }(obsData)

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -301,7 +301,7 @@ object ObsTabTiles:
               .zoom(ModelUndoStacks.forObservationData[IO])
               .zoom(atMapWithDefault(props.obsId, UndoStacks.empty)),
             targetCoords,
-            agsState.get
+            agsState
           )
 
         val rglRender: LayoutsMap => VdomNode = (l: LayoutsMap) =>

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -263,7 +263,7 @@ object ObsTabTiles:
           props.undoStacks.zoom(ModelUndoStacks.forSiderealTarget),
           props.searching,
           "Targets",
-          agsState = agsState.some,
+          agsState = (props.obsId, agsState).some,
           backButton = none
         )
 
@@ -295,7 +295,8 @@ object ObsTabTiles:
             props.undoStacks
               .zoom(ModelUndoStacks.forObservationData[IO])
               .zoom(atMapWithDefault(props.obsId, UndoStacks.empty)),
-            targetCoords
+            targetCoords,
+            agsState.get
           )
 
         val rglRender: LayoutsMap => VdomNode = (l: LayoutsMap) =>

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -57,6 +57,7 @@ import react.semanticui.modules.dropdown.Dropdown
 
 import java.time.Instant
 import scala.collection.immutable.SortedMap
+import explore.model.enums.AgsState
 
 case class ObsTabTiles(
   userId:           Option[User.Id],
@@ -136,7 +137,9 @@ object ObsTabTiles:
       }
       // ITC selected target. Here to be shared by the ITC tile body and title
       .useStateView(none[ItcTarget])
-      .render { (props, ctx, obsView, itcTarget) =>
+      // Ags state
+      .useStateView[AgsState](AgsState.Idle)
+      .render { (props, ctx, obsView, itcTarget, agsState) =>
         import ctx.given
 
         val obsViewPot = obsView.toPot
@@ -260,7 +263,8 @@ object ObsTabTiles:
           props.undoStacks.zoom(ModelUndoStacks.forSiderealTarget),
           props.searching,
           "Targets",
-          none
+          agsState = agsState.some,
+          backButton = none
         )
 
         // The ExploreStyles.ConstraintsTile css adds a z-index to the constraints tile react-grid wrapper

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -22,10 +22,12 @@ import lucuma.ui.syntax.all.given
 import monocle.std.option.some
 
 import java.time.Instant
+import explore.model.enums.AgsState
+import lucuma.core.model.Observation
 
 object SiderealTargetEditorTile {
 
-  def sideralTargetEditorTile(
+  def siderealTargetEditorTile(
     userId:     Option[User.Id],
     targetId:   Target.Id,
     target:     View[Target.Sidereal],
@@ -34,6 +36,7 @@ object SiderealTargetEditorTile {
     searching:  View[Set[Target.Id]],
     title:      String,
     fullScreen: View[AladinFullScreen],
+    oidAndAgs:  Option[(Observation.Id, View[AgsState])],
     backButton: Option[VdomNode] = none
   ) =
     Tile(ObsTabTilesIds.TargetId.id,
@@ -58,6 +61,7 @@ object SiderealTargetEditorTile {
               none,
               undoStacks,
               searching,
+              agsState = oidAndAgs.map(_._2),
               renderInTitle = renderInTitle.some,
               fullScreen = fullScreen
             )

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -61,7 +61,7 @@ object SiderealTargetEditorTile {
               none,
               undoStacks,
               searching,
-              agsState = oidAndAgs.map(_._2),
+              agsState = oidAndAgs,
               renderInTitle = renderInTitle.some,
               fullScreen = fullScreen
             )

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -22,8 +22,6 @@ import lucuma.ui.syntax.all.given
 import monocle.std.option.some
 
 import java.time.Instant
-import explore.model.enums.AgsState
-import lucuma.core.model.Observation
 
 object SiderealTargetEditorTile {
 
@@ -36,7 +34,6 @@ object SiderealTargetEditorTile {
     searching:  View[Set[Target.Id]],
     title:      String,
     fullScreen: View[AladinFullScreen],
-    oidAndAgs:  Option[(Observation.Id, View[AgsState])],
     backButton: Option[VdomNode] = none
   ) =
     Tile(ObsTabTilesIds.TargetId.id,
@@ -58,10 +55,9 @@ object SiderealTargetEditorTile {
               none,
               none,
               none,
-              none,
               undoStacks,
               searching,
-              agsState = oidAndAgs,
+              posAngleView = none,
               renderInTitle = renderInTitle.some,
               fullScreen = fullScreen
             )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -434,6 +434,7 @@ object TargetTabContents extends TwoPanels:
           props.targetsUndoStacks,
           props.searching,
           title,
+          none,
           backButton.some
         )
 
@@ -493,7 +494,7 @@ object TargetTabContents extends TwoPanels:
 
       val title = s"Editing Target ${target.name.value} [$targetId]"
 
-      val targetTile = SiderealTargetEditorTile.sideralTargetEditorTile(
+      val targetTile = SiderealTargetEditorTile.siderealTargetEditorTile(
         props.userId,
         targetId,
         targetView,
@@ -502,6 +503,7 @@ object TargetTabContents extends TwoPanels:
         props.searching,
         title,
         fullScreen,
+        none,
         backButton.some
       )
 

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -409,7 +409,6 @@ object TargetTabContents extends TwoPanels:
 
       val constraints = obsConf.map(_._1)
       val scienceMode = obsConf.map(_._2)
-      val posAngle    = obsConf.map(_._3)
       val wavelength  = obsConf.map(_._4)
 
       def setCurrentTarget(programId: Program.Id, oids: ObsIdSet)(
@@ -425,7 +424,6 @@ object TargetTabContents extends TwoPanels:
           idsToEdit,
           Pot(asterismView, scienceMode),
           Pot(vizTimeView),
-          posAngle,
           constraints,
           wavelength,
           props.focused.target,
@@ -503,7 +501,6 @@ object TargetTabContents extends TwoPanels:
         props.searching,
         title,
         fullScreen,
-        none,
         backButton.some
       )
 

--- a/explore/src/main/scala/explore/targeteditor/AgsOverlay.scala
+++ b/explore/src/main/scala/explore/targeteditor/AgsOverlay.scala
@@ -67,16 +67,16 @@ object AgsOverlay {
             <.div(
               ExploreStyles.AgsDescription,
               analysis.match {
-                case AgsAnalysis.Usable(_, _, Some(GuideSpeed.Fast), _, _)   =>
+                case AgsAnalysis.Usable(_, _, Some(GuideSpeed.Fast), _, _, _)   =>
                   Icons.CircleSmall.withClass(ExploreStyles.AgsFast)
-                case AgsAnalysis.Usable(_, _, Some(GuideSpeed.Medium), _, _) =>
+                case AgsAnalysis.Usable(_, _, Some(GuideSpeed.Medium), _, _, _) =>
                   Icons.CircleSmall.withClass(ExploreStyles.AgsMedium)
-                case AgsAnalysis.Usable(_, _, Some(GuideSpeed.Slow), _, _)   =>
+                case AgsAnalysis.Usable(_, _, Some(GuideSpeed.Slow), _, _, _)   =>
                   Icons.CircleSmall.withClass(ExploreStyles.AgsSlow)
-                case _                                                       => ""
+                case _                                                          => ""
               },
               analysis match {
-                case AgsAnalysis.Usable(_, _, Some(speed), _, _) =>
+                case AgsAnalysis.Usable(_, _, Some(speed), _, _, _) =>
                   React.Fragment(
                     <.div(ExploreStyles.AgsGuideSpeed, speed.tag),
                     <.div(ExploreStyles.AgsGBrightness,
@@ -88,7 +88,7 @@ object AgsOverlay {
                           s"(${formatCoordinates(analysis.target.tracking.baseCoordinates)})"
                     )
                   )
-                case _                                           => EmptyVdom
+                case _                                              => EmptyVdom
               }
             )
           )

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -202,7 +202,7 @@ object AladinCell extends ModelOptics with AladinCommon:
       // Analysis results
       .useSerialState(List.empty[AgsAnalysis])
       // Request data again if vizTime changes more than a month
-      .useEffectWithDepsBy((p, _, __, _, _) => p.obsConf.vizTime) {
+      .useEffectWithDepsBy((p, _, _, _, _) => p.obsConf.vizTime) {
         (props, ctx, _, gs, _) => vizTime =>
           import ctx.given
 

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -154,6 +154,7 @@ object AladinContainer extends AladinCommon {
         }
 
         val usableGuideStar = gs.exists(_.isUsable)
+        cats.effect.IO.cede
 
         val shapes = posAngle
           .map { posAngle =>
@@ -227,8 +228,8 @@ object AladinContainer extends AladinCommon {
                       .toInstant()
 
                   val vignettesScience = g match
-                    case AgsAnalysis.VignettesScience(_) => true
-                    case _                               => false
+                    case AgsAnalysis.VignettesScience(_, _) => true
+                    case _                                  => false
 
                   val candidateCss = g.match
                     case _ if scienceMode.isEmpty                             =>

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -154,7 +154,6 @@ object AladinContainer extends AladinCommon {
         }
 
         val usableGuideStar = gs.exists(_.isUsable)
-        cats.effect.IO.cede
 
         val shapes = posAngle
           .map { posAngle =>

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -234,7 +234,7 @@ object AladinContainer extends AladinCommon {
                     case _ if scienceMode.isEmpty                             =>
                       // Don't color the stars for guide speed if there is no mode selected
                       Css.Empty
-                    case AgsAnalysis.Usable(_, _, Some(s), _, _)              =>
+                    case AgsAnalysis.Usable(_, _, Some(s), _, _, _)           =>
                       speedCss(s)
                     case AgsAnalysis.NotReachableAtPosition(_, _, Some(s), _) =>
                       speedCss(s)

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -23,6 +23,7 @@ import explore.model.ScienceMode
 import explore.model.SiderealTargetWithId
 import explore.model.TargetWithId
 import explore.model.TargetWithOptId
+import explore.model.enums.AgsState
 import explore.model.reusability.*
 import explore.model.reusability.given
 import explore.optics.*
@@ -36,6 +37,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.data.Zipper
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
+import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
 import lucuma.core.model.Target
@@ -59,8 +61,6 @@ import react.primereact.Button
 import react.semanticui.modules.checkbox.*
 
 import java.time.Instant
-import explore.model.enums.AgsState
-import lucuma.core.model.Observation
 
 case class AsterismEditor(
   userId:         User.Id,
@@ -69,7 +69,6 @@ case class AsterismEditor(
   asterism:       View[Option[Asterism]],
   potVizTime:     Pot[View[Option[Instant]]],
   scienceMode:    Option[ScienceMode],
-  posAngle:       Option[PosAngleConstraint],
   constraints:    Option[ConstraintSet],
   wavelength:     Option[Wavelength],
   currentTarget:  Option[Target.Id],
@@ -78,8 +77,10 @@ case class AsterismEditor(
   undoStacks:     View[Map[Target.Id, UndoStacks[IO, Target.Sidereal]]],
   searching:      View[Set[Target.Id]],
   renderInTitle:  Tile.RenderInTitle,
-  agsState:       Option[(Observation.Id, View[AgsState])]
-) extends ReactFnProps(AsterismEditor.component)
+  posAngleView:   Option[(View[PosAngleConstraint], View[AgsState])]
+) extends ReactFnProps(AsterismEditor.component) {
+  val posAngle: Option[PosAngleConstraint] = posAngleView.map(_._1.get)
+}
 
 object AsterismEditor {
   private type Props = AsterismEditor
@@ -247,7 +248,6 @@ object AsterismEditor {
                           props.userId,
                           asterism,
                           vizTime,
-                          props.posAngle,
                           props.scienceMode,
                           props.constraints,
                           props.wavelength,
@@ -259,7 +259,7 @@ object AsterismEditor {
                               props.sharedInObsIds.some
                             else none,
                           fullScreen = fullScreen,
-                          agsState = props.agsState
+                          posAngleView = props.posAngleView
                         )
                       )
                     )

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -59,6 +59,7 @@ import react.primereact.Button
 import react.semanticui.modules.checkbox.*
 
 import java.time.Instant
+import explore.model.enums.AgsState
 
 case class AsterismEditor(
   userId:        User.Id,
@@ -75,7 +76,8 @@ case class AsterismEditor(
   otherObsCount: Target.Id => Int,
   undoStacks:    View[Map[Target.Id, UndoStacks[IO, Target.Sidereal]]],
   searching:     View[Set[Target.Id]],
-  renderInTitle: Tile.RenderInTitle
+  renderInTitle: Tile.RenderInTitle,
+  agsState:      Option[View[AgsState]]
 ) extends ReactFnProps(AsterismEditor.component)
 
 object AsterismEditor {
@@ -255,7 +257,8 @@ object AsterismEditor {
                             if (otherObsCount > 0 && editScope.get === EditScope.CurrentOnly)
                               props.obsIds.some
                             else none,
-                          fullScreen = fullScreen
+                          fullScreen = fullScreen,
+                          agsState = props.agsState
                         )
                       )
                     )

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -65,6 +65,7 @@ import react.common.ReactFnProps
 
 import java.time.Instant
 import explore.model.enums.AgsState
+import lucuma.core.model.Observation
 
 case class SearchCallback(
   searchTerm: NonEmptyString,
@@ -88,7 +89,7 @@ case class SiderealTargetEditor(
   onClone:       TargetWithId => Callback = _ => Callback.empty,
   renderInTitle: Option[Tile.RenderInTitle] = none,
   fullScreen:    View[AladinFullScreen],
-  agsState:      Option[View[AgsState]]
+  agsState:      Option[(Observation.Id, View[AgsState])]
 ) extends ReactFnProps(SiderealTargetEditor.component)
 
 object SiderealTargetEditor {
@@ -307,7 +308,6 @@ object SiderealTargetEditor {
                 AladinCell(
                   props.uid,
                   tid,
-                  props.obsIdSubset.foldMap(_.idSet.toList),
                   ObsConfiguration(
                     vizTime,
                     props.scienceMode,

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -64,6 +64,7 @@ import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 
 import java.time.Instant
+import explore.model.enums.AgsState
 
 case class SearchCallback(
   searchTerm: NonEmptyString,
@@ -86,7 +87,8 @@ case class SiderealTargetEditor(
   obsIdSubset:   Option[ObsIdSet] = None,
   onClone:       TargetWithId => Callback = _ => Callback.empty,
   renderInTitle: Option[Tile.RenderInTitle] = none,
-  fullScreen:    View[AladinFullScreen]
+  fullScreen:    View[AladinFullScreen],
+  agsState:      Option[View[AgsState]]
 ) extends ReactFnProps(SiderealTargetEditor.component)
 
 object SiderealTargetEditor {
@@ -289,6 +291,7 @@ object SiderealTargetEditor {
               }
 
           val disabled = props.searching.get.exists(_ === tid) || cloning.value
+          println(props.obsIdSubset.foldMap(_.idSet.toList))
 
           React.Fragment(
             props.renderInTitle
@@ -304,6 +307,7 @@ object SiderealTargetEditor {
                 AladinCell(
                   props.uid,
                   tid,
+                  props.obsIdSubset.foldMap(_.idSet.toList),
                   ObsConfiguration(
                     vizTime,
                     props.scienceMode,
@@ -312,7 +316,8 @@ object SiderealTargetEditor {
                     props.wavelength
                   ),
                   props.asterism.get,
-                  props.fullScreen
+                  props.fullScreen,
+                  props.agsState
                 )
               )(vizTime),
               <.div(LucumaStyles.FormColumnVeryCompact, ExploreStyles.TargetForm)(

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -292,7 +292,6 @@ object SiderealTargetEditor {
               }
 
           val disabled = props.searching.get.exists(_ === tid) || cloning.value
-          println(props.obsIdSubset.foldMap(_.idSet.toList))
 
           React.Fragment(
             props.renderInTitle

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -29,6 +29,7 @@ import explore.model.ObsIdSet
 import explore.model.ScienceMode
 import explore.model.SiderealTargetWithId
 import explore.model.TargetWithId
+import explore.model.enums.AgsState
 import explore.model.formats.*
 import explore.model.util.*
 import explore.undo.UndoContext
@@ -64,8 +65,6 @@ import queries.schemas.odb.ODBConversions.*
 import react.common.ReactFnProps
 
 import java.time.Instant
-import explore.model.enums.AgsState
-import lucuma.core.model.Observation
 
 case class SearchCallback(
   searchTerm: NonEmptyString,
@@ -79,7 +78,6 @@ case class SiderealTargetEditor(
   uid:           User.Id,
   asterism:      View[Asterism],
   vizTime:       Option[Instant],
-  posAngle:      Option[PosAngleConstraint],
   scienceMode:   Option[ScienceMode],
   constraints:   Option[ConstraintSet],
   wavelength:    Option[Wavelength],
@@ -89,8 +87,10 @@ case class SiderealTargetEditor(
   onClone:       TargetWithId => Callback = _ => Callback.empty,
   renderInTitle: Option[Tile.RenderInTitle] = none,
   fullScreen:    View[AladinFullScreen],
-  agsState:      Option[(Observation.Id, View[AgsState])]
-) extends ReactFnProps(SiderealTargetEditor.component)
+  posAngleView:  Option[(View[PosAngleConstraint], View[AgsState])]
+) extends ReactFnProps(SiderealTargetEditor.component) {
+  val posAngle: Option[PosAngleConstraint] = posAngleView.map(_._1.get)
+}
 
 object SiderealTargetEditor {
   private type Props = SiderealTargetEditor
@@ -317,7 +317,7 @@ object SiderealTargetEditor {
                   ),
                   props.asterism.get,
                   props.fullScreen,
-                  props.agsState
+                  props.posAngleView
                 )
               )(vizTime),
               <.div(LucumaStyles.FormColumnVeryCompact, ExploreStyles.TargetForm)(

--- a/explore/src/main/scala/explore/visualization/VisualizationOverlay.scala
+++ b/explore/src/main/scala/explore/visualization/VisualizationOverlay.scala
@@ -29,14 +29,14 @@ case class SVGVisualizationOverlay(
 ) extends ReactFnProps(SVGVisualizationOverlay.component)
 
 object SVGVisualizationOverlay {
-  type Props = SVGVisualizationOverlay
+  private type Props = SVGVisualizationOverlay
 
   val JtsPolygon    = Css("viz-polygon")
   val JtsCollection = Css("viz-collecttion")
   val JtsGuides     = Css("viz-guides")
   val JtsSvg        = Css("visualization-overlay-svg")
 
-  def forGeometry(css: Css, g: Geometry): VdomNode =
+  private def forGeometry(css: Css, g: Geometry): VdomNode =
     g match {
       case p: Polygon            =>
         val points = p.getCoordinates
@@ -51,10 +51,10 @@ object SVGVisualizationOverlay {
       case _                     => EmptyVdom
     }
 
-  val canvasWidth  = VdomAttr("width")
-  val canvasHeight = VdomAttr("height")
+  private val canvasWidth  = VdomAttr("width")
+  private val canvasHeight = VdomAttr("height")
 
-  val component =
+  private val component =
     ScalaFnComponent[Props] { p =>
       // Render the svg
       val evald: NonEmptyMap[Css, JtsShape] = p.shapes

--- a/model/shared/src/main/scala/explore/events/AgsMessage.scala
+++ b/model/shared/src/main/scala/explore/events/AgsMessage.scala
@@ -5,6 +5,7 @@ package explore.events
 
 import boopickle.DefaultBasic.*
 import boopickle.Pickler
+import cats.data.NonEmptyList
 import explore.model.boopickle.CatalogPicklers.given
 import lucuma.ags.AgsAnalysis
 import lucuma.ags.AgsParams
@@ -15,7 +16,6 @@ import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Target
 import workers.WorkerRequest
-import cats.data.NonEmptyList
 
 object AgsMessage {
   case class Request(

--- a/model/shared/src/main/scala/explore/events/AgsMessage.scala
+++ b/model/shared/src/main/scala/explore/events/AgsMessage.scala
@@ -15,6 +15,7 @@ import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Target
 import workers.WorkerRequest
+import cats.data.NonEmptyList
 
 object AgsMessage {
   case class Request(
@@ -23,7 +24,7 @@ object AgsMessage {
     wavelength:         Wavelength,
     baseCoordinates:    Coordinates,
     scienceCoordinates: List[Coordinates],
-    position:           List[AgsPosition],
+    positions:          NonEmptyList[AgsPosition],
     params:             AgsParams,
     candidates:         List[GuideStarCandidate]
   ) extends WorkerRequest {

--- a/model/shared/src/main/scala/explore/events/AgsMessage.scala
+++ b/model/shared/src/main/scala/explore/events/AgsMessage.scala
@@ -23,7 +23,7 @@ object AgsMessage {
     wavelength:         Wavelength,
     baseCoordinates:    Coordinates,
     scienceCoordinates: List[Coordinates],
-    position:           AgsPosition,
+    position:           List[AgsPosition],
     params:             AgsParams,
     candidates:         List[GuideStarCandidate]
   ) extends WorkerRequest {

--- a/model/shared/src/main/scala/explore/model/enums/AgsState.scala
+++ b/model/shared/src/main/scala/explore/model/enums/AgsState.scala
@@ -8,6 +8,10 @@ import cats.Eq
 enum AgsState:
   case Idle, LoadingCandidates, Calculating, Error
 
+  def canRecalculate: Boolean = this match
+    case Idle | Error => true
+    case _ => false
+
 object AgsState:
   /** @group Typeclass Instances */
   given Eq[AgsState] = Eq.fromUniversalEquals

--- a/model/shared/src/main/scala/explore/model/enums/AgsState.scala
+++ b/model/shared/src/main/scala/explore/model/enums/AgsState.scala
@@ -10,7 +10,7 @@ enum AgsState:
 
   def canRecalculate: Boolean = this match
     case Idle | Error => true
-    case _ => false
+    case _            => false
 
 object AgsState:
   /** @group Typeclass Instances */

--- a/model/shared/src/main/scala/explore/model/enums/AgsState.scala
+++ b/model/shared/src/main/scala/explore/model/enums/AgsState.scala
@@ -6,7 +6,7 @@ package explore.model.enums
 import cats.Eq
 
 enum AgsState:
-  case Idle, LoadingCandidates, Calculating, Error
+  case Idle, LoadingCandidates, Calculating, Saving, Error
 
   def canRecalculate: Boolean = this match
     case Idle | Error => true

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -28,7 +28,7 @@ object Settings {
     val log4CatsLogLevel = "0.3.1"
     val lucumaBC         = "0.4.0"
     val lucumaCore       = "0.60.0"
-    val lucumaCatalog    = "0.35.0"
+    val lucumaCatalog    = "0.36-4c9c6e8-20221214T184909Z-SNAPSHOT"
     val lucumaReact      = "0.25.0"
     val lucumaRefined    = "0.1.1"
     val lucumaSchemas    = "0.39.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -28,7 +28,7 @@ object Settings {
     val log4CatsLogLevel = "0.3.1"
     val lucumaBC         = "0.4.0"
     val lucumaCore       = "0.60.0"
-    val lucumaCatalog    = "0.36-4c9c6e8-20221214T184909Z-SNAPSHOT"
+    val lucumaCatalog    = "0.36-a47d164-20221218T204933Z-SNAPSHOT"
     val lucumaReact      = "0.25.0"
     val lucumaRefined    = "0.1.1"
     val lucumaSchemas    = "0.39.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -28,7 +28,7 @@ object Settings {
     val log4CatsLogLevel = "0.3.1"
     val lucumaBC         = "0.4.0"
     val lucumaCore       = "0.60.0"
-    val lucumaCatalog    = "0.36-a47d164-20221218T204933Z-SNAPSHOT"
+    val lucumaCatalog    = "0.36.0"
     val lucumaReact      = "0.25.0"
     val lucumaRefined    = "0.1.1"
     val lucumaSchemas    = "0.39.0"

--- a/workers/src/main/scala/workers/AgsServer.scala
+++ b/workers/src/main/scala/workers/AgsServer.scala
@@ -36,7 +36,7 @@ object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
                      r.wavelength,
                      r.baseCoordinates,
                      r.scienceCoordinates,
-                     r.position,
+                     r.positions,
                      r.params,
                      r.candidates
         )

--- a/workers/src/main/scala/workers/AgsServer.scala
+++ b/workers/src/main/scala/workers/AgsServer.scala
@@ -17,9 +17,9 @@ import workers.*
 
 import java.time.Duration
 import java.time.Instant
+import scala.concurrent.duration.*
 import scala.scalajs.js.annotation.JSExport
 import scala.scalajs.js.annotation.JSExportTopLevel
-import scala.concurrent.duration.*
 
 @JSExportTopLevel("AgsServer", moduleID = "exploreworkers")
 object AgsServer extends WorkerServer[IO, AgsMessage.Request] {

--- a/workers/src/main/scala/workers/AgsServer.scala
+++ b/workers/src/main/scala/workers/AgsServer.scala
@@ -19,6 +19,7 @@ import java.time.Duration
 import java.time.Instant
 import scala.scalajs.js.annotation.JSExport
 import scala.scalajs.js.annotation.JSExportTopLevel
+import scala.concurrent.duration.*
 
 @JSExportTopLevel("AgsServer", moduleID = "exploreworkers")
 object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
@@ -53,6 +54,9 @@ object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
         case req @ AgsMessage.Request(_, _, _, _, _, _, _, _) =>
           val cacheableRequest =
             Cacheable(CacheName("ags"), CacheVersion(AgsCacheVersion), agsCalculation)
-          cache.eval(cacheableRequest).apply(req).flatMap(m => invocation.respond(m))
+          cache
+            .eval(cacheableRequest)
+            .apply(req)
+            .flatMap(m => invocation.respond(m))
       }
 }

--- a/workers/src/main/scala/workers/AgsServer.scala
+++ b/workers/src/main/scala/workers/AgsServer.scala
@@ -26,7 +26,7 @@ object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
   @JSExport
   def runWorker(): Unit = run.unsafeRunAndForget()
 
-  private val AgsCacheVersion: Int = 4
+  private val AgsCacheVersion: Int = 5
 
   private val CacheRetention: Duration = Duration.ofDays(60)
 
@@ -57,6 +57,6 @@ object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
           cache
             .eval(cacheableRequest)
             .apply(req)
-            .flatMap(m => invocation.respond(m))
+            .flatMap(invocation.respond)
       }
 }

--- a/workers/src/main/scala/workers/WorkerServer.scala
+++ b/workers/src/main/scala/workers/WorkerServer.scala
@@ -95,7 +95,7 @@ trait WorkerServer[F[_]: Async, T: Pickler](using Monoid[F[Unit]]):
                         postAsTransferable[F, FromServer](
                           self,
                           FromServer.Error(id, WorkerException.fromThrowable(t))
-                        )
+                        ) >> F.cede
                       )
                       .guarantee(cancelTokens.update(_ - id))
                       .start


### PR DESCRIPTION
This PR adds support for the `Allow flip` mode in AGS. Besides the algorithm changes there are some changes on the UI which are relevant:
* The pos angle control is now disabled while calculations are taking place
* Eventually if the flip mode needs to change the PA the value will be directly updated on the controls

The new feature can be seen here:

https://user-images.githubusercontent.com/3615303/208494418-b13e3c14-60a5-4862-a835-6a7380ec3d34.mp4

