### PR TITLE
Fixes to previous cache refactor

### DIFF
--- a/common/src/main/scala/explore/TODO.md
+++ b/common/src/main/scala/explore/TODO.md
@@ -8,6 +8,3 @@
 - Test all optics.
 - URL storing mechanism in undo history.
 - Root URL doesn't work.
-
-- observations:  View[ObservationList], should not be a view in ObsSummaryTable.
-- Pass more refined parameters to AsterismGroupObsList.

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -67,7 +67,7 @@ import scala.scalajs.js
 final case class ObsSummaryTable(
   userId:        Option[User.Id],
   programId:     Program.Id,
-  observations:  View[ObservationList],
+  observations:  ObservationList,
   allTargets:    TargetList,
   renderInTitle: Tile.RenderInTitle
 ) extends ReactFnProps(ObsSummaryTable.component)
@@ -259,7 +259,7 @@ object ObsSummaryTable extends TableHooks:
       )
     }
     // Rows
-    .useMemoBy((props, _, _) => (props.observations.get.toList, props.allTargets))((_, _, _) =>
+    .useMemoBy((props, _, _) => (props.observations.toList, props.allTargets))((_, _, _) =>
       (obsList, allTargets) =>
         obsList.toList
           .map(obs =>

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -201,7 +201,7 @@ object ObsTabContents extends TwoPanels:
           ObsSummaryTable(
             props.userId,
             props.programId,
-            observations,
+            observations.get,
             targetsUndoCtx.model.get,
             renderInTitle
           )

--- a/explore/src/main/scala/explore/targets/ObservationInsertAction.scala
+++ b/explore/src/main/scala/explore/targets/ObservationInsertAction.scala
@@ -31,13 +31,8 @@ object ObservationInsertAction {
   private def setter(obsId: Observation.Id)(
     optObs: Option[ObsSummary]
   ): ProgramSummaries => ProgramSummaries = agwo =>
-    optObs.fold {
-      // we're undoing - look to see what the current targets are.
-      val targets =
-        agwo.observations
-          .getValue(obsId)
-          .fold(SortedSet.empty[Target.Id])(o => SortedSet.from(o.scienceTargetIds))
-      agwo.removeObsWithTargets(obsId, targets)
+    optObs.fold { // undo
+      agwo.removeObs(obsId)
     } { // do or re-do
       agwo.insertObs
     }

--- a/explore/src/main/scala/explore/targets/ObservationPasteAction.scala
+++ b/explore/src/main/scala/explore/targets/ObservationPasteAction.scala
@@ -40,13 +40,7 @@ object ObservationPasteAction {
   ): ProgramSummaries => ProgramSummaries = agwo =>
     otwol.fold {
       // the Option[List]] is empty, so we're deleting.
-      ids.foldLeft(agwo) { case (grps, (obsId, tid)) =>
-        // the target list could have been edited, so we'll look for the current list
-        val targetIds = grps.observations
-          .getValue(obsId)
-          .fold(SortedSet(tid))(o => SortedSet.from(o.scienceTargetIds))
-        grps.removeObsWithTargets(obsId, targetIds)
-      }
+      ids.foldLeft(agwo) { case (grps, (obsId, tid)) => grps.removeObs(obsId) }
 
     } {
       // we insert the ones we received back into the agwo

--- a/model/shared/src/main/scala/explore/data/KeyedIndexedList.scala
+++ b/model/shared/src/main/scala/explore/data/KeyedIndexedList.scala
@@ -112,16 +112,16 @@ object KeyedIndexedList:
   given eqKeyedIndexedList[K, A: Eq]: Eq[KeyedIndexedList[K, A]] =
     Eq.by(_.list: Map[K, (A, Int)])
 
-  given keyIndexedListAt[K, A]: At[KeyedIndexedList[K, A], K, Option[(A, Int)]] =
+  given keyedIndexedListAt[K, A]: At[KeyedIndexedList[K, A], K, Option[(A, Int)]] =
     At(i =>
       Lens((_: KeyedIndexedList[K, A]).getValueAndIndex(i))(optV =>
         kil => optV.fold(kil.removed(i))((v, idx) => kil.inserted(i, v, idx))
       )
     )
 
-  given treeSeqMapIndex[K, A]: Index[KeyedIndexedList[K, A], K, (A, Int)] = fromAt
+  given keyedIndexedIndex[K, A]: Index[KeyedIndexedList[K, A], K, (A, Int)] = fromAt
 
-  given keyIndexedListFilterIndex[K, A]: FilterIndex[KeyedIndexedList[K, A], K, (A, Int)] =
+  given keyedIndexedListFilterIndex[K, A]: FilterIndex[KeyedIndexedList[K, A], K, (A, Int)] =
     new FilterIndex[KeyedIndexedList[K, A], K, (A, Int)]:
       import cats.syntax.applicative._
       import cats.syntax.functor._

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -64,10 +64,7 @@ case class ProgramSummaries(
       _.inserted(obsSummary.id, obsSummary, observations.length)
     )(this)
 
-  def removeObsWithTargets(
-    obsId:     Observation.Id,
-    targetIds: SortedSet[Target.Id]
-  ): ProgramSummaries =
+  def removeObs(obsId: Observation.Id): ProgramSummaries =
     ProgramSummaries.observations.modify(_.removed(obsId))(this)
 }
 


### PR DESCRIPTION
- `ObsSummaryTable` doesn't need a `View[ObservationList]` (just the `ObservationList`).
- Fix some copy & paste naming errors.
- Simplify logic for removing observations: it's not necessary to pass its targets anymore since there's no maintenance of a target's observations (it is recomputed).