### PR TITLE
Improvements when inserting new target

### DIFF
--- a/common/src/main/scala/explore/common/TargetQueries.scala
+++ b/common/src/main/scala/explore/common/TargetQueries.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.common
+
+import queries.common.TargetQueriesGQL
+import lucuma.core.model.Target
+import cats.effect.IO
+import lucuma.core.model.Program
+import lucuma.schemas.odb.input.*
+import explore.DefaultErrorPolicy
+import clue.FetchClient
+import lucuma.schemas.ObservationDB
+import explore.model.AppContext
+import explore.utils.*
+import cats.effect.Sync
+import cats.syntax.all.*
+
+object TargetQueries:
+  def insertTarget[F[_]: Sync](
+    programId: Program.Id,
+    target:    Target.Sidereal,
+    toastRef:  ToastRefF[F]
+  )(using
+    FetchClient[F, ?, ObservationDB]
+  ): F[Target.Id] =
+    TargetQueriesGQL
+      .CreateTargetMutation[F]
+      .execute(target.toCreateTargetInput(programId))
+      .map(_.createTarget.target.id)
+      .flatTap(id => toastRef.showToast(s"Created new target [$id]"))

--- a/common/src/main/scala/explore/common/TargetQueries.scala
+++ b/common/src/main/scala/explore/common/TargetQueries.scala
@@ -3,29 +3,29 @@
 
 package explore.common
 
-import queries.common.TargetQueriesGQL
-import lucuma.core.model.Target
 import cats.effect.IO
-import lucuma.core.model.Program
-import lucuma.schemas.odb.input.*
-import explore.DefaultErrorPolicy
+import cats.effect.Sync
+import cats.syntax.all.given
 import clue.FetchClient
-import lucuma.schemas.ObservationDB
+import explore.DefaultErrorPolicy
 import explore.model.AppContext
 import explore.utils.*
-import cats.effect.Sync
-import cats.syntax.all.*
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.odb.input.*
+import queries.common.TargetQueriesGQL
 
 object TargetQueries:
   def insertTarget[F[_]: Sync](
     programId: Program.Id,
-    target:    Target.Sidereal,
-    toastRef:  ToastRefF[F]
+    target:    Target.Sidereal
   )(using
-    FetchClient[F, ?, ObservationDB]
+    FetchClient[F, ?, ObservationDB],
+    ToastCtx[F]
   ): F[Target.Id] =
     TargetQueriesGQL
       .CreateTargetMutation[F]
       .execute(target.toCreateTargetInput(programId))
       .map(_.createTarget.target.id)
-      .flatTap(id => toastRef.showToast(s"Created new target [$id]"))
+      .flatTap(id => ToastCtx[F].showToast(s"Created new target [$id]"))

--- a/common/src/main/scala/explore/model/AppContext.scala
+++ b/common/src/main/scala/explore/model/AppContext.scala
@@ -16,6 +16,7 @@ import explore.events.*
 import explore.model.enums.AppTab
 import explore.model.enums.ExecutionEnvironment
 import explore.utils
+import explore.utils.ToastCtx
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.feature.Context
@@ -41,7 +42,7 @@ case class AppContext[F[_]](
   broadcastChannel: BroadcastChannel[ExploreEvent],
   toastRef:         Deferred[F, ToastRef]
 )(using
-  val F:            Applicative[F],
+  val F:            Sync[F],
   val logger:       Logger[F],
   val P:            Parallel[F]
 ):
