### PR TITLE
Remove human-format

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "brotli-size": "4.0.0",
     "bundlemon": "^2.0.1",
     "chokidar": "3.5.3",
-    "human-format": "0.11.0",
     "less": "4.1.3",
     "less-watch-compiler": "1.16.3",
     "prettier": "^2.8.7",


### PR DESCRIPTION
I'm not sure where this npm dependency comes from but I'm not sure it is needed, is it?