### PR TITLE
Request the itc data to use it when the mode has been selected

### DIFF
--- a/common-queries/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -145,14 +145,10 @@ object ObsQueriesGQL:
       }
     """
 
-    object Scalars:
-      type SignalToNoise = lucuma.core.math.SignalToNoise
-
     object Data:
       object Itc:
         object Result:
           type ExposureTime = lucuma.core.util.TimeSpan
-          type Exposures    = NonNegInt
 
       object Sequence:
         type ExecutionConfig = explore.model.ExecutionOffsets

--- a/common-queries/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -6,6 +6,7 @@ package queries.common
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import explore.model
+import eu.timepit.refined.types.numeric.NonNegInt
 import lucuma.core.{model => coreModel}
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.odb.*
@@ -75,6 +76,16 @@ object ObsQueriesGQL:
           observingMode $ObservingModeSubquery
         }
 
+        itc(programId: $$programId, observationId: $$obsId) {
+          result {
+            exposureTime {
+              milliseconds
+            }
+            exposures
+            signalToNoise
+          }
+        }
+
         sequence(programId: $$programId, observationId: $$obsId) {
           executionConfig {
             ... on GmosSouthExecutionConfig {
@@ -134,7 +145,15 @@ object ObsQueriesGQL:
       }
     """
 
+    object Scalars:
+      type SignalToNoise = lucuma.core.math.SignalToNoise
+
     object Data:
+      object Itc:
+        object Result:
+          type ExposureTime = lucuma.core.util.TimeSpan
+          type Exposures    = NonNegInt
+
       object Sequence:
         type ExecutionConfig = explore.model.ExecutionOffsets
 

--- a/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
@@ -100,7 +100,6 @@ sealed trait AdvancedConfigurationPanel[T <: ObservingMode, Input]:
   def subtitle: Option[NonEmptyString]
   def observingMode: Aligner[T, Input]
   def spectroscopyRequirements: SpectroscopyRequirementsData
-  def potITC: View[Pot[Option[OdbItcResult.Success]]]
   def deleteConfig: Callback
   def confMatrix: SpectroscopyModesMatrix
   def selectedConfig: View[Option[BasicConfigAndItc]]
@@ -544,7 +543,7 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
         }
 
         val invalidateITC: Callback =
-          props.potITC.set(Pot.pending[Option[OdbItcResult.Success]])
+          Callback.empty
 
         // val originalSignalToNoiseText =
         //   props.spectroscopyRequirements.signalToNoise.fold("None")(sn =>
