### PR TITLE
Support accepting multiple target's graphs

### DIFF
--- a/explore/src/main/scala/explore/tabs/ItcTile.scala
+++ b/explore/src/main/scala/explore/tabs/ItcTile.scala
@@ -32,7 +32,7 @@ object ItcTile:
     selectedTarget:  View[Option[ItcTarget]],
     allTargets:      TargetList,
     itcProps:        ItcPanelProps,
-    itcChartResults: Pot[Map[ItcTarget, ItcChartResult]],
+    itcChartResults: Map[ItcTarget, Pot[ItcChartResult]],
     itcLoading:      LoadingState
   ) =
     Tile(

--- a/model/shared/src/main/scala/explore/events/ItcMessage.scala
+++ b/model/shared/src/main/scala/explore/events/ItcMessage.scala
@@ -67,7 +67,7 @@ object ItcMessage extends ItcPicklers {
     targets:      NonEmptyList[ItcTarget],
     modes:        InstrumentRow
   ) extends Request {
-    type ResponseType = Either[ItcQueryProblems, ItcChartResult]
+    type ResponseType = Map[ItcTarget, Either[ItcQueryProblems, ItcChartResult]]
   }
 
   private given Pickler[SpectroscopyMatrixRequest] = generatePickler

--- a/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
+++ b/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
@@ -212,8 +212,6 @@ trait ItcPicklers extends CommonPicklers {
 
   given Pickler[OptimizedSpectroscopyGraphResult] = generatePickler
 
-  given Pickler[Either[ItcQueryProblems, ItcChartResult]] = generatePickler
-
 }
 
 object ItcPicklers extends ItcPicklers


### PR DESCRIPTION
In the case of multiple targets we were only plotting one, An improvement for larger asterisms could be to request each target  in parallel