@@ -60,6 +61,8 @@ case class AppContext[F[_]](
   given catalogWorker: WorkerClient[F, CatalogMessage.Request] = workerClients.catalog
   given agsWorker: WorkerClient[F, AgsMessage.Request]         = workerClients.ags
   given plotWorker: WorkerClient[F, PlotMessage.Request]       = workerClients.plot
+
+  given ToastCtx[F] = new ToastCtx(toastRef)
 
   export explore.DefaultErrorPolicy
 

--- a/common/src/main/scala/explore/utils/ToastCtx.scala
+++ b/common/src/main/scala/explore/utils/ToastCtx.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.utils
+
+import cats.Applicative
+import cats.effect.Deferred
+import cats.effect.Sync
+import cats.syntax.all.given
+import crystal.react.implicits.*
+import react.primereact.Message
+import react.primereact.ToastRef
+
+class ToastCtx[F[_]: Sync](toastRef: Deferred[F, ToastRef]):
+  def showToast(text: String, severity: Message.Severity = Message.Severity.Info): F[Unit] =
+    toastRef.tryGet.flatMap(_.map(_.show(text, severity).to[F]).getOrElse(Applicative[F].unit))
+
+  def clear(): F[Unit] =
+    toastRef.tryGet.flatMap(_.map(_.clear().to[F]).getOrElse(Applicative[F].unit))
+
+object ToastCtx:
+  def apply[F[_]](using ToastCtx[F]): ToastCtx[F] = summon[ToastCtx[F]]

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -160,7 +160,9 @@ extension (toastRef: ToastRef)
       )
     )
 
-extension [F[_]: Sync](toastRef: Deferred[F, ToastRef])
+type ToastRefF[F[_]] = Deferred[F, ToastRef]
+
+extension [F[_]: Sync](toastRef: ToastRefF[F])
   def showToast(text: String, severity: Message.Severity = Message.Severity.Info): F[Unit] =
     toastRef.tryGet.flatMap(_.map(_.show(text, severity).to[F]).getOrElse(Applicative[F].unit))
 

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -14,6 +14,7 @@ import crystal.react.implicits.*
 import explore.DefaultErrorPolicy
 import explore.Icons
 import explore.common.AsterismQueries.*
+import explore.common.TargetQueries
 import explore.components.ui.ExploreStyles
 import explore.components.undo.UndoButtons
 import explore.model.AppContext
@@ -141,15 +142,12 @@ object AsterismGroupObsList:
     undoCtx:               UndoContext[AsterismGroupsWithObs],
     adding:                View[AddingTargetOrObs],
     selectTargetOrSummary: Option[Target.Id] => Callback,
-    toastRef:              Deferred[IO, ToastRef]
+    toastRef:              ToastRefF[IO]
   )(using FetchClient[IO, ?, ObservationDB], Logger[IO]): IO[Unit] =
     adding.async.set(AddingTargetOrObs(true)) >>
-      TargetQueriesGQL
-        .CreateTargetMutation[IO]
-        .execute(EmptySiderealTarget.toCreateTargetInput(programId))
-        .flatMap { data =>
-          val targetId = data.createTarget.target.id
-
+      TargetQueries
+        .insertTarget(programId, EmptySiderealTarget, toastRef)
+        .flatMap { targetId =>
           TargetAddDeleteActions
             .insertTarget(
               targetId,
@@ -171,7 +169,7 @@ object AsterismGroupObsList:
     adding:             View[AddingTargetOrObs],
     expandedIds:        View[SortedSet[ObsIdSet]],
     selectObsOrSummary: Option[Observation.Id] => Callback,
-    toastRef:           Deferred[IO, ToastRef]
+    toastRef:           ToastRefF[IO]
   )(using FetchClient[IO, ?, ObservationDB], Logger[IO]): IO[Unit] =
     adding.async.set(AddingTargetOrObs(true)) >>
       ObsQueries

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -161,9 +161,10 @@ object ObsList:
                       .set(undoCtx) _).compose((_: ObsActiveStatus).some).some,
                     setSubtitleCB = (obsEditSubtitle(props.programId, obs.id)
                       .set(undoCtx) _).compose((_: Option[NonEmptyString]).some).some,
-                    deleteCB = obsExistence(props.programId,
-                                            obs.id,
-                                            o => setObs(props.programId, o.some, ctx)
+                    deleteCB = obsExistence(
+                      props.programId,
+                      obs.id,
+                      o => setObs(props.programId, o.some, ctx)
                     )
                       .mod(undoCtx)(obsListMod.delete)
                       .showToastCB(ctx)(s"Deleted obs ${obs.id.show}")
@@ -177,7 +178,7 @@ object ObsList:
                       adding.async.set(true),
                       adding.async.set(false)
                     )
-                      .withToast(ctx)(s"Duplicating obs ${obs.id}")
+                      .withToast(s"Duplicating obs ${obs.id}")
                       .runAsync
                       .some
                   )

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -302,7 +302,7 @@ object ObsTabContents extends TwoPanels:
               .map(id =>
                 ExploreClipboard
                   .set(LocalClipboard.CopiedObservations(ObsIdSet.one(id)))
-                  .withToast(ctx)(s"Copied obs $id")
+                  .withToast(s"Copied obs $id")
               )
               .orUnit
               .runAsync
