### PR TITLE
Populate cache beyond query limit

### DIFF
--- a/common-queries/src/clue/scala/queries/common/AsterismQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/AsterismQueriesGQL.scala
@@ -5,29 +5,12 @@ package queries.common
 
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
-import explore.model
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.odb.*
 
-import java.time
 // gql: import lucuma.schemas.decoders.given
 
 object AsterismQueriesGQL {
-  @GraphQL
-  trait AsterismGroupObsQuery extends GraphQLOperation[ObservationDB] {
-    val document: String = s"""
-      query($$programId: ProgramId!) {
-        targets(WHERE: {programId: { EQ: $$programId }}) {
-          matches $TargetWithIdSubquery
-        }
-
-        observations(programId: $$programId) {
-          matches $ObservationSummarySubquery
-        }
-      }
-    """
-  }
-
   @GraphQL
   trait UpdateAsterismsMutation extends GraphQLOperation[ObservationDB] {
     val document = """

--- a/common-queries/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLOperation
+import clue.annotation.GraphQL
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.odb.*
+// gql: import lucuma.schemas.decoders.given
+
+object ProgramSummaryQueriesGQL {
+  @GraphQL
+  trait AllProgramObservations extends GraphQLOperation[ObservationDB] {
+    val document: String = s"""
+      query($$programId: ProgramId!, $$OFFSET: ObservationId) {
+        observations(programId: $$programId, OFFSET: $$OFFSET) {
+          matches $ObservationSummarySubquery
+          hasMore
+        }
+      }
+    """
+  }
+  @GraphQL
+  trait AllProgramTargets      extends GraphQLOperation[ObservationDB] {
+    val document: String = s"""
+      query($$programId: ProgramId!, $$OFFSET: TargetId) {
+        targets(WHERE: { programId: { EQ: $$programId } }, OFFSET: $$OFFSET) {
+          matches $TargetWithIdSubquery
+          hasMore
+        }
+      }
+    """
+  }
+}

--- a/common/src/main/scala/explore/common/AsterismQueries.scala
+++ b/common/src/main/scala/explore/common/AsterismQueries.scala
@@ -22,7 +22,6 @@ import explore.model.ProgramSummaries
 import explore.model.TargetList
 import explore.model.TargetWithObs
 import explore.model.TargetWithObsList
-import explore.model.syntax.all.*
 import japgolly.scalajs.react.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program
@@ -36,15 +35,6 @@ import queries.common.AsterismQueriesGQL.*
 import queries.common.ObsQueriesGQL.*
 
 object AsterismQueries:
-  private val queryToAsterismGroupWithObsGetter
-    : Getter[AsterismGroupObsQuery.Data, ProgramSummaries] = data =>
-    ProgramSummaries(
-      data.targets.matches.toSortedMap(_.id, _.target),
-      KeyedIndexedList.fromList(data.observations.matches, ObsSummary.id.get)
-    )
-
-  extension (self: AsterismGroupObsQuery.Data.type)
-    def asAsterismGroupWithObs = queryToAsterismGroupWithObsGetter
 
   def replaceAsterism[F[_]: Async](
     programId: Program.Id,

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -8,8 +8,11 @@ import cats.Order.given
 import cats.data.NonEmptySet
 import cats.derived.*
 import cats.implicits.*
+import explore.data.KeyedIndexedList
+import explore.model.syntax.all.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Target
+import lucuma.schemas.model.TargetWithId
 import monocle.Focus
 import monocle.Lens
 
@@ -73,3 +76,9 @@ object ProgramSummaries:
   val targets: Lens[ProgramSummaries, TargetList]           = Focus[ProgramSummaries](_.targets)
   val observations: Lens[ProgramSummaries, ObservationList] =
     Focus[ProgramSummaries](_.observations)
+
+  def fromLists(targetList: List[TargetWithId], obsList: List[ObsSummary]): ProgramSummaries =
+    ProgramSummaries(
+      targetList.toSortedMap(_.id, _.target),
+      KeyedIndexedList.fromList(obsList, ObsSummary.id.get)
+    )


### PR DESCRIPTION
Keep querying the ODB if there are more than 1000 observations or targets in the program.