### PR TITLE
Quick fix for the ODB change to the itc query

### DIFF
--- a/common-graphql/src/main/scala/queries/common/ObsQueriesGQL.scala
+++ b/common-graphql/src/main/scala/queries/common/ObsQueriesGQL.scala
@@ -146,22 +146,6 @@ object ObsQueriesGQL {
           }
           observingMode $ObservingModeSubquery
         }
-
-        itc(programId: $$programId, observationId: $$obsId) {
-          result {
-            ... on ItcSuccess {
-              exposureTime $TimeSpanSubquery
-              exposures
-              signalToNoise
-            }
-            ... on ItcMissingParams {
-              params
-            }
-            ... on ItcServiceError {
-              message
-            }
-          }
-        }
       }
     """
 

--- a/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -112,7 +112,7 @@ object ObsQueries:
   extension (data: ObsEditQuery.Data)
     def asObsEditData: Option[ObsEditData] =
       data.observation.map { obs =>
-        val itcSuccess = data.itc.flatMap(OdbItcResult.success.getOption)
+        val itcSuccess = none[OdbItcResult.Success]
         ObsEditData(
           id = obs.id,
           title = obs.title,


### PR DESCRIPTION
This is a temporary fix for the change to the ODB itc query that was deployed with this PR https://github.com/gemini-hlsw/lucuma-odb/pull/268

I will update lucuma-schemas, and then we can decide which way we want to go. We can 

1. call the itc directly
2. have the odb reinstate a non-failing itc query
3. use the odb itc query, but make it so that it won't fail our entire ObsEditQuery. Which, I think it will do now. I will double check that after I update lucuma-schemas.

Update:
Yes, an invalid ITC breaks the entire ObsEditQuery.
BTW, we are not currently displaying the ITC results, anyway.