### PR TITLE
Update ags logic and add a default 0 offset for ags calculations

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -95,12 +95,14 @@ case class AladinCell(
     } yield angles
 
   val positions: Option[NonEmptyList[AgsPosition]] =
-    (anglesToTest, obsConf.map(_.scienceOffsets.getOrElse(NonEmptyList.of(Offset.Zero)))).mapN {
-      (anglesToTest, offsets) =>
-        for {
-          pa  <- anglesToTest
-          off <- offsets
-        } yield AgsPosition(pa, off)
+    val offsets: NonEmptyList[Offset] = obsConf.flatMap(_.scienceOffsets) match
+      case Some(offsets) => offsets.prepend(Offset.Zero)
+      case None          => NonEmptyList.of(Offset.Zero)
+    anglesToTest.map { anglesToTest =>
+      for {
+        pa  <- anglesToTest
+        off <- offsets
+      } yield AgsPosition(pa, off)
     }
 
   def canRunAGS: Boolean = obsConf.exists(o => o.constraints.isDefined && o.wavelength.isDefined)

--- a/explore/src/main/scala/explore/targeteditor/GmosGeometry.scala
+++ b/explore/src/main/scala/explore/targeteditor/GmosGeometry.scala
@@ -64,18 +64,12 @@ object GmosGeometry:
     configuration: Option[BasicConfiguration],
     port:          PortDisposition,
     extraCss:      Css = Css.Empty
-  ): (Css, ShapeExpression) = {
-    pprint.pprintln(
-      offsets
-        .map(patrolField(posAngle, _, configuration, port))
-        .collect { case Some(s) => s }
-    )
+  ): (Css, ShapeExpression) =
     (Css("patrol-field-intersection") |+| extraCss) ->
       offsets
         .map(patrolField(posAngle, _, configuration, port))
         .collect { case Some(s) => s }
         .reduce(_ ∩ _)
-  }
 
   // Shape for the patrol field at a single position
   def patrolField(
@@ -158,12 +152,12 @@ object GmosGeometry:
             val offsets = configuration.flatMap(_.scienceOffsets) |+|
               configuration.flatMap(_.acquisitionOffsets)
 
-            val offsetIntersection = offsets.map(o =>
+            val patrolFieldIntersection = offsets.map(o =>
               GmosGeometry
                 .patrolFieldIntersection(posAngle, o.distinct, basicConf, port)
             )
 
-            offsetIntersection.fold(probeShape)(probeShape + _)
+            patrolFieldIntersection.fold(probeShape)(probeShape + _)
           }
           .getOrElse(SortedMap.empty[Css, ShapeExpression])
       }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -22,7 +22,7 @@ object Versions {
   val log4CatsLogLevel       = "0.3.1"
   val lucumaBC               = "0.4.0"
   val lucumaCore             = "0.74.0"
-  val lucumaCatalog          = "0.40.3"
+  val lucumaCatalog          = "0.40.4"
   val lucumaReact            = "0.34.0"
   val lucumaRefined          = "0.1.1"
   val lucumaSchemas          = "0.49.0"

--- a/workers/src/main/scala/workers/AgsServer.scala
+++ b/workers/src/main/scala/workers/AgsServer.scala
@@ -26,7 +26,7 @@ object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
   @JSExport
   def runWorker(): Unit = run.unsafeRunAndForget()
 
-  private val AgsCacheVersion: Int = 10
+  private val AgsCacheVersion: Int = 11
 
   private val CacheRetention: Duration = Duration.ofDays(60)
 


### PR DESCRIPTION
Fixes an issue where the selected guidestar could be out of the patrol field and another issue when using flip or unconstrained modes