@@ -867,7 +866,6 @@ object AdvancedConfigurationPanel {
     subtitle:                 Option[NonEmptyString],
     observingMode:            Aligner[ObservingMode.GmosNorthLongSlit, GmosNorthLongSlitInput],
     spectroscopyRequirements: SpectroscopyRequirementsData,
-    potITC:                   View[Pot[Option[OdbItcResult.Success]]],
     deleteConfig:             Callback,
     confMatrix:               SpectroscopyModesMatrix,
     selectedConfig:           View[Option[BasicConfigAndItc]]
@@ -1071,7 +1069,6 @@ object AdvancedConfigurationPanel {
     subtitle:                 Option[NonEmptyString],
     observingMode:            Aligner[ObservingMode.GmosSouthLongSlit, GmosSouthLongSlitInput],
     spectroscopyRequirements: SpectroscopyRequirementsData,
-    potITC:                   View[Pot[Option[OdbItcResult.Success]]],
     deleteConfig:             Callback,
     confMatrix:               SpectroscopyModesMatrix,
     selectedConfig:           View[Option[BasicConfigAndItc]]

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -257,7 +257,6 @@ object ConfigurationPanel:
                       props.subtitle,
                       northAligner,
                       requirementsCtx.model.get.spectroscopy,
-                      props.scienceData.model.zoom(ScienceData.potITC),
                       deleteConfiguration,
                       confMatrix,
                       props.selectedConfig
@@ -273,7 +272,6 @@ object ConfigurationPanel:
                       props.subtitle,
                       southAligner,
                       requirementsCtx.model.get.spectroscopy,
-                      props.scienceData.model.zoom(ScienceData.potITC),
                       deleteConfiguration,
                       confMatrix,
                       props.selectedConfig

--- a/explore/src/main/scala/explore/itc/ItcPanelProps.scala
+++ b/explore/src/main/scala/explore/itc/ItcPanelProps.scala
@@ -11,6 +11,7 @@ import cats.syntax.all.*
 import eu.timepit.refined.*
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosBigDecimal
+import eu.timepit.refined.types.numeric.PosInt
 import explore.events.ItcMessage
 import explore.model.BasicConfigAndItc
 import explore.model.TargetList
@@ -19,6 +20,7 @@ import explore.model.boopickle.ItcPicklers.given
 import explore.model.itc.ItcChartExposureTime
 import explore.model.itc.ItcChartResult
 import explore.model.itc.ItcQueryProblems
+import explore.model.itc.ItcResult
 import explore.model.itc.ItcTarget
 import explore.model.itc.OverridenExposureTime
 import explore.modes.GmosNorthSpectroscopyRow
@@ -57,6 +59,11 @@ case class ItcPanelProps(
         case None    => (none, none)
       }
   }
+
+  val finalSelectedConfig =
+    (finalConfig, finalExposure).mapN((c, t) =>
+      BasicConfigAndItc(c, ItcResult.Result(t.time, PosInt.unsafeFrom(t.count.value)).asRight.some)
+    )
 
   val signalToNoiseAt: Option[Wavelength] = spectroscopyRequirements.flatMap(_.signalToNoiseAt)
 

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -15,6 +15,7 @@ import crystal.implicits.*
 import crystal.react.*
 import crystal.react.hooks.*
 import crystal.react.implicits.*
+import eu.timepit.refined.types.numeric.PosInt
 import explore.*
 import explore.common.TimingWindowsQueries
 import explore.components.Tile
@@ -130,6 +131,7 @@ object ObsTabTiles:
         _.get.itcExposureTime
           .map(r => ItcChartExposureTime(OverridenExposureTime.FromItc, r.time, r.count))
       )
+      .orElse(obsView.toOption.flatMap(_.get.itc.map(_.toItcChartExposureTime)))
     (obsViewPot, scienceData, observingMode, scienceReqs, chartExposureTime)
 
   private def itcQueryProps(
@@ -297,7 +299,7 @@ object ObsTabTiles:
               props.userId,
               props.obsId,
               chartExposureTime,
-              selectedConfig.get,
+              selectedConfig.get.orElse(itcProps.value.finalSelectedConfig),
               selectedItcTarget,
               props.allTargets,
               itcProps.value,

--- a/model/shared/src/main/scala/explore/model/OdbItcResult.scala
+++ b/model/shared/src/main/scala/explore/model/OdbItcResult.scala
@@ -8,9 +8,12 @@ import cats.derived.*
 import eu.timepit.refined.cats.given
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.numeric.PosBigDecimal
+import explore.model.itc.ItcChartExposureTime
+import explore.model.itc.OverridenExposureTime
 import io.circe.Decoder
 import io.circe.generic.semiauto
 import io.circe.refined.*
+import lucuma.core.math.SignalToNoise
 import lucuma.core.util.TimeSpan
 import lucuma.schemas.decoders.given
 import monocle.Focus
@@ -26,9 +29,12 @@ object OdbItcResult {
   case class Success(
     exposureTime:  TimeSpan,
     exposures:     NonNegInt,
-    signalToNoise: PosBigDecimal
+    signalToNoise: SignalToNoise
   ) extends OdbItcResult
-      derives Eq
+      derives Eq {
+    def toItcChartExposureTime =
+      ItcChartExposureTime(OverridenExposureTime.FromItc, exposureTime, exposures)
+  }
 
   case class MissingParams(
     params: List[String]


### PR DESCRIPTION
Once a mode is selected we loose track of the actual results of the itc and cannot do the graph.
This PR fixes it requesting the itc info from the odb and it uses it to do the plot as needed