### PR TITLE
In modes table, handle case of no brightnesses

### DIFF
--- a/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
+++ b/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
@@ -185,6 +185,7 @@ trait ItcPicklers extends CommonPicklers {
   given Pickler[ItcQueryProblems.MissingWavelength.type]    = generatePickler
   given Pickler[ItcQueryProblems.MissingSignalToNoise.type] = generatePickler
   given Pickler[ItcQueryProblems.MissingTargetInfo.type]    = generatePickler
+  given Pickler[ItcQueryProblems.MissingBrightness.type]    = generatePickler
   given Pickler[ItcQueryProblems.GenericError]              = generatePickler
 
   given Pickler[ItcQueryProblems] =
@@ -193,6 +194,7 @@ trait ItcPicklers extends CommonPicklers {
       .addConcreteType[ItcQueryProblems.MissingWavelength.type]
       .addConcreteType[ItcQueryProblems.MissingSignalToNoise.type]
       .addConcreteType[ItcQueryProblems.MissingTargetInfo.type]
+      .addConcreteType[ItcQueryProblems.MissingBrightness.type]
       .addConcreteType[ItcQueryProblems.GenericError]
 
   given Pickler[ItcRequestParams] = generatePickler

--- a/model/shared/src/main/scala/explore/model/itc/ItcTarget.scala
+++ b/model/shared/src/main/scala/explore/model/itc/ItcTarget.scala
@@ -37,9 +37,7 @@ object ItcTarget:
 
   extension (targets: List[ItcTarget])
     def brightestAt(wv: Wavelength): Option[ItcTarget] =
-      targets
-        .filter(t => selectedBand(t.profile, wv).isDefined)
-        .minByOption(_.brightnessNearestTo(wv).map(_._2))
+      targets.minByOption(_.brightnessNearestTo(wv).map(_._2))
 
   // We may consider adjusting this to consider small variations of RV identical for the
   // purpose of doing ITC calculations

--- a/model/shared/src/main/scala/explore/model/itc/ItcTarget.scala
+++ b/model/shared/src/main/scala/explore/model/itc/ItcTarget.scala
@@ -37,7 +37,9 @@ object ItcTarget:
 
   extension (targets: List[ItcTarget])
     def brightestAt(wv: Wavelength): Option[ItcTarget] =
-      targets.minByOption(_.brightnessNearestTo(wv).map(_._2))
+      targets
+        .filter(t => selectedBand(t.profile, wv).isDefined)
+        .minByOption(_.brightnessNearestTo(wv).map(_._2))
 
   // We may consider adjusting this to consider small variations of RV identical for the
   // purpose of doing ITC calculations

--- a/model/shared/src/main/scala/explore/model/itc/package.scala
+++ b/model/shared/src/main/scala/explore/model/itc/package.scala
@@ -29,6 +29,7 @@ object ItcQueryProblems {
   case object MissingWavelength        extends ItcQueryProblems
   case object MissingSignalToNoise     extends ItcQueryProblems
   case object MissingTargetInfo        extends ItcQueryProblems
+  case object MissingBrightness        extends ItcQueryProblems
   case class GenericError(msg: String) extends ItcQueryProblems
 }
 


### PR DESCRIPTION
In the case where the target for an observation didn't have any brightnesses defined, all the rows in the spectroscopy modes table would have spinners for the itc results an would never resolve. This is because the `brightestAt` extension I modified would return a target, which would result in the SpectroscopyModesTable attempting to make an `ItcClient.request`. However, `ItcRequests.queryItc` calls the `selectedBand` method and maps on the result for the requests. Since `selectedBand` returns `None`, no itc call is made, but the SpectroscopyModesTable doesn't know that.

The easiest solution for me to understand was to filter the targets in `brightestAt` so that if there are no targets with brightnesses,  the table rows will have a `Missing target info` itc error message. It is possible, even likely, this is not the best solution, but I created this PR as a starting point.

UPDATE:
 I added an `ItcQueryProblems.MissingBrightness` to differentiate the message from the `MissingTargetInfo`. 

Also, whenever the wavelength was missing, the `MissingTargetInfo` error would come along for the ride because even if the target(s) are OK, there is no `brightestAt` without an `At` wavelength. So, I suppressed the `MissingTargetInfo` message if there isn't a wavelength. This does mean they may only see a `MissingWavelength` error, but when they fix it a `MissingBrightness` will appear. That seemed better than having the spurious error.