### PR TITLE
Timing windows exclude, refactor of potRender

### DIFF
--- a/common-graphql/src/main/resources/graphql/schemas/UserPreferencesDB.graphql
+++ b/common-graphql/src/main/resources/graphql/schemas/UserPreferencesDB.graphql
@@ -2698,6 +2698,7 @@ type TmpTimingWindows {
   closeOn: timestamptz
   forever: Boolean
   id: Int!
+  include: Boolean!
   remainOpenFor: Int
   repeatForever: Boolean
   repeatPeriod: Int
@@ -2748,6 +2749,7 @@ input TmpTimingWindowsBoolExp {
   closeOn: TimestamptzComparisonExp
   forever: BooleanComparisonExp
   id: IntComparisonExp
+  include: BooleanComparisonExp
   remainOpenFor: IntComparisonExp
   repeatForever: BooleanComparisonExp
   repeatPeriod: IntComparisonExp
@@ -2782,6 +2784,7 @@ input TmpTimingWindowsInsertInput {
   closeOn: timestamptz
   forever: Boolean
   id: Int
+  include: Boolean
   remainOpenFor: Int
   repeatForever: Boolean
   repeatPeriod: Int
@@ -2834,6 +2837,7 @@ input TmpTimingWindowsOrderBy {
   closeOn: OrderBy
   forever: OrderBy
   id: OrderBy
+  include: OrderBy
   remainOpenFor: OrderBy
   repeatForever: OrderBy
   repeatPeriod: OrderBy
@@ -2860,6 +2864,9 @@ enum TmpTimingWindowsSelectColumn {
   id
 
   """column name"""
+  include
+
+  """column name"""
   remainOpenFor
 
   """column name"""
@@ -2882,6 +2889,7 @@ input TmpTimingWindowsSetInput {
   closeOn: timestamptz
   forever: Boolean
   id: Int
+  include: Boolean
   remainOpenFor: Int
   repeatForever: Boolean
   repeatPeriod: Int
@@ -2933,6 +2941,9 @@ enum TmpTimingWindowsUpdateColumn {
 
   """column name"""
   id
+
+  """column name"""
+  include
 
   """column name"""
   remainOpenFor
@@ -5746,6 +5757,7 @@ input tmpTimingWindows_streamCursorValueInput {
   closeOn: timestamptz
   forever: Boolean
   id: Int
+  include: Boolean
   remainOpenFor: Int
   repeatForever: Boolean
   repeatPeriod: Int

--- a/common-graphql/src/main/scala/queries/common/TimingWindowsGQL.scala
+++ b/common-graphql/src/main/scala/queries/common/TimingWindowsGQL.scala
@@ -20,8 +20,9 @@ object TimingWindowsGQL:
   @GraphQL
   trait TimingWindowsQuery extends GraphQLOperation[UserPreferencesDB] {
     val document = """
-      query queryTimingWindwons {
+      query {
         tmpTimingWindows(orderBy: {id: ASC}) {
+          include
           startsOn
           repeatPeriod
           repeatForever

--- a/common/src/main/public/development.conf.json
+++ b/common/src/main/public/development.conf.json
@@ -1,7 +1,7 @@
 {
   "environment": "DEVELOPMENT",
   "odbURI": "wss://lucuma-postgres-odb-staging.herokuapp.com/ws",
-  "preferencesDBURI": "wss://user-prefs-master.herokuapp.com/v1/graphql",
+  "preferencesDBURI": "wss://user-prefs-development.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-development.herokuapp.com/itc",
   "sso": {
     "uri": "https://sso.gpp.lucuma.xyz",

--- a/common/src/main/public/development.conf.json
+++ b/common/src/main/public/development.conf.json
@@ -1,7 +1,7 @@
 {
   "environment": "DEVELOPMENT",
   "odbURI": "wss://lucuma-postgres-odb-staging.herokuapp.com/ws",
-  "preferencesDBURI": "wss://user-prefs-development.herokuapp.com/v1/graphql",
+  "preferencesDBURI": "wss://user-prefs-master.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-development.herokuapp.com/itc",
   "sso": {
     "uri": "https://sso.gpp.lucuma.xyz",

--- a/common/src/main/scala/explore/common/TimingWindowQueries.scala
+++ b/common/src/main/scala/explore/common/TimingWindowQueries.scala
@@ -40,8 +40,9 @@ object TimingWindowQueries:
       .execute(
         twe.id.assign,
         TmpTimingWindowsSetInput(
+          include = twe.include.assign,
           startsOn = twe.startsOn.assign,
-          forever = tw.openForever.assign,
+          forever = tw.forever.assign,
           closeOn = twe.closeOn.orUnassign,
           remainOpenFor = twe.remainOpenFor.orUnassign,
           repeatPeriod = twe.repeatPeriod.orUnassign,

--- a/common/src/main/scala/explore/components/UserSelectionForm.scala
+++ b/common/src/main/scala/explore/components/UserSelectionForm.scala
@@ -77,7 +77,7 @@ object UserSelectionForm:
           showHeader = false,
           clazz = ExploreStyles.Dialog.Small
         )(
-          browserInfoPot.render(browserInfo =>
+          browserInfoPot.renderPot(browserInfo =>
             React.Fragment(
               <.div(
                 ExploreStyles.LoginBoxLayout,

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -33,8 +33,6 @@ object ExploreStyles:
   val TileSMH: Css            = Css("tile-sm-height")
   val TileMDH: Css            = Css("tile-md-height")
 
-  val Loader: Css = Css("explore-loader")
-
   val Accented: Css   = Css("explore-accented")
   val TextPlain: Css  = Css("explore-text-plain")
   val TextNoWrap: Css = Css("explore-text-nowrap")
@@ -468,10 +466,17 @@ object ExploreStyles:
   val TimingWindowsList: Css                    = Css("timing-windows-list")
   val TimingWindowsTable: Css                   = Css("timing-windows-table")
   val TimingWindowEditor: Css                   = Css("timing-window-editor")
+  val TimingWindowEditorHeader: Css             = Css("timing-window-editor-header")
+  val TimingWindowTypeEditor: Css               = Css("timing-window-type-editor")
+  val TimingWindowFromEditor: Css               = Css("timing-window-from-editor")
+  val TimingWindowEditorBody: Css               = Css("timing-window-editor-body")
   val TimingWindowRemainOpen: Css               = Css("timing-window-remain-open")
   val TimingWindowRepeatEditor: Css             = Css("timing-window-repeat-editor")
   val TimingWindowRepeatEditorAlternatives: Css = Css("timing-window-repeat-editor-alternatives")
   val TimingWindowRepeatEditorNTimes: Css       = Css("timing-window-repeat-editor-n-times")
   val TimingWindowsHeader: Css                  = Css("timing-windows-header")
+  val TimingWindowsType: Css                    = Css("timing-windows-type")
+  val TimingWindowInclude: Css                  = Css("timing-window-include")
+  val TimingWindowExclude: Css                  = Css("timing-window-exclude")
 
   val SingleTileMaximized: Css = Css("explore-single-tile-maximized")

--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -11,6 +11,7 @@ import explore.model.Constants
 import explore.utils.*
 import japgolly.scalajs.react.callback.Callback
 import japgolly.scalajs.react.util.Effect
+import japgolly.scalajs.react.vdom.VdomNode
 import org.scalablytyped.runtime.StringDictionary
 import org.scalajs.dom.Window
 import org.typelevel.log4cats.Logger

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -79,42 +79,6 @@ def version(environment: ExecutionEnvironment): NonEmptyString = {
   )
 }
 
-// TODO All the "potRender" methods should go in lucuma-ui
-val DefaultPendingRender: VdomNode = ProgressSpinner(clazz = ExploreStyles.Loader)
-
-val DefaultErrorRender: Throwable => VdomNode =
-  t => Message(text = t.getMessage, severity = Message.Severity.Error)
-
-def potRender[A](
-  valueRender:   A => VdomNode,
-  pendingRender: => VdomNode = DefaultPendingRender,
-  errorRender:   Throwable => VdomNode = DefaultErrorRender
-): Pot[A] => VdomNode =
-  _.fold(pendingRender, errorRender, valueRender)
-
-def potRenderView[A](
-  valueRender:   A => VdomNode,
-  pendingRender: => VdomNode = DefaultPendingRender,
-  errorRender:   Throwable => VdomNode = DefaultErrorRender
-): View[Pot[A]] => VdomNode =
-  _.get.fold(pendingRender, errorRender, valueRender)
-
-final implicit class PotRenderOps[A](val pot: Pot[A]) extends AnyVal {
-  inline def render(
-    valueRender:   A => VdomNode,
-    pendingRender: => VdomNode = DefaultPendingRender,
-    errorRender:   Throwable => VdomNode = DefaultErrorRender
-  ): VdomNode = potRender(valueRender, pendingRender, errorRender)(pot)
-}
-
-final implicit class PotOptionRenderOps[A](val po: PotOption[A]) extends AnyVal {
-  inline def render(
-    valueRender:   A => VdomNode,
-    pendingRender: => VdomNode = DefaultPendingRender,
-    errorRender:   Throwable => VdomNode = DefaultErrorRender
-  ): VdomNode = po.toPot.render(valueRender, pendingRender, errorRender)
-}
-
 inline def showCount(count: Int, unit: String, plural: String): String =
   if (count == 1) s"$count $unit"
   else s"$count $plural"

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -213,18 +213,6 @@ a:hover {
   box-shadow: -0 0 2px 1px var(--warning-background-color);
 }
 
-.explore-loader {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  margin: 0;
-  text-align: center;
-  z-index: 1000;
-  width: 4rem;
-  height: 4rem;
-  font-size: 1em;
-}
-
 // -----
 // Table toolbar
 // -----
@@ -1967,6 +1955,20 @@ $help-title-height: 40px;
     @include timing-window-list;
   }
 
+  @mixin timing-window-type {
+    font-weight: bold;
+  }
+
+  .timing-window-include {
+    @include timing-window-type;
+    color: var(--green-400);
+  }
+
+  .timing-window-exclude {
+    @include timing-window-type;
+    color: var(--red-400);
+  }
+
   .timing-window-editor {
     @include react-datepicker-input;
     @include react-datepicker-wrapper;
@@ -1991,32 +1993,50 @@ $help-title-height: 40px;
       margin-bottom: 0.5em;
     }
 
-    .timing-window-repeat-editor {
-      margin-left: 1.5em;
-    }
-
-    .timing-window-remain-open,
-    .timing-window-repeat-editor,
-    .timing-window-repeat-editor-n-times {
+    .timing-window-editor-header {
       display: flex;
-      align-items: baseline;
+      align-items: center;
 
-      label {
-        margin-right: 0.5em;
+      .timing-window-type-editor {
+        display: inline-flex;
+        flex-direction: column;
       }
 
-      .pl-form-field {
-        margin-right: 0.5em;
-        width: 9ch;
+      .timing-window-from-editor {
+        margin-left: 0.5vw;
       }
     }
 
-    .timing-window-repeat-editor-alternatives {
-      display: flex;
-      flex-direction: column;
-      row-gap: 0.5em;
-      margin-top: 0.5em;
-      margin-left: 3em;
+    .timing-window-editor-body {
+      margin-left: 2vw;
+
+      .timing-window-repeat-editor {
+        margin-left: 1.5em;
+      }
+
+      .timing-window-remain-open,
+      .timing-window-repeat-editor,
+      .timing-window-repeat-editor-n-times {
+        display: flex;
+        align-items: baseline;
+
+        label {
+          margin-right: 0.5em;
+        }
+
+        .pl-form-field {
+          margin-right: 0.5em;
+          width: 9ch;
+        }
+      }
+
+      .timing-window-repeat-editor-alternatives {
+        display: flex;
+        flex-direction: column;
+        row-gap: 0.5em;
+        margin-top: 0.5em;
+        margin-left: 3em;
+      }
     }
   }
 

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1961,11 +1961,13 @@ $help-title-height: 40px;
 
   .timing-window-include {
     @include timing-window-type;
+
     color: var(--green-400);
   }
 
   .timing-window-exclude {
     @include timing-window-type;
+
     color: var(--red-400);
   }
 

--- a/explore/src/main/scala/explore/UnderConstruction.scala
+++ b/explore/src/main/scala/explore/UnderConstruction.scala
@@ -9,14 +9,12 @@ import explore.syntax.ui.*
 import explore.syntax.ui.given
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import react.fa.Flip
 import react.fa.IconSize
 import react.fa.given
 
-object UnderConstruction {
-
+object UnderConstruction:
   protected val component =
     ScalaComponent
       .builder[Unit]
@@ -26,10 +24,11 @@ object UnderConstruction {
           ExploreStyles.HVCenter,
           <.div(
             <.div("Under Construction"),
-            <.div(ExploreStyles.HVCenter,
-                  Icons.Gears
-                    .withSize(IconSize.X5)
-                    .withTitle("Under construction")
+            <.div(
+              ExploreStyles.HVCenter,
+              Icons.Gears
+                .withSize(IconSize.X5)
+                .withTitle("Under construction")
             )
           )
         )
@@ -37,5 +36,3 @@ object UnderConstruction {
       .build
 
   def apply() = component()
-
-}

--- a/explore/src/main/scala/explore/config/VizTimeEditor.scala
+++ b/explore/src/main/scala/explore/config/VizTimeEditor.scala
@@ -32,7 +32,7 @@ object VizTimeEditor {
     ScalaFnComponent[Props] { p =>
       <.div(
         ExploreStyles.ObsInstantTileTitle,
-        potRender[View[Option[Instant]]](
+        p.vizTimeView.renderPot(
           pendingRender = EmptyVdom,
           valueRender = instant =>
             React.Fragment(
@@ -51,7 +51,7 @@ object VizTimeEditor {
                 .dateFormat("yyyy-MM-dd HH:mm"),
               <.label("UTC")
             )
-        )(p.vizTimeView)
+        )
       )
     }
 

--- a/explore/src/main/scala/explore/config/sequence/GeneratedSequenceViewer.scala
+++ b/explore/src/main/scala/explore/config/sequence/GeneratedSequenceViewer.scala
@@ -51,7 +51,7 @@ object GeneratedSequenceViewer:
       .render((props, _, config) =>
         props.changed.get
           .flatMap(_ => config.toPot.flatten)
-          .render(
+          .renderPot(
             _.fold[VdomNode](<.div("Default observation not found"))(config =>
               GeneratedSequenceTables(props.obsId, config)
             )

--- a/explore/src/main/scala/explore/config/sequence/SequenceEditor.scala
+++ b/explore/src/main/scala/explore/config/sequence/SequenceEditor.scala
@@ -12,6 +12,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
 import lucuma.schemas.odb.input.*
 import lucuma.ui.syntax.all.given
+import lucuma.ui.syntax.pot.*
 import queries.common.ManualSequenceGQL.*
 import react.common.ReactFnProps
 
@@ -34,4 +35,4 @@ object SequenceEditor:
           .query(props.programId)
           .map(_.observations.matches.headOption.flatMap(_.config))
       }
-      .render((_, _, config) => potRender(renderFn)(config))
+      .render((_, _, config) => config.renderPot(renderFn))

--- a/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
+++ b/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
@@ -52,6 +52,7 @@ import lucuma.core.model.User
 import lucuma.schemas.model.ObservingMode
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.given
+import lucuma.ui.syntax.pot.*
 import monocle.Focus
 import monocle.Lens
 import queries.common.UserPreferencesQueriesGQL.*
@@ -180,5 +181,6 @@ object ItcGraphPanel:
               ItcPlotControl(chartTypeView, detailsView)
             )
 
-        potRenderView[ItcGraphProperties](renderPlot)(settings)
+        settings.renderPotView(renderPlot)
+        // potRenderView[ItcGraphProperties](renderPlot)(settings)
       }

--- a/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
+++ b/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
@@ -182,5 +182,4 @@ object ItcGraphPanel:
             )
 
         settings.renderPotView(renderPlot)
-        // potRenderView[ItcGraphProperties](renderPlot)(settings)
       }

--- a/explore/src/main/scala/explore/itc/ItcPanelTitle.scala
+++ b/explore/src/main/scala/explore/itc/ItcPanelTitle.scala
@@ -31,6 +31,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.schemas.model.ObservingMode
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.given
+import lucuma.ui.syntax.pot.*
 import queries.schemas.itc.ITCConversions.*
 import queries.schemas.odb.ObsQueries.*
 import react.common.ReactFnProps
@@ -123,12 +124,10 @@ object ItcPanelTitle:
           React.Fragment(
             <.label(title),
             if (existTargets) {
-              potRender[ItcChartResult](
+              selectedResult.renderPot(
                 fn,
                 Icons.Spinner.withSpin(true),
                 e => <.span(MissingInfoIcon).withTooltip(e.getMessage)
-              )(
-                selectedResult
               )
             } else {
               <.span(MissingInfoIcon).withTooltip(MissingInfoMsg)

--- a/explore/src/main/scala/explore/programs/ProgramTable.scala
+++ b/explore/src/main/scala/explore/programs/ProgramTable.scala
@@ -223,7 +223,7 @@ object ProgramTable:
         )
 
       <.div(
-        programsPot.render(programs =>
+        programsPot.renderPotOption(programs =>
           React.Fragment(
             <.div(ExploreStyles.ProgramTable)(
               PrimeAutoHeightVirtualizedTable(

--- a/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -31,6 +31,7 @@ import lucuma.schemas.ObservationDB.Types.*
 import lucuma.schemas.odb.input.*
 import lucuma.ui.primereact.*
 import lucuma.ui.syntax.all.given
+import lucuma.ui.syntax.pot.*
 import monocle.Focus
 import monocle.Lens
 import org.typelevel.log4cats.Logger
@@ -131,7 +132,7 @@ object ProposalTabContents:
         .reRunOnResourceSignals(ProgramEditSubscription.subscribe[IO](props.programId.assign))
     }
     .render { (props, ctx, optPropInfo) =>
-      optPropInfo.render(renderFn(props.programId, props.user, props.undoStacks, ctx) _)
+      optPropInfo.renderPotOption(renderFn(props.programId, props.user, props.undoStacks, ctx) _)
     }
 
 case class ProposalInfo(optProposal: Option[Proposal], executionTime: TimeSpan)

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -90,7 +90,7 @@ object AsterismEditorTile:
       control = s => control.some.filter(_ => s === TileSizeState.Minimized),
       bodyClass = Some(ExploreStyles.TargetTileBody)
     )((renderInTitle: Tile.RenderInTitle) =>
-      potAsterismMode.render((asterism, configuration) =>
+      potAsterismMode.renderPot((asterism, configuration) =>
         userId.map(uid =>
           AsterismEditor(
             uid,

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -43,21 +43,20 @@ object ConfigurationTile {
       "Configuration",
       canMinimize = true
     )(renderInTitle =>
-      potRender[(String, Option[NonEmptyString], View[ScienceData])] {
-        (title, subtitle, scienceData) =>
-          ConfigurationPanel(
-            userId,
-            programId,
-            obsId,
-            title,
-            subtitle,
-            UndoContext(undoStacks, scienceData),
-            obsConf,
-            scienceData.get.itcTargets,
-            baseCoordinates,
-            selectedConfig,
-            renderInTitle
-          )
-      }(obsData)
+      obsData.renderPot((title, subtitle, scienceData) =>
+        ConfigurationPanel(
+          userId,
+          programId,
+          obsId,
+          title,
+          subtitle,
+          UndoContext(undoStacks, scienceData),
+          obsConf,
+          scienceData.get.itcTargets,
+          baseCoordinates,
+          selectedConfig,
+          renderInTitle
+        )
+      )
     )
 }

--- a/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
@@ -51,6 +51,7 @@ import lucuma.core.model.Program
 import lucuma.core.model.User
 import lucuma.refined.*
 import lucuma.refined.*
+import lucuma.ui.DefaultPendingRender
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -282,7 +283,7 @@ object ConstraintsTabContents extends TwoPanels:
                   .withKey(s"timing-window-${timingWindowsView.get.length}")
             )
 
-          val rglRender: LayoutsMap => VdomNode = (l: LayoutsMap) =>
+          layouts.renderPotView(l =>
             TileController(
               props.userId,
               resize.width.getOrElse(1),
@@ -292,7 +293,7 @@ object ConstraintsTabContents extends TwoPanels:
               GridLayoutSection.ConstraintsLayout,
               None
             )
-          potRender[LayoutsMap](rglRender)(layouts.get)
+          )
         }
 
     makeOneOrTwoPanels(
@@ -369,7 +370,7 @@ object ConstraintsTabContents extends TwoPanels:
       .useResizeDetector()
       .render { (props, ctx, layout, defaultLayout, state, constraintsWithObs, resize) =>
         React.Fragment(
-          constraintsWithObs.render(
+          constraintsWithObs.renderPotOption(
             renderFn(props, state, defaultLayout, layout, resize, ctx) _,
             <.span(DefaultPendingRender).withRef(resize.ref)
           )

--- a/explore/src/main/scala/explore/tabs/ConstraintsTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTile.scala
@@ -37,9 +37,7 @@ object ConstraintsTile {
       control = _ => control,
       controllerClass = clazz
     )(renderInTitle =>
-      potRender[View[ConstraintSet]](cs =>
-        ConstraintsPanel(programId, List(obsId), cs, undoStacks, renderInTitle)
-      )(csPot)
+      csPot.renderPot(cs => ConstraintsPanel(programId, List(obsId), cs, undoStacks, renderInTitle))
     )
 
 }

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -44,6 +44,7 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.refined.*
 import lucuma.schemas.ObservationDB
+import lucuma.ui.DefaultPendingRender
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -385,7 +386,7 @@ object ObsTabContents extends TwoPanels:
           obsWithConstraints
         ) =>
           React.Fragment(
-            obsWithConstraints.render(
+            obsWithConstraints.renderPotOption(
               renderFn(
                 props,
                 twoPanelState,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -91,7 +91,7 @@ object ObsTabTiles:
     constraintGroups: View[ConstraintsList],
     obsView:          Pot[View[ObsEditData]]
   )(using FetchClient[IO, ?, ObservationDB]): VdomNode =
-    potRender[View[ObsEditData]] { vod =>
+    obsView.renderPot { vod =>
       val cgOpt: Option[ConstraintGroup] =
         constraintGroups.get.find(_._1.contains(vod.get.id)).map(_._2)
 
@@ -121,7 +121,7 @@ object ObsTabTiles:
           )
           .toList
       )
-    }(obsView)
+    }
 
   private def otherObsCount(
     targetObsMap: SortedMap[Target.Id, TargetSummary],
@@ -352,7 +352,7 @@ object ObsTabTiles:
             selectedConfig
           )
 
-        val rglRender: LayoutsMap => VdomNode = (l: LayoutsMap) =>
+        props.layouts.renderPotView(l =>
           TileController(
             props.userId,
             props.resize.width.getOrElse(0),
@@ -369,6 +369,5 @@ object ObsTabTiles:
             GridLayoutSection.ObservationsLayout,
             clazz = ExploreStyles.ObservationTiles.some
           )
-
-        potRenderView[LayoutsMap](rglRender)(props.layouts)
+        )
       }

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -54,6 +54,7 @@ import lucuma.core.model.Target.Sidereal
 import lucuma.core.model.User
 import lucuma.refined.*
 import lucuma.schemas.model.*
+import lucuma.ui.DefaultPendingRender
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
@@ -554,7 +555,7 @@ object TargetTabContents extends TwoPanels:
       val tileList: Option[List[Tile]] = tileListObSelectedOpt.map(_._1)
       val obsSelected: Boolean         = tileListObSelectedOpt.map(_._2).exists(identity)
 
-      layouts.get.render(l =>
+      layouts.renderPotView(l =>
         TileController(
           props.userId,
           resize.width.getOrElse(1),
@@ -777,7 +778,7 @@ object TargetTabContents extends TwoPanels:
           fullScreen
         ) =>
           React.Fragment(
-            asterismGroupsWithObs.render(
+            asterismGroupsWithObs.renderPotOption(
               renderFn(
                 props,
                 twoPanelState,

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -672,11 +672,9 @@ object AladinCell extends ModelOptics with AladinCommon:
                   Icons.ThinSliders
                 )
               ),
-              potRenderView[(UserGlobalPreferences, TargetVisualOptions)](renderCell)(options),
-              potRenderView[(UserGlobalPreferences, TargetVisualOptions)](renderToolbar)(options),
-              potRenderView[(UserGlobalPreferences, TargetVisualOptions)](renderAgsOverlay)(
-                options
-              )
+              options.renderPotView(renderCell),
+              options.renderPotView(renderToolbar),
+              options.renderPotView(renderAgsOverlay)
             ),
             PopupMenu(model = menuItems, clazz = ExploreStyles.AladinSettingsMenu)
               .withRef(menuRef.ref)

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
@@ -148,6 +148,7 @@ object ElevationPlotSection:
                 timingWindows.partition(_.isInclude).toList.map(windowsToIntervals)
 
               val windowsIntervals =
+                // Intersection of "Include" intervals with the complement of "Exclude" intervals
                 (windowsIntervalsParts(0) & ~windowsIntervalsParts(1)).intervals.toList
                   .map(BoundedInterval.fromInterval)
                   .flattenOption
@@ -234,5 +235,4 @@ object ElevationPlotSection:
             )
 
         options.renderPotView(renderPlot)
-        // potRenderView[ElevationPlotOptions](renderPlot)(options)
       }

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -293,16 +293,16 @@ object SiderealTargetEditor {
                 UndoButtons(undoCtx, disabled = disabled)
                   .when(props.renderInTitle.isEmpty && props.obsIdSubset.isEmpty)
               ),
-              potRender[Instant](vizTime =>
+              vizTime.renderPot(vt =>
                 AladinCell(
                   props.userId,
                   tid,
-                  vizTime,
+                  vt,
                   props.obsConf,
                   props.asterism.get,
                   props.fullScreen
                 )
-              )(vizTime),
+              ),
               <.div(LucumaStyles.FormColumnVeryCompact, ExploreStyles.TargetForm)(
                 // Keep the search field and the coords always together
                 SearchForm(

--- a/explore/src/main/scala/explore/users/UserPreferencesPopup.scala
+++ b/explore/src/main/scala/explore/users/UserPreferencesPopup.scala
@@ -23,7 +23,6 @@ import explore.model.display.given
 import explore.model.enums.RoleType
 import explore.model.reusability.given
 import explore.model.userVault.*
-import explore.syntax.ui.given
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -39,6 +38,7 @@ import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.given
+import lucuma.ui.syntax.pot.*
 import lucuma.ui.table.*
 import lucuma.ui.utils.*
 import org.http4s.Credentials
@@ -198,7 +198,7 @@ object UserPreferencesContent:
     .render { (props, ctx, active, user, newKey, _, _, table, newRoleType) =>
       import ctx.given
 
-      potRender[SSOUser] { ssoUser =>
+      user.renderPot { ssoUser =>
         val id   = ssoUser.user.id
         val name = s"${ssoUser.user.givenName.orEmpty} ${ssoUser.user.familyName.orEmpty}"
         val role = ssoUser.role.`type`.shortName
@@ -274,5 +274,5 @@ object UserPreferencesContent:
           ),
           ConfirmDialog()
         )
-      }(user)
+      }
     }

--- a/hasura/user-prefs/metadata/databases/default/tables/public_exploreTargetPreferences.yaml
+++ b/hasura/user-prefs/metadata/databases/default/tables/public_exploreTargetPreferences.yaml
@@ -2,6 +2,6 @@ table:
   name: exploreTargetPreferences
   schema: public
 object_relationships:
-- name: lucuma_target
-  using:
-    foreign_key_constraint_on: targetId
+  - name: lucuma_target
+    using:
+      foreign_key_constraint_on: targetId

--- a/hasura/user-prefs/metadata/databases/default/tables/public_lucumaItcPlotPreferences.yaml
+++ b/hasura/user-prefs/metadata/databases/default/tables/public_lucumaItcPlotPreferences.yaml
@@ -2,6 +2,6 @@ table:
   name: lucumaItcPlotPreferences
   schema: public
 object_relationships:
-- name: lucuma_observation
-  using:
-    foreign_key_constraint_on: observationId
+  - name: lucuma_observation
+    using:
+      foreign_key_constraint_on: observationId

--- a/hasura/user-prefs/metadata/databases/default/tables/public_lucumaObservation.yaml
+++ b/hasura/user-prefs/metadata/databases/default/tables/public_lucumaObservation.yaml
@@ -2,10 +2,10 @@ table:
   name: lucumaObservation
   schema: public
 array_relationships:
-- name: lucuma_itc_plot_preferences
-  using:
-    foreign_key_constraint_on:
-      column: observationId
-      table:
-        name: lucumaItcPlotPreferences
-        schema: public
+  - name: lucuma_itc_plot_preferences
+    using:
+      foreign_key_constraint_on:
+        column: observationId
+        table:
+          name: lucumaItcPlotPreferences
+          schema: public

--- a/hasura/user-prefs/metadata/databases/default/tables/public_lucumaTarget.yaml
+++ b/hasura/user-prefs/metadata/databases/default/tables/public_lucumaTarget.yaml
@@ -2,10 +2,10 @@ table:
   name: lucumaTarget
   schema: public
 array_relationships:
-- name: lucuma_target_preferences
-  using:
-    foreign_key_constraint_on:
-      column: targetId
-      table:
-        name: exploreTargetPreferences
-        schema: public
+  - name: lucuma_target_preferences
+    using:
+      foreign_key_constraint_on:
+        column: targetId
+        table:
+          name: exploreTargetPreferences
+          schema: public

--- a/hasura/user-prefs/metadata/databases/default/tables/public_lucumaUserPreferences.yaml
+++ b/hasura/user-prefs/metadata/databases/default/tables/public_lucumaUserPreferences.yaml
@@ -2,6 +2,6 @@ table:
   name: lucumaUserPreferences
   schema: public
 object_relationships:
-- name: lucuma_user
-  using:
-    foreign_key_constraint_on: userId
+  - name: lucuma_user
+    using:
+      foreign_key_constraint_on: userId

--- a/hasura/user-prefs/migrations/default/1679585248916_exclude_timing_windows/down.sql
+++ b/hasura/user-prefs/migrations/default/1679585248916_exclude_timing_windows/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."tmpTimingWindows" DROP COLUMN "include";

--- a/hasura/user-prefs/migrations/default/1679585248916_exclude_timing_windows/up.sql
+++ b/hasura/user-prefs/migrations/default/1679585248916_exclude_timing_windows/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."tmpTimingWindows" ADD COLUMN "include" BOOLEAN NOT NULL DEFAULT true;

--- a/model/shared/src/main/scala/explore/model/Constants.scala
+++ b/model/shared/src/main/scala/explore/model/Constants.scala
@@ -26,19 +26,28 @@ trait Constants:
   val MaxConcurrentItcRequests = 4
   val DefaultSED               = UnnormalizedSED.StellarLibrary(StellarLibrarySpectrum.O5V)
 
-  val GppDateFormatter: DateTimeFormatter   = DateTimeFormatter.ofPattern("yyyy-MMM-dd")
-  val GppTimeFormatter: DateTimeFormatter   = DateTimeFormatter.ofPattern("HH:mm")
-  val GppTimeTZFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm z")
-  val IsoUTCFormatter: DateTimeFormatter    =
+  val GppDateFormatter: DateTimeFormatter       = DateTimeFormatter.ofPattern("yyyy-MMM-dd")
+  val GppTimeFormatter: DateTimeFormatter       = DateTimeFormatter.ofPattern("HH:mm")
+  val GppTimeTZFormatter: DateTimeFormatter     =
+    DateTimeFormatter.ofPattern("HH:mm 'UTC'").withZone(ZoneOffset.UTC)
+  val IsoUTCFormatter: DateTimeFormatter        =
     DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC)
-  val UtcFormatter: DateTimeFormatter       =
+  val UtcFormatter: DateTimeFormatter           =
     DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneOffset.UTC)
-  val DurationFormatter: Duration => String = d =>
+  val DurationFormatter: Duration => String     = d =>
     val hours: Option[Long]  = d.toHours.some.filter(_ > 0)
     val minutes: Option[Int] = d.toMinutesPart.some.filter(_ > 0 || hours.isDefined)
     val seconds: Int         = d.toSecondsPart
-
     hours.map(h => s"${h}h").orEmpty + minutes.map(m => s"${m}m").orEmpty + s"${seconds}s"
+  val DurationLongFormatter: Duration => String = d =>
+    val days: Option[Long]   = d.toDays.some.filter(_ > 0)
+    val hours: Option[Int]   = d.toHoursPart.some.filter(_ > 0)
+    val minutes: Option[Int] = d.toMinutesPart.some.filter(_ > 0 || (days.isEmpty && hours.isEmpty))
+    List(days, hours, minutes)
+      .zip(List("day", "hour", "minute"))
+      .map((nOpt, units) => nOpt.map(n => s"$n $units" + (if (n != 1) "s" else "")))
+      .flattenOption
+      .mkString(", ")
 
   val NoGuideStarMessage = "No guidestar available"
 

--- a/model/shared/src/main/scala/explore/model/formats.scala
+++ b/model/shared/src/main/scala/explore/model/formats.scala
@@ -128,7 +128,7 @@ trait formats:
             "Duration parsing errors".refined[NonEmpty]
           }
           .toEitherErrors,
-      ts => f"${ts.toHoursPart}:${ts.toMinutesPart}%02d"
+      ts => f"${ts.toHours.toLong}:${ts.toMinutesPart}%02d"
     )
 
   val durationHMS: InputValidWedge[TimeSpan] =
@@ -146,7 +146,7 @@ trait formats:
             f"${ts.toSecondsPart}%02d.${ts.toMillisPart}%03d"
           else
             f"${ts.toSecondsPart}%02d"
-        f"${ts.toHoursPart}:${ts.toMinutesPart}%02d:$secs"
+        f"${ts.toHours.toLong}:${ts.toMinutesPart}%02d:$secs"
       }
     )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -34,7 +34,7 @@ object Settings {
     val lucumaRefined          = "0.1.1"
     val lucumaSchemas          = "0.47.0"
     val lucumaSSO              = "0.5.4"
-    val lucumaUI               = "0.68.2"
+    val lucumaUI               = "0.69.0"
     val monocle                = "3.2.0"
     val mouse                  = "1.2.1"
     val mUnit                  = "0.7.29"


### PR DESCRIPTION
This PR implements exclusion, or "negative" timing windows, as dicussed in https://app.shortcut.com/lucuma/story/2077/scheduling-windows-ui. For example, the following definition:
<img width="601" alt="image" src="https://user-images.githubusercontent.com/1895643/227664996-8414ea1d-80f1-4956-abcc-c349664ce103.png">

results in a semester plot of:
<img width="950" alt="image" src="https://user-images.githubusercontent.com/1895643/227665193-1e963651-12fb-406a-ab3e-5047ae9c929b.png">

Since a timing window can now be `Include` or `Exclude`, the "open" and "close" names don't seem fitting anymore. Names were changed to reflect this. However, the names in the DB were not migrated, since it's temporary anyway.

Changes were made to the display of the timing window info, now using the `Render` typeclass. Also the `ChangeAuditor`s for the time fields were redefined in order to allow invalid intermediate values when editing (eg: we couldn't completely delete the hours to type a new value).

Finally, other changes were made throughout the code regarding `renderPot*` extension methods, which were redefined and moved to `lucuma-ui`.