### PR TITLE
Observation Summary Table

### DIFF
--- a/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/common-queries/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -4,9 +4,9 @@
 package queries.schemas.odb
 
 import cats.Eq
+import cats.derived.*
 import cats.effect.Async
 import cats.implicits.*
-import cats.derived.*
 import clue.TransactionalClient
 import clue.data.syntax.*
 import crystal.Pot
@@ -14,13 +14,13 @@ import eu.timepit.refined.types.numeric.PosBigDecimal
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.data.KeyedIndexedList
 import explore.model.ConstraintGroup
-import explore.model.OdbItcResult
 import explore.model.ObsIdSet
 import explore.model.ObsSummaryWithTitleAndConstraints
 import explore.model.ObsSummaryWithTitleConstraintsAndConf
+import explore.model.OdbItcResult
 import explore.model.TargetSummary
-import explore.optics.all.*
 import explore.model.syntax.all.*
+import explore.optics.all.*
 import japgolly.scalajs.react.*
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
@@ -28,18 +28,18 @@ import lucuma.core.model.ExposureTimeMode.FixedExposure
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
-import lucuma.core.syntax.time.*
 import lucuma.core.model.Target
+import lucuma.core.syntax.time.*
+import lucuma.core.util.Timestamp
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Enums.*
 import lucuma.schemas.ObservationDB.Types.*
 import lucuma.schemas.model.ObservingMode
+import lucuma.schemas.odb.input.*
 import monocle.Focus
 import monocle.Getter
 import monocle.Lens
 import queries.common.ObsQueriesGQL.*
-import lucuma.schemas.odb.input.*
-import lucuma.core.util.Timestamp
 
 import java.time.Duration
 import java.time.Instant
@@ -145,7 +145,7 @@ object ObsQueries:
               mtch.constraintSet,
               mtch.status,
               mtch.activeStatus,
-              mtch.plannedTime.execution.toDuration,
+              mtch.plannedTime.execution,
               mtch.observingMode,
               none // mtch.visualizationTime
             )
@@ -253,7 +253,7 @@ object ObsQueries:
         obs.constraintSet,
         obs.status,
         obs.activeStatus,
-        obs.plannedTime.execution.toDuration
+        obs.plannedTime.execution
       )
     }
 
@@ -279,7 +279,7 @@ object ObsQueries:
           obs.constraintSet,
           obs.status,
           obs.activeStatus,
-          obs.plannedTime.execution.toDuration
+          obs.plannedTime.execution
         )
       }
 
@@ -297,7 +297,7 @@ object ObsQueries:
           newObs.constraintSet,
           newObs.status,
           newObs.activeStatus,
-          newObs.plannedTime.execution.toDuration
+          newObs.plannedTime.execution
         )
       }
 
@@ -323,7 +323,7 @@ object ObsQueries:
           newObs.constraintSet,
           newObs.status,
           newObs.activeStatus,
-          newObs.plannedTime.execution.toDuration
+          newObs.plannedTime.execution
         )
       }
 

--- a/common/src/main/scala/explore/common/AsterismQueries.scala
+++ b/common/src/main/scala/explore/common/AsterismQueries.scala
@@ -114,7 +114,7 @@ object AsterismQueries:
       obsR.constraintSet,
       obsR.status,
       obsR.activeStatus,
-      obsR.plannedTime.execution.toDuration,
+      obsR.plannedTime.execution,
       obsR.targetEnvironment.asterism.map(_.id).toSet,
       obsR.observingMode,
       obsR.visualizationTime.map(_.toInstant),

--- a/common/src/main/scala/explore/common/ConstraintGroupQueries.scala
+++ b/common/src/main/scala/explore/common/ConstraintGroupQueries.scala
@@ -44,7 +44,7 @@ object ConstraintGroupQueries:
       obsR.subtitle,
       obsR.status,
       obsR.activeStatus,
