### PR TITLE
Fix target column anchor

### DIFF
--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -198,10 +198,8 @@ object ObsSummaryTable extends TableHooks:
         column(TargetTypeColumnId, _ => ())
           .setCell(_ => Icons.Star.withFixedWidth())
           .setSize(35.toPx),
-        column[String | TagOf[Anchor]](TargetColumnId,
-                                       _.obs.title,
-                                       r => targetUrl(r.obsId, r.targetWithId)
-        ),
+        column(TargetColumnId, r => <.span(r.obs.title), r => targetUrl(r.obsId, r.targetWithId))
+          .setCell(_.value),
         column(
           RAColumnId,
           r =>


### PR DESCRIPTION
I made a small mistake in #2813 

Before:

<img width="542" alt="image" src="https://user-images.githubusercontent.com/10114577/227576732-aab6ee6a-8caf-43ef-9d5e-61a7de200f4c.png">


After:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/10114577/227576461-8c745b06-9e0d-4ddb-b4f7-750ad4546947.png">
