### PR TITLE
Update explore for the itc/sequence changes in the odb

### DIFF
--- a/common-graphql/src/main/scala/queries/common/GeneratedSequenceSQL.scala
+++ b/common-graphql/src/main/scala/queries/common/GeneratedSequenceSQL.scala
@@ -18,61 +18,59 @@ object GeneratedSequenceSQL {
   @GraphQL
   trait SequenceSteps extends GraphQLOperation[ObservationDB] {
     val document = s"""
-      query($$obsId: ObservationId!) {
-        observation(observationId: $$obsId) {
-          execution {
-            config:executionConfig {
-              instrument
-              ... on GmosNorthExecutionConfig {
-                staticN: static {
-                  stageMode
-                  detector
-                  mosPreImaging
-                  nodAndShuffle {
-                    ...nodAndShuffleFields
-                  }
-                }          
-                acquisitionN:acquisition {
-                  nextAtom {
-                    ...northSequenceFields
-                  }
-                  possibleFuture {
-                    ...northSequenceFields
-                  }
+      query($$programId: ProgramId!, $$obsId: ObservationId!) {
+        sequence(programId: $$programId, observationId: $$obsId) {
+          config:executionConfig {
+            instrument
+            ... on GmosNorthExecutionConfig {
+              staticN: static {
+                stageMode
+                detector
+                mosPreImaging
+                nodAndShuffle {
+                  ...nodAndShuffleFields
                 }
-                scienceN:science {
-                  nextAtom {
-                    ...northSequenceFields
-                  }
-                  possibleFuture {
-                    ...northSequenceFields
-                  }
+              }          
+              acquisitionN:acquisition {
+                nextAtom {
+                  ...northSequenceFields
+                }
+                possibleFuture {
+                  ...northSequenceFields
                 }
               }
-              ... on GmosSouthExecutionConfig {
-                staticS: static {
-                  stageMode
-                  detector
-                  mosPreImaging
-                  nodAndShuffle {
-                    ...nodAndShuffleFields
-                  }
-                }          
-                acquisitionS: acquisition {
-                  nextAtom {
-                    ...southSequenceFields
-                  }
-                  possibleFuture {
-                    ...southSequenceFields
-                  }            
+              scienceN:science {
+                nextAtom {
+                  ...northSequenceFields
                 }
-                scienceS:science {
-                  nextAtom {
-                    ...southSequenceFields
-                  }
-                  possibleFuture {
-                    ...southSequenceFields
-                  }
+                possibleFuture {
+                  ...northSequenceFields
+                }
+              }
+            }
+            ... on GmosSouthExecutionConfig {
+              staticS: static {
+                stageMode
+                detector
+                mosPreImaging
+                nodAndShuffle {
+                  ...nodAndShuffleFields
+                }
+              }          
+              acquisitionS: acquisition {
+                nextAtom {
+                  ...southSequenceFields
+                }
+                possibleFuture {
+                  ...southSequenceFields
+                }            
+              }
+              scienceS:science {
+                nextAtom {
+                  ...southSequenceFields
+                }
+                possibleFuture {
+                  ...southSequenceFields
                 }
               }
             }
@@ -197,10 +195,8 @@ object GeneratedSequenceSQL {
     )
 
     object Data {
-      object Observation {
-        object Execution {
-          type Config = FutureExecutionConfig
-        }
+      object Sequence {
+        type Config = FutureExecutionConfig
       }
     }
   }

--- a/common-graphql/src/main/scala/queries/common/VisitsSQL.scala
+++ b/common-graphql/src/main/scala/queries/common/VisitsSQL.scala
@@ -1,218 +1,218 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package queries.common
+// package queries.common
 
-import clue.GraphQLOperation
-import clue.annotation.GraphQL
-import io.circe.Decoder
-import lucuma.schemas.ObservationDB
-import lucuma.schemas.model.ExecutionVisits
-import lucuma.schemas.model.Visit
-import lucuma.schemas.odb.*
-// gql: import lucuma.schemas.decoders.given
+// import clue.GraphQLOperation
+// import clue.annotation.GraphQL
+// import io.circe.Decoder
+// import lucuma.schemas.ObservationDB
+// import lucuma.schemas.model.ExecutionVisits
+// import lucuma.schemas.model.Visit
+// import lucuma.schemas.odb.*
+// // gql: import lucuma.schemas.decoders.given
 
-object VisitsSQL:
+// object VisitsSQL:
 
-  @GraphQL
-  trait Visits extends GraphQLOperation[ObservationDB]:
-    val document = s"""
-      query($$obsId: ObservationId!) {
-        observation(observationId: $$obsId) {
-          execution {
-            executionConfig {
-              instrument
-              ...on GmosNorthExecutionConfig {
-                visits {
-                  id
-                  created
-                  startTime
-                  endTime
-                  duration {
-                    microseconds
-                  }
-                  staticN:staticConfig {
-                    stageMode
-                    detector
-                    mosPreImaging
-                    nodAndShuffle {
-                      ...nodAndShuffleFields
-                    }                
-                  }
-                  stepsN:steps {
-                    ...gmosNorthStepRecordFields
-                  }
-                  sequenceEvents {
-                    id
-                    received
-                    payload {
-                      command
-                    }
-                  }              
-                }
-              }
-              ...on GmosSouthExecutionConfig {
-                visits {
-                  id
-                  created
-                  startTime
-                  endTime
-                  duration $TimeSpanSubquery         
-                  staticS:staticConfig {
-                    stageMode
-                    detector
-                    mosPreImaging
-                    nodAndShuffle {
-                      ...nodAndShuffleFields
-                    }
-                  }
-                  stepsS:steps {
-                    ...gmosSouthStepRecordFields
-                  }
-                  sequenceEvents {
-                    id
-                    received
-                    payload {
-                      command
-                    }
-                  }
-                }
-              }          
-            }
-          }
-        }
-      }
+//   @GraphQL
+//   trait Visits extends GraphQLOperation[ObservationDB]:
+//     val document = s"""
+//       query($$obsId: ObservationId!) {
+//         observation(observationId: $$obsId) {
+//           execution {
+//             executionConfig {
+//               instrument
+//               ...on GmosNorthExecutionConfig {
+//                 visits {
+//                   id
+//                   created
+//                   startTime
+//                   endTime
+//                   duration {
+//                     microseconds
+//                   }
+//                   staticN:staticConfig {
+//                     stageMode
+//                     detector
+//                     mosPreImaging
+//                     nodAndShuffle {
+//                       ...nodAndShuffleFields
+//                     }
+//                   }
+//                   stepsN:steps {
+//                     ...gmosNorthStepRecordFields
+//                   }
+//                   sequenceEvents {
+//                     id
+//                     received
+//                     payload {
+//                       command
+//                     }
+//                   }
+//                 }
+//               }
+//               ...on GmosSouthExecutionConfig {
+//                 visits {
+//                   id
+//                   created
+//                   startTime
+//                   endTime
+//                   duration $TimeSpanSubquery
+//                   staticS:staticConfig {
+//                     stageMode
+//                     detector
+//                     mosPreImaging
+//                     nodAndShuffle {
+//                       ...nodAndShuffleFields
+//                     }
+//                   }
+//                   stepsS:steps {
+//                     ...gmosSouthStepRecordFields
+//                   }
+//                   sequenceEvents {
+//                     id
+//                     received
+//                     payload {
+//                       command
+//                     }
+//                   }
+//                 }
+//               }
+//             }
+//           }
+//         }
+//       }
 
-      fragment nodAndShuffleFields on GmosNodAndShuffle {
-        posA $OffsetSubquery
-        posB $OffsetSubquery
-        eOffset
-        shuffleOffset
-        shuffleCycles
-      }
+//       fragment nodAndShuffleFields on GmosNodAndShuffle {
+//         posA $OffsetSubquery
+//         posB $OffsetSubquery
+//         eOffset
+//         shuffleOffset
+//         shuffleCycles
+//       }
 
-      fragment gmosNorthStepRecordFields on GmosNorthStepRecord {
-        id
-        created
-        startTime
-        endTime
-        duration $TimeSpanSubquery
-        instrumentConfig {
-          exposure {
-            microseconds
-          }
-          readout $GmosCcdModeSubquery
-          dtax
-          roi
-          gratingConfig {
-            grating
-            order
-            wavelength {
-              picometers
-            }
-          }
-          filter
-          fpu {
-            customMask {
-              filename
-              slitWidth
-            }
-            builtin
-          }
-        }
-        stepConfig {
-          stepType
-          ...on Gcal {
-            continuum
-            arcs
-            filter
-            diffuser
-            shutter
-          }
-          ...on Science {
-            offset $OffsetSubquery
-          }
-        }
-        stepEvents {
-          id
-          received
-          payload {
-            sequenceType
-            stepStage
-          }
-        }
-        stepQaState
-        datasets {
-          id {
-            index
-          }
-          filename
-          qaState
-        }
-      }
+//       fragment gmosNorthStepRecordFields on GmosNorthStepRecord {
+//         id
+//         created
+//         startTime
+//         endTime
+//         duration $TimeSpanSubquery
+//         instrumentConfig {
+//           exposure {
+//             microseconds
+//           }
+//           readout $GmosCcdModeSubquery
+//           dtax
+//           roi
+//           gratingConfig {
+//             grating
+//             order
+//             wavelength {
+//               picometers
+//             }
+//           }
+//           filter
+//           fpu {
+//             customMask {
+//               filename
+//               slitWidth
+//             }
+//             builtin
+//           }
+//         }
+//         stepConfig {
+//           stepType
+//           ...on Gcal {
+//             continuum
+//             arcs
+//             filter
+//             diffuser
+//             shutter
+//           }
+//           ...on Science {
+//             offset $OffsetSubquery
+//           }
+//         }
+//         stepEvents {
+//           id
+//           received
+//           payload {
+//             sequenceType
+//             stepStage
+//           }
+//         }
+//         stepQaState
+//         datasets {
+//           id {
+//             index
+//           }
+//           filename
+//           qaState
+//         }
+//       }
 
-      fragment gmosSouthStepRecordFields on GmosSouthStepRecord {
-        id
-        created
-        startTime
-        endTime
-        duration $TimeSpanSubquery
-        instrumentConfig {
-          exposure {
-            microseconds
-          }
-          readout $GmosCcdModeSubquery
-          dtax
-          roi
-          gratingConfig {
-            grating
-            order
-            wavelength {
-              picometers
-            }
-          }
-          filter
-          fpu {
-            customMask {
-              filename
-              slitWidth
-            }
-            builtin
-          }
-        }
-        stepConfig {
-          stepType
-          ...on Gcal {
-            continuum
-            arcs
-            filter
-            diffuser
-            shutter
-          }
-          ...on Science {
-            offset $OffsetSubquery
-          }
-        }
-        stepEvents {
-          id
-          received
-          payload {
-            sequenceType
-            stepStage
-          }
-        }
-        stepQaState
-        datasets {
-          id {
-            index
-          }
-          filename
-          qaState
-        }
-      }
-    """
+//       fragment gmosSouthStepRecordFields on GmosSouthStepRecord {
+//         id
+//         created
+//         startTime
+//         endTime
+//         duration $TimeSpanSubquery
+//         instrumentConfig {
+//           exposure {
+//             microseconds
+//           }
+//           readout $GmosCcdModeSubquery
+//           dtax
+//           roi
+//           gratingConfig {
+//             grating
+//             order
+//             wavelength {
+//               picometers
+//             }
+//           }
+//           filter
+//           fpu {
+//             customMask {
+//               filename
+//               slitWidth
+//             }
+//             builtin
+//           }
+//         }
+//         stepConfig {
+//           stepType
+//           ...on Gcal {
+//             continuum
+//             arcs
+//             filter
+//             diffuser
+//             shutter
+//           }
+//           ...on Science {
+//             offset $OffsetSubquery
+//           }
+//         }
+//         stepEvents {
+//           id
+//           received
+//           payload {
+//             sequenceType
+//             stepStage
+//           }
+//         }
+//         stepQaState
+//         datasets {
+//           id {
+//             index
+//           }
+//           filename
+//           qaState
+//         }
+//       }
+//     """
 
-    object Data:
-      object Observation:
-        object Execution:
-          type ExecutionConfig = ExecutionVisits
+//     object Data:
+//       object Observation:
+//         object Execution:
+//           type ExecutionConfig = ExecutionVisits

--- a/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
@@ -57,6 +57,7 @@ import lucuma.core.math.WavelengthDither
 import lucuma.core.math.units.Micrometer
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
 import lucuma.core.syntax.all.*
 import lucuma.core.util.Display
 import lucuma.core.util.Enumerated
@@ -93,6 +94,7 @@ import scalajs.js
 import scalajs.js.JSConverters.*
 
 sealed trait AdvancedConfigurationPanel[T <: ObservingMode, Input]:
+  def programId: Program.Id
   def obsId: Observation.Id
   def title: String
   def subtitle: Option[NonEmptyString]
@@ -783,6 +785,7 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
           ),
           <.div(ExploreStyles.AdvancedConfigurationButtons)(
             SequenceEditorPopup(
+              props.programId,
               props.obsId,
               props.title,
               props.subtitle,
@@ -858,6 +861,7 @@ object AdvancedConfigurationPanel {
 
   // Gmos North Long Slit
   case class GmosNorthLongSlit(
+    programId:                Program.Id,
     obsId:                    Observation.Id,
     title:                    String,
     subtitle:                 Option[NonEmptyString],
@@ -1061,6 +1065,7 @@ object AdvancedConfigurationPanel {
 // Gmos South Long Slit
 
   case class GmosSouthLongSlit(
+    programId:                Program.Id,
     obsId:                    Observation.Id,
     title:                    String,
     subtitle:                 Option[NonEmptyString],

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -241,6 +241,7 @@ object ConfigurationPanel:
                 optNorthAligner.map(northAligner =>
                   AdvancedConfigurationPanel
                     .GmosNorthLongSlit(
+                      props.programId,
                       props.obsId,
                       props.title,
                       props.subtitle,
@@ -256,6 +257,7 @@ object ConfigurationPanel:
                 optSouthAligner.map(southAligner =>
                   AdvancedConfigurationPanel
                     .GmosSouthLongSlit(
+                      props.programId,
                       props.obsId,
                       props.title,
                       props.subtitle,

--- a/explore/src/main/scala/explore/config/sequence/GeneratedSequenceTables.scala
+++ b/explore/src/main/scala/explore/config/sequence/GeneratedSequenceTables.scala
@@ -24,7 +24,7 @@ object GeneratedSequenceTables:
       .render(props =>
         Panel()(
           <.div(ExploreStyles.SequencesPanel)(
-            VisitsViewer(props.obsId),
+            // VisitsViewer(props.obsId),
             <.h3("Acquisition"),
             GmosSequenceTable(
               props.config.acquisition.nextAtom +: props.config.acquisition.possibleFuture

--- a/explore/src/main/scala/explore/config/sequence/GeneratedSequenceViewer.scala
+++ b/explore/src/main/scala/explore/config/sequence/GeneratedSequenceViewer.scala
@@ -14,14 +14,18 @@ import explore.utils._
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import queries.common.GeneratedSequenceSQL._
 import queries.common.ObsQueriesGQL
 import react.common.ReactFnProps
 
-case class GeneratedSequenceViewer(obsId: Observation.Id, changed: View[Pot[Unit]])
-    extends ReactFnProps(GeneratedSequenceViewer.component)
+case class GeneratedSequenceViewer(
+  programId: Program.Id,
+  obsId:     Observation.Id,
+  changed:   View[Pot[Unit]]
+) extends ReactFnProps(GeneratedSequenceViewer.component)
 
 object GeneratedSequenceViewer:
   private type Props = GeneratedSequenceViewer
@@ -34,8 +38,8 @@ object GeneratedSequenceViewer:
         import ctx.given
 
         SequenceSteps
-          .query(props.obsId)
-          .map(_.observation.map(_.execution.config))
+          .query(props.programId, props.obsId)
+          .map(_.sequence.map(_.config))
           .attemptPot
           .resetOnResourceSignals(
             ObsQueriesGQL.ObservationEditSubscription.subscribe[IO](props.obsId)

--- a/explore/src/main/scala/explore/config/sequence/SequenceEditorPopup.scala
+++ b/explore/src/main/scala/explore/config/sequence/SequenceEditorPopup.scala
@@ -13,6 +13,7 @@ import explore.given
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Observation
+import lucuma.core.model.Program
 import lucuma.core.util.NewType
 import lucuma.ui.primereact.LucumaStyles
 import lucuma.ui.syntax.all.*
@@ -24,6 +25,7 @@ import react.primereact.Dialog
 import react.primereact.DialogPosition
 
 case class SequenceEditorPopup(
+  programId:      Program.Id,
   obsId:          Observation.Id,
   title:          String,
   subtitle:       Option[NonEmptyString],
@@ -73,7 +75,7 @@ object SequenceEditorPopup:
                 props.offsetsControl(changed.set(Pot.pending))
               )
             ),
-            GeneratedSequenceViewer(props.obsId, changed)
+            GeneratedSequenceViewer(props.programId, props.obsId, changed)
           )
         )
       }

--- a/explore/src/main/scala/explore/config/sequence/VisitsViewer.scala
+++ b/explore/src/main/scala/explore/config/sequence/VisitsViewer.scala
@@ -1,113 +1,113 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package explore.config.sequence
+// package explore.config.sequence
 
-import cats.effect.IO
-import cats.syntax.all.*
-import crystal.Pot
-import crystal.react.View
-import crystal.react.hooks.*
-import crystal.react.implicits.*
-import explore.*
-import explore.components.ui.ExploreStyles
-import explore.model.AppContext
-import explore.model.Constants
-import explore.model.display.given
-import explore.model.reusability.given
-import explore.utils.*
-import japgolly.scalajs.react.*
-import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.core.enums.SequenceType
-import lucuma.core.model.Observation
-import lucuma.core.model.sequence.DynamicConfig
-import lucuma.core.syntax.all.given
-import lucuma.react.syntax.*
-import lucuma.react.table.*
-import lucuma.schemas.model.StepRecord
-import lucuma.schemas.model.Visit
-import lucuma.ui.syntax.all.*
-import lucuma.ui.syntax.all.given
-import lucuma.ui.table.*
-import queries.common.ObsQueriesGQL
-import queries.common.VisitsSQL.*
-import react.common.ReactFnProps
-import react.primereact.AccordionMultiple
-import react.primereact.AccordionTab
+// import cats.effect.IO
+// import cats.syntax.all.*
+// import crystal.Pot
+// import crystal.react.View
+// import crystal.react.hooks.*
+// import crystal.react.implicits.*
+// import explore.*
+// import explore.components.ui.ExploreStyles
+// import explore.model.AppContext
+// import explore.model.Constants
+// import explore.model.display.given
+// import explore.model.reusability.given
+// import explore.utils.*
+// import japgolly.scalajs.react.*
+// import japgolly.scalajs.react.vdom.html_<^.*
+// import lucuma.core.enums.SequenceType
+// import lucuma.core.model.Observation
+// import lucuma.core.model.sequence.DynamicConfig
+// import lucuma.core.syntax.all.given
+// import lucuma.react.syntax.*
+// import lucuma.react.table.*
+// import lucuma.schemas.model.StepRecord
+// import lucuma.schemas.model.Visit
+// import lucuma.ui.syntax.all.*
+// import lucuma.ui.syntax.all.given
+// import lucuma.ui.table.*
+// import queries.common.ObsQueriesGQL
+// import queries.common.VisitsSQL.*
+// import react.common.ReactFnProps
+// import react.primereact.AccordionMultiple
+// import react.primereact.AccordionTab
 
-import java.time.Duration
-import java.time.ZoneOffset
+// import java.time.Duration
+// import java.time.ZoneOffset
 
-case class VisitsViewer(obsId: Observation.Id) extends ReactFnProps(VisitsViewer.component)
+// case class VisitsViewer(obsId: Observation.Id) extends ReactFnProps(VisitsViewer.component)
 
-object VisitsViewer:
-  private type Props = VisitsViewer
+// object VisitsViewer:
+//   private type Props = VisitsViewer
 
-  private def stepDuration(step: StepRecord): Duration =
-    step.instrumentConfig match
-      case DynamicConfig.GmosNorth(exposure, _, _, _, _, _, _) => exposure.toDuration
-      case DynamicConfig.GmosSouth(exposure, _, _, _, _, _, _) => exposure.toDuration
+//   private def stepDuration(step: StepRecord): Duration =
+//     step.instrumentConfig match
+//       case DynamicConfig.GmosNorth(exposure, _, _, _, _, _, _) => exposure.toDuration
+//       case DynamicConfig.GmosSouth(exposure, _, _, _, _, _, _) => exposure.toDuration
 
-  private def renderSequence(
-    sequenceType: SequenceType,
-    steps:        List[StepRecord]
-  ): Option[AccordionTab] =
-    Option.when(steps.nonEmpty)(
-      AccordionTab(
-        clazz = ExploreStyles.VisitSection,
-        header = <.div(ExploreStyles.VisitHeader)(
-          <.span(
-            steps.headOption
-              .flatMap(_.startTime)
-              .fold("---")(start => Constants.UtcFormatter.format(start))
-          ),
-          <.span(sequenceType.shortName),
-          <.span(s"Steps: 1 - ${steps.length}"),
-          <.span {
-            val datasetIndices = steps.flatMap(_.datasets).map(_.index.value)
-            "Files: " + datasetIndices.minOption
-              .map(min => s"$min - ${datasetIndices.max}")
-              .getOrElse("---")
-          },
-          <.span(
-            Constants.DurationFormatter(
-              steps
-                .map(step => stepDuration(step))
-                .reduce(_.plus(_))
-            )
-          )
-        )
-      )(VisitTable(steps))
-    )
+//   private def renderSequence(
+//     sequenceType: SequenceType,
+//     steps:        List[StepRecord]
+//   ): Option[AccordionTab] =
+//     Option.when(steps.nonEmpty)(
+//       AccordionTab(
+//         clazz = ExploreStyles.VisitSection,
+//         header = <.div(ExploreStyles.VisitHeader)(
+//           <.span(
+//             steps.headOption
+//               .flatMap(_.startTime)
+//               .fold("---")(start => Constants.UtcFormatter.format(start))
+//           ),
+//           <.span(sequenceType.shortName),
+//           <.span(s"Steps: 1 - ${steps.length}"),
+//           <.span {
+//             val datasetIndices = steps.flatMap(_.datasets).map(_.index.value)
+//             "Files: " + datasetIndices.minOption
+//               .map(min => s"$min - ${datasetIndices.max}")
+//               .getOrElse("---")
+//           },
+//           <.span(
+//             Constants.DurationFormatter(
+//               steps
+//                 .map(step => stepDuration(step))
+//                 .reduce(_.plus(_))
+//             )
+//           )
+//         )
+//       )(VisitTable(steps))
+//     )
 
-  private val component =
-    ScalaFnComponent
-      .withHooks[Props]
-      .useContext(AppContext.ctx)
-      .useStreamResourceOnMountBy { (props, ctx) =>
-        import ctx.given
+//   private val component =
+//     ScalaFnComponent
+//       .withHooks[Props]
+//       .useContext(AppContext.ctx)
+//       .useStreamResourceOnMountBy { (props, ctx) =>
+//         import ctx.given
 
-        Visits
-          .query(props.obsId)
-          .map(_.observation.map(_.execution.executionConfig))
-          .attemptPot
-          .resetOnResourceSignals(
-            ObsQueriesGQL.ObservationEditSubscription.subscribe[IO](props.obsId)
-          )
-      }
-      .render((_, _, visits) =>
-        visits.toPot.flatten
-          .map(_.map(_.visits).orEmpty)
-          .render(visits =>
-            AccordionMultiple(tabs =
-              visits
-                .flatMap(visit =>
-                  List(
-                    renderSequence(SequenceType.Acquisition, visit.acquisitionSteps),
-                    renderSequence(SequenceType.Science, visit.scienceSteps)
-                  )
-                )
-                .flattenOption
-            )
-          )
-      )
+//         Visits
+//           .query(props.obsId)
+//           .map(_.observation.map(_.execution.executionConfig))
+//           .attemptPot
+//           .resetOnResourceSignals(
+//             ObsQueriesGQL.ObservationEditSubscription.subscribe[IO](props.obsId)
+//           )
+//       }
+//       .render((_, _, visits) =>
+//         visits.toPot.flatten
+//           .map(_.map(_.visits).orEmpty)
+//           .render(visits =>
+//             AccordionMultiple(tabs =
+//               visits
+//                 .flatMap(visit =>
+//                   List(
+//                     renderSequence(SequenceType.Acquisition, visit.acquisitionSteps),
+//                     renderSequence(SequenceType.Science, visit.scienceSteps)
+//                   )
+//                 )
+//                 .flattenOption
+//             )
+//           )
+//       )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -32,7 +32,7 @@ object Settings {
     val lucumaCatalog          = "0.40.0"
     val lucumaReact            = "0.32.0"
     val lucumaRefined          = "0.1.1"
-    val lucumaSchemas          = "0.44.0"
+    val lucumaSchemas          = "0.45.0"
     val lucumaSSO              = "0.5.3"
     val lucumaUI               = "0.68.1"
     val monocle                = "3.2.0"


### PR DESCRIPTION
This sort of restores the sequence viewing. However:

1. Visits are not currently in the schema, so I commented that stuff out.
2. Not everything in the schema is currently mapped, so actually trying to view the sequence will result in an error. When the server has everything mapped, we shouldn't need any changes for it to work.