### PR TITLE
Target save error handling and global toastRef

### DIFF
--- a/common/src/main/scala/explore/common/AlignerF.scala
+++ b/common/src/main/scala/explore/common/AlignerF.scala
@@ -4,6 +4,7 @@
 package explore.common
 
 import cats.MonadError
+import cats.syntax.all.*
 import crystal.react.View
 import crystal.react.implicits.*
 import explore.undo.UndoContext

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -24,6 +24,7 @@ import lucuma.schemas.ObservationDB
 import org.typelevel.log4cats.Logger
 import queries.schemas.ITC
 import queries.schemas.UserPreferencesDB
+import react.primereact.ToastRef
 import workers.WebWorkerF
 import workers.WorkerClient
 
@@ -36,7 +37,8 @@ case class AppContext[F[_]](
   setPageVia:       (AppTab, Program.Id, Focused, SetRouteVia) => Callback,
   environment:      ExecutionEnvironment,
   exploreClipboard: Ref[F, LocalClipboard],
-  broadcastChannel: BroadcastChannel[ExploreEvent]
+  broadcastChannel: BroadcastChannel[ExploreEvent],
+  toastRef:         Deferred[F, ToastRef]
 )(using
   val F:            Applicative[F],
   val logger:       Logger[F],
@@ -67,7 +69,8 @@ object AppContext:
     setPageVia:           (AppTab, Program.Id, Focused, SetRouteVia) => Callback,
     workerClients:        WorkerClients[F],
     exploreClipboard:     Ref[F, LocalClipboard],
-    broadcastChannel:     BroadcastChannel[ExploreEvent]
+    broadcastChannel:     BroadcastChannel[ExploreEvent],
+    toastRef:             Deferred[F, ToastRef]
   ): F[AppContext[F]] =
     for {
       clients <-
@@ -83,7 +86,8 @@ object AppContext:
       setPageVia,
       config.environment,
       exploreClipboard,
-      broadcastChannel
+      broadcastChannel,
+      toastRef
     )
 
   given [F[_]]: Reusability[AppContext[F]] = Reusability.always

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -9,6 +9,7 @@ import cats.effect.IOApp
 import cats.effect.Ref
 import cats.effect.Resource
 import cats.effect.Sync
+import cats.effect.kernel.Deferred
 import cats.effect.std.Dispatcher
 import cats.syntax.all.*
 import clue.WebSocketReconnectionStrategy
@@ -54,6 +55,7 @@ import org.scalajs.dom
 import org.scalajs.dom.Element
 import org.scalajs.dom.RequestCache
 import org.typelevel.log4cats.Logger
+import react.primereact.ToastRef
 
 import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.*
@@ -176,6 +178,7 @@ object ExploreMain extends IOApp.Simple {
         _                    <- Logger[IO].info(s"Git Commit: [${utils.gitHash.getOrElse("NONE")}]")
         _                    <- Logger[IO].info(s"Config: ${appConfig.show}")
         clipboard            <- Ref.of[IO, LocalClipboard](LocalClipboard.Empty)
+        toastRef             <- Deferred[IO, ToastRef]
         ctx                  <-
           AppContext.from[IO](
             appConfig,
@@ -184,7 +187,8 @@ object ExploreMain extends IOApp.Simple {
             setPageVia,
             workerClients,
             clipboard,
-            bc
+            bc,
+            toastRef
           )
         _                    <- setupReusabilityOverlay(appConfig.environment)
         r                    <- (ctx.sso.whoami, setupDOM[IO], showEnvironment[IO](appConfig.environment)).parTupled

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -107,14 +107,8 @@ object SearchForm:
               ).tiny.compact,
               onSelected = targetWithId =>
                 (targetWithId.target match
-                  case t @ Target.Sidereal(_, _, _, _) =>
-                    props.targetSet(t)
-                  // .onError { case t: Throwable =>
-                  //   Logger[IO].error(t)("Error saving target").runAsync
-                  //     >> toastRef.info("Error saving target")
-                  // }
-
-                  case _ => Callback.empty
+                  case t @ Target.Sidereal(_, _, _, _) => props.targetSet(t)
+                  case _                               => Callback.empty
                 ) >> searchComplete,
               onCancel = searchComplete,
               initialSearch = term.get.some,

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -35,6 +35,7 @@ import org.scalajs.dom
 import org.scalajs.dom.HTMLButtonElement
 import org.scalajs.dom.ext.KeyCode
 import org.scalajs.dom.ext.KeyValue
+import org.typelevel.log4cats.Logger
 import react.common.ReactFnProps
 import react.primereact.Button
 
@@ -76,7 +77,7 @@ object SearchForm:
             .void
       )
       .useRefToVdom[HTMLButtonElement]
-      .render { (props, ctx, term, enabled, error, buttonRef) =>
+      .render { (props, ctx, term, enabled, error, buttonRef) => // , toastRef) =>
         import ctx.given
 
         val searchComplete: Callback = props.searching.mod(_ - props.id)
@@ -106,8 +107,14 @@ object SearchForm:
               ).tiny.compact,
               onSelected = targetWithId =>
                 (targetWithId.target match
-                  case t @ Target.Sidereal(_, _, _, _) => props.targetSet(t)
-                  case _                               => Callback.empty
+                  case t @ Target.Sidereal(_, _, _, _) =>
+                    props.targetSet(t)
+                  // .onError { case t: Throwable =>
+                  //   Logger[IO].error(t)("Error saving target").runAsync
+                  //     >> toastRef.info("Error saving target")
+                  // }
+
+                  case _ => Callback.empty
                 ) >> searchComplete,
               onCancel = searchComplete,
               initialSearch = term.get.some,

--- a/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
@@ -169,12 +169,6 @@ object TargetSelectionPopup:
     .useState(PopupState.Closed)
     // selectedTarget
     .useStateView(none[SelectedTarget])
-    // targetSources
-    // .useMemoBy((_, _, _, _, _, _, _, _) => ()) { (props, ctx, _, _, _, _, _, _) => _ =>
-    //   import ctx.given
-
-    //   TargetSource.FromProgram[IO](props.programId) :: TargetSource.forAllCatalogs[IO]
-    // }
     // aladinRef
     .useMemo(())(_ => Ref.toScalaComponent(Aladin.component))
     // re render when selected changes
@@ -196,7 +190,6 @@ object TargetSelectionPopup:
         singleEffect,
         isOpen,
         selectedTarget,
-        // targetSources,
         aladinRef
       ) =>
         import ctx.given
@@ -259,7 +252,8 @@ object TargetSelectionPopup:
                     id = "name".refined,
                     placeholder = "Name",
                     value = inputValue,
-                    preAddons = List(if (searching.get.value) Icons.Spinner else Icons.Search),
+                    preAddons =
+                      List(if (searching.get.value) Icons.Spinner.withSpin(true) else Icons.Search),
                     onTextChange = (t: String) =>
                       inputValue.set(t) >>
                         singleEffect

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -67,8 +67,7 @@ case class TargetSummaryTable(
   selectTargetOrSummary: Option[Target.Id] => Callback,
   renderInTitle:         Tile.RenderInTitle,
   selectedTargetIds:     View[List[Target.Id]],
-  undoCtx:               UndoContext[AsterismGroupsWithObs],
-  toastRef:              ToastRef
+  undoCtx:               UndoContext[AsterismGroupsWithObs]
 ) extends ReactFnProps(TargetSummaryTable.component)
 
 object TargetSummaryTable extends TableHooks:
@@ -229,13 +228,11 @@ object TargetSummaryTable extends TableHooks:
                     selectedRowsIds,
                     props.programId,
                     props.selectTargetOrSummary(none).to[IO],
-                    props.toastRef.info(_).to[IO]
+                    ctx.toastRef.showToast(_)
                   )
                   .set(props.undoCtx)(selectedRowsIds.map(_ => none[TargetWithObs]))
                   .to[IO]
-                  .guarantee(
-                    deletingTargets.async.set(DeletingTargets(false))
-                  )).runAsyncAndForget,
+                  .guarantee(deletingTargets.async.set(DeletingTargets(false)))).runAsyncAndForget,
             acceptClass = PrimeStyles.ButtonSmall,
             rejectClass = PrimeStyles.ButtonSmall,
             icon = Icons.SkullCrossBones.withColor("red")


### PR DESCRIPTION
- There is a single `Toast` instance in the app and its `toastRef` is stored in the `AppContext`.
- User is informed now if there's an error when saving a target to the DB.

We should consider notifying users of errors in all interactions with the DB.