### PR TITLE
Enforce SED always present when importing

### DIFF
--- a/explore/src/main/scala/explore/config/TargetImportPopup.scala
+++ b/explore/src/main/scala/explore/config/TargetImportPopup.scala
@@ -14,6 +14,7 @@ import crystal.react.reuse.*
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.model.AppContext
+import explore.model.Constants
 import fs2.*
 import fs2.text
 import japgolly.scalajs.react.*
@@ -90,9 +91,7 @@ object TargetImportPopup:
           stateUpdate(State.targetErrors.modify(e => e :++ a.toList.map(_.displayValue)))
         case Right(tgt) =>
           // FIXME The backend needs a SED
-          val target = Target.Sidereal.unnormalizedSED.replace(
-            UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.O5V).some
-          )(tgt)
+          val target = Target.Sidereal.unnormalizedSED.replace(Constants.DefaultSED.some)(tgt)
           CreateTargetMutation
             .execute(target.toCreateTargetInput(programId))
             .map(_.createTarget.target.id.some)

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -154,6 +154,7 @@ object AsterismEditor extends AsterismModifier:
           ExploreStyles.AladinFullScreen.when(fullScreen.get.value),
           props.renderInTitle(
             TargetSelectionPopup(
+              "Add Target",
               TargetSource.FromProgram[IO](props.programId) :: TargetSource.forAllCatalogs[IO],
               selectExistingLabel = "Link",
               selectExistingIcon = Icons.Link,

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -91,6 +91,7 @@ object SearchForm:
         val searchIcon: VdomNode =
           if (enabled.value)
             TargetSelectionPopup(
+              "Replace Target Data",
               TargetSource.forAllSiderealCatalogs[IO],
               "",
               Icons.Ban,

--- a/explore/src/main/scala/explore/targets/TargetSearchResult.scala
+++ b/explore/src/main/scala/explore/targets/TargetSearchResult.scala
@@ -5,12 +5,14 @@ package explore.targets
 
 import cats.Eq
 import cats.syntax.all.*
+import explore.model.Constants
 import explore.model.TargetWithOptId
 import japgolly.scalajs.react.ReactCats.*
 import japgolly.scalajs.react.Reusability
 import lucuma.catalog.AngularSize
 import lucuma.catalog.CatalogTargetResult
 import lucuma.core.model.CatalogInfo
+import lucuma.core.model.SourceProfile
 import lucuma.core.model.Target
 
 case class TargetSearchResult(
@@ -23,7 +25,15 @@ case class TargetSearchResult(
 
 object TargetSearchResult {
   def fromCatalogTargetResult(r: CatalogTargetResult): TargetSearchResult =
-    TargetSearchResult(TargetWithOptId(none, r.target), r.angularSize)
+    TargetSearchResult(
+      TargetWithOptId(
+        none,
+        Target.Sidereal.sourceProfile
+          .andThen(SourceProfile.unnormalizedSED)
+          .modify(_.orElse(Constants.DefaultSED.some))(r.target) // Ensure SED is always present.
+      ),
+      r.angularSize
+    )
 
   given Eq[TargetSearchResult] =
     Eq.by(t =>

--- a/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
@@ -49,6 +49,7 @@ import scala.collection.immutable.SortedMap
 import scala.concurrent.duration.*
 
 case class TargetSelectionPopup(
+  title:               String,
   targetSources:       NonEmptyList[TargetSource[IO]],
   selectExistingLabel: String,
   selectExistingIcon:  FontAwesomeIcon,
@@ -249,7 +250,7 @@ object TargetSelectionPopup:
             dismissableMask = true,
             onHide = singleEffect.cancel.runAsync >> isOpen
               .setState(PopupState.Closed) >> cleanState >> props.onCancel,
-            header = "Add Target"
+            header = props.title
           )(
             React.Fragment(
               <.span(ExploreStyles.TargetSearchTop)(

--- a/model/shared/src/main/scala/explore/model/Constants.scala
+++ b/model/shared/src/main/scala/explore/model/Constants.scala
@@ -4,7 +4,9 @@
 package explore.model
 
 import cats.syntax.all.*
+import lucuma.core.enums.StellarLibrarySpectrum
 import lucuma.core.math.Angle
+import lucuma.core.model.UnnormalizedSED
 
 import java.time.Duration
 import java.time.ZoneOffset
@@ -22,6 +24,7 @@ trait Constants:
   val PreviewFov: Angle        = Angle.fromMicroarcseconds(60000000L)
   val SimbadResultLimit        = 50
   val MaxConcurrentItcRequests = 4
+  val DefaultSED               = UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.O5V)
 
   val GppDateFormatter: DateTimeFormatter   = DateTimeFormatter.ofPattern("yyyy-MMM-dd")
   val GppTimeFormatter: DateTimeFormatter   = DateTimeFormatter.ofPattern("HH:mm")


### PR DESCRIPTION
When the target data was replaced by using the magnifying glass, the DB update was failing because of the missing SED.