### PR TITLE
Rework the way shortcuts are built

### DIFF
--- a/common/src/main/scala/react/hotkeys/package.scala
+++ b/common/src/main/scala/react/hotkeys/package.scala
@@ -28,17 +28,20 @@ trait HotkeysOptions extends js.Object {
 object HotkeysOptions {
 
   def apply(
-    enabled: js.UndefOr[Boolean] = js.undefined
+    enabled:              js.UndefOr[Boolean] = js.undefined,
+    filterPreventDefault: js.UndefOr[Boolean] = js.undefined,
+    splitKey:             js.UndefOr[String] = js.undefined
   ): HotkeysOptions =
     val p = js.Dynamic.literal().asInstanceOf[HotkeysOptions]
     p.enabled.foreach(o => p.enabled = o)
+    p.filterPreventDefault.foreach(o => p.filterPreventDefault = o)
+    p.splitKey.foreach(o => p.splitKey = o)
     p
 }
 
 @js.native
 trait HotkeysEvent extends js.Object {
   val alt: Boolean
-  val ctrl: Boolean
   val shift: Boolean
   val meta: Boolean
   val mod: Boolean

--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -58,13 +58,11 @@ val Down = Shortcut("j")
 val Up   = Shortcut("k")
 
 val CopyAlt1 = Shortcut("y")
-val CopyAlt2 = Shortcut("ctrl+c")
-val CopyAlt3 = Shortcut("meta+c")
+val CopyAlt2 = Shortcut("meta+c")
 
-val CopyKeys = List(CopyAlt1, CopyAlt2, CopyAlt3)
+val CopyKeys = List(CopyAlt1, CopyAlt2)
 
 val PasteAlt1 = Shortcut("p")
-val PasteAlt2 = Shortcut("ctrl+v")
-val PasteAlt3 = Shortcut("meta+v")
+val PasteAlt2 = Shortcut("meta+v")
 
-val PasteKeys = List(PasteAlt1, PasteAlt2, PasteAlt3)
+val PasteKeys = List(PasteAlt1, PasteAlt2)

--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -13,8 +13,19 @@ import react.hotkeys.HotkeysEvent
 import scala.scalajs.js.JSConverters.*
 
 object Shortcut extends NewType[List[String]] {
-  inline def apply(key: String): Shortcut = Shortcut(List(key))
+  inline def apply(key: String): Shortcut = Shortcut(
+    List(key.toLowerCase.trim.filterNot(_.isWhitespace))
+  )
+
+  // This- maybe improved to consider cases where there are more than one matching key
+  def withModifiers(e: HotkeysEvent): List[Shortcut] =
+    if (e.meta) e.keys.toList.map(k => Shortcut(s"meta+$k"))
+    else if (e.shift) e.keys.toList.map(k => Shortcut(s"shift+$k"))
+    else if (e.alt) e.keys.toList.map(k => Shortcut(s"alt+$k"))
+    else if (e.mod) e.keys.toList.map(k => Shortcut(s"mod+$k"))
+    else e.keys.toList.map(k => Shortcut(k))
 }
+
 type Shortcut = Shortcut.Type
 
 extension (shortcuts: List[Shortcut]) def toHotKeys: List[String] = shortcuts.flatMap(_.value)
@@ -23,29 +34,37 @@ type ShortcutCallbacks = PartialFunction[Shortcut, Callback]
 
 given Conversion[PartialFunction[Shortcut, Callback], HotkeysCallback] with
   def apply(p: PartialFunction[Shortcut, Callback]): HotkeysCallback =
-    (e: HotkeysEvent) => p.applyOrElse(Shortcut(e.keys.toList), _ => Callback.empty)
+    (e: HotkeysEvent) =>
+      Shortcut
+        .withModifiers(e)
+        .collectFirst {
+          case s if p.isDefinedAt(s) =>
+            p.applyOrElse(s, _ => Callback.empty)
+        }
+        .headOption
+        .getOrElse(Callback.empty)
 
 val GoToObs         = Shortcut("o")
 val GoToTargets     = Shortcut("t")
 val GoToProposals   = Shortcut("r")
-val GoToConstraints = Shortcut("c")
+val GoToConstraints = Shortcut("n")
 val GoToOverview    = Shortcut("w")
 val GoToSummary     = Shortcut("s")
 
 val Esc           = Shortcut("ESC")
-val ShortcutsHelp = Shortcut("shift+/")
+val ShortcutsHelp = Shortcut("F1")
 
 val Down = Shortcut("j")
 val Up   = Shortcut("k")
 
 val CopyAlt1 = Shortcut("y")
 val CopyAlt2 = Shortcut("ctrl+c")
-val CopyAlt3 = Shortcut("cmd+c")
+val CopyAlt3 = Shortcut("meta+c")
 
 val CopyKeys = List(CopyAlt1, CopyAlt2, CopyAlt3)
 
 val PasteAlt1 = Shortcut("p")
 val PasteAlt2 = Shortcut("ctrl+v")
-val PasteAlt3 = Shortcut("cmd+v")
+val PasteAlt3 = Shortcut("meta+v")
 
 val PasteKeys = List(PasteAlt1, PasteAlt2, PasteAlt3)

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -292,14 +292,15 @@ object ObsTabContents extends TwoPanels:
         val obsPos = observationIds.find(a => obs.forall(_ === a._1)).map(_._2)
 
         def callbacks: ShortcutCallbacks = {
-          case CopyAlt1 | CopyAlt2 | CopyAlt3 =>
+          case CopyAlt1 | CopyAlt2 =>
             obs
               .map(id =>
                 (ctx.exploreClipboard.set(LocalClipboard.CopiedObservations(ObsIdSet.one(id))) >>
                   ctx.toastRef.showToast(s"Copied obs $id")).runAsync
               )
               .getOrEmpty
-          case Down                           =>
+
+          case Down        =>
             obsPos
               .filter(_ < observationIds.length && obsList.nonEmpty)
               .flatMap { p =>
@@ -313,7 +314,7 @@ object ObsTabContents extends TwoPanels:
                 }
               }
               .getOrEmpty
-          case Up                             =>
+          case Up          =>
             obsPos
               .filter(_ > 0)
               .flatMap { p =>
@@ -326,7 +327,7 @@ object ObsTabContents extends TwoPanels:
                 }
               }
               .getOrEmpty
-          case GoToSummary                    =>
+          case GoToSummary =>
             ctx.setPageVia(AppTab.Observations,
                            props.programId,
                            Focused.None,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -682,7 +682,7 @@ object TargetTabContents extends TwoPanels:
           obsIds => ctx.pushPage(AppTab.Targets, props.programId, Focused.obsSet(obsIds)).to[IO]
 
         def callbacks: ShortcutCallbacks = {
-          case CopyAlt1 | CopyAlt2 | CopyAlt3 =>
+          case CopyAlt1 | CopyAlt2 =>
             target.obsSet
               .map(ids =>
                 (ctx.exploreClipboard.set(LocalClipboard.CopiedObservations(ids)) >>
@@ -699,7 +699,7 @@ object TargetTabContents extends TwoPanels:
               )
               .getOrEmpty
 
-          case PasteAlt1 | PasteAlt2 | PasteAlt3 =>
+          case PasteAlt1 | PasteAlt2 =>
             ctx.exploreClipboard.get.flatMap {
               case LocalClipboard.CopiedObservations(id) =>
                 val treeTargets =


### PR DESCRIPTION
With the new version of hotkeys some shortcuts are not working. This should re enable cmd/ctrl+v/c