### PR TITLE
Fix problem of ITC not being called for spectroscopy modes table.

### DIFF
--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -557,7 +557,6 @@ private object SpectroscopyModesTable extends TableHooks:
                 (for
                   _       <- Resource.eval(itcProgress.setStateAsync(progressZero))
                   request <-
-                    println("Calling ItcClient.request(ItcMessage.Query)")
                     ItcClient[IO]
                       .request(
                         ItcMessage.Query(w, sn, constraints, t, modes.map(_.entry), signalToNoiseAt)

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -505,21 +505,23 @@ private object SpectroscopyModesTable extends TableHooks:
       // atTop
       .useState(false)
       // Recalculate ITC values if the wv or sn change or if the rows get modified
-      .useStreamResourceBy((props, _, _, _, _, _, _, _, _, visibleRows, _) =>
+      .useStreamResourceBy((props, _, _, rows, _, _, _, _, _, _, _) =>
         (
           props.spectroscopyRequirements.wavelength,
           props.spectroscopyRequirements.signalToNoise,
           props.spectroscopyRequirements.signalToNoiseAt,
           props.constraints,
-          props.brightestTarget
+          props.brightestTarget,
+          rows.length
         )
       ) {
-        (_, ctx, itcResults, _, itcProgress, _, _, _, table, visibleRows, _) => (
+        (_, ctx, itcResults, _, itcProgress, _, _, _, table, _, _) => (
           wavelength,
           signalToNoise,
           signalToNoiseAt,
           constraints,
-          brightestTarget
+          brightestTarget,
+          _
         ) =>
           import ctx.given
 
@@ -555,6 +557,7 @@ private object SpectroscopyModesTable extends TableHooks:
                 (for
                   _       <- Resource.eval(itcProgress.setStateAsync(progressZero))
                   request <-
+                    println("Calling ItcClient.request(ItcMessage.Query)")
                     ItcClient[IO]
                       .request(
                         ItcMessage.Query(w, sn, constraints, t, modes.map(_.entry), signalToNoiseAt)


### PR DESCRIPTION
The problem was that the rows that needed itc calls for were checked before the data for the table was loaded. It wasn't checked again unless an itc parameter was changed. So, now I also check to see if the table data has changed and recalculate the itc if it has. 

I'm guessing that until recently, the data had always loaded by the time this point was hit. But, something changed that...