@@ -326,7 +326,7 @@ object ObsTabContents extends TwoPanels:
                       )
                     )
                     .void
-                    .withToast(ctx)(s"Duplicating obs ${idSet.idSet.mkString_(", ")}")
+                    .withToast(s"Duplicating obs ${idSet.idSet.mkString_(", ")}")
                 }.orUnit
               case _                                        => IO.unit
             }.runAsync

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -687,7 +687,7 @@ object TargetTabContents extends TwoPanels:
               .map(ids =>
                 ExploreClipboard
                   .set(LocalClipboard.CopiedObservations(ids))
-                  .withToast(ctx)(s"Copied obs ${ids.idSet.toList.mkString(", ")}")
+                  .withToast(s"Copied obs ${ids.idSet.toList.mkString(", ")}")
               )
               .orElse(
                 TargetIdSet
@@ -695,7 +695,7 @@ object TargetTabContents extends TwoPanels:
                   .map(tids =>
                     ExploreClipboard
                       .set(LocalClipboard.CopiedTargets(tids))
-                      .withToast(ctx)(s"Copied targets ${tids.toList.mkString(", ")}")
+                      .withToast(s"Copied targets ${tids.toList.mkString(", ")}")
                   )
               )
               .orUnit
@@ -721,7 +721,7 @@ object TargetTabContents extends TwoPanels:
                         ctx,
                         props.listUndoStacks,
                         props.expandedIds
-                      ).withToast(ctx)(s"Pasting obs ${id.idSet.toList.mkString(", ")}")
+                      ).withToast(s"Pasting obs ${id.idSet.toList.mkString(", ")}")
                     )
                     .orEmpty
                 else IO.unit

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -671,6 +671,9 @@ object TargetTabContents extends TwoPanels:
       }
       // Selected targets on the summary table
       .useStateViewBy((props, _, _, _, _, _, _) => props.focused.target.toList)
+      .useEffectWithDepsBy((props, _, _, _, _, _, _, _) => props.focused.target)(
+        (_, _, _, _, _, _, _, selIds) => _.foldMap(focusedTarget => selIds.set(List(focusedTarget)))
+      )
       .useGlobalHotkeysWithDepsBy((props, ctx, _, _, _, _, asterismGroupWithObs, selIds) =>
         (props.focused, asterismGroupWithObs.toOption.map(_.get.asterismGroups), selIds.get)
       ) { (props, ctx, _, _, _, _, poagwov, _) => (target, asterismGroups, selectedIds) =>

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -169,8 +169,7 @@ object AsterismEditor extends AsterismModifier:
                     props.programId,
                     props.sharedInObsIds,
                     props.asterism,
-                    targetWithOptId,
-                    ctx.toastRef
+                    targetWithOptId
                   ).flatMap(oTargetId => targetView.async.set(oTargetId))
                     .guarantee(adding.async.set(AreAdding(false)))).runAsync
             )

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -169,7 +169,8 @@ object AsterismEditor extends AsterismModifier:
                     props.programId,
                     props.sharedInObsIds,
                     props.asterism,
-                    targetWithOptId
+                    targetWithOptId,
+                    ctx.toastRef
                   ).flatMap(oTargetId => targetView.async.set(oTargetId))
                     .guarantee(adding.async.set(AreAdding(false)))).runAsync
             )

--- a/explore/src/main/scala/explore/targeteditor/AsterismModifier.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismModifier.scala
@@ -9,10 +9,11 @@ import clue.FetchClient
 import crystal.react.View
 import crystal.react.implicits.*
 import explore.DefaultErrorPolicy
-import explore.common.TargetQueries
 import explore.common.AsterismQueries
+import explore.common.TargetQueries
 import explore.model.Asterism
 import explore.model.ObsIdSet
+import explore.utils.ToastCtx
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.schemas.ObservationDB
@@ -20,20 +21,18 @@ import lucuma.schemas.model.TargetWithId
 import lucuma.schemas.model.TargetWithOptId
 import lucuma.schemas.odb.input.*
 import org.typelevel.log4cats.Logger
-import explore.utils.ToastRefF
 
 trait AsterismModifier:
   protected def insertSiderealTarget(
     programId:       Program.Id,
     obsIds:          ObsIdSet,
     asterism:        View[Option[Asterism]],
-    targetWithOptId: TargetWithOptId,
-    toastRef:        ToastRefF[IO]
-  )(using FetchClient[IO, ?, ObservationDB], Logger[IO]): IO[Option[Target.Id]] =
+    targetWithOptId: TargetWithOptId
+  )(using FetchClient[IO, ?, ObservationDB], Logger[IO], ToastCtx[IO]): IO[Option[Target.Id]] =
     targetWithOptId match
       case TargetWithOptId(oTargetId, target @ Target.Sidereal(_, _, _, _)) =>
         val targetId: IO[Target.Id] = oTargetId.fold(
-          TargetQueries.insertTarget(programId, target, toastRef)
+          TargetQueries.insertTarget[IO](programId, target)
         )(IO(_))
 
         targetId

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -168,7 +168,7 @@ object SiderealTargetEditor {
             ).andThen(
               _.handleErrorWith(t =>
                 Logger[IO].error(t)(s"Error updating target [$tid]") >>
-                  ctx.toastRef.showToast(s"Error saving target [$tid]", Message.Severity.Error)
+                  ToastCtx[IO].showToast(s"Error saving target [$tid]", Message.Severity.Error)
               )
             )
 

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -228,7 +228,7 @@ object TargetSummaryTable extends TableHooks:
                     selectedRowsIds,
                     props.programId,
                     props.selectTargetOrSummary(none).to[IO],
-                    ctx.toastRef.showToast(_)
+                    ToastCtx[IO].showToast(_)
                   )
                   .set(props.undoCtx)(selectedRowsIds.map(_ => none[TargetWithObs]))
                   .to[IO]

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -54,6 +54,7 @@ import react.primereact.ConfirmDialog
 import react.primereact.DialogPosition
 import react.primereact.PrimeStyles
 import react.primereact.ToastRef
+import lucuma.typed.{tanstackVirtualCore => rawVirtual}
 
 import scala.collection.immutable.SortedSet
 
@@ -91,11 +92,17 @@ object TargetSummaryTable extends TableHooks:
     TargetColumns.NameColumnId -> (ExploreStyles.StickyColumn |+| ExploreStyles.TargetSummaryName |+| ExploreStyles.WithId)
   )
 
