### PR TITLE
Fix missing magnitudes in case of more columns

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -388,6 +388,8 @@ object ExploreStyles:
   val TargetSummarySubRowCell: Css = Css("explore-target-summary-subrow-cell")
   val ConstraintsSummaryEdit: Css  = Css("explore-constraints-summary-edit")
 
+  val CursorPointer: Css = Css("explore-cursor-pointer")
+
   object Dialog: // SUI has Mini, Tiny, Small, Large and Fullscreen.
     val Small: Css = Css("pl-dialog-small")
     val Large: Css = Css("pl-dialog-large")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -376,6 +376,7 @@ a:hover {
   grid-column: 1 / -1;
   justify-self: stretch;
   align-self: stretch;
+  grid-row-start: 5;
 
   .p-panel.p-panel-toggleable {
     height: 100%;
@@ -558,15 +559,15 @@ a:hover {
 
 .pl-form-column.target-source-profile-editor {
   align-self: stretch;
-  grid-template-rows: repeat(2, auto) 1fr;
+  grid-template-rows: repeat(3, auto) 1fr;
 
   &.with-gaussian,
   &.with-catalog-info {
-    grid-template-rows: repeat(3, auto) 1fr;
+    grid-template-rows: repeat(4, auto) 1fr;
   }
 
   &.with-gaussian.with-catalog-info {
-    grid-template-rows: repeat(4, auto) 1fr;
+    grid-template-rows: repeat(5, auto) 1fr;
   }
 }
 
@@ -1467,6 +1468,10 @@ img.partner-split-flag {
   & .selected-down {
     bottom: 2em;
   }
+}
+
+.explore-cursor-pointer {
+  cursor: pointer;
 }
 
 .explore-border-table,

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -126,12 +126,6 @@ object ObsSummaryTable extends TableHooks:
           : ColumnDef.Single[ObsSummaryWithTitleConstraintsAndConf, V] =
           ColDef(id, accessor, columnNames(id))
 
-        def obsUrl(obsId: Observation.Id): String =
-          ctx.pageUrl(AppTab.Observations, props.programId, Focused.singleObs(obsId))
-
-        def goToObs(obsId: Observation.Id): Callback =
-          ctx.pushPage(AppTab.Observations, props.programId, Focused.singleObs(obsId))
-
         def constraintUrl(constraintId: Observation.Id): String =
           ctx.pageUrl(AppTab.Constraints, props.programId, Focused.singleObs(constraintId))
 
@@ -140,14 +134,7 @@ object ObsSummaryTable extends TableHooks:
 
         List(
           // TODO: GroupsColumnId
-          column(ObservationIdColumnId, _.id)
-            .setCell(cell =>
-              <.a(^.href := obsUrl(cell.value),
-                  ^.onClick ==> (_.preventDefaultCB *> goToObs(cell.value)),
-                  cell.value.toString
-              )
-            )
-            .sortable,
+          column(ObservationIdColumnId, _.id).sortable,
 
           // TODO: ValidationCheckColumnId
           column(StatusColumnId, _.status),
@@ -190,7 +177,9 @@ object ObsSummaryTable extends TableHooks:
         TableStore(props.userId, TableId.ObservationsSummary, cols)
       )
     )
-    .render { (props, _, _, _, table) =>
+    .render { (props, ctx, _, _, table) =>
+      import ctx.given
+
       <.div(
         props.renderInTitle(
           React.Fragment(
@@ -203,6 +192,19 @@ object ObsSummaryTable extends TableHooks:
         PrimeTable(
           table,
           striped = true,
+          rowMod = row =>
+            TagMod(
+              ExploreStyles.CursorPointer,
+              ExploreStyles.TableRowSelected.when(row.getIsSelected()),
+              ^.role := "link",
+              ^.onClick ==> { (e: ReactMouseEvent) =>
+                e.preventDefaultCB *> ctx.pushPage(
+                  AppTab.Observations,
+                  props.programId,
+                  Focused.singleObs(Observation.Id.parse(row.id).get)
+                )
+              }
+            ),
           compact = Compact.Very,
           tableMod = ExploreStyles.ExploreTable,
           headerCellMod = _ => ExploreStyles.StickyHeader


### PR DESCRIPTION
In #2788, the table height was fixed only if a certain amount of rows are in the grid. With this change, the table is always the 'last' row, so it is always shown. I tried making the row height dynamic, but it didn't work out. I think this is a good compromise.
