### PR TITLE
PWA fixes

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -33,9 +33,10 @@ object ExploreStyles:
   val TileSMH: Css            = Css("tile-sm-height")
   val TileMDH: Css            = Css("tile-md-height")
 
-  val Accented: Css   = Css("explore-accented")
-  val TextPlain: Css  = Css("explore-text-plain")
-  val TextNoWrap: Css = Css("explore-text-nowrap")
+  val Accented: Css    = Css("explore-accented")
+  val TextPlain: Css   = Css("explore-text-plain")
+  val TextNoWrap: Css  = Css("explore-text-nowrap")
+  val UpgradeLink: Css = Css("explore-upgrade-link")
 
   val FlexContainer: Css = Css("explore-flex-container")
   val FlexWrap: Css      = Css("explore-flex-wrap")

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -108,7 +108,7 @@ extension (toastRef: ToastRef)
       )
     )
 
-  def prompt(text: String, callback: Callback): Callback =
+  def upgradePrompt(text: VdomNode, callback: Callback): Callback =
     toastRef.show(
       MessageItem(
         content = <.div(

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1517,6 +1517,10 @@ table.explore-border-table {
       align-items: start;
       width: 100%;
 
+      span {
+        padding-bottom: 0.9em;
+      }
+
       button {
         align-self: end;
       }
@@ -2443,4 +2447,15 @@ div.spectroscopy-table-emptymessage {
   .explore-constraints-summary-edit {
     left: 0;
   }
+}
+
+// Needed to make sure the PWA update toast is always on top
+.p-toast:has(.explore-prompt-toast) {
+  z-index: 2000;
+}
+
+a.explore-upgrade-link {
+  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
+  color: var(--text-secondary-color);
+  text-decoration: underline;
 }

--- a/explore/src/main/scala/explore/ExplorePWA.scala
+++ b/explore/src/main/scala/explore/ExplorePWA.scala
@@ -6,14 +6,20 @@ package explore
 import cats.effect.IO
 import explore.components.ui.ExploreStyles
 import explore.events.ExploreEvent
+import japgolly.scalajs.react.callback.AsyncCallback
 import japgolly.scalajs.react.callback.Callback
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.broadcastchannel.*
+import lucuma.typed.std.RequestInit
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
+import org.scalajs.dom
+import org.scalajs.dom.Fetch
+import org.scalajs.dom.Request
 import react.fa.IconSize
 
 import scala.annotation.nowarn
+import scala.concurrent.ExecutionContext
 import scala.scalajs.js
 import scala.scalajs.js.annotation.*
 
@@ -25,13 +31,14 @@ object ExplorePWA {
   // https://vite-plugin-pwa.netlify.app/
   @js.native
   trait ServiceWorkerRegistration extends js.Object {
-    def update(): Unit = js.native
+    def update(): Unit      = js.native
+    def installing: Boolean = js.native
   }
 
   @js.native
   trait RegisterSWOptions extends js.Object {
     var onRegisterError: js.Function1[js.Any, Unit]
-    var onRegistered: js.Function1[ServiceWorkerRegistration, Unit]
+    var onRegisteredSW: js.Function2[String, ServiceWorkerRegistration, Unit]
     var onNeedRefresh: js.Function0[Unit]
     var onOfflineReady: js.Function0[Unit]
   }
@@ -40,14 +47,26 @@ object ExplorePWA {
     def apply(
       onNeedRefresh:   js.UndefOr[Callback] = js.undefined,
       onOfflineReady:  js.UndefOr[Callback] = js.undefined,
-      onRegistered:    js.UndefOr[ServiceWorkerRegistration => Callback] = js.undefined,
+      onRegisteredSW:  js.UndefOr[(String, ServiceWorkerRegistration) => Callback] = js.undefined,
       onRegisterError: js.UndefOr[js.Any => Callback] = js.undefined
     ): RegisterSWOptions = {
       val p = (new js.Object).asInstanceOf[RegisterSWOptions]
-      onNeedRefresh.foreach(q => p.onNeedRefresh = () => q.runNow())
-      onOfflineReady.foreach(q => p.onOfflineReady = () => q.runNow())
-      onRegisterError.foreach(q => p.onRegisterError = (x: js.Any) => q(x).runNow())
-      onRegistered.foreach(q => p.onRegistered = (x: ServiceWorkerRegistration) => q(x).runNow())
+      onNeedRefresh.foreach(q =>
+        p.onNeedRefresh =
+          () => q.handleError(t => Callback.log(s"SW Error Refresh ${t.getMessage}")).runNow()
+      )
+      onOfflineReady.foreach(q =>
+        p.onOfflineReady =
+          () => q.handleError(t => Callback.log(s"SW Error Offline ready ${t.getMessage}")).runNow()
+      )
+      onRegisterError.foreach(q =>
+        p.onRegisterError = (x: js.Any) =>
+          q(x).handleError(t => Callback.log(s"SW Error register error ${t.getMessage}")).runNow()
+      )
+      onRegisteredSW.foreach(q =>
+        p.onRegisteredSW = (u: String, x: ServiceWorkerRegistration) =>
+          q(u, x).handleError(t => Callback.log(s"SW Error on Register ${t.getMessage}")).runNow()
+      )
       p
     }
   }
@@ -64,15 +83,30 @@ object ExplorePWA {
   // Check every 10 min maybe too often but we are doing lots of development
   val intervalMS = 10 * 60 * 1000
 
-  def scheduleUpdateCheck(r: ServiceWorkerRegistration): Callback =
-    (Callback.log("Check for new explore version") *> Callback(r.update())).attempt
+  def scheduleUpdateCheck(u: String, r: ServiceWorkerRegistration): Callback = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    (Callback.log("Check for new explore version") *>
+      pingSW(u)
+        .flatMap(go => Callback(r.update()).when(go).asAsyncCallback)
+        .toCallback
+        .attempt
+        .void)
       .setIntervalMs(intervalMS.toDouble)
       .void
+  }
 
   // Ask the user if an updates should be reloaded
   def requestUserConfirmation(bc: BroadcastChannel[ExploreEvent]): Callback = Callback {
     bc.postMessage(ExploreEvent.PWAUpdate)
   }.void
+
+  def pingSW(url: String)(using ExecutionContext): AsyncCallback[Boolean] =
+    AsyncCallback.fromFuture {
+      import js.Thenable.Implicits.*
+      val responseStatus =
+        dom.fetch(Request(url)).map(_.status)
+      responseStatus.map(_ == 200).recover { case _ => false }
+    }
 
   // Setup the service worker
   def setupSW(): Callback =
@@ -97,7 +131,7 @@ object ExplorePWA {
           RegisterSWOptions(
             onNeedRefresh =
               // If a new version is detected ask the usser
-              Callback.log("New version available") *>
+              Callback.log("New version available, ask the user to update") *>
                 // Delay a bit to let the front setup the listener
                 requestUserConfirmation(bc),
             onOfflineReady = Callback.log(s"Offline ready"),
@@ -105,11 +139,22 @@ object ExplorePWA {
               Callback.log(s"Error on service worker registration $x") *> Callback(
                 org.scalajs.dom.window.console.log(x)
               ),
-            onRegistered = (r: ServiceWorkerRegistration) =>
+            onRegisteredSW = (u: String, r: ServiceWorkerRegistration) =>
+              import scala.concurrent.ExecutionContext.Implicits.global
               // https://vite-plugin-pwa.netlify.app/guide/periodic-sw-updates.html
+              val isOffline =
+                !(!(r.installing && !js.isUndefined(org.scalajs.dom.window.navigator))) ||
+                  (dom.window.navigator.hasOwnProperty("connection") && dom.window.navigator.onLine)
               Callback.log(s"Service worker registered, setup self update task") *>
-                Callback(r.update()).delayMs(2000.0).toCallback *> // Inital check
-                scheduleUpdateCheck(r)                             // Periodic checks
+                pingSW(u)
+                  .flatMap(go =>
+                    Callback(r.update())
+                      .delayMs(2000.0)
+                      .when(go)
+                      .attempt
+                  )
+                  .toCallback *>          // Inital check
+                scheduleUpdateCheck(u, r) // Periodic checks
           )
         )
     }

--- a/heroku/static.json
+++ b/heroku/static.json
@@ -16,6 +16,15 @@
     "/": {
       "Cache-Control": "no-store, no-cache"
     },
+    "/sw.js": {
+      "Cache-Control": "no-store, no-cache"
+    },
+    "/index.html": {
+      "Cache-Control": "no-store, no-cache"
+    },
+    "/manifest.webmanifest": {
+      "Cache-Control": "no-store, no-cache"
+    },
     "/assets/**": {
       "Cache-Control": "public, max-age=31536000"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/react-fontawesome": "^0.1.18",
         "@tanstack/react-table": "^8.8.5",
         "@tanstack/react-virtual": "v3.0.0-beta.54",
-        "broadcast-channel": "4.20.2",
+        "broadcast-channel": "5.1.0",
         "copy-to-clipboard": "3.3.3",
         "github-markdown-css": "^5.1.0",
         "highcharts": "10.3.3",
@@ -1648,9 +1648,9 @@
       "dev": true
     },
     "node_modules/@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -3191,11 +3191,11 @@
       }
     },
     "node_modules/broadcast-channel": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.20.2.tgz",
-      "integrity": "sha512-v0lJgMzC+MX4e2KCFWYXChZ2mKTqm5mnJGId6tqJp3NfylggbNd8c2uKeP4MQxD2ucKOesY68aN98zwl9d6Tvg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-5.1.0.tgz",
+      "integrity": "sha512-wAbP+mtQ28N+iX3scX6Q97UN39ER5jRWOtM3r1BNPLWFOMt3AGmwN9kS3fqwgaUW0tbWHRSfTpsT+pAvrzQz0Q==",
       "dependencies": {
-        "@babel/runtime": "7.20.7",
+        "@babel/runtime": "7.21.0",
         "oblivious-set": "1.1.1",
         "p-queue": "6.6.2",
         "rimraf": "3.0.2",
@@ -11167,9 +11167,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
-      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
@@ -12235,11 +12235,11 @@
       }
     },
     "broadcast-channel": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-4.20.2.tgz",
-      "integrity": "sha512-v0lJgMzC+MX4e2KCFWYXChZ2mKTqm5mnJGId6tqJp3NfylggbNd8c2uKeP4MQxD2ucKOesY68aN98zwl9d6Tvg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-5.1.0.tgz",
+      "integrity": "sha512-wAbP+mtQ28N+iX3scX6Q97UN39ER5jRWOtM3r1BNPLWFOMt3AGmwN9kS3fqwgaUW0tbWHRSfTpsT+pAvrzQz0Q==",
       "requires": {
-        "@babel/runtime": "7.20.7",
+        "@babel/runtime": "7.21.0",
         "oblivious-set": "1.1.1",
         "p-queue": "6.6.2",
         "rimraf": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/react-fontawesome": "^0.1.18",
     "@tanstack/react-table": "^8.8.5",
     "@tanstack/react-virtual": "v3.0.0-beta.54",
-    "broadcast-channel": "4.20.2",
+    "broadcast-channel": "5.1.0",
     "copy-to-clipboard": "3.3.3",
     "github-markdown-css": "^5.1.0",
     "highcharts": "10.3.3",

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -23,7 +23,7 @@ object Versions {
   val lucumaBC               = "0.4.0"
   val lucumaCore             = "0.75.1"
   val lucumaCatalog          = "0.40.4"
-  val lucumaReact            = "0.34.1"
+  val lucumaReact            = "0.35.0"
   val lucumaRefined          = "0.1.1"
   val lucumaSchemas          = "0.50.0"
   val lucumaSSO              = "0.5.9"

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -39,6 +39,7 @@ const imageCache = ({ name, pattern }) => ({
   options: {
     cacheName: name,
     expiration: {
+      purgeOnQuotaError: true,
       maxEntries: 2500,
       maxAgeSeconds: 60 * 60 * 24 * 14, // 1week
     },
@@ -55,6 +56,7 @@ const itcCache = ({ name, pattern }) => ({
   options: {
     cacheName: name,
     expiration: {
+      purgeOnQuotaError: true,
       maxEntries: 5000,
       maxAgeSeconds: 60 * 60 * 24 * 7, // 1week
     },
@@ -233,14 +235,9 @@ export default defineConfig(({ command, mode }) => {
             }),
             itcCache({
               pattern:
-                /^https:\/\/(itc-staging.lucuma.xyz|itc.gpp.gemini.edu)\/itc/,
-              name: 'itc-cache',
-            }),
-            itcCache({
-              pattern:
                 /^https:\/\/cors-proxy.(lucuma.xyz|gpp.gemini.edu)\/http:\/\/aladin.unistra.fr\/java\/nph-aladin.*/,
               name: 'cors-cache',
-            }),
+            })
           ],
         },
       }),


### PR DESCRIPTION
This PR introduces a few small but important fixes around PWA. This started because locally I didn't get updates and it was at last linked to running out of drive space which made Chrome block the service worker installation.

It is an edge case which cannot be generally solved but can be alleviated a bit. The setup of the service worker is now more robust and includes a few other fixes:

* Update the interface of the PWA plugin
* More robust checking in case the user is offline or the server unreachable
* Purge caches when they are full
* In some cases the upgrade toast would get not displayed and instead would go to the background. This is now fixed
* The upgrade toast includes an experimental link to the commits since the last upgrade
* Update to broadcast_channel