### PR TITLE
Auto-expanding of groups reinstated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ stats.html
 .firebase/
 .direnv
 .jvmopts
+
+# Local development environment
+local.conf.json

--- a/common/src/main/scala/explore/TODO.md
+++ b/common/src/main/scala/explore/TODO.md
@@ -1,10 +1,7 @@
 - Unify UndoStacks for ProgramSummaries and ObservationList (and SiderealTarget).
-- STOP FIBER AND CLEANUP WHEN THE PROGRAM CHANGES.
 - RESTART CACHE IN CASE OF INTERRUPTED SUBSCRIPTION.
-- Revise if ProgramSummaries should be a context or passed as parameters.
-- Pass UndoContext[ProgramSummaries] everywhere?
-- Reinstate auto expanding ids on clone & drag'n'drop.
+- Pass UndoContext[ProgramSummaries] everywhere? (instead of a View).
 - UndoContext.mapValue mechanism, or similar.
 - Test all optics.
 - URL storing mechanism in undo history.
-- Root URL doesn't work.
+- Check if auto expanding ids on clone works.

--- a/explore/src/main/scala/explore/constraints/ConstraintsSummaryTable.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsSummaryTable.scala
@@ -225,7 +225,7 @@ object ConstraintsSummaryTable extends TableHooks:
       )
       // Memo rows
       .useMemoBy((props, _, _) => props.constraintList)((_, _, _) =>
-        _.map(ConstraintGroup.fromTuple).toList
+        _.map(ConstraintGroup.fromTuple).toList.sortBy(_.constraintSet.summaryString)
       )
       .useReactTableWithStateStoreBy((props, ctx, cols, rows) =>
         import ctx.given

--- a/model/shared/src/main/scala/explore/model/ObsIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/ObsIdSet.scala
@@ -15,7 +15,10 @@ import monocle.Prism
 
 import scala.collection.immutable.SortedSet
 
-case class ObsIdSet(idSet: NonEmptySet[Observation.Id])
+case class ObsIdSet(idSet: NonEmptySet[Observation.Id]):
+  def ++(other: ObsIdSet): ObsIdSet = ObsIdSet(idSet ++ other.idSet)
+  def --(other: ObsIdSet): Option[ObsIdSet] =
+    NonEmptySet.fromSet(idSet -- (other.idSet)).map(ObsIdSet(_))
 
 object ObsIdSet {
   given Order[ObsIdSet] = Order.by(_.idSet)

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -6,6 +6,8 @@ package explore.model.syntax
 import cats.syntax.all.*
 import explore.model.AsterismGroup
 import explore.model.AsterismGroupList
+import explore.model.ConstraintGroup
+import explore.model.ConstraintGroupList
 import explore.model.ObsIdSet
 import explore.model.enums.PosAngleOptions
 import lucuma.core.enums.Site
@@ -16,6 +18,7 @@ import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
 import lucuma.core.util.TimeSpan
 
+import scala.annotation.targetName
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 
@@ -43,6 +46,11 @@ object all:
 
     def findWithTargetIds(targetIds: SortedSet[Target.Id]): Option[AsterismGroup] =
       self.find { case (_, grpIds) => grpIds === targetIds }.map(AsterismGroup.fromTuple)
+
+  extension (self: ConstraintGroupList)
+    @targetName("findContainingObsIdsCS")
+    def findContainingObsIds(obsIds: ObsIdSet): Option[ConstraintGroup] =
+      self.find { case (ids, _) => obsIds.subsetOf(ids) }.map(ConstraintGroup.fromTuple)
 
   extension [A](list: Iterable[A])
     def toSortedMap[K: Ordering, V](getKey: A => K, getValue: A => V = identity[A](_)) =

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -92,8 +92,11 @@ export default defineConfig(({ command, mode }) => {
   const publicDirDev = path.resolve(common, 'src/main/publicdev');
   const lucumaCss = path.resolve(__dirname, 'explore/target/lucuma-css')
   fs.mkdir(publicDirDev, (err) => {
+    const localConf = path.resolve(publicDirProd, 'local.conf.json');
+    const devConf = path.resolve(publicDirProd, 'development.conf.json');
+
     fs.copyFileSync(
-      path.resolve(publicDirProd, 'development.conf.json'),
+      fs.existsSync(localConf) ? localConf : devConf,
       path.resolve(publicDirDev, 'conf.json')
     );
     fs.copyFileSync(


### PR DESCRIPTION
I'm not sure this is working when cloning observations in the target tab since attempting it is raising an exception in the ODB.

Also added logic to allow developers to have a local configuration, in case we use a local instance of the ODB or other services.