### PR TITLE
Replace last SUI component and remove lucuma-react-semantic-ui

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -302,12 +302,10 @@ object ExploreStyles:
 
   val StepGuided: Css = Css("step-guided")
 
-  val ExploreForm: Css             = Css("explore-form")
   val TargetImportForm: Css        = Css("explore-target-import-form")
   val TargetImportDescription: Css = Css("explore-target-import-description")
   val TargetImportErrors: Css      = Css("explore-target-import-errors")
   val TargetImportDialog: Css      = Css("explore-target-import-dialog")
-  val SkipToNext: Css              = Css("explore-skip-to-next")
   val SeqGenParametersForm: Css    = Css("seq-gen-parameters-form")
 
   // Configuration tile
@@ -327,7 +325,6 @@ object ExploreStyles:
   val AdvancedConfigurationCol3: Css    = Css("explore-advanced-configuration-col3")
   val AdvancedConfigurationButtons: Css = Css("explore-advanced-configuration-buttons")
   val ConfigurationFilter: Css          = Css("explore-configuration-filter") |+| Css("field")
-  val ConfigurationFilterItem: Css      = Css("explore-configuration-filter-item")
   val ExploreTable: Css                 = Css("explore-table")
   val ExploreTableEmpty: Css            = Css("explore-table-emptymessage")
   val SpectroscopyTableEmpty: Css       = Css("spectroscopy-table-emptymessage")

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -447,11 +447,6 @@ object ExploreStyles:
   // For icons that will be show instead of an input during some circumstances.
   val InputReplacementIcon: Css = Css("input-replacement-icon") |+| Css("field")
 
-  // For making a Input have a "X" icon for clearing, like the dropdowns do.
-  // See `clearInputIcon` in `explore.utils.package`
-  val ClearableInputIcon: Css         = Css("clearable-input-icon")
-  val ClearableInputPaddingReset: Css = Css("clearable-input-padding-reset")
-
   val SummaryTableToolbar: Css = Css("summary-table-toolbar")
 
   // TODO: to lucuma-ui

--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -11,8 +11,6 @@ import explore.model.Constants
 import explore.utils.*
 import japgolly.scalajs.react.callback.Callback
 import japgolly.scalajs.react.util.Effect
-import lucuma.ui.forms.ExternalValue
-import lucuma.ui.forms.FormInputEV
 import org.scalablytyped.runtime.StringDictionary
 import org.scalajs.dom.Window
 import org.typelevel.log4cats.Logger
@@ -25,21 +23,6 @@ extension (self: Window)
   // Keep this as def to take the value window.innerWidth at the current time
   def canFitTwoPanels: Boolean =
     self.innerWidth > Constants.TwoPanelCutoff
-
-extension [EV[_], A, B](input: FormInputEV[EV, Option[A]])
-  def clearable(using ev: ExternalValue[EV], ev3: Eq[A]) =
-    input.copy(icon = clearInputIcon[EV, A](input.value))
-
-  // When an icon is added to a FormInputEV, SUI adds extra padding on the right to make
-  // space for the icon. However, with some layouts this can cause resizing issues, so this
-  // method removes that extra padding. See `clearInputIcon` for more details.
-  def clearableNoPadding(using ev: ExternalValue[EV], ev3: Eq[A]) = {
-    val newClazz: UndefOr[Css] =
-      input.clazz.fold(ExploreStyles.ClearableInputPaddingReset)(
-        _ |+| ExploreStyles.ClearableInputPaddingReset
-      )
-    input.copy(icon = clearInputIcon[EV, A](input.value), clazz = newClazz)
-  }
 
 extension [A](c: js.UndefOr[A => Callback])
   def toJs: js.UndefOr[js.Function1[A, Unit]] = c.map(x => (a: A) => x(a).runNow())

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -29,7 +29,6 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.util.NewType
 import lucuma.ui.enums.Theme
-import lucuma.ui.forms.ExternalValue
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.utils.versionDateFormatter
@@ -132,28 +131,6 @@ def forceAssign[T, S](mod: Endo[Input[S]] => Endo[T])(base: S): Endo[S] => Endo[
       case Assign(edit) => modS(edit).assign
       case _            => modS(base).assign
     }
-
-/**
- * Creates an `X` icon that clears the data from a `FormInputEV` which uses a `View[Option[A]]` It
- * should be assigned to the `icon` parameter of `FormInputEV` and use the same `View`. It is styled
- * to look like the clear icon for the `EnumViewOptionalSelect`s.
- *
- * Depending on the layout containing the `FormInputEV`, you may also need to add the
- * `ExploreStyles.ClearableInputPaddingReset` class. When an icon is added to a FormInput, it
- * changes the padding for the enclosed `input` to make room for the icon - lots of room - which can
- * change your layout. The above class resets the padding to the standard for FormInputs without
- * icons. The downside, of course, is that if your content can extend all the wqy to the right side
- * of the input, the `X` icon will sit on top of it. Usually this is not a problem. Note that this
- * will override that for `InputWithUnits` this will override the default `clazz` of
- * `ExploreStyles.Grow(1), so you may need to add that, too.
- */
-def clearInputIcon[EV[_], A](
-  view:     EV[Option[A]]
-)(using ev: ExternalValue[EV]): js.UndefOr[VdomNode] =
-  ev.get(view)
-    .flatten
-    .map(_ => <.i(ExploreStyles.ClearableInputIcon, ^.onClick --> ev.set(view)(None)))
-    .orUndefined
 
 // TODO Move these to lucuma-ui
 extension (toastRef: ToastRef)

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -1,6 +1,5 @@
+// These need to be kept until we unify the colors in `variables-*.less` with the primereact colors.
 @import 'suithemes/default/globals/site.variables';
-@import 'suithemes/default/modules/dropdown.variables';
-@import 'theme/site/collections/form.variables';
 @import 'theme/site/globals/site.variables';
 
 // vertical buttons
@@ -545,28 +544,6 @@ html {
 .explore-button-summary {
   width: 100%;
   justify-content: center;
-}
-
-.explore-title-select-columns {
-  text-align: right;
-  display: none;
-}
-
-@media (min-width: @mobile-responsive-cutoff) {
-  .explore-title-select-columns {
-    display: inline;
-  }
-}
-
-.explore-select-columns {
-  .menu {
-    max-height: 30em !important;
-    z-index: 3000 !important;
-
-    .item {
-      font-size: small !important;
-    }
-  }
 }
 
 .explore-target-summary-delete {

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -167,27 +167,6 @@ tfoot {
   .full-height-width();
 }
 
-// Used as part of creating headers in a FormSelect.
-// Selector is very specific to avoid affecting other controls
-.ui.dropdown.selection .menu .item.header.disabled {
-  text-align: right;
-  color: var(--dropdown-item-color);
-
-  &:hover {
-    color: var(--dropdown-item-color);
-    background: unset;
-  }
-}
-
-.constraints-grid.ui.form .field {
-  margin-bottom: 0;
-}
-
-.ui.selection.dropdown.constraints-tile-selector {
-  font-size: smaller;
-  margin-right: 0.5em;
-}
-
 //----------
 // Main title
 //----------
@@ -390,26 +369,6 @@ tfoot {
   background-color: var(--negative-background-color);
 }
 
-.ui.label.explore-error-label {
-  .error-label-mixin();
-}
-
-.ui.form .field>.explore-error-label {
-  .error-label-mixin();
-}
-
-.ui.form .field>label {
-  margin: 0;
-}
-
-.ui.basic.label.explore-section-label {
-  background-color: transparent;
-  border: none;
-  letter-spacing: 0.15em;
-  border-radius: 0;
-  border-bottom: 1px solid var(--input-color);
-}
-
 .explore-table-units-label {
   margin-left: 0.25em;
   font-size: x-small;
@@ -422,10 +381,6 @@ tfoot {
 .minimum-percent {
   width: 5.5em;
   padding-left: 0.5em !important;
-
-  div& .ui.input input {
-    text-align: right;
-  }
 
   span& {
     text-align: end;
@@ -470,11 +425,6 @@ div.partner-split-total {
   }
 }
 
-// position all fields relative so that error labels position properly.
-.ui .field {
-  position: relative;
-}
-
 .explore-input-error-mixin() {
   left: 30%;
   z-index: 3;
@@ -490,44 +440,6 @@ div.partner-split-total {
   .explore-input-error-mixin();
 }
 
-.ui.button.blended-button {
-  border: none;
-  background-color: transparent;
-  box-shadow: none;
-
-  &:hover {
-    outline: 1px var(--site-border-color) solid;
-  }
-}
-
-// TODO: This was also used in the brightness tables, but is no longer needed.
-// When the obs badge is converted to primereact, this may be able to go away, or
-// be made specific to the obs badge
-.ui.button.delete-button {
-  padding: 0;
-  margin: 0;
-  margin-right: 0.4em;
-  border: none;
-  background-color: transparent;
-  box-shadow: none;
-  display: flex;
-  justify-content: center;
-
-  &:hover {
-    outline: 1px var(--site-border-color) solid;
-  }
-}
-
-.ui.form .field.flat-form-field {
-  margin-bottom: 0;
-}
-
-// There is already an anolog to this in explore.scss
-.warning-label-mixin() {
-  color: var(--warning-text-color);
-  background-color: var(--warning-background-color);
-}
-
 span.fa-layers-text {
   font-weight: 900;
   transform: scale(0.6) translate(-1em, -2.4em) rotate(30deg);
@@ -536,10 +448,6 @@ span.fa-layers-text {
 div.field.explore-warning-input,
 div.inline.field.explore-warning-input {
   box-shadow: -0 0 2px 1px var(--warning-background-color);
-}
-
-.ui.label.explore-warning-label {
-  .warning-label-mixin();
 }
 
 #staging-banner {
@@ -602,11 +510,6 @@ html {
   text-align: center;
 }
 
-.ui.wide.right.sidebar {
-  max-width: 100%;
-  overflow: hidden !important;
-}
-
 .step-guided {
   color: lightgreen;
 }
@@ -617,31 +520,6 @@ html {
   padding: 0.5em;
   gap: 0.5em;
   height: 100%;
-}
-
-.explore-form {
-  display: grid;
-  justify-items: start;
-  align-items: baseline;
-  align-self: start;
-  grid-template-columns: [label] minmax(120px, 10%) [field] 1fr [units] auto;
-
-  .field {
-    justify-self: stretch;
-  }
-
-  .explore-units-label {
-    justify-self: start;
-  }
-
-  .field .ui.input,
-  .field .ui.selection.dropdown {
-    min-width: 100%;
-  }
-}
-
-.explore-skip-to-next {
-  grid-column: 1;
 }
 
 .seq-gen-parameters-form {
@@ -660,34 +538,6 @@ html {
   justify-content: space-between;
 }
 
-.ui.dropdown.explore-configuration-filter {
-  min-width: 100%;
-
-  .menu>.item>.header {
-    text-align: center;
-    text-transform: uppercase;
-    text-decoration: underline;
-    font-size: smaller;
-    pointer-events: none;
-    cursor: unset;
-  }
-}
-
-.explore-configuration-filter-item {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  justify-items: end;
-
-  span:first-child {
-    justify-self: start;
-  }
-
-  span:not(:first-child) {
-    color: var(--site-input-placeholder-focus-color);
-    font-size: smaller;
-  }
-}
-
 .explore-button-copy {
   border: 0 !important; // important to override SUI's style.
 }
@@ -695,15 +545,6 @@ html {
 .explore-button-summary {
   width: 100%;
   justify-content: center;
-}
-
-.ui.labeled.icon.button.verycompact {
-  padding-left: 2.3em !important;
-  padding-right: 0.5em !important;
-
-  .icon {
-    width: 2em;
-  }
 }
 
 .explore-title-select-columns {
@@ -792,13 +633,6 @@ html {
   padding-left: 10px;
 }
 
-.ui.label.explore-modes-table-target {
-  display: block;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .explore-modes-table-count {
   flex-shrink: 0;
 }
@@ -825,21 +659,7 @@ html {
   white-space: nowrap;
 }
 
-.ui.button.compact,
-.ui.labeled.icon.button.left.verycompact {
-  padding-left: 0.5em !important;
-  padding-right: 0.5em !important;
-}
-
-.ui.icon.button svg.svg-inline--fa,
-.ui.button.compact svg.svg-inline--fa,
-.ui.button.verycompact svg.svg-inline--fa {
-  width: 1.5em;
-}
-
-svg.padded-right-icon.svg-inline--fa,
-.ui.icon.labeled.button svg.svg-inline--fa,
-.ui.menu .ui.dropdown .menu>.item svg.svg-inline--fa {
+svg.padded-right-icon.svg-inline--fa {
   margin-right: 3px;
 }
 
@@ -864,18 +684,6 @@ svg[focusable='false']:focus {
 .user-selection-buttons {
   display: flex;
   flex-direction: column;
-}
-
-.ui.selectable.table>tbody>tr:hover,
-.ui.selectable.table .tbody .tr:not(.disabled):not(.thead > .tr):not(.tfoot > .tr):hover,
-.ui.table tbody tr td.selectable:hover,
-.ui.table .tbody .tr:not(.disabled) .td.selectable:not(.thead > .tr):not(.tfoot > .tr):hover {
-  box-shadow: inset 0 1px 0 0 var(--explore-accent-color),
-    inset 0 -1px 0 0 var(--explore-accent-color);
-}
-
-.ui.popup.explore-compact {
-  padding: 0.5em;
 }
 
 .explore-modes-table-itc-cell {
@@ -925,99 +733,4 @@ thead tr th.sticky-header {
   .CircularProgressbar-path {
     stroke: var(--site-text-color) !important;
   }
-}
-
-.ui.striped.table tr:nth-child(2n + 1) td.sticky-column,
-.ui.striped.table tr:nth-child(2n + 1) .td.sticky-column {
-  background-color: var(--table-background);
-}
-
-.ui.striped.table tr:nth-child(2n) td.sticky-column,
-.ui.striped.table tr:nth-child(2n) .td.sticky-column {
-  background-color: var(--table-striped-background);
-}
-
-.ui.striped.table tr:hover td.sticky-column,
-.ui.striped.table tr:hover .td.sticky-column {
-  background: var(--table-selectable-background);
-  color: var(--table-selectable-color);
-}
-
-// Override SUI's default, which prevented shrinking on small screens.
-.ui.form .field .ui.input input,
-.ui.form .fields .field .ui.input input {
-  width: 100%;
-}
-
-.ui.form .field .ui.icon.input input,
-.ui.form .fields .field .ui.icon.input input {
-  width: auto;
-}
-
-.ui.form .field.field input:-webkit-autofill,
-.ui.form .field.field input:-webkit-autofill:hover,
-.ui.form .field.field input:-webkit-autofill:focus,
-.ui.form .field.field input:-webkit-autofill:active,
-.ui.input input:-webkit-autofill,
-.ui.input input:-webkit-autofill:hover,
-.ui.input input:-webkit-autofill:focus,
-.ui.input input:-webkit-autofill:active,
-.ui.form input:-webkit-autofill,
-.ui.form input:-webkit-autofill:hover,
-.ui.form input:-webkit-autofill:focus,
-.ui.form input:-webkit-autofill:active,
-input:-webkit-autofill,
-input:-webkit-autofill:hover,
-input:-webkit-autofill:focus,
-input:-webkit-autofill:active {
-  box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
-  -webkit-box-shadow: 0 0 0 30px var(--form-input-background) inset !important;
-  -webkit-text-fill-color: var(--input-color);
-  border: 1px solid var(--site-border-color) !important;
-}
-
-// Reusability overlays.
-body.hide-reusability {
-  &>div:not(#root)[title^="Last update reason"] {
-    display: none;
-  }
-}
-
-.input-replacement-icon {
-  line-height: @inputLineHeight;
-  border: 1px dashed transparent; // the border makes the sizing work.
-  padding: @inputPadding;
-}
-
-
-.ui.ui.ui.ui.icon.input .clearable-input-icon {
-  // These values were obtained empirically by using the debugger to find
-  // the values used by `.dropdown.icon`. They are being calculated somewhere
-  // in SUI, but I haven't found the location.
-  position: absolute;
-  font-family: "Dropdown";
-  backface-visibility: hidden;
-  font-weight: normal;
-  font-style: normal;
-  text-align: center;
-  float: right;
-  opacity: 0.6;
-  top: 0.35714286em;
-  right: 0.42857143em;
-  z-index: 3;
-  margin: -0.35714286em;
-  padding: 0.41666667em;
-  line-height: 1.21428571em;
-
-  &:before {
-    content: "⨉";
-    top: 0.2em;
-    right: 0.2em;
-    position: absolute;
-    font-size: medium;
-  }
-}
-
-.field.clearable-input-padding-reset>.ui.ui.ui.ui.icon.input>input {
-  padding: @inputPadding;
 }

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -49,6 +49,21 @@ body {
   width: 100dvw;
 }
 
+// Reusability overlays.
+body.hide-reusability {
+  &>div:not(#root)[title^="Last update reason"] {
+    display: none;
+  }
+}
+
+.input-replacement-icon {
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  line-height: var(--pl-input-line-height);
+  border: 1px dashed transparent; // the border makes the sizing work.
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  padding: var(--pl-input-padding)
+}
+
 // -------
 // Tile
 // -------
@@ -970,6 +985,28 @@ $search-preview-margin: 5px;
 .obs-tree-item .obs-badge.obs-badge-selected {
   background-color: var(--obs-selected-badge-background);
   box-shadow: 0 0 0 2px var(--site-solid-border-color);
+}
+
+// ------
+// Imaging Configuration
+// ------
+.explore-configuration-filter .p-multiselect-item >span {
+  width: 100%;
+
+  div {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    justify-items: end;
+
+    span:first-child {
+      justify-self: start;
+    }
+
+    span:not(:first-child) {
+      color: var(--site-input-placeholder-focus-color);
+      font-size: smaller;
+    }
+  }
 }
 
 // ------

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -36,6 +36,13 @@ body {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+
+  // set font from primereact
+  font-family: var(--font-family);
+
+  // these were taken from SUI
+  font-size: 14px;
+  line-height: 1.4285em;
 }
 
 body {
@@ -62,6 +69,11 @@ body.hide-reusability {
   border: 1px dashed transparent; // the border makes the sizing work.
   /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   padding: var(--pl-input-padding)
+}
+
+// taken from SUI
+a, a:hover {
+  text-decoration: none;
 }
 
 // -------
@@ -1505,6 +1517,57 @@ table.explore-border-table {
   svg.fa-check {
     grid-area: progress;
     color: var(--explore-accent-color);
+  }
+}
+
+// ----------
+// Target table column selector menu
+// ----------
+.explore-title-select-columns {
+  text-align: right;
+  display: none;
+}
+
+@media (min-width: $mobile-responsive-cutoff) {
+  .explore-title-select-columns {
+    display: inline;
+  }
+}
+
+.explore-select-columns {
+  &.p-component.p-button.p-button-text {
+    color: var(--text-color);
+
+    .p-button-icon-right {
+      margin-left: 0.5rem;
+    }
+
+    &:focus {
+      box-shadow: none;
+    }
+  }
+
+  &.p-menu {
+    max-height: 25rem;
+    overflow-y: scroll;
+
+    .p-menuitem {
+      padding-top: 0;
+      padding-bottom: 0.2rem;
+
+      .p-checkbox {
+        .p-checkbox-box {
+          height: 16px;
+          width: 16px;
+          margin-top: 2px;
+        }
+
+        label {
+          /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+          font-size: var(--pl-tiny-font-size);
+        }
+      }
+    }
   }
 }
 

--- a/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
@@ -29,7 +29,6 @@ import lucuma.core.model.Observation
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.User
 import lucuma.refined.*
-import lucuma.ui.forms.EnumViewSelect
 import lucuma.ui.primereact.FormEnumDropdownView
 import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given

--- a/explore/src/main/scala/explore/config/ImagingConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ImagingConfigurationPanel.scala
@@ -25,8 +25,6 @@ import lucuma.core.math.units.*
 import lucuma.core.util.Display
 import lucuma.core.validation.*
 import lucuma.refined.*
-import lucuma.ui.forms.EnumViewOptionalSelect
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.FormEnumDropdownOptionalView
 import lucuma.ui.primereact.FormInputTextView

--- a/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
@@ -20,8 +20,6 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.math.Wavelength
 import lucuma.core.validation.*
 import lucuma.refined.*
-import lucuma.ui.forms.EnumViewOptionalSelect
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.FormEnumDropdownOptionalView
 import lucuma.ui.primereact.FormInputTextView

--- a/explore/src/main/scala/explore/config/sequence/SequenceEditorPopup.scala
+++ b/explore/src/main/scala/explore/config/sequence/SequenceEditorPopup.scala
@@ -14,6 +14,7 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Observation
 import lucuma.core.util.NewType
+import lucuma.ui.primereact.LucumaStyles
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.utils.given
@@ -65,10 +66,10 @@ object SequenceEditorPopup:
             )
           )(
             <.div(ExploreStyles.SeqGenParametersForm)(
-              <.div(ExploreStyles.ExploreForm)(
+              <.div(LucumaStyles.FormColumn)(
                 props.dithersControl(changed.set(Pot.pending))
               ),
-              <.div(ExploreStyles.ExploreForm)(
+              <.div(LucumaStyles.FormColumn)(
                 props.offsetsControl(changed.set(Pot.pending))
               )
             ),

--- a/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -31,8 +31,6 @@ import lucuma.core.util.Enumerated
 import lucuma.core.validation.*
 import lucuma.refined.*
 import lucuma.schemas.ObservationDB.Types.*
-import lucuma.ui.forms.EnumViewSelect
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.EnumDropdownView
 import lucuma.ui.primereact.FormInputTextView

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -22,7 +22,6 @@ import lucuma.core.enums.ObsStatus
 import lucuma.core.model.Observation
 import lucuma.core.util.Enumerated
 import lucuma.core.util.Gid
-import lucuma.ui.forms.EnumViewSelect
 import lucuma.ui.primereact.EnumDropdownView
 import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -52,7 +52,6 @@ import lucuma.core.validation.*
 import lucuma.refined.*
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Types.*
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.primereact.FormInputTextView
 import lucuma.ui.primereact.LucumaStyles

--- a/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
@@ -31,7 +31,6 @@ import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.util.NewType
 import lucuma.refined.*
-import lucuma.ui.forms.FormInputEV
 import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given
 import lucuma.ui.reusability.*

--- a/explore/src/main/webapp/main.jsx
+++ b/explore/src/main/webapp/main.jsx
@@ -1,4 +1,3 @@
-import "/common/theme/semantic.less";
 import "/common/sass/explore-primereact.scss";
 import "/lucuma-css/lucuma-ui-table.scss";
 import "primereact/resources/primereact.min.css"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@tanstack/react-virtual": "v3.0.0-beta.35",
         "broadcast-channel": "4.20.1",
         "copy-to-clipboard": "3.3.3",
-        "fomantic-ui-less": "2.8.8",
         "github-markdown-css": "^5.1.0",
         "highcharts": "10.3.2",
         "loglevel": "1.8.1",
@@ -41,7 +40,6 @@
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
         "remark-parse": "^10.0.1",
-        "semantic-ui-react": "2.1.3",
         "styled-components": "5.3.6",
         "ua-parser-js": "1.0.32"
       },
@@ -1861,36 +1859,6 @@
         "react-dom": ">=16.8.0"
       }
     },
-    "node_modules/@fluentui/react-component-event-listener": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
-      "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.4"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/@fluentui/react-component-ref": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
-      "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "react-is": "^16.6.3"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18",
-        "react-dom": "^16.8.0 || ^17 || ^18"
-      }
-    },
-    "node_modules/@fluentui/react-component-ref/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-    },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "6.2.1",
       "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.2.1/fontawesome-common-types-6.2.1.tgz",
@@ -2395,19 +2363,6 @@
       },
       "peerDependencies": {
         "stylelint": "10 - 14"
-      }
-    },
-    "node_modules/@semantic-ui-react/event-stack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
-      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
-      "dependencies": {
-        "exenv": "^1.2.2",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -4184,11 +4139,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
-    "node_modules/exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
-    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4344,14 +4294,6 @@
         "debug": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fomantic-ui-less": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/fomantic-ui-less/-/fomantic-ui-less-2.8.8.tgz",
-      "integrity": "sha512-wy8kuTmD9bmJ0WK8GgIBQKktMA86x4OsaMk7wQxCYK1rP/u9r1UURzXsk8Ok6BRLcqqsfMNd9BDGvIFdEf2k9g==",
-      "dependencies": {
-        "jquery": "^3.4.0"
       }
     },
     "node_modules/for-each": {
@@ -5553,11 +5495,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
-      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5639,11 +5576,6 @@
       "bin": {
         "katex": "cli.js"
       }
-    },
-    "node_modules/keyboard-key": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -5746,7 +5678,8 @@
     "node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -8260,30 +8193,6 @@
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/semantic-ui-react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.3.tgz",
-      "integrity": "sha512-dd2pqalMk0ycJoHf7hn4mYd0xohg0NMk7ohlpPVOigCfMLrKk2e3NZdRk0yBetvD+qJXPqZ04jA43bDwqOM5OA==",
-      "dependencies": {
-        "@babel/runtime": "^7.10.5",
-        "@fluentui/react-component-event-listener": "~0.63.0",
-        "@fluentui/react-component-ref": "~0.63.0",
-        "@popperjs/core": "^2.6.0",
-        "@semantic-ui-react/event-stack": "^3.1.3",
-        "clsx": "^1.1.1",
-        "keyboard-key": "^1.1.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6 || ^17.0.0 || ^18.0.0",
-        "react-popper": "^2.3.0",
-        "shallowequal": "^1.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/semver": {
@@ -11357,30 +11266,6 @@
         "tabbable": "^6.0.1"
       }
     },
-    "@fluentui/react-component-event-listener": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-event-listener/-/react-component-event-listener-0.63.1.tgz",
-      "integrity": "sha512-gSMdOh6tI3IJKZFqxfQwbTpskpME0CvxdxGM2tdglmf6ZPVDi0L4+KKIm+2dN8nzb8Ya1A8ZT+Ddq0KmZtwVQg==",
-      "requires": {
-        "@babel/runtime": "^7.10.4"
-      }
-    },
-    "@fluentui/react-component-ref": {
-      "version": "0.63.1",
-      "resolved": "https://registry.npmjs.org/@fluentui/react-component-ref/-/react-component-ref-0.63.1.tgz",
-      "integrity": "sha512-8MkXX4+R3i80msdbD4rFpEB4WWq2UDvGwG386g3ckIWbekdvN9z2kWAd9OXhRGqB7QeOsoAGWocp6gAMCivRlw==",
-      "requires": {
-        "@babel/runtime": "^7.10.4",
-        "react-is": "^16.6.3"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
-      }
-    },
     "@fortawesome/fontawesome-common-types": {
       "version": "6.2.1",
       "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.2.1/fontawesome-common-types-6.2.1.tgz",
@@ -11745,15 +11630,6 @@
       "dev": true,
       "requires": {
         "postcss-values-parser": "^3.2.1"
-      }
-    },
-    "@semantic-ui-react/event-stack": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@semantic-ui-react/event-stack/-/event-stack-3.1.3.tgz",
-      "integrity": "sha512-FdTmJyWvJaYinHrKRsMLDrz4tTMGdFfds299Qory53hBugiDvGC0tEJf+cHsi5igDwWb/CLOgOiChInHwq8URQ==",
-      "requires": {
-        "exenv": "^1.2.2",
-        "prop-types": "^15.6.2"
       }
     },
     "@surma/rollup-plugin-off-main-thread": {
@@ -12994,11 +12870,6 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
     },
-    "exenv": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
-      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw=="
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -13122,14 +12993,6 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
       "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "dev": true
-    },
-    "fomantic-ui-less": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/fomantic-ui-less/-/fomantic-ui-less-2.8.8.tgz",
-      "integrity": "sha512-wy8kuTmD9bmJ0WK8GgIBQKktMA86x4OsaMk7wQxCYK1rP/u9r1UURzXsk8Ok6BRLcqqsfMNd9BDGvIFdEf2k9g==",
-      "requires": {
-        "jquery": "^3.4.0"
-      }
     },
     "for-each": {
       "version": "0.3.3",
@@ -13975,11 +13838,6 @@
         }
       }
     },
-    "jquery": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
-      "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14037,11 +13895,6 @@
       "requires": {
         "commander": "^8.0.0"
       }
-    },
-    "keyboard-key": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/keyboard-key/-/keyboard-key-1.1.0.tgz",
-      "integrity": "sha512-qkBzPTi3rlAKvX7k0/ub44sqOfXeLc/jcnGGmj5c7BJpU8eDrEVPyhCvNYAaoubbsLm9uGWwQJO1ytQK1a9/dQ=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -14121,7 +13974,8 @@
     "lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -15833,26 +15687,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "semantic-ui-react": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/semantic-ui-react/-/semantic-ui-react-2.1.3.tgz",
-      "integrity": "sha512-dd2pqalMk0ycJoHf7hn4mYd0xohg0NMk7ohlpPVOigCfMLrKk2e3NZdRk0yBetvD+qJXPqZ04jA43bDwqOM5OA==",
-      "requires": {
-        "@babel/runtime": "^7.10.5",
-        "@fluentui/react-component-event-listener": "~0.63.0",
-        "@fluentui/react-component-ref": "~0.63.0",
-        "@popperjs/core": "^2.6.0",
-        "@semantic-ui-react/event-stack": "^3.1.3",
-        "clsx": "^1.1.1",
-        "keyboard-key": "^1.1.0",
-        "lodash": "^4.17.21",
-        "lodash-es": "^4.17.21",
-        "prop-types": "^15.7.2",
-        "react-is": "^16.8.6 || ^17.0.0 || ^18.0.0",
-        "react-popper": "^2.3.0",
-        "shallowequal": "^1.1.0"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@tanstack/react-virtual": "v3.0.0-beta.35",
     "broadcast-channel": "4.20.1",
     "copy-to-clipboard": "3.3.3",
-    "fomantic-ui-less": "2.8.8",
     "github-markdown-css": "^5.1.0",
     "highcharts": "10.3.2",
     "loglevel": "1.8.1",
@@ -36,7 +35,6 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "remark-parse": "^10.0.1",
-    "semantic-ui-react": "2.1.3",
     "styled-components": "5.3.6",
     "ua-parser-js": "1.0.32"
   },

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -245,7 +245,6 @@ object Settings {
         "edu.gemini" %%% "lucuma-react-highcharts",
         "edu.gemini" %%% "lucuma-react-hotkeys",
         "edu.gemini" %%% "lucuma-react-resize-detector",
-        "edu.gemini" %%% "lucuma-react-semantic-ui",
         "edu.gemini" %%% "lucuma-react-moon",
         "edu.gemini" %%% "lucuma-react-prime-react"
       )(lucumaReact)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
     val lucumaRefined          = "0.1.1"
     val lucumaSchemas          = "0.39.1"
     val lucumaSSO              = "0.4.5"
-    val lucumaUI               = "0.64.2"
+    val lucumaUI               = "0.65.0"
     val monocle                = "3.2.0"
     val mouse                  = "1.2.1"
     val mUnit                  = "0.7.29"


### PR DESCRIPTION
I was able to remove `lucuma-react-semantic-ui` from the build and clean up our CSS somewhat, but am not yet able to remove the `fomantic-ui-less` npm package. It seems some of our styles still rely on it. I will continue to look into that in parallel with the work on getting the new backend working in Explore.

<img width="484" alt="image" src="https://user-images.githubusercontent.com/6035943/211392875-40501540-ec4d-43cc-97cb-036123ce7f7c.png">
