### PR TITLE
PM correct the base target of asterisms

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -184,13 +184,17 @@ object ObsTabTiles:
         // asterism base coordinates at viz time or default to base coordinates
         val targetCoords: Option[CoordinatesAtVizTime] =
           (vizTime, potAsterism.toOption)
-            .mapN((instant, asterism) => asterism.get.flatMap(_.baseTracking.at(instant)))
+            .mapN { (instant, asterism) =>
+              asterism.get.flatMap(
+                _.baseTrackingAt(instant).map(r => CoordinatesAtVizTime(r.baseCoordinates))
+              )
+            }
             .flatten
-            .orElse(
+            .orElse {
               // If e.g. vizTime isn't defined default to the asterism base coordinates
               potAsterism.toOption
                 .flatMap(_.get.map(x => CoordinatesAtVizTime(x.baseTracking.baseCoordinates)))
-            )
+            }
 
         val spectroscopyReqs: Option[ScienceRequirementsData] =
           obsView.toOption.map(_.get.scienceData.requirements)

--- a/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinContainer.scala
@@ -102,10 +102,11 @@ object AladinContainer extends AladinCommon {
         ExploreStyles.GuideSpeedSlow
 
   private def baseAndScience(p: Props) = {
-    val base    = p.asterism.baseTracking
-      .at(p.obsConf.vizTime)
-      .map(_.value)
+    val base = p.asterism
+      .baseTrackingAt(p.obsConf.vizTime)
+      .map(_.baseCoordinates)
       .getOrElse(p.asterism.baseTracking.baseCoordinates)
+
     val science = p.asterism.toSidereal
       .map(t =>
         (t.id === p.asterism.focus.id,

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
@@ -71,6 +71,7 @@ object ElevationPlotSection:
       .getOrElse {
         if (c.coords.value.dec.toAngle.toSignedDoubleDegrees > -5) Site.GN else Site.GS
       }
+
   private def prefsSetter(
     props:   Props,
     options: View[Pot[ElevationPlotOptions]],

--- a/model/shared/src/main/scala/explore/model/Asterism.scala
+++ b/model/shared/src/main/scala/explore/model/Asterism.scala
@@ -20,6 +20,17 @@ import monocle.*
 import java.time.Instant
 
 extension (a: NonEmptyList[TargetWithId])
+  // We calculate the coordinates at a given time by doing PM
+  // correction of each target and finding the center
+  def centerOfAt(vizTime: Instant): Option[Coordinates] =
+    val coords = a
+      .map(_.toSidereal)
+      .collect { case Some(x) =>
+        x.target.tracking.at(vizTime)
+      }
+      .sequence
+    coords.map(Coordinates.centerOf(_))
+
   def centerOf: Coordinates =
     val coords = a.map(_.toSidereal).collect { case Some(x) =>
       x.target.tracking.baseCoordinates
@@ -56,6 +67,11 @@ case class Asterism(private val targets: Zipper[TargetWithId]) derives Eq {
 
   def focusOn(tid: Target.Id): Asterism =
     targets.findFocus(_.id === tid).map(Asterism.apply).getOrElse(this)
+
+  def baseTrackingAt(vizTime: Instant): Option[ObjectTracking] =
+    if (targets.length > 1)
+      targets.toNel.centerOfAt(vizTime).map(ObjectTracking.const(_))
+    else ObjectTracking.fromTarget(targets.focus.target).some
 
   def baseTracking: ObjectTracking =
     if (targets.length > 1)


### PR DESCRIPTION
We should calculate the base position with the average of each target position corrected by proper motion. At the moment the base is calculated with the uncorrected values

before:
![Explore 2023-02-21 13-06-55](https://user-images.githubusercontent.com/3615303/220399444-0fdc2b81-09fc-4727-afc3-124c555308be.png)

After
![Explore 2023-02-21 13-10-59](https://user-images.githubusercontent.com/3615303/220399738-2022c631-e574-42ed-b316-86e9cbb526f1.png)
