### PR TITLE
Display and/or groups in obsList

### DIFF
--- a/common-queries/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -105,10 +105,52 @@ object ProgramQueriesGQL {
   }
 
   @GraphQL
+  trait ProgramGroupsQuery extends GraphQLOperation[ObservationDB] {
+    val document: String = """#graphql
+      query ($programId: ProgramId!) {
+        program(programId: $programId) {
+          allGroupElements {
+            observation {
+              id
+            }
+            group {
+              id
+              name
+              minimumRequired
+              elements {
+                group {
+                  id
+                }
+                observation {
+                  id
+                }
+              }
+            }
+            parentGroupId
+          }
+        }
+      }
+    """
+  }
+
+  @GraphQL
   trait ProgramEditSubscription extends GraphQLOperation[ObservationDB] {
     val document: String = """
       subscription($programId: ProgramId) {
         programEdit(input: {programId: $programId}) {
+          value {
+            id
+          }
+        }
+      }
+    """
+  }
+
+  @GraphQL
+  trait GroupEditSubscription extends GraphQLOperation[ObservationDB] {
+    val document: String = """
+      subscription($programId: ProgramId) {
+        groupEdit(input: { programId: $programId }) {
           value {
             id
           }

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -103,6 +103,7 @@ object ExploreStyles:
   val UnselectedObsTreeGroup: Css  = Css("unselected-obs-tree-group")
   val ObsTreeGroupHeader: Css      = Css("obs-tree-group-header")
   val ObsTreeItem: Css             = Css("obs-tree-item")
+  val ObsTreeGroupLeaf: Css        = Css("obs-tree-group-leaf")
   val TreeToolbar: Css             = Css("tree-toolbar")
   val ObsBadge: Css                = Css("obs-badge")
   val ObsBadgeSubtitle: Css        = Css("obs-badge-subtitle")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -55,7 +55,7 @@ body {
 
 // Reusability overlays.
 body.hide-reusability {
-  &>div:not(#root)[title^="Last update reason"] {
+  & > div:not(#root)[title^="Last update reason"] {
     display: none;
   }
 }
@@ -342,7 +342,7 @@ a:hover {
     content: attr(data-abbrv);
   }
 
-  label[data-abbrv]>span {
+  label[data-abbrv] > span {
     display: none;
   }
 
@@ -355,7 +355,7 @@ a:hover {
       content: "";
     }
 
-    label[data-abbrv]>span {
+    label[data-abbrv] > span {
       display: unset;
     }
 
@@ -412,7 +412,7 @@ a:hover {
     inset-block-end: 0;
     height: 100%;
 
-    >tr>td {
+    > tr > td {
       vertical-align: bottom;
       padding: 0 !important; // Reset default padding
     }
@@ -527,7 +527,7 @@ a:hover {
   display: flex;
   flex-direction: column;
 
-  >div {
+  > div {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -550,7 +550,7 @@ a:hover {
     display: none;
   }
 
-  >div .target-grid {
+  > div .target-grid {
     @include hide-hidden-target-cells(true);
 
     grid-template:
@@ -567,7 +567,7 @@ a:hover {
   &.with-catalog-info {
     grid-template-rows: repeat(4, auto) 1fr;
 
-    >.explore-brightnesses-wrapper {
+    > .explore-brightnesses-wrapper {
       grid-row-start: 5;
     }
   }
@@ -628,7 +628,6 @@ a:hover {
   margin-right: 0.5em;
 }
 
-
 // ------
 // Target search popup styles
 // ------
@@ -638,7 +637,7 @@ a:hover {
   flex-direction: column;
   max-height: 85vh; // Don't let the form grow too large
 
-  .p-dialog-footer>div {
+  .p-dialog-footer > div {
     display: flex;
     justify-content: space-between;
   }
@@ -668,7 +667,9 @@ $search-preview-margin: 5px;
 
   @media (min-width: common.$tablet-responsive-cutoff) {
     min-height: calc($search-preview-width + 2 * $search-preview-margin);
-    padding-right: calc($search-preview-width + 3 * $search-preview-margin ) !important;
+    padding-right: calc(
+      $search-preview-width + 3 * $search-preview-margin
+    ) !important;
     padding-bottom: $search-preview-margin;
     grid-template-rows: min-content min-content;
   }
@@ -713,11 +714,13 @@ $search-preview-margin: 5px;
   border-radius: 0.28rem;
   justify-content: center;
   align-items: center;
-  background: repeating-linear-gradient(-45deg,
-      black,
-      black 10px,
-      var(--site-border-color) 10px,
-      var(--site-border-color) 11px);
+  background: repeating-linear-gradient(
+    -45deg,
+    black,
+    black 10px,
+    var(--site-border-color) 10px,
+    var(--site-border-color) 11px
+  );
 }
 
 .explore-target-search-results {
@@ -784,7 +787,7 @@ $search-preview-margin: 5px;
 }
 
 .pl-react-table.pl-celled-table {
-  .p-datatable-tbody>tr>td {
+  .p-datatable-tbody > tr > td {
     &.explore-table-cell-hide-border {
       border-left-width: 0;
     }
@@ -948,7 +951,8 @@ $search-preview-margin: 5px;
     $active-status-translate-y: 2.5em;
 
     .p-component.p-inputswitch.obs-active-status-toggle {
-      transform: rotate(270deg) scale(0.6) translateY($active-status-translate-y);
+      transform: rotate(270deg) scale(0.6)
+        translateY($active-status-translate-y);
       height: 21px;
 
       &.p-inputswitch-checked .p-inputswitch-slider {
@@ -1036,7 +1040,7 @@ $search-preview-margin: 5px;
 // ------
 // Imaging Configuration
 // ------
-.explore-configuration-filter .p-multiselect-item>span {
+.explore-configuration-filter .p-multiselect-item > span {
   width: 100%;
 
   div {
@@ -1113,8 +1117,10 @@ $search-preview-margin: 5px;
 
   --column-wide-span: 3;
 
-  grid-template-columns: [label1] max-content [field1] minmax(20ch, 3fr) [label2] max-content [field2] minmax(20ch,
-      3fr);
+  grid-template-columns: [label1] max-content [field1] minmax(20ch, 3fr) [label2] max-content [field2] minmax(
+      20ch,
+      3fr
+    );
 
   .elevation-range-picker {
     width: 9em;
@@ -1402,7 +1408,7 @@ img.partner-split-flag {
 
     th:last-child,
     td:last-child,
-    td:last-child>span>div {
+    td:last-child > span > div {
       width: 4em !important;
     }
 
@@ -1455,7 +1461,8 @@ img.partner-split-flag {
       height: 0;
       border-style: solid;
       border-width: 0 10px 10px 0;
-      border-color: transparent var(--explore-selected-box-color) transparent transparent;
+      border-color: transparent var(--explore-selected-box-color) transparent
+        transparent;
       left: 0;
       top: 0;
       transform: rotate(-90deg);
@@ -1507,7 +1514,7 @@ table.explore-border-table {
     justify-content: space-between;
 
     /* stylelint-disable-next-line selector-class-pattern */
-    span>svg.svg-inline--fa {
+    span > svg.svg-inline--fa {
       padding-right: 0.5em;
     }
 
@@ -1536,7 +1543,7 @@ table.explore-border-table {
 }
 
 .p-button.p-fileupload {
-  +input[type="file"] {
+  + input[type="file"] {
     display: none;
   }
 }
@@ -1648,14 +1655,20 @@ table.explore-border-table {
   height: 100dvh;
   width: 100%;
   overflow: hidden;
-  grid-template: "header"$top-bottom-space "body" minmax(calc(100% - $top-bottom-space - $top-bottom-space),
-    1fr
-  ) "sidebar"#{$top-bottom-space} / 1fr;
+  grid-template:
+    "header" $top-bottom-space "body" minmax(
+      calc(100% - $top-bottom-space - $top-bottom-space),
+      1fr
+    )
+    "sidebar" #{$top-bottom-space} / 1fr;
 
   @media (min-width: common.$tablet-responsive-cutoff) {
-    grid-template: "header header"$top-bottom-space "sidebar body" minmax(calc(100% - $top-bottom-space),
+    grid-template:
+      "header header" $top-bottom-space "sidebar body" minmax(
+        calc(100% - $top-bottom-space),
         1fr
-      ) / 50px auto;
+      )
+      / 50px auto;
   }
 }
 
@@ -1746,6 +1759,32 @@ table.explore-border-table {
   min-height: 0;
   height: 100%;
   overflow: hidden;
+
+  // Remove indent on _first_ level tree nodes (observations)
+  .p-tree-container > .p-treenode.p-treenode-leaf {
+    .p-tree-toggler {
+      display: none;
+    }
+    // .obs-tree-group-leaf {
+    //   margin: 8px;
+    // }
+  }
+  .p-tree-container > .p-treenode > .p-treenode-content {
+    >.obs-tree-group-leaf {
+      margin: 8px;
+    }
+  }
+
+  .p-treenode-content {
+    width: 100%;
+  }
+  .obs-item {
+    width: 100%;
+  }
+  .p-tree.p-component {
+    padding: 0;
+    border: none;
+  }
 }
 
 // -------
@@ -1776,7 +1815,7 @@ table.explore-border-table {
     padding: 0;
     overflow-y: unset;
 
-    &>div {
+    & > div {
       height: 100%;
     }
   }
@@ -1854,7 +1893,7 @@ $help-title-height: 40px;
     fill: hsl(0deg 87% 66%);
   }
 
-  >div {
+  > div {
     height: 100%;
     max-height: 100%;
 
@@ -2002,7 +2041,7 @@ $help-title-height: 40px;
       margin-right: 0.3em;
     }
 
-    >* {
+    > * {
       margin-bottom: 0.5em;
     }
 
@@ -2163,7 +2202,7 @@ $help-title-height: 40px;
 
 // Move to lucuma-ui?
 .explore-table:has(.p-datatable-emptymessage) {
-  tr>td.p-datatable-emptymessage {
+  tr > td.p-datatable-emptymessage {
     padding: 0;
   }
 }
@@ -2383,15 +2422,15 @@ div.spectroscopy-table-emptymessage {
   .explore-target-summary-delete {
     left: 0;
 
-    ~.explore-target-summary-type {
+    ~ .explore-target-summary-type {
       left: 35px;
 
-      ~.explore-target-summary-name {
+      ~ .explore-target-summary-name {
         left: 70px;
       }
     }
 
-    ~.explore-target-summary-name {
+    ~ .explore-target-summary-name {
       left: 35px;
     }
   }
@@ -2406,15 +2445,15 @@ div.spectroscopy-table-emptymessage {
       justify-content: space-evenly;
     }
 
-    ~.explore-target-summary-type {
+    ~ .explore-target-summary-type {
       left: 75px;
 
-      ~.explore-target-summary-name {
+      ~ .explore-target-summary-name {
         left: 109px;
       }
     }
 
-    ~.explore-target-summary-name {
+    ~ .explore-target-summary-name {
       left: 75px;
     }
   }
@@ -2424,15 +2463,15 @@ div.spectroscopy-table-emptymessage {
     width: 55px;
     min-width: 55px;
 
-    ~.explore-target-summary-type {
+    ~ .explore-target-summary-type {
       left: 55px;
 
-      ~.explore-target-summary-name {
+      ~ .explore-target-summary-name {
         left: 89px;
       }
     }
 
-    ~.explore-target-summary-name {
+    ~ .explore-target-summary-name {
       left: 55px;
     }
   }

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -55,7 +55,7 @@ body {
 
 // Reusability overlays.
 body.hide-reusability {
-  & > div:not(#root)[title^="Last update reason"] {
+  &>div:not(#root)[title^="Last update reason"] {
     display: none;
   }
 }
@@ -342,7 +342,7 @@ a:hover {
     content: attr(data-abbrv);
   }
 
-  label[data-abbrv] > span {
+  label[data-abbrv]>span {
     display: none;
   }
 
@@ -355,7 +355,7 @@ a:hover {
       content: "";
     }
 
-    label[data-abbrv] > span {
+    label[data-abbrv]>span {
       display: unset;
     }
 
@@ -412,7 +412,7 @@ a:hover {
     inset-block-end: 0;
     height: 100%;
 
-    > tr > td {
+    >tr>td {
       vertical-align: bottom;
       padding: 0 !important; // Reset default padding
     }
@@ -527,7 +527,7 @@ a:hover {
   display: flex;
   flex-direction: column;
 
-  > div {
+  >div {
     flex-grow: 1;
     display: flex;
     flex-direction: column;
@@ -550,7 +550,7 @@ a:hover {
     display: none;
   }
 
-  > div .target-grid {
+  >div .target-grid {
     @include hide-hidden-target-cells(true);
 
     grid-template:
@@ -567,7 +567,7 @@ a:hover {
   &.with-catalog-info {
     grid-template-rows: repeat(4, auto) 1fr;
 
-    > .explore-brightnesses-wrapper {
+    >.explore-brightnesses-wrapper {
       grid-row-start: 5;
     }
   }
@@ -628,6 +628,7 @@ a:hover {
   margin-right: 0.5em;
 }
 
+
 // ------
 // Target search popup styles
 // ------
@@ -637,7 +638,7 @@ a:hover {
   flex-direction: column;
   max-height: 85vh; // Don't let the form grow too large
 
-  .p-dialog-footer > div {
+  .p-dialog-footer>div {
     display: flex;
     justify-content: space-between;
   }
@@ -667,9 +668,7 @@ $search-preview-margin: 5px;
 
   @media (min-width: common.$tablet-responsive-cutoff) {
     min-height: calc($search-preview-width + 2 * $search-preview-margin);
-    padding-right: calc(
-      $search-preview-width + 3 * $search-preview-margin
-    ) !important;
+    padding-right: calc($search-preview-width + 3 * $search-preview-margin ) !important;
     padding-bottom: $search-preview-margin;
     grid-template-rows: min-content min-content;
   }
@@ -714,13 +713,11 @@ $search-preview-margin: 5px;
   border-radius: 0.28rem;
   justify-content: center;
   align-items: center;
-  background: repeating-linear-gradient(
-    -45deg,
-    black,
-    black 10px,
-    var(--site-border-color) 10px,
-    var(--site-border-color) 11px
-  );
+  background: repeating-linear-gradient(-45deg,
+      black,
+      black 10px,
+      var(--site-border-color) 10px,
+      var(--site-border-color) 11px);
 }
 
 .explore-target-search-results {
@@ -787,7 +784,7 @@ $search-preview-margin: 5px;
 }
 
 .pl-react-table.pl-celled-table {
-  .p-datatable-tbody > tr > td {
+  .p-datatable-tbody>tr>td {
     &.explore-table-cell-hide-border {
       border-left-width: 0;
     }
@@ -951,8 +948,7 @@ $search-preview-margin: 5px;
     $active-status-translate-y: 2.5em;
 
     .p-component.p-inputswitch.obs-active-status-toggle {
-      transform: rotate(270deg) scale(0.6)
-        translateY($active-status-translate-y);
+      transform: rotate(270deg) scale(0.6) translateY($active-status-translate-y);
       height: 21px;
 
       &.p-inputswitch-checked .p-inputswitch-slider {
@@ -1040,7 +1036,7 @@ $search-preview-margin: 5px;
 // ------
 // Imaging Configuration
 // ------
-.explore-configuration-filter .p-multiselect-item > span {
+.explore-configuration-filter .p-multiselect-item>span {
   width: 100%;
 
   div {
@@ -1117,10 +1113,8 @@ $search-preview-margin: 5px;
 
   --column-wide-span: 3;
 
-  grid-template-columns: [label1] max-content [field1] minmax(20ch, 3fr) [label2] max-content [field2] minmax(
-      20ch,
-      3fr
-    );
+  grid-template-columns: [label1] max-content [field1] minmax(20ch, 3fr) [label2] max-content [field2] minmax(20ch,
+      3fr);
 
   .elevation-range-picker {
     width: 9em;
@@ -1408,7 +1402,7 @@ img.partner-split-flag {
 
     th:last-child,
     td:last-child,
-    td:last-child > span > div {
+    td:last-child>span>div {
       width: 4em !important;
     }
 
@@ -1461,8 +1455,7 @@ img.partner-split-flag {
       height: 0;
       border-style: solid;
       border-width: 0 10px 10px 0;
-      border-color: transparent var(--explore-selected-box-color) transparent
-        transparent;
+      border-color: transparent var(--explore-selected-box-color) transparent transparent;
       left: 0;
       top: 0;
       transform: rotate(-90deg);
@@ -1514,7 +1507,7 @@ table.explore-border-table {
     justify-content: space-between;
 
     /* stylelint-disable-next-line selector-class-pattern */
-    span > svg.svg-inline--fa {
+    span>svg.svg-inline--fa {
       padding-right: 0.5em;
     }
 
@@ -1543,7 +1536,7 @@ table.explore-border-table {
 }
 
 .p-button.p-fileupload {
-  + input[type="file"] {
+  +input[type="file"] {
     display: none;
   }
 }
@@ -1655,20 +1648,14 @@ table.explore-border-table {
   height: 100dvh;
   width: 100%;
   overflow: hidden;
-  grid-template:
-    "header" $top-bottom-space "body" minmax(
-      calc(100% - $top-bottom-space - $top-bottom-space),
-      1fr
-    )
-    "sidebar" #{$top-bottom-space} / 1fr;
+  grid-template: "header"$top-bottom-space "body" minmax(calc(100% - $top-bottom-space - $top-bottom-space),
+    1fr
+  ) "sidebar"#{$top-bottom-space} / 1fr;
 
   @media (min-width: common.$tablet-responsive-cutoff) {
-    grid-template:
-      "header header" $top-bottom-space "sidebar body" minmax(
-        calc(100% - $top-bottom-space),
+    grid-template: "header header"$top-bottom-space "sidebar body" minmax(calc(100% - $top-bottom-space),
         1fr
-      )
-      / 50px auto;
+      ) / 50px auto;
   }
 }
 
@@ -1815,7 +1802,7 @@ table.explore-border-table {
     padding: 0;
     overflow-y: unset;
 
-    & > div {
+    &>div {
       height: 100%;
     }
   }
@@ -1893,7 +1880,7 @@ $help-title-height: 40px;
     fill: hsl(0deg 87% 66%);
   }
 
-  > div {
+  >div {
     height: 100%;
     max-height: 100%;
 
@@ -2041,7 +2028,7 @@ $help-title-height: 40px;
       margin-right: 0.3em;
     }
 
-    > * {
+    >* {
       margin-bottom: 0.5em;
     }
 
@@ -2202,7 +2189,7 @@ $help-title-height: 40px;
 
 // Move to lucuma-ui?
 .explore-table:has(.p-datatable-emptymessage) {
-  tr > td.p-datatable-emptymessage {
+  tr>td.p-datatable-emptymessage {
     padding: 0;
   }
 }
@@ -2422,15 +2409,15 @@ div.spectroscopy-table-emptymessage {
   .explore-target-summary-delete {
     left: 0;
 
-    ~ .explore-target-summary-type {
+    ~.explore-target-summary-type {
       left: 35px;
 
-      ~ .explore-target-summary-name {
+      ~.explore-target-summary-name {
         left: 70px;
       }
     }
 
-    ~ .explore-target-summary-name {
+    ~.explore-target-summary-name {
       left: 35px;
     }
   }
@@ -2445,15 +2432,15 @@ div.spectroscopy-table-emptymessage {
       justify-content: space-evenly;
     }
 
-    ~ .explore-target-summary-type {
+    ~.explore-target-summary-type {
       left: 75px;
 
-      ~ .explore-target-summary-name {
+      ~.explore-target-summary-name {
         left: 109px;
       }
     }
 
-    ~ .explore-target-summary-name {
+    ~.explore-target-summary-name {
       left: 75px;
     }
   }
@@ -2463,15 +2450,15 @@ div.spectroscopy-table-emptymessage {
     width: 55px;
     min-width: 55px;
 
-    ~ .explore-target-summary-type {
+    ~.explore-target-summary-type {
       left: 55px;
 
-      ~ .explore-target-summary-name {
+      ~.explore-target-summary-name {
         left: 89px;
       }
     }
 
-    ~ .explore-target-summary-name {
+    ~.explore-target-summary-name {
       left: 55px;
     }
   }

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1752,10 +1752,12 @@ table.explore-border-table {
     .p-tree-toggler {
       display: none;
     }
+
     // .obs-tree-group-leaf {
     //   margin: 8px;
     // }
   }
+
   .p-tree-container > .p-treenode > .p-treenode-content {
     >.obs-tree-group-leaf {
       margin: 8px;
@@ -1765,9 +1767,11 @@ table.explore-border-table {
   .p-treenode-content {
     width: 100%;
   }
+
   .obs-item {
     width: 100%;
   }
+
   .p-tree.p-component {
     padding: 0;
     border: none;

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -6,6 +6,7 @@ package explore.observationtree
 import cats.effect.IO
 import cats.syntax.all.*
 import clue.FetchClient
+import crystal.Pot
 import crystal.react.View
 import crystal.react.hooks.*
 import crystal.react.implicits.*
@@ -30,28 +31,20 @@ import lucuma.core.model.Observation
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.schemas.ObservationDB
+import lucuma.typed.primereact.treeTreeMod.TreeNodeTemplateOptions
 import lucuma.ui.primereact.*
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.utils.*
 import org.typelevel.log4cats.Logger
+import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements
+import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements.Group
 import queries.schemas.odb.ObsQueries
 import react.common.ReactFnProps
 import react.primereact.Button
 
 import ObsQueries.*
-import explore.model.ObsSummary
-import explore.data.KeyedIndexedList
-import lucuma.typed.primereact.treeTreeMod.TreeNodeTemplateOptions
-import explore.observationtree.ObsNode.Obs
-import explore.observationtree.ObsNode.And
-import explore.observationtree.ObsNode.Or
-import eu.timepit.refined.*
-import lucuma.refined.*
-import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements.Group
-import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements
-import crystal.Pot
 
 case class ObsList(
   obsUndoCtx:      UndoContext[ObservationList],
@@ -134,7 +127,7 @@ object ObsList:
 
         def renderItem(node: ObsNode, options: TreeNodeTemplateOptions) =
           node match
-            case Obs(obs)   =>
+            case ObsNode.Obs(obs)   =>
               val id       = obs.id
               val selected = props.focusedObs.exists(_ === id)
               <.a(
@@ -180,8 +173,8 @@ object ObsList:
                     .some
                 )
               )
-            case And(group) => renderGroup("AND", group)
-            case Or(group)  => renderGroup("OR", group)
+            case ObsNode.And(group) => renderGroup("AND", group)
+            case ObsNode.Or(group)  => renderGroup("OR", group)
 
         def renderGroup(title: String, group: Group) =
           <.span(title,

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -62,22 +62,6 @@ case class ObsList(
   groups:          Pot[View[List[AllGroupElements]]]
 ) extends ReactFnProps(ObsList.component):
   val observations: ObservationList = obsUndoCtx.model.get
-  // val groupings: KeyedIndexedList[Group.Elements, Group] = ???
-  //   KeyedIndexedList.fromListMany(
-  //   List(
-  //     Group(Group.Id(12L.refined),
-  //              "Name 1".some,
-  //              observations.toList.take(2).map(o => GroupElement(o.id.asRight))
-  //     ),
-  //     Group(Group.Id(13L.refined),
-  //              "Name 2".some,
-  //              observations.toList.drop(2).map(o => GroupElement(o.id.asRight)) :+ GroupElement(
-  //                Grouping.Id(12L.refined).asLeft
-  //              )
-  //     )
-  //   ),
-  //   _.elements
-  // )
 
 object ObsList:
   private type Props = ObsList

--- a/explore/src/main/scala/explore/observationtree/ObsListTree.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsListTree.scala
@@ -34,50 +34,15 @@ object ObsListTree:
   private type Props[A] = ObsListTree[A]
 
   private val ColDef = ColumnDef[Expandable[ObsNode]]
-  // private def treeToData(
-  //   tree:             KeyedIndexedTree[ObsNode.Id, ObsNode],
-  //   collapsedItemIds: Set[AtlasTree.ItemId]
-  // ): AtlasTree.Data[ObsNode] =
-  //   def valueChildrenToData(
-  //     keyValue: Option[(ObsNode.Id, ObsNode)],
-  //     children: List[Node[(ObsNode.Id, ObsNode)]],
-  //     accum:    List[(String, AtlasTree.Item[ObsNode])] = List.empty
-  //   ): List[(String, AtlasTree.Item[ObsNode])] = {
-  //     val getKey: ((ObsNode.Id, ObsNode)) => String = (id, _) => id.fold(_.toString, _.toString)
-  //     val key                                       = keyValue.map(getKey).getOrElse("")
-  //     children.foldLeft(
-  //       accum :+
-  //         (key -> AtlasTree.Item[ObsNode](
-  //           key,
-  //           children.map(node => getKey(node.value)),
-  //           hasChildren = children.nonEmpty,
-  //           isExpanded = !collapsedItemIds.contains(key),
-  //           isChildrenLoading = false,
-  //           keyValue.map(_._2).orUndefined
-  //         ))
-  //     )((nodeAccum, node) => valueChildrenToData(node.value.some, node.children, nodeAccum))
-  //   }
-  //   AtlasTree.Data(
-  //     rootId = "",
-  //     items = valueChildrenToData(none, tree.toKeyedTree.children).toMap
-  //   )
 
   private def component[A] =
     ScalaFnComponent
       .withHooks[Props[A]]
-      .render((props) =>
-        // val onCollapse =
-        //   (itemId: AtlasTree.ItemId, _: AtlasTree.Path) => collapsedItemIds.modState(_ + itemId)
-
-        // val onExpand =
-        //   (itemId: AtlasTree.ItemId, _: AtlasTree.Path) => collapsedItemIds.modState(_ - itemId)
-
+      .render(props =>
         <.div(
           Tree(
             props.obsList,
             nodeTemplate = props.renderItem
           )
-
         )
       )
-

--- a/explore/src/main/scala/explore/observationtree/ObsListTree.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsListTree.scala
@@ -25,7 +25,7 @@ import explore.components.ui.ExploreStyles
 import react.primereact.Tree
 import lucuma.typed.primereact.treeTreeMod.TreeNodeTemplateOptions
 
-final case class ObsListTree[A](
+case class ObsListTree[A](
   obsList:    Seq[Tree.Node[A]],
   renderItem: (A, TreeNodeTemplateOptions) => VdomNode
 ) extends ReactFnProps(ObsListTree.component)

--- a/explore/src/main/scala/explore/observationtree/ObsListTree.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsListTree.scala
@@ -4,26 +4,18 @@
 package explore.observationtree
 
 import explore.data.tree.KeyedIndexedTree
-import react.common.ReactFnProps
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
-import cats.syntax.all.*
-import explore.data.tree.Node
-import scala.scalajs.js
+import lucuma.react.table.*
+import lucuma.typed.primereact.treeTreeMod.TreeNodeTemplateOptions
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
-import js.JSConverters._
-import lucuma.react.table.Expandable
 import lucuma.ui.table.*
-import explore.model.reusability.given
-import lucuma.ui.reusability.given
-import lucuma.react.table.*
-import lucuma.react.table.ColumnDef
 import org.scalajs.dom.HTMLDivElement
-import explore.observationtree.ObsNode.given
-import explore.components.ui.ExploreStyles
+import react.common.ReactFnProps
 import react.primereact.Tree
-import lucuma.typed.primereact.treeTreeMod.TreeNodeTemplateOptions
+
+import scala.scalajs.js
 
 case class ObsListTree[A](
   obsList:    Seq[Tree.Node[A]],

--- a/explore/src/main/scala/explore/observationtree/ObsListTree.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsListTree.scala
@@ -1,0 +1,83 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.observationtree
+
+import explore.data.tree.KeyedIndexedTree
+import react.common.ReactFnProps
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import cats.syntax.all.*
+import explore.data.tree.Node
+import scala.scalajs.js
+import lucuma.ui.syntax.all.*
+import lucuma.ui.syntax.all.given
+import js.JSConverters._
+import lucuma.react.table.Expandable
+import lucuma.ui.table.*
+import explore.model.reusability.given
+import lucuma.ui.reusability.given
+import lucuma.react.table.*
+import lucuma.react.table.ColumnDef
+import org.scalajs.dom.HTMLDivElement
+import explore.observationtree.ObsNode.given
+import explore.components.ui.ExploreStyles
+import react.primereact.Tree
+import lucuma.typed.primereact.treeTreeMod.TreeNodeTemplateOptions
+
+final case class ObsListTree[A](
+  obsList:    Seq[Tree.Node[A]],
+  renderItem: (A, TreeNodeTemplateOptions) => VdomNode
+) extends ReactFnProps(ObsListTree.component)
+
+object ObsListTree:
+  private type Props[A] = ObsListTree[A]
+
+  private val ColDef = ColumnDef[Expandable[ObsNode]]
+  // private def treeToData(
+  //   tree:             KeyedIndexedTree[ObsNode.Id, ObsNode],
+  //   collapsedItemIds: Set[AtlasTree.ItemId]
+  // ): AtlasTree.Data[ObsNode] =
+  //   def valueChildrenToData(
+  //     keyValue: Option[(ObsNode.Id, ObsNode)],
+  //     children: List[Node[(ObsNode.Id, ObsNode)]],
+  //     accum:    List[(String, AtlasTree.Item[ObsNode])] = List.empty
+  //   ): List[(String, AtlasTree.Item[ObsNode])] = {
+  //     val getKey: ((ObsNode.Id, ObsNode)) => String = (id, _) => id.fold(_.toString, _.toString)
+  //     val key                                       = keyValue.map(getKey).getOrElse("")
+  //     children.foldLeft(
+  //       accum :+
+  //         (key -> AtlasTree.Item[ObsNode](
+  //           key,
+  //           children.map(node => getKey(node.value)),
+  //           hasChildren = children.nonEmpty,
+  //           isExpanded = !collapsedItemIds.contains(key),
+  //           isChildrenLoading = false,
+  //           keyValue.map(_._2).orUndefined
+  //         ))
+  //     )((nodeAccum, node) => valueChildrenToData(node.value.some, node.children, nodeAccum))
+  //   }
+  //   AtlasTree.Data(
+  //     rootId = "",
+  //     items = valueChildrenToData(none, tree.toKeyedTree.children).toMap
+  //   )
+
+  private def component[A] =
+    ScalaFnComponent
+      .withHooks[Props[A]]
+      .render((props) =>
+        // val onCollapse =
+        //   (itemId: AtlasTree.ItemId, _: AtlasTree.Path) => collapsedItemIds.modState(_ + itemId)
+
+        // val onExpand =
+        //   (itemId: AtlasTree.ItemId, _: AtlasTree.Path) => collapsedItemIds.modState(_ - itemId)
+
+        <.div(
+          Tree(
+            props.obsList,
+            nodeTemplate = props.renderItem
+          )
+
+        )
+      )
+

--- a/explore/src/main/scala/explore/observationtree/obsTree.scala
+++ b/explore/src/main/scala/explore/observationtree/obsTree.scala
@@ -18,21 +18,18 @@ import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroup
 import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements.Group.Elements
 import react.primereact.Tree
 import react.primereact.Tree.Node
+import cats.derived.*
 
 import java.util.UUID
 import scala.scalajs.js.JSConverters._
+import cats.Eq
 
-sealed trait ObsNode
+enum ObsNode derives Eq:
+  case Obs(value: ObsSummary)
+  case And(group: Group)
+  case Or(group: Group)
 
 object ObsNode {
-
-  // given Reusability[ObsNode] = Reusability.byEq
-
-  case class Obs(value: ObsSummary) extends ObsNode
-
-  case class And(group: Group) extends ObsNode
-
-  case class Or(group: Group) extends ObsNode
 
   def fromList(
     obsList: KeyedIndexedList[Observation.Id, ObsSummary],
@@ -74,14 +71,14 @@ object ObsNode {
     }
 
     // Uncomment to debug trees
-    pprint
-      .copy(additionalHandlers = {
-        case _: ObsSummary      =>
-          pprint.Tree.Apply("ObsSummary", List(pprint.Tree.Literal("...")).iterator)
-        case id: GroupId        => pprint.Tree.Literal(pprint.Util.literalize(id.toString()))
-        case id: Observation.Id => pprint.Tree.Literal(pprint.Util.literalize(id.toString()))
-      })
-      .pprintln(treeNodes)
+    // pprint
+    //   .copy(additionalHandlers = {
+    //     case _: ObsSummary      =>
+    //       pprint.Tree.Apply("ObsSummary", List(pprint.Tree.Literal("...")).iterator)
+    //     case id: GroupId        => pprint.Tree.Literal(pprint.Util.literalize(id.toString()))
+    //     case id: Observation.Id => pprint.Tree.Literal(pprint.Util.literalize(id.toString()))
+    //   })
+    //   .pprintln(treeNodes)
     treeNodes
 
 }

--- a/explore/src/main/scala/explore/observationtree/obsTree.scala
+++ b/explore/src/main/scala/explore/observationtree/obsTree.scala
@@ -1,0 +1,87 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.observationtree
+
+import cats.syntax.all.*
+import explore.data.KeyedIndexedList
+import explore.model.ObsSummary
+import japgolly.scalajs.react.Reusability
+import lucuma.core.model.Group.{Id => GroupId}
+import lucuma.core.model.Observation
+import lucuma.refined.*
+import lucuma.ui.reusability.given
+import monocle.Lens
+import monocle.macros.GenLens
+import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements
+import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements.Group
+import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements.Group.Elements
+import react.primereact.Tree
+import react.primereact.Tree.Node
+
+import java.util.UUID
+import scala.scalajs.js.JSConverters._
+
+sealed trait ObsNode
+
+object ObsNode {
+
+  // given Reusability[ObsNode] = Reusability.byEq
+
+  case class Obs(value: ObsSummary) extends ObsNode
+
+  case class And(group: Group) extends ObsNode
+
+  case class Or(group: Group) extends ObsNode
+
+  def fromList(
+    obsList: KeyedIndexedList[Observation.Id, ObsSummary],
+    groups:  List[AllGroupElements]
+  ): Seq[Node[ObsNode]] =
+
+    val rootGroups = groups.filter(_.parentGroupId.isEmpty)
+    val groupings  = groups.flatMap(_.group)
+
+    def createGroupFromIds(
+      maybeGroup: Option[GroupId],
+      maybeObs:   Option[Observation.Id]
+    ): Seq[Node[ObsNode]] =
+      val groupNodes =
+        maybeGroup.flatMap(group => groupings.find(_.id === group).map(createGroup))
+      val obsNodes   = maybeObs.flatMap(groupObs =>
+        obsList.getValue(groupObs).map(n => Tree.Node(Tree.Id(n.id.toString), Obs(n)))
+      )
+      (groupNodes ++ obsNodes).toSeq
+
+    def createGroup(group: Group): Node[ObsNode] =
+      val children = group.elements.flatMap { case Elements(maybeGroup, maybeObs) =>
+        createGroupFromIds(maybeGroup.map(_.id), maybeObs.map(_.id))
+      }
+      // is and if minimumRequired is not defined, or same length as group.elements
+      val isAnd    = group.minimumRequired.forall(_.value == group.elements.length)
+      val data     = if isAnd then And(group) else Or(group)
+      Tree.Node(Tree.Id(group.id.toString), data, children = children)
+
+    val treeNodes = rootGroups.flatMap { case AllGroupElements(maybeObs, maybeGroup, _) =>
+      createGroupFromIds(maybeGroup.map(_.id), maybeObs.map(_.id))
+      val groupNode = maybeGroup
+        .flatMap(group => groupings.find(g => g.id === group.id).map(createGroup))
+      val obsNode   = maybeObs
+        .flatMap(groupObs =>
+          obsList.getValue(groupObs.id).map(n => Tree.Node(Tree.Id(n.id.toString), Obs(n)))
+        )
+      groupNode ++ obsNode
+    }
+
+    // Uncomment to debug trees
+    pprint
+      .copy(additionalHandlers = {
+        case _: ObsSummary      =>
+          pprint.Tree.Apply("ObsSummary", List(pprint.Tree.Literal("...")).iterator)
+        case id: GroupId        => pprint.Tree.Literal(pprint.Util.literalize(id.toString()))
+        case id: Observation.Id => pprint.Tree.Literal(pprint.Util.literalize(id.toString()))
+      })
+      .pprintln(treeNodes)
+    treeNodes
+
+}

--- a/explore/src/main/scala/explore/observationtree/obsTree.scala
+++ b/explore/src/main/scala/explore/observationtree/obsTree.scala
@@ -3,6 +3,8 @@
 
 package explore.observationtree
 
+import cats.Eq
+import cats.derived.*
 import cats.syntax.all.*
 import explore.data.KeyedIndexedList
 import explore.model.ObsSummary
@@ -18,11 +20,9 @@ import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroup
 import queries.common.ProgramQueriesGQL.ProgramGroupsQuery.Data.Program.AllGroupElements.Group.Elements
 import react.primereact.Tree
 import react.primereact.Tree.Node
-import cats.derived.*
 
 import java.util.UUID
 import scala.scalajs.js.JSConverters._
-import cats.Eq
 
 enum ObsNode derives Eq:
   case Obs(value: ObsSummary)

--- a/model/shared/src/main/scala/explore/data/KeyedIndexedList.scala
+++ b/model/shared/src/main/scala/explore/data/KeyedIndexedList.scala
@@ -103,11 +103,6 @@ object KeyedIndexedList:
       (getKey(a), (a, idx))
     }))
 
-  def fromListMany[K, A](list: List[A], getKey: A => Seq[K]): KeyedIndexedList[K, A] =
-    KeyedIndexedList(TreeSeqMap.from(list.flatMap(a => getKey(a).tupleRight(a)).zipWithIndex.map {
-      case ((k, a), idx) => (k, (a, idx))
-    }))
-
   def unsafeFromTreeSeqMap[K, A](list: TreeSeqMap[K, (A, Int)]): KeyedIndexedList[K, A] =
     KeyedIndexedList(list)
 

--- a/model/shared/src/main/scala/explore/data/KeyedIndexedList.scala
+++ b/model/shared/src/main/scala/explore/data/KeyedIndexedList.scala
@@ -103,6 +103,11 @@ object KeyedIndexedList:
       (getKey(a), (a, idx))
     }))
 
+  def fromListMany[K, A](list: List[A], getKey: A => Seq[K]): KeyedIndexedList[K, A] =
+    KeyedIndexedList(TreeSeqMap.from(list.flatMap(a => getKey(a).tupleRight(a)).zipWithIndex.map {
+      case ((k, a), idx) => (k, (a, idx))
+    }))
+
   def unsafeFromTreeSeqMap[K, A](list: TreeSeqMap[K, (A, Int)]): KeyedIndexedList[K, A] =
     KeyedIndexedList(list)
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -25,7 +25,7 @@ object Versions {
   val lucumaCatalog          = "0.40.5"
   val lucumaReact            = "0.35.0"
   val lucumaRefined          = "0.1.1"
-  val lucumaSchemas          = "0.52.0"
+  val lucumaSchemas          = "0.52.1"
   val lucumaSSO              = "0.5.10"
   val lucumaUI               = "0.69.1"
   val lucumaITC              = "0.12.1"


### PR DESCRIPTION
Sorting is based on groups sorting, so might slightly change from the original order of 'just' observations. Group view works for both AND and OR groups (based on minimumRequired field of a group).

TODO (other PR's):

- 'Edit' groups view
- Create new groups
- Delete groups
- Move observations between groups
- Keep tree state when switching between observations (now collapses all)

Lucuma-schemas release is still processing, so build will fail until then.