-      obsR.plannedTime.execution.toDuration,
+      obsR.plannedTime.execution,
       obsR.observingMode
     )
 

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -33,6 +33,7 @@ import react.floatingui.syntax.*
 import react.primereact.Button
 import react.primereact.InputSwitch
 import react.primereact.TooltipOptions
+import explore.model.syntax.all.*
 
 case class ObsBadge(
   obs:               ObsSummary, // The layout will depend on the mixins of the ObsSummary.
@@ -183,9 +184,7 @@ object ObsBadge {
                 ^.onClick ==> { e => e.preventDefaultCB >> e.stopPropagationCB }
               )
             ),
-            <.span(
-              s"${obs.duration.toHours}hrs ${obs.duration.toMinutes % 60}mins"
-            )
+            <.span(obs.executionTime.toHoursMinutes)
           )
         )
       )

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -14,6 +14,7 @@ import explore.model.ObsSummary
 import explore.model.ObsWithConf
 import explore.model.ObsWithConstraints
 import explore.model.ObsWithTitle
+import explore.model.syntax.all.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.feature.ReactFragment
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -33,7 +34,6 @@ import react.floatingui.syntax.*
 import react.primereact.Button
 import react.primereact.InputSwitch
 import react.primereact.TooltipOptions
-import explore.model.syntax.all.*
 
 case class ObsBadge(
   obs:               ObsSummary, // The layout will depend on the mixins of the ObsSummary.

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -1,0 +1,189 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.observationtree
+
+import cats.Order.*
+import cats.effect.IO
+import cats.syntax.all.*
+import crystal.react.View
+import crystal.react.hooks.*
+import crystal.react.implicits.*
+import crystal.react.reuse.*
+import explore.Icons
+import explore.common.ConstraintGroupQueries.*
+import explore.common.UserPreferencesQueries.TableStore
+import explore.components.Tile
+import explore.components.ui.ExploreStyles
+import explore.model.AppContext
+import explore.model.Focused
+import explore.model.ObsSummaryWithTitleConstraintsAndConf
+import explore.model.ObsWithConstraints
+import explore.model.enums.AppTab
+import explore.model.enums.TableId
+import explore.model.reusability.given
+import explore.model.syntax.all.*
+import explore.shortcuts.GoToSummary
+import explore.shortcuts.ShortcutCallbacks
+import explore.shortcuts.toHotKeys
+import explore.syntax.ui.*
+import explore.undo.UndoStacks
+import japgolly.scalajs.react.ScalaFnComponent
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.extra.router.SetRouteVia
+import japgolly.scalajs.react.vdom.html_<^.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.model.Program
+import lucuma.core.model.User
+import lucuma.react.syntax.*
+import lucuma.react.table.ColumnDef
+import lucuma.react.table.ColumnId
+import lucuma.react.table.*
+import lucuma.typed.tanstackReactTable.tanstackReactTableStrings.columnVisibility
+import lucuma.ui.syntax.all.*
+import lucuma.ui.syntax.all.given
+import lucuma.ui.table.TableHooks
+import lucuma.ui.table.TableOptionsWithStateStore
+import lucuma.ui.table.*
+import org.typelevel.log4cats.Logger
+import queries.schemas.odb.ObsQueries.ConstraintsList
+import queries.schemas.odb.ObsQueries.ObservationList
+import react.common.ReactFnProps
+import react.hotkeys.*
+import react.hotkeys.hooks.*
+
+final case class ObsSummaryTable(
+  userId:        Option[User.Id],
+  programId:     Program.Id,
+  observations:  View[ObservationList],
+  obsListStacks: View[UndoStacks[IO, ObservationList]],
+  renderInTitle: Tile.RenderInTitle
+) extends ReactFnProps(
+      ObsSummaryTable.component
+    )
+
+object ObsSummaryTable extends TableHooks:
+  private type Props = ObsSummaryTable
+
+  private val ColDef = ColumnDef[ObsSummaryWithTitleConstraintsAndConf]
+
+  private val GroupsColumnId          = ColumnId("groups")
+  private val ObservationIdColumnId   = ColumnId("observation_id")
+  private val ValidationCheckColumnId = ColumnId("validation_check")
+  private val StatusColumnId          = ColumnId("status")
+  private val CompletionColumnId      = ColumnId("completion")
+  private val TargetTypeColumnId      = ColumnId("target_type")
+  private val TargetColumnId          = ColumnId("target")
+  private val ConstraintsColumnId     = ColumnId("constraints")
+  private val FindingChartColumnId    = ColumnId("finding_chart")
+  private val ConfigurationColumnId   = ColumnId("configuration")
+  private val DurationColumnId        = ColumnId("duration")
+
+  private val PriorityColumnId      = ColumnId("priority")
+  private val RAColumnId            = ColumnId("ra")
+  private val DecColumnId           = ColumnId("dec")
+  private val TimingWindowsColumnId = ColumnId("timing_windows")
+  private val SEDColumnId           = ColumnId("sed")
+  private val ChargedTimeColumnId   = ColumnId("charged_time")
+
+  private val columnNames: Map[ColumnId, String] = Map(
+    // Default columns
+    GroupsColumnId          -> "Groups",
+    ObservationIdColumnId   -> "Observation Id",
+    ValidationCheckColumnId -> " ",
+    StatusColumnId          -> "Status",
+    CompletionColumnId      -> "Completion",
+    TargetTypeColumnId      -> " ",
+    TargetColumnId          -> "Target",
+    ConstraintsColumnId     -> "Constraints",
+    FindingChartColumnId    -> "Finding Chart",
+    ConfigurationColumnId   -> "Configuration",
+    DurationColumnId        -> "Duration",
+
+    // Default hidden columns
+    PriorityColumnId      -> "Priority",
+    RAColumnId            -> "RA",
+    DecColumnId           -> "Dec",
+    TimingWindowsColumnId -> "Timing Windows",
+    SEDColumnId           -> "SED",
+    ChargedTimeColumnId   -> "ChargedTime"
+  )
+
+  private val DefaultColVisibility: ColumnVisibility = ColumnVisibility(
+    PriorityColumnId      -> Visibility.Hidden,
+    RAColumnId            -> Visibility.Hidden,
+    DecColumnId           -> Visibility.Hidden,
+    TimingWindowsColumnId -> Visibility.Hidden,
+    SEDColumnId           -> Visibility.Hidden,
+    ChargedTimeColumnId   -> Visibility.Hidden
+  )
+
+  private val component = ScalaFnComponent
+    .withHooks[Props]
+    .useContext(AppContext.ctx)
+    // Columns
+    .useMemoBy((_, _) => ())((props, ctx) =>
+      _ =>
+        def column[V](id: ColumnId, accessor: ObsSummaryWithTitleConstraintsAndConf => V)
+          : ColumnDef.Single[ObsSummaryWithTitleConstraintsAndConf, V] =
+          ColDef(id, accessor, columnNames(id))
+
+        List(
+          // TODO: GroupsColumnId
+          column(ObservationIdColumnId, _.id).sortable,
+
+          // TODO: ValidationCheckColumnId
+          column(StatusColumnId, _.status),
+          // TODO: CompletionColumnId
+          // TODO: TargetTypeColumnId
+          column(TargetTypeColumnId, _ => ())
+            .setCell(_ => Icons.Star.withFixedWidth())
+            .setSize(35.toPx),
+          column(TargetColumnId, _.title),
+          column(ConstraintsColumnId, _.constraints).setCell(_.value.summaryString),
+          // TODO: FindingChartColumnId
+          column(ConfigurationColumnId, _.conf),
+          column(DurationColumnId, _.executionTime.toHoursMinutes)
+
+          // TODO: PriorityColumnId
+          // TODO: RAColumnId
+          // TODO: DecColumnId
+          // TODO: TimingColumnId
+          // TODO: SEDColumnId
+          // TODO: ChargedTimeColumnId
+        )
+    )
+    // Rows
+    .useMemoBy((props, _, _) => props.observations.get)((_, _, _) => _.toList)
+    // TODO: useReactTableWithStateStoreBy
+    .useReactTableBy((props, ctx, cols, rows) =>
+      // import ctx.given
+      // TableOptionsWithStateStore(
+      TableOptions(
+        cols,
+        rows,
+        getRowId = (row, _, _) => RowId(row.id.toString),
+        initialState = TableState(columnVisibility = DefaultColVisibility)
+      ),
+      // TableStore(props.userId, TableId.ObservationsSummary, cols)
+      // )
+    )
+    .render { (props, _, _, _, table) =>
+      <.div(
+        props.renderInTitle(
+          React.Fragment(
+            <.span(), // Push column selector to right
+            <.span(ExploreStyles.TitleSelectColumns)(
+              ColumnSelector(table, columnNames, ExploreStyles.SelectColumns)
+            )
+          )
+        ),
+        PrimeTable(
+          table,
+          striped = true,
+          compact = Compact.Very,
+          tableMod = ExploreStyles.ExploreTable,
+          headerCellMod = _ => ExploreStyles.StickyHeader
+        )
+      )
+    }

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -28,7 +28,6 @@ import explore.shortcuts.GoToSummary
 import explore.shortcuts.ShortcutCallbacks
 import explore.shortcuts.toHotKeys
 import explore.syntax.ui.*
-import explore.undo.UndoStacks
 import japgolly.scalajs.react.ScalaFnComponent
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
@@ -49,7 +48,6 @@ import lucuma.ui.table.TableHooks
 import lucuma.ui.table.TableOptionsWithStateStore
 import lucuma.ui.table.*
 import org.typelevel.log4cats.Logger
-import queries.schemas.odb.ObsQueries.ConstraintsList
 import queries.schemas.odb.ObsQueries.ObservationList
 import react.common.ReactFnProps
 import react.hotkeys.*
@@ -59,11 +57,8 @@ final case class ObsSummaryTable(
   userId:        Option[User.Id],
   programId:     Program.Id,
   observations:  View[ObservationList],
-  obsListStacks: View[UndoStacks[IO, ObservationList]],
   renderInTitle: Tile.RenderInTitle
-) extends ReactFnProps(
-      ObsSummaryTable.component
-    )
+) extends ReactFnProps(ObsSummaryTable.component)
 
 object ObsSummaryTable extends TableHooks:
   private type Props = ObsSummaryTable

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -178,18 +178,17 @@ object ObsSummaryTable extends TableHooks:
     )
     // Rows
     .useMemoBy((props, _, _) => props.observations.get)((_, _, _) => _.toList)
-    // TODO: useReactTableWithStateStoreBy
-    .useReactTableBy((props, ctx, cols, rows) =>
-      // import ctx.given
-      // TableOptionsWithStateStore(
-      TableOptions(
-        cols,
-        rows,
-        getRowId = (row, _, _) => RowId(row.id.toString),
-        initialState = TableState(columnVisibility = DefaultColVisibility)
-      ),
-      // TableStore(props.userId, TableId.ObservationsSummary, cols)
-      // )
+    .useReactTableWithStateStoreBy((props, ctx, cols, rows) =>
+      import ctx.given
+      TableOptionsWithStateStore(
+        TableOptions(
+          cols,
+          rows,
+          getRowId = (row, _, _) => RowId(row.id.toString),
+          initialState = TableState(columnVisibility = DefaultColVisibility)
+        ),
+        TableStore(props.userId, TableId.ObservationsSummary, cols)
+      )
     )
     .render { (props, _, _, _, table) =>
       <.div(

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -192,11 +192,15 @@ object ObsTabContents extends TwoPanels:
           "observations".refined,
           "Observations Summary",
           backButton.some
-        )(_ =>
-          <.div(
-            ExploreStyles.HVCenter |+| ExploreStyles.EmptyTreeContent,
-            <.div("Select or add an observation")
+        )(renderInTitle =>
+          ObsSummaryTable(
+            props.userId,
+            props.programId,
+            observations,
+            props.obsListStacks,
+            renderInTitle
           )
+          // TODO: elevation view
         )
       )(obsId =>
         ObsTabTiles(

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -197,7 +197,6 @@ object ObsTabContents extends TwoPanels:
             props.userId,
             props.programId,
             observations,
-            props.obsListStacks,
             renderInTitle
           )
           // TODO: elevation view

--- a/hasura/user-prefs/migrations/default/1678192196158_insert_obs_summary_into_public_lucumaTableIds/down.sql
+++ b/hasura/user-prefs/migrations/default/1678192196158_insert_obs_summary_into_public_lucumaTableIds/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."lucumaTableIds" WHERE "id" = 'observations_summary';

--- a/hasura/user-prefs/migrations/default/1678192196158_insert_obs_summary_into_public_lucumaTableIds/up.sql
+++ b/hasura/user-prefs/migrations/default/1678192196158_insert_obs_summary_into_public_lucumaTableIds/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."lucumaTableIds"("id") VALUES (E'observations_summary');

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
@@ -3,37 +3,40 @@
 
 package explore.model.arb
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Cogen
-import eu.timepit.refined.types.string.NonEmptyString
 import eu.timepit.refined.scalacheck.string.*
+import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.ObsSummaryWithConstraints
-import explore.model.ObsSummaryWithTitleAndConstraints
 import explore.model.ObsSummaryWithConstraintsAndConf
-import explore.model.ObsSummaryWithTitleConstraintsAndConf
 import explore.model.ObsSummaryWithTitleAndConf
+import explore.model.ObsSummaryWithTitleAndConstraints
+import explore.model.ObsSummaryWithTitleConstraintsAndConf
+import lucuma.core.arb.ArbTime
 import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
-import lucuma.core.model.Observation
-import lucuma.core.model.Target
-import lucuma.core.arb.ArbTime
-import lucuma.core.model.arb.ArbPosAngleConstraint.*
+import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbWavelength.*
-import lucuma.core.util.arb.ArbGid.*
+import lucuma.core.model.Observation
+import lucuma.core.model.PosAngleConstraint
+import lucuma.core.model.Target
+import lucuma.core.model.arb.ArbPosAngleConstraint.*
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.arb.ArbEnumerated.*
+import lucuma.core.util.arb.ArbGid.*
+import lucuma.core.util.arb.ArbTimeSpan
 import lucuma.schemas.model.BasicConfiguration
 import lucuma.schemas.model.ConstraintsSummary
 import lucuma.schemas.model.arb.ArbBasicConfiguration
-import java.time.Duration
-import java.time.Instant
-import lucuma.core.model.PosAngleConstraint
-import lucuma.core.math.Wavelength
 import lucuma.schemas.model.arb.ArbConstraintsSummary
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen
+
+import java.time.Instant
 
 trait ArbObsSummary {
   import ArbBasicConfiguration.given
   import ArbConstraintsSummary.given
+  import ArbTimeSpan.given
   import ArbTime.*
 
   implicit val arbObsSummaryWithConstraints: Arbitrary[ObsSummaryWithConstraints] =
@@ -43,17 +46,17 @@ trait ArbObsSummary {
         constraints  <- arbitrary[ConstraintsSummary]
         status       <- arbitrary[ObsStatus]
         activeStatus <- arbitrary[ObsActiveStatus]
-        duration     <- arbitrary[Duration]
+        executionTime     <- arbitrary[TimeSpan]
         targets      <- arbitrary[Set[Target.Id]]
-      } yield ObsSummaryWithConstraints(id, constraints, status, activeStatus, duration, targets)
+      } yield ObsSummaryWithConstraints(id, constraints, status, activeStatus, executionTime, targets)
     }
 
   implicit val cogenObsSummaryWithConstraints: Cogen[ObsSummaryWithConstraints] =
     Cogen[
-      (Observation.Id, ConstraintsSummary, ObsStatus, ObsActiveStatus, Duration, List[Target.Id])
+      (Observation.Id, ConstraintsSummary, ObsStatus, ObsActiveStatus, TimeSpan, List[Target.Id])
     ]
       .contramap(o =>
-        (o.id, o.constraints, o.status, o.activeStatus, o.duration, o.scienceTargetIds.toList)
+        (o.id, o.constraints, o.status, o.activeStatus, o.executionTime, o.scienceTargetIds.toList)
       )
 
   implicit val arbObsSummaryWithTitleAndConstraints: Arbitrary[ObsSummaryWithTitleAndConstraints] =
@@ -65,7 +68,7 @@ trait ArbObsSummary {
         constraints  <- arbitrary[ConstraintsSummary]
         status       <- arbitrary[ObsStatus]
         activeStatus <- arbitrary[ObsActiveStatus]
-        duration     <- arbitrary[Duration]
+        executionTime     <- arbitrary[TimeSpan]
       } yield ObsSummaryWithTitleAndConstraints(
         id,
         title,
@@ -73,7 +76,7 @@ trait ArbObsSummary {
         constraints,
         status,
         activeStatus,
-        duration
+        executionTime
       )
     }
 
@@ -85,7 +88,7 @@ trait ArbObsSummary {
        ConstraintsSummary,
        ObsStatus,
        ObsActiveStatus,
-       Duration
+       TimeSpan
       )
     ]
       .contramap(o =>
@@ -95,7 +98,7 @@ trait ArbObsSummary {
          o.constraints,
          o.status,
          o.activeStatus,
-         o.duration
+         o.executionTime
         )
       )
 
@@ -109,7 +112,7 @@ trait ArbObsSummary {
         constraints   <- arbitrary[ConstraintsSummary]
         status        <- arbitrary[ObsStatus]
         activeStatus  <- arbitrary[ObsActiveStatus]
-        duration      <- arbitrary[Duration]
+        executionTime      <- arbitrary[TimeSpan]
         configuration <- arbitrary[Option[BasicConfiguration]]
         vizTime       <- arbitrary[Option[Instant]]
       } yield ObsSummaryWithTitleConstraintsAndConf(
@@ -119,7 +122,7 @@ trait ArbObsSummary {
         constraints,
         status,
         activeStatus,
-        duration,
+        executionTime,
         configuration,
         vizTime
       )
@@ -134,7 +137,7 @@ trait ArbObsSummary {
        ConstraintsSummary,
        ObsStatus,
        ObsActiveStatus,
-       Duration,
+       TimeSpan,
        Option[BasicConfiguration]
       )
     ]
@@ -145,7 +148,7 @@ trait ArbObsSummary {
          o.constraints,
          o.status,
          o.activeStatus,
-         o.duration,
+         o.executionTime,
          o.configuration
         )
       )
@@ -158,7 +161,7 @@ trait ArbObsSummary {
         subtitle      <- arbitrary[Option[NonEmptyString]]
         status        <- arbitrary[ObsStatus]
         activeStatus  <- arbitrary[ObsActiveStatus]
-        duration      <- arbitrary[Duration]
+        executionTime      <- arbitrary[TimeSpan]
         configuration <- arbitrary[Option[BasicConfiguration]]
       } yield ObsSummaryWithTitleAndConf(
         id,
@@ -166,7 +169,7 @@ trait ArbObsSummary {
         subtitle,
         status,
         activeStatus,
-        duration,
+        executionTime,
         configuration
       )
     }
@@ -178,7 +181,7 @@ trait ArbObsSummary {
        Option[String],
        ObsStatus,
        ObsActiveStatus,
-       Duration,
+       TimeSpan,
        Option[BasicConfiguration]
       )
     ]
@@ -188,7 +191,7 @@ trait ArbObsSummary {
          o.subtitle.map(_.value),
          o.status,
          o.activeStatus,
-         o.duration,
+         o.executionTime,
          o.configuration
         )
       )
@@ -200,7 +203,7 @@ trait ArbObsSummary {
         constraints   <- arbitrary[ConstraintsSummary]
         status        <- arbitrary[ObsStatus]
         activeStatus  <- arbitrary[ObsActiveStatus]
-        duration      <- arbitrary[Duration]
+        executionTime      <- arbitrary[TimeSpan]
         targets       <- arbitrary[Set[Target.Id]]
         configuration <- arbitrary[Option[BasicConfiguration]]
         vizTime       <- arbitrary[Option[Instant]]
@@ -211,7 +214,7 @@ trait ArbObsSummary {
         constraints,
         status,
         activeStatus,
-        duration,
+        executionTime,
         targets,
         configuration,
         vizTime,
@@ -226,7 +229,7 @@ trait ArbObsSummary {
        ConstraintsSummary,
        ObsStatus,
        ObsActiveStatus,
-       Duration,
+       TimeSpan,
        Option[BasicConfiguration],
        List[Target.Id],
        Option[Instant],
@@ -239,7 +242,7 @@ trait ArbObsSummary {
          o.constraints,
          o.status,
          o.activeStatus,
-         o.duration,
+         o.executionTime,
          o.configuration,
          o.scienceTargetIds.toList,
          o.visualizationTime,

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -15,19 +15,19 @@ import lucuma.core.math.Wavelength
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
+import lucuma.core.util.TimeSpan
 import lucuma.schemas.model.BasicConfiguration
 import lucuma.schemas.model.ConstraintsSummary
 import monocle.Focus
 import org.typelevel.cats.time.*
 
-import java.time.Duration
 import java.time.Instant
 
 trait ObsSummary {
   val id: Observation.Id
   val status: ObsStatus
   val activeStatus: ObsActiveStatus
-  val duration: Duration
+  val executionTime: TimeSpan
 }
 
 object ObsSummary {
@@ -71,12 +71,12 @@ trait ObsWithTitle extends ObsSummary {
 }
 
 case class ObsSummaryWithConstraints(
-  override val id:           Observation.Id,
-  override val constraints:  ConstraintsSummary,
-  override val status:       ObsStatus,
-  override val activeStatus: ObsActiveStatus,
-  override val duration:     Duration,
-  scienceTargetIds:          Set[Target.Id]
+  override val id:            Observation.Id,
+  override val constraints:   ConstraintsSummary,
+  override val status:        ObsStatus,
+  override val activeStatus:  ObsActiveStatus,
+  override val executionTime: TimeSpan,
+  scienceTargetIds:           Set[Target.Id]
 ) extends ObsSummary
     with ObsWithConstraints
     derives Eq
@@ -86,13 +86,13 @@ object ObsSummaryWithConstraints {
 }
 
 case class ObsSummaryWithTitleAndConstraints(
-  override val id:           Observation.Id,
-  override val title:        String,
-  override val subtitle:     Option[NonEmptyString],
-  override val constraints:  ConstraintsSummary,
-  override val status:       ObsStatus,
-  override val activeStatus: ObsActiveStatus,
-  override val duration:     Duration
+  override val id:            Observation.Id,
+  override val title:         String,
+  override val subtitle:      Option[NonEmptyString],
+  override val constraints:   ConstraintsSummary,
+  override val status:        ObsStatus,
+  override val activeStatus:  ObsActiveStatus,
+  override val executionTime: TimeSpan
 ) extends ObsSummary
     with ObsWithTitle
     with ObsWithConstraints
@@ -105,7 +105,7 @@ case class ObsSummaryWithTitleAndConstraints(
       constraints,
       status,
       activeStatus,
-      duration,
+      executionTime,
       none,
       none
     )
@@ -116,7 +116,7 @@ case class ObsSummaryWithTitleAndConstraints(
       constraints,
       status,
       activeStatus,
-      duration,
+      executionTime,
       targetIds,
       none,
       none,
@@ -140,7 +140,7 @@ case class ObsSummaryWithTitleConstraintsAndConf(
   override val constraints:       ConstraintsSummary,
   override val status:            ObsStatus,
   override val activeStatus:      ObsActiveStatus,
-  override val duration:          Duration,
+  override val executionTime:     TimeSpan,
   override val configuration:     Option[BasicConfiguration],
   override val visualizationTime: Option[Instant]
 ) extends ObsSummary
@@ -163,7 +163,7 @@ case class ObsSummaryWithTitleAndConf(
   override val subtitle:      Option[NonEmptyString],
   override val status:        ObsStatus,
   override val activeStatus:  ObsActiveStatus,
-  override val duration:      Duration,
+  override val executionTime: TimeSpan,
   override val configuration: Option[BasicConfiguration]
 ) extends ObsSummary
     with ObsWithTitle
@@ -179,7 +179,7 @@ case class ObsSummaryWithConstraintsAndConf(
   override val constraints:       ConstraintsSummary,
   override val status:            ObsStatus,
   override val activeStatus:      ObsActiveStatus,
-  override val duration:          Duration,
+  override val executionTime:     TimeSpan,
   scienceTargetIds:               Set[Target.Id],
   override val configuration:     Option[BasicConfiguration],
   override val visualizationTime: Option[Instant],

--- a/model/shared/src/main/scala/explore/model/enums/TableIds.scala
+++ b/model/shared/src/main/scala/explore/model/enums/TableIds.scala
@@ -9,7 +9,8 @@ import lucuma.core.util.Enumerated
  * Enum to give an id to each table
  */
 enum TableId(val tag: String) derives Enumerated:
-  case ConstraintsSummary extends TableId("constraints_summary")
-  case TargetsSummary     extends TableId("targets_summary")
-  case AsterismTargets    extends TableId("asterism_targets")
-  case SpectroscopyModes  extends TableId("spectroscopy_modes")
+  case ObservationsSummary extends TableId("observations_summary")
+  case ConstraintsSummary  extends TableId("constraints_summary")
+  case TargetsSummary      extends TableId("targets_summary")
+  case AsterismTargets     extends TableId("asterism_targets")
+  case SpectroscopyModes   extends TableId("spectroscopy_modes")

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -9,6 +9,7 @@ import lucuma.core.enums.Site
 import lucuma.core.math.Angle
 import lucuma.core.math.Declination
 import lucuma.core.model.PosAngleConstraint
+import lucuma.core.util.TimeSpan
 
 import scala.collection.immutable.SortedMap
 
@@ -41,3 +42,10 @@ object all:
         case d if d < -40.0 => site === Site.GS
         case d if d > 30.0  => site === Site.GN
         case _              => true
+
+  extension (timespan: TimeSpan)
+    /**
+     * Format a timespan in the format `${hh}hrs ${mm}mins`
+     */
+    def toHoursMinutes: String =
+      s"${timespan.toHours.toLong}hrs ${(timespan.toMinutes.toLong) % 60}mins"


### PR DESCRIPTION
Adds the observation summary table view when not selecting an observation.

There's still some work to be done for the table:

- Some columns are not supported yet, this will have to be picked up later when the fields are added
- Some target-specific columns are not added yet as grouping should be done for those
- Elevation view