### PR TITLE
Keep target summary visible when editing target

### DIFF
--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -33,7 +33,6 @@ case class Tile(
   canMinimize:       Boolean = false,
   canMaximize:       Boolean = false,
   state:             TileSizeState = TileSizeState.Normal,
-  fadeIn:            Boolean = true,
   sizeStateCallback: TileSizeState => Callback = _ => Callback.empty,
   controllerClass:   Option[Css] = None, // applied to wrapping div when in a TileController.
   bodyClass:         Option[Css] = None, // applied to tile body
@@ -105,7 +104,7 @@ object Tile {
             .runNow()
 
         <.div(
-          ExploreStyles.Tile |+| ExploreStyles.FadeIn.when_(p.fadeIn) |+| p.tileClass.orEmpty,
+          ExploreStyles.Tile |+| ExploreStyles.FadeIn |+| p.tileClass.orEmpty,
           ^.key := p.id.value
         )(
           // Tile title, set classes based on size

--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -33,8 +33,8 @@ case class Tile(
   canMinimize:       Boolean = false,
   canMaximize:       Boolean = false,
   state:             TileSizeState = TileSizeState.Normal,
+  fadeIn:            Boolean = true,
   sizeStateCallback: TileSizeState => Callback = _ => Callback.empty,
-  key:               js.UndefOr[Key] = js.undefined,
   controllerClass:   Option[Css] = None, // applied to wrapping div when in a TileController.
   bodyClass:         Option[Css] = None, // applied to tile body
   tileClass:         Option[Css] = None, // applied to the tile
@@ -105,7 +105,8 @@ object Tile {
             .runNow()
 
         <.div(
-          ExploreStyles.Tile |+| ExploreStyles.FadeIn |+| p.tileClass.orEmpty
+          ExploreStyles.Tile |+| ExploreStyles.FadeIn.when_(p.fadeIn) |+| p.tileClass.orEmpty,
+          ^.key := p.id.value
         )(
           // Tile title, set classes based on size
           ResponsiveComponent(

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -479,3 +479,5 @@ object ExploreStyles:
   val TimingWindowRepeatEditorAlternatives: Css = Css("timing-window-repeat-editor-alternatives")
   val TimingWindowRepeatEditorNTimes: Css       = Css("timing-window-repeat-editor-n-times")
   val TimingWindowsHeader: Css                  = Css("timing-windows-header")
+
+  val SingleTileMaximized: Css = Css("explore-single-tile-maximized")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -98,16 +98,16 @@ body {
 }
 
 .p-progress-spinner.explore-loader {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    margin: 0;
-    text-align: center;
-    z-index: 1000;
-    transform: translateX(-50%) translateY(-50%);
-    width: 4rem;
-    height: 4rem;
-    font-size: 1em;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  margin: 0;
+  text-align: center;
+  z-index: 1000;
+  transform: translateX(-50%) translateY(-50%);
+  width: 4rem;
+  height: 4rem;
+  font-size: 1em;
 }
 
 // -----
@@ -385,7 +385,7 @@ body {
   }
 }
 
-.tile-xs-width .target-grid{
+.tile-xs-width .target-grid {
   @include hide-hidden-target-cells(false);
 
   grid-template:
@@ -731,7 +731,7 @@ $search-preview-margin: 5px;
     color: var(--site-text-color) !important;
 
     &:hover {
-      outline: 1px  var(--site-border-color) solid;
+      outline: 1px var(--site-border-color) solid;
     }
   }
 
@@ -1689,4 +1689,14 @@ div.spectroscopy-table-emptymessage {
 
 .indicator-fail {
   color: var(--red-500);
+}
+
+.explore-single-tile-maximized.react-grid-layout {
+  height: 100% !important; // !important overrides element attributes
+  width: 100% !important;
+
+  .react-grid-item:first-child {
+    height: 100% !important;
+    width: 100% !important;
+  }
 }

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -230,7 +230,6 @@ object AsterismGroupObsList:
       val selectedTargetIds: SortedSet[Target.Id] =
         props.focused.obsSet
           .flatMap(ids => props.asterismsWithObs.get.asterismGroups.get(ids).map(_.targetIds))
-          .orElse(props.focused.target.map(SortedSet(_)))
           .getOrElse(SortedSet.from(props.selectedSummaryTargets.get))
 
       def isObsSelected(obsId: Observation.Id): Boolean =

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -54,12 +54,11 @@ case class AsterismGroupObsList(
   asterismsWithObs:       View[AsterismGroupsWithObs],
   programId:              Program.Id,
   focused:                Focused,
-  setSummaryPanel:        Callback,
   expandedIds:            View[SortedSet[ObsIdSet]],
   undoCtx:                UndoContext[AsterismGroupsWithObs],
   toastRef:               ToastRef,
   selectTargetOrSummary:  Option[Target.Id] => Callback,
-  selectedSummaryTargets: List[Target.Id]
+  selectedSummaryTargets: View[List[Target.Id]]
 ) extends ReactFnProps[AsterismGroupObsList](AsterismGroupObsList.component)
     with ViewCommon:
   override val focusedObsSet: Option[ObsIdSet] = focused.obsSet
@@ -232,7 +231,7 @@ object AsterismGroupObsList:
         props.focused.obsSet
           .flatMap(ids => props.asterismsWithObs.get.asterismGroups.get(ids).map(_.targetIds))
           .orElse(props.focused.target.map(SortedSet(_)))
-          .getOrElse(SortedSet.from(props.selectedSummaryTargets))
+          .getOrElse(SortedSet.from(props.selectedSummaryTargets.get))
 
       def isObsSelected(obsId: Observation.Id): Boolean =
         props.focused.obsSet.exists(_.contains(obsId))
@@ -371,13 +370,14 @@ object AsterismGroupObsList:
               severity = Button.Severity.Success,
               disabled = addingTargetOrObs.get.value,
               loading = addingTargetOrObs.get.value,
-              onClick = insertObs(props.programId,
-                                  selectedTargetIds,
-                                  props.undoCtx,
-                                  addingTargetOrObs,
-                                  props.expandedIds,
-                                  selectObsOrSummary,
-                                  props.toastRef
+              onClick = insertObs(
+                props.programId,
+                selectedTargetIds,
+                props.undoCtx,
+                addingTargetOrObs,
+                props.expandedIds,
+                selectObsOrSummary,
+                props.toastRef
               ).runAsync
             ).compact.mini,
             Button(
@@ -386,11 +386,12 @@ object AsterismGroupObsList:
               severity = Button.Severity.Success,
               disabled = addingTargetOrObs.get.value,
               loading = addingTargetOrObs.get.value,
-              onClick = insertSiderealTarget(props.programId,
-                                             props.undoCtx,
-                                             addingTargetOrObs,
-                                             props.selectTargetOrSummary,
-                                             props.toastRef
+              onClick = insertSiderealTarget(
+                props.programId,
+                props.undoCtx,
+                addingTargetOrObs,
+                props.selectTargetOrSummary,
+                props.toastRef
               ).runAsync
             ).compact.mini,
             UndoButtons(props.undoCtx, size = PlSize.Mini)
@@ -398,7 +399,9 @@ object AsterismGroupObsList:
           <.div(
             Button(
               severity = Button.Severity.Secondary,
-              onClick = setFocused(Focused.None) >> props.setSummaryPanel,
+              onClick =
+                ctx.pushPage(AppTab.Targets, props.programId, props.focused.withoutObsSet) >>
+                  props.selectedSummaryTargets.set(props.focused.target.toList),
               clazz = ExploreStyles.ButtonSummary
             )(
               Icons.ListIcon.withClass(ExploreStyles.PaddedRightIcon),

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -57,8 +57,7 @@ object AsterismEditorTile:
     title:           String,
     posAngle:        Option[(Observation.Id, View[PosAngleConstraint], View[AgsState])],
     backButton:      Option[VdomNode] = none
-  )(using TransactionalClient[IO, ObservationDB], Logger[IO]) = {
-
+  )(using TransactionalClient[IO, ObservationDB], Logger[IO]): Tile = {
     // Save the time here. this works for the obs and target tabs
     val vizTimeView = potVizTime.map(_.withOnMod { t =>
       ObsQueries.updateVisualizationTime[IO](sharedInObsIds.toList, t).runAsync
@@ -86,7 +85,7 @@ object AsterismEditorTile:
       control = s => control.some.filter(_ => s === TileSizeState.Minimized),
       bodyClass = Some(ExploreStyles.TargetTileBody)
     )((renderInTitle: Tile.RenderInTitle) =>
-      potRender[(View[Option[Asterism]], Option[ScienceMode])] { case (asterism, scienceMode) =>
+      potAsterismMode.render((asterism, scienceMode) =>
         userId.map(uid =>
           AsterismEditor(
             uid,
@@ -106,8 +105,6 @@ object AsterismEditorTile:
             posAngleView
           )
         )
-      }(
-        potAsterismMode
       )
     )
   }

--- a/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
@@ -196,10 +196,10 @@ object ConstraintsTabContents extends TwoPanels:
           findConstraintGroup(ids, constraintsWithObs.get.constraintGroups).map(cg => (ids, cg))
         )
         .fold[VdomNode] {
-          Tile("constraints".refined,
-               "Constraints Summary",
-               backButton.some,
-               key = "constraintsSummary"
+          Tile(
+            "constraints".refined,
+            "Constraints Summary",
+            backButton.some
           )(renderInTitle =>
             ConstraintsSummaryTable(
               props.userId,

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -188,10 +188,10 @@ object ObsTabContents extends TwoPanels:
 
     def rightSide = (resize: UseResizeDetectorReturn) =>
       props.focusedObs.fold[VdomNode](
-        Tile("observations".refined,
-             "Observations Summary",
-             backButton.some,
-             key = "observationsSummary"
+        Tile(
+          "observations".refined,
+          "Observations Summary",
+          backButton.some
         )(_ =>
           <.div(
             ExploreStyles.HVCenter |+| ExploreStyles.EmptyTreeContent,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -678,7 +678,6 @@ object TargetTabContents extends TwoPanels:
       .useToastRef
       // Selected targets on the summary table
       .useStateViewBy((props, _, _, _, _, _, _, _, _) => props.focused.target.toList)
-      // .useStateView(List.empty[Target.Id])
       .useGlobalHotkeysWithDepsBy((props, ctx, _, _, _, _, _, asterismGroupWithObs, _, selIds) =>
         (props.focused, asterismGroupWithObs.toOption.map(_.get.asterismGroups), selIds.get)
       ) {

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -729,7 +729,7 @@ object TargetTabContents extends TwoPanels:
                             props.expandedIds
                           )
                         )
-                        .getOrElse(IO.unit)
+                        .orEmpty
                     else IO.unit
 
                   case LocalClipboard.CopiedTargets(tids) =>
@@ -752,7 +752,6 @@ object TargetTabContents extends TwoPanels:
                       )
 
                   case _ => IO.unit
-
                 }.runAsync
 
               case GoToSummary =>

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -713,7 +713,7 @@ object TargetTabContents extends TwoPanels:
                     val treeTargets =
                       props.focused.obsSet
                         .flatMap(i => asterismGroups.flatMap(_.get(i).map(_.targetIds.toList)))
-                        .getOrElse(props.focused.target.toList)
+                        .getOrElse(selectedIds)
 
                     if (treeTargets.nonEmpty)
                       // Apply the obs to selected targets on the tree
@@ -722,21 +722,6 @@ object TargetTabContents extends TwoPanels:
                           applyObs(
                             id.idSet.toList,
                             treeTargets,
-                            loading,
-                            agwov,
-                            ctx,
-                            props.listUndoStacks,
-                            props.expandedIds
-                          )
-                        )
-                        .getOrElse(IO.unit)
-                    else if (selectedIds.nonEmpty)
-                      // Apply the obs to selected targets on the summary table to each target
-                      optViewAgwo
-                        .map(agwov =>
-                          applyObs(
-                            id.idSet.toList,
-                            selectedIds,
                             loading,
                             agwov,
                             ctx,

--- a/explore/src/main/scala/explore/tabs/package.scala
+++ b/explore/src/main/scala/explore/tabs/package.scala
@@ -7,10 +7,12 @@ import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.refined.*
 
 enum ObsTabTilesIds:
-  case NotesId, TargetId, PlotId, ConstraintsId, ConfigurationId, ItcId, TimingWindowsId
+  case NotesId, TargetSummaryId, TargetId, PlotId, ConstraintsId, ConfigurationId, ItcId,
+    TimingWindowsId
 
   def id: NonEmptyString = this match
     case NotesId         => "notes".refined
+    case TargetSummaryId => "targetSummary".refined
     case TargetId        => "target".refined
     case PlotId          => "elevationPlot".refined
     case ConstraintsId   => "constraints".refined


### PR DESCRIPTION
Also, if a target is being edited within an observation, it remains selected when switching to the Target Summary.

![Kapture 2022-12-21 at 11 53 20](https://user-images.githubusercontent.com/1895643/208934391-55dbd36b-d491-488c-993c-8a93826db3ff.gif)