-  private val colNames: Map[ColumnId, String] = TargetColumns.allColNames ++ Map(
+  private val ColNames: Map[ColumnId, String] = TargetColumns.allColNames ++ Map(
     IdColumnId           -> "Id",
     CountColumnId        -> "Count",
     ObservationsColumnId -> "Observations"
   )
+
+  private val ScrollOptions =
+    rawVirtual.mod
+      .ScrollToOptions()
+      .setBehavior(rawVirtual.mod.ScrollBehavior.smooth)
+      .setAlign(rawVirtual.mod.ScrollAlignment.center)
 
   protected val component =
     ScalaFnComponent
@@ -104,7 +111,7 @@ object TargetSummaryTable extends TableHooks:
       // cols
       .useMemoBy((_, _) => ()) { (props, ctx) => _ =>
         def column[V](id: ColumnId, accessor: TargetWithIdAndObs => V) =
-          ColDef(id, row => accessor(row), colNames(id))
+          ColDef(id, row => accessor(row), ColNames(id))
 
         def obsUrl(targetId: Target.Id, obsId: Observation.Id): String =
           ctx.pageUrl(AppTab.Targets, props.programId, Focused.singleObs(obsId, targetId.some))
@@ -207,7 +214,22 @@ object TargetSummaryTable extends TableHooks:
               )
               .getOrElse(ctx.pushPage(AppTab.Targets, props.programId, Focused.None))
       )
-      .render((props, ctx, _, _, table, filesToImport, deletingTargets) =>
+      .useRef(none[HTMLTableVirtualizer])
+      .useEffectWithDepsBy((props, _, _, _, _, _, _, _) => props.selectedTargetIds.get.headOption)(
+        (_, _, _, _, table, _, _, virtualizerRef) =>
+          _.foldMap(selectedHead =>
+            virtualizerRef.get.flatMap(refOpt =>
+              val selectedIdStr = selectedHead.toString
+              Callback(
+                for
+                  virtualizer <- refOpt
+                  idx          = table.getRowModel().flatRows.indexWhere(_.id === selectedIdStr)
+                yield virtualizer.scrollToIndex(idx + 1, ScrollOptions)
+              )
+            )
+          )
+      )
+      .render((props, ctx, _, _, table, filesToImport, deletingTargets, virtualizerRef) =>
         import ctx.given
 
         val selectedRows    = table.getSelectedRowModel().rows.toList
@@ -282,11 +304,7 @@ object TargetSummaryTable extends TableHooks:
                 ConfirmDialog()
               ),
               <.span(ExploreStyles.TitleSelectColumns)(
-                ColumnSelector(
-                  table,
-                  colNames,
-                  ExploreStyles.SelectColumns
-                )
+                ColumnSelector(table, ColNames, ExploreStyles.SelectColumns)
               )
             )
           ),
@@ -345,6 +363,7 @@ object TargetSummaryTable extends TableHooks:
                 }
               ),
             cellMod = cell => columnClasses.get(ColumnId(cell.column.id)).orEmpty,
+            virtualizerRef = virtualizerRef,
             emptyMessage = <.div("No targets present")
             // workaround to redraw when files are imported
           ).withKey(s"summary-table-${filesToImport.get.size}")

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -39,6 +39,7 @@ import lucuma.react.syntax.*
 import lucuma.react.table.*
 import lucuma.refined.*
 import lucuma.typed.{tanstackTableCore => raw}
+import lucuma.typed.{tanstackVirtualCore => rawVirtual}
 import lucuma.ui.primereact.*
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.*
@@ -54,7 +55,6 @@ import react.primereact.ConfirmDialog
 import react.primereact.DialogPosition
 import react.primereact.PrimeStyles
 import react.primereact.ToastRef
-import lucuma.typed.{tanstackVirtualCore => rawVirtual}
 
 import scala.collection.immutable.SortedSet
 


### PR DESCRIPTION
- Show a toast notifying the new target was created.
- If the target summary table was in view, scroll it to the new target (This also has the effect of scrolling a manually selected target to the center of the view, which seems unnecessary, but seems like it would be a bit of work to avoid it).
- Introduce a `ToastCtx[F[_]]` typeclass, which makes it easier to invoke toasts by passing it implicitly.