### PR TITLE
Actually show timing windows, log other twilights

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -317,13 +317,21 @@ object ObsTabTiles:
               props.allConstraintSets
             )
 
+          val timingWindows: View[List[TimingWindow]] =
+            TimingWindowsQueries.viewWithRemoteMod(
+              props.programId,
+              ObsIdSet.one(props.obsId),
+              props.obsUndoCtx.undoableView[List[TimingWindow]](ObsSummary.timingWindows)
+            )
+
           val skyPlotTile =
             ElevationPlotTile.elevationPlotTile(
               props.userId,
               props.focusedTarget.orElse(props.observation.scienceTargetIds.headOption),
               observingMode.map(_.siteFor),
               targetCoords,
-              vizTime
+              vizTime,
+              timingWindows.get
             )
 
           def setCurrentTarget(programId: Program.Id, oid: Option[Observation.Id])(
@@ -402,13 +410,6 @@ object ObsTabTiles:
                 props.obsUndoCtx.zoom(ObsSummary.constraints),
                 renderInTitle
               )
-            )
-
-          val timingWindows: View[List[TimingWindow]] =
-            TimingWindowsQueries.viewWithRemoteMod(
-              props.programId,
-              ObsIdSet.one(props.obsId),
-              props.obsUndoCtx.undoableView[List[TimingWindow]](ObsSummary.timingWindows)
             )
 
           val timingWindowsTile =

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotNight.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotNight.scala
@@ -256,8 +256,8 @@ object ElevationPlotNight {
             s"<strong>$time ($timeDisplay)</strong><br/>${ctx.series.name}: $value"
         }
 
-        val sunset  = instantFormat(tbNauticalNight.start)
-        val sunrise = instantFormat(tbNauticalNight.end)
+        val dusk = instantFormat(tbNauticalNight.start)
+        val dawn = instantFormat(tbNauticalNight.end)
 
         val targetBelowHorizon =
           ElevationSeries.Elevation
@@ -302,7 +302,7 @@ object ElevationPlotNight {
                       .setZIndex(1)
                       .setLabel(
                         XAxisPlotBandsLabelOptions()
-                          .setText(s"  Evening 12° - Twilight: $sunset")
+                          .setText(s"  Evening 12° - Twilight: $dusk")
                           .setRotation(270)
                           .setAlign(AlignValue.left)
                           .setTextAlign(AlignValue.center)
@@ -315,7 +315,7 @@ object ElevationPlotNight {
                       .setZIndex(1)
                       .setLabel(
                         XAxisPlotBandsLabelOptions()
-                          .setText(s"  Morning 12° - Twilight: $sunrise")
+                          .setText(s"  Morning 12° - Twilight: $dawn")
                           .setRotation(270)
                           .setAlign(AlignValue.left)
                           .setTextAlign(AlignValue.center)
@@ -423,10 +423,9 @@ object ElevationPlotNight {
         val moonIllum = midOfNightResult.lunarIlluminatedFraction.toDouble
 
         dom.console.log(
-          s"Moon brightness computed at [${midOfNight.atZone(ZoneOffset.UTC)}]: [$moonIllum]\n",
-          s"Official Twilights:\n",
-          s" >>> [${start.atZone(ZoneOffset.UTC)}]\n",
-          s" <<< [${end.atZone(ZoneOffset.UTC)}]"
+          s"Nautical Twilights:\n",
+          s" >>> [${tbNauticalNight.start.atZone(ZoneOffset.UTC)}]\n",
+          s" <<< [${tbNauticalNight.end.atZone(ZoneOffset.UTC)}]"
         )
 
         <.div(


### PR DESCRIPTION
All the logic was in place but for some reason in the merged code we were not passing the timing windows to the plot. Looks like a rebase error.

Unrelated, we now show in the console the nautical twilights instead of the official nows, by request from Andy.