### PR TITLE
Improve the AGS flip mode with a new algorithm and allow manual

### DIFF
--- a/common/src/main/webapp/sass/visualization.scss
+++ b/common/src/main/webapp/sass/visualization.scss
@@ -345,7 +345,7 @@ $brightness: var(--aladin-image-brightness);
     align-items: center;
 
     .ags-navigation {
-      margin-left: auto;
+      margin-left: 0.3em;
     }
 
     .ags-navigation-button {

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -234,7 +234,7 @@ object AladinContainer extends AladinCommon {
                     case _ if scienceMode.isEmpty                             =>
                       // Don't color the stars for guide speed if there is no mode selected
                       Css.Empty
-                    case AgsAnalysis.Usable(_, _, Some(s), _, _, _)           =>
+                    case AgsAnalysis.Usable(_, _, Some(s), _, _)              =>
                       speedCss(s)
                     case AgsAnalysis.NotReachableAtPosition(_, _, Some(s), _) =>
                       speedCss(s)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -28,7 +28,7 @@ object Settings {
     val log4CatsLogLevel = "0.3.1"
     val lucumaBC         = "0.4.0"
     val lucumaCore       = "0.60.0"
-    val lucumaCatalog    = "0.36.0"
+    val lucumaCatalog    = "0.37.0"
     val lucumaReact      = "0.26.0"
     val lucumaRefined    = "0.1.1"
     val lucumaSchemas    = "0.39.0"

--- a/workers/src/main/scala/workers/AgsServer.scala
+++ b/workers/src/main/scala/workers/AgsServer.scala
@@ -26,7 +26,7 @@ object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
   @JSExport
   def runWorker(): Unit = run.unsafeRunAndForget()
 
-  private val AgsCacheVersion: Int = 5
+  private val AgsCacheVersion: Int = 6
 
   private val CacheRetention: Duration = Duration.ofDays(60)
 


### PR DESCRIPTION
In this version we are globally looking at all the PAs (just two in flip mode) and find the best possible including brightness which wasn't included before.
We can also now do manual override and will change the PA if needed:


https://user-images.githubusercontent.com/3615303/209148348-0e92a620-309e-4fe8-9185-93d3a7d06dbd.mp4

