### PR TITLE
Sort the target tree by name

### DIFF
--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -109,8 +109,7 @@ object AsterismGroupObsList:
       destination <- result.destination.toOption
       destIds     <- ObsIdSet.fromString.getOption(destination.droppableId)
       draggedIds  <- getDraggedIds(result.draggableId, props)
-      destAg      <-
-        props.asterismsWithObs.get.asterismGroups.values.find(_.obsIds === destIds)
+      destAg      <- props.asterismsWithObs.get.asterismGroups.get(destIds)
       srcAg       <- props.asterismsWithObs.get.asterismGroups.findContainingObsIds(draggedIds)
     } yield (destAg, draggedIds, srcAg.obsIds)
 
@@ -275,14 +274,16 @@ object AsterismGroupObsList:
           } else Callback.empty // Not in the same group
         }
 
-      def getAsterismGroupName(asterismGroup: AsterismGroup): String = {
-        val targets = asterismGroup.targetIds.toList.map(targetWithObsMap.get).flatten
+      def getAsterismGroupNames(asterismGroup: AsterismGroup): List[String] =
+        asterismGroup.targetIds.toList
+          .map(tid => targetWithObsMap.get(tid).map(_.target.name.value))
+          .flatten
 
-        if (targets.isEmpty) "<No Targets>"
-        else targets.map(_.target.name).mkString("; ")
-      }
+      def makeAsterismGroupName(names: List[String]): String =
+        if (names.isEmpty) "<No Targets>"
+        else names.mkString("; ")
 
-      def renderAsterismGroup(asterismGroup: AsterismGroup): VdomNode = {
+      def renderAsterismGroup(asterismGroup: AsterismGroup, names: List[String]): VdomNode = {
         val obsIds        = asterismGroup.obsIds
         val cgObs         = obsIds.toList.map(id => observations.get(id)).flatten
         // if this group or something in it is selected
@@ -309,7 +310,7 @@ object AsterismGroupObsList:
             val csHeader = <.span(ExploreStyles.ObsTreeGroupHeader)(
               icon,
               <.span(ExploreStyles.ObsGroupTitleWithWrap)(
-                getAsterismGroupName(asterismGroup)
+                makeAsterismGroupName(names)
               ),
               <.span(ExploreStyles.ObsCount, s"${obsIds.size} Obs")
             )
@@ -407,7 +408,11 @@ object AsterismGroupObsList:
           ),
           <.div(ExploreStyles.ObsTree)(
             <.div(ExploreStyles.ObsScrollTree)(
-              asterismGroups.toTagMod(renderAsterismGroup)
+              asterismGroups
+                .map(ag => (ag, getAsterismGroupNames(ag)))
+                .toList
+                .sortBy(_._2)
+                .toTagMod(t => renderAsterismGroup(t._1, t._2))
             )
           )
         )


### PR DESCRIPTION
I'm not sure this is the best approach. But, since the target names aren't part of the data that is creating the tree, the best I came up with was sorting it at the usage site.

Originally, it was essentially being sorted by the first obsId in the the group, but somewhere along the line, that sorting got lost. So, the initial sort order was by the number of observations in the group. Which is really not a reasonable sort order.