### PR TITLE
Use localStorage for copy/paste of targets/observations

### DIFF
--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -36,7 +36,6 @@ case class AppContext[F[_]](
   pageUrl:          (AppTab, Program.Id, Focused) => String,
   setPageVia:       (AppTab, Program.Id, Focused, SetRouteVia) => Callback,
   environment:      ExecutionEnvironment,
-  exploreClipboard: Ref[F, LocalClipboard],
   broadcastChannel: BroadcastChannel[ExploreEvent],
   toastRef:         Deferred[F, ToastRef]
 )(using
@@ -68,7 +67,6 @@ object AppContext:
     pageUrl:              (AppTab, Program.Id, Focused) => String,
     setPageVia:           (AppTab, Program.Id, Focused, SetRouteVia) => Callback,
     workerClients:        WorkerClients[F],
-    exploreClipboard:     Ref[F, LocalClipboard],
     broadcastChannel:     BroadcastChannel[ExploreEvent],
     toastRef:             Deferred[F, ToastRef]
   ): F[AppContext[F]] =
@@ -85,7 +83,6 @@ object AppContext:
       pageUrl,
       setPageVia,
       config.environment,
-      exploreClipboard,
       broadcastChannel,
       toastRef
     )

--- a/common/src/main/scala/explore/model/ExploreClipboard.scala
+++ b/common/src/main/scala/explore/model/ExploreClipboard.scala
@@ -1,0 +1,32 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.effect.IO
+import explore.model.LocalClipboard.*
+import org.scalajs.dom
+
+object ExploreClipboard:
+  private val storageKey = "clipboard"
+
+  def get: IO[LocalClipboard] = IO {
+    // getItem returns null when storage isn't set.
+    Option(dom.window.localStorage.getItem(storageKey)).fold(LocalClipboard.Empty)(value =>
+      ObsIdSet.fromString
+        .getOption(value)
+        .map(LocalClipboard.CopiedObservations.apply)
+        .orElse(TargetIdSet.fromString.getOption(value).map(LocalClipboard.CopiedTargets.apply))
+        .getOrElse(LocalClipboard.Empty)
+    )
+  }
+
+  def set(item: LocalClipboard): IO[Unit] = IO {
+    item match {
+      case CopiedObservations(oids) =>
+        dom.window.localStorage.setItem(storageKey, ObsIdSet.fromString.reverseGet(oids))
+      case CopiedTargets(tids)      =>
+        dom.window.localStorage.setItem(storageKey, TargetIdSet.fromString.reverseGet(tids))
+      case Empty                    => dom.window.localStorage.removeItem(storageKey)
+    }
+  }

--- a/common/src/main/scala/explore/model/ExploreClipboard.scala
+++ b/common/src/main/scala/explore/model/ExploreClipboard.scala
@@ -6,11 +6,12 @@ package explore.model
 import cats.effect.IO
 import explore.model.LocalClipboard.*
 import org.scalajs.dom
+import org.typelevel.log4cats.Logger
 
 object ExploreClipboard:
   private val storageKey = "clipboard"
 
-  def get: IO[LocalClipboard] = IO {
+  def get(using Logger[IO]): IO[LocalClipboard] = IO {
     // getItem returns null when storage isn't set.
     Option(dom.window.localStorage.getItem(storageKey)).fold(LocalClipboard.Empty)(value =>
       ObsIdSet.fromString
@@ -19,9 +20,11 @@ object ExploreClipboard:
         .orElse(TargetIdSet.fromString.getOption(value).map(LocalClipboard.CopiedTargets.apply))
         .getOrElse(LocalClipboard.Empty)
     )
-  }
+  }.handleErrorWith(t =>
+    Logger[IO].error(t)("Error getting value from localStorage") >> IO(LocalClipboard.Empty)
+  )
 
-  def set(item: LocalClipboard): IO[Unit] = IO {
+  def set(item: LocalClipboard)(using Logger[IO]): IO[Unit] = IO {
     item match {
       case CopiedObservations(oids) =>
         dom.window.localStorage.setItem(storageKey, ObsIdSet.fromString.reverseGet(oids))
@@ -29,4 +32,4 @@ object ExploreClipboard:
         dom.window.localStorage.setItem(storageKey, TargetIdSet.fromString.reverseGet(tids))
       case Empty                    => dom.window.localStorage.removeItem(storageKey)
     }
-  }
+  }.handleErrorWith(t => Logger[IO].error(t)("Error setting localStorage"))

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -6,7 +6,6 @@ package explore
 import cats.effect.Async
 import cats.effect.IO
 import cats.effect.IOApp
-import cats.effect.Ref
 import cats.effect.Resource
 import cats.effect.Sync
 import cats.effect.kernel.Deferred
@@ -30,7 +29,6 @@ import explore.model.AppContext
 import explore.model.ExploreLocalPreferences
 import explore.model.Focused
 import explore.model.Help
-import explore.model.LocalClipboard
 import explore.model.RootModel
 import explore.model.RoutingInfo
 import explore.model.UserVault
@@ -173,7 +171,6 @@ object ExploreMain {
         appConfig            <- fetchConfig[IO]
         _                    <- Logger[IO].info(s"Git Commit: [${utils.gitHash.getOrElse("NONE")}]")
         _                    <- Logger[IO].info(s"Config: ${appConfig.show}")
-        clipboard            <- Ref.of[IO, LocalClipboard](LocalClipboard.Empty)
         toastRef             <- Deferred[IO, ToastRef]
         ctx                  <-
           AppContext.from[IO](
@@ -182,7 +179,6 @@ object ExploreMain {
             pageUrl,
             setPageVia,
             workerClients,
-            clipboard,
             bc,
             toastRef
           )

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -297,7 +297,7 @@ object ObsTabContents extends TwoPanels:
           case CopyAlt1 | CopyAlt2 =>
             obs
               .map(id =>
-                ctx.exploreClipboard
+                ExploreClipboard
                   .set(LocalClipboard.CopiedObservations(ObsIdSet.one(id)))
                   .withToast(ctx)(s"Copied obs $id")
               )
@@ -305,7 +305,7 @@ object ObsTabContents extends TwoPanels:
               .runAsync
 
           case PasteAlt1 | PasteAlt2 =>
-            ctx.exploreClipboard.get.flatMap {
+            ExploreClipboard.get.flatMap {
               case LocalClipboard.CopiedObservations(idSet) =>
                 obsList.toOption.map { obsWithConstraints =>
                   val observations =

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -686,7 +686,7 @@ object TargetTabContents extends TwoPanels:
           case CopyAlt1 | CopyAlt2 =>
             target.obsSet
               .map(ids =>
-                ctx.exploreClipboard
+                ExploreClipboard
                   .set(LocalClipboard.CopiedObservations(ids))
                   .withToast(ctx)(s"Copied obs ${ids.idSet.toList.mkString(", ")}")
               )
@@ -694,7 +694,7 @@ object TargetTabContents extends TwoPanels:
                 TargetIdSet
                   .fromTargetIdList(selectedIds)
                   .map(tids =>
-                    ctx.exploreClipboard
+                    ExploreClipboard
                       .set(LocalClipboard.CopiedTargets(tids))
                       .withToast(ctx)(s"Copied targets ${tids.toList.mkString(", ")}")
                   )
@@ -703,7 +703,7 @@ object TargetTabContents extends TwoPanels:
               .runAsync
 
           case PasteAlt1 | PasteAlt2 =>
-            ctx.exploreClipboard.get.flatMap {
+            ExploreClipboard.get.flatMap {
               case LocalClipboard.CopiedObservations(id) =>
                 val treeTargets =
                   props.focused.obsSet

--- a/model/shared/src/main/scala/explore/model/TargetIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/TargetIdSet.scala
@@ -9,6 +9,7 @@ import cats.syntax.all.*
 import explore.model.util.NonEmptySetWrapper
 import lucuma.core.model.Target
 import monocle.Iso
+import monocle.Prism
 
 case class TargetIdSet(idSet: NonEmptySet[Target.Id])
 
@@ -27,7 +28,13 @@ object TargetIdSet {
       case head :: tail => TargetIdSet(NonEmptySet.of(head, tail: _*)).some
     }
 
+  val fromString: Prism[String, TargetIdSet] =
+    Prism(parse)(_.idSet.toSortedSet.map(_.toString).mkString(","))
+
   def one(id: Target.Id): TargetIdSet = TargetIdSet(NonEmptySet.one(id))
 
   def of(id: Target.Id, ids: Target.Id*): TargetIdSet = TargetIdSet(NonEmptySet.of(id, ids: _*))
+
+  private def parse(idSetStr: String): Option[TargetIdSet] =
+    idSetStr.split(",").toList.traverse(Target.Id.parse).flatMap(fromTargetIdList)
 }


### PR DESCRIPTION
This implements Andy's request. We just need to decide if we want this implementation. It uses localStorage, so the "clipboard" is shared between all tabs within the same browser of the same "instance" of explore (staging, production, etc.). It also persists between runs of the browser, which could be seen as good or bad, I guess.