### PR TITLE
Add Observation Attachments Table

### DIFF
--- a/common-queries/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package queries.common
 
 import clue.GraphQLSubquery

--- a/common-queries/src/clue/scala/queries/common/ObsAttachmentSubquery.scala
+++ b/common-queries/src/clue/scala/queries/common/ObsAttachmentSubquery.scala
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLSubquery
+import explore.model.ObsAttachment
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.odb.*
+import clue.annotation.GraphQL
+
+@GraphQL
+object ObsAttachmentSubquery
+    extends GraphQLSubquery.Typed[ObservationDB, ObsAttachment]("ObsAttachment"):
+  override val subquery: String = s"""
+    {
+      id
+      attachmentType
+      fileName
+      description
+      checked
+      fileSize
+      updatedAt
+    }
+  """

--- a/common-queries/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -55,6 +55,19 @@ object ProgramQueriesGQL {
   }
 
   @GraphQL
+  trait UpdateObsAttachmentMutation extends GraphQLOperation[ObservationDB] {
+    val document: String = """
+    mutation($input: UpdateObsAttachmentsInput!) {
+      updateObsAttachments(input: $input) {
+        obsAttachments {
+          id
+        }
+      }
+    }
+   """
+  }
+
+  @GraphQL
   trait ProgramProposalQuery extends GraphQLOperation[ObservationDB] {
     val document: String = """
       query($programId: ProgramId!) {

--- a/common-queries/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
+++ b/common-queries/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
@@ -32,4 +32,16 @@ object ProgramSummaryQueriesGQL {
       }
     """
   }
+
+  @GraphQL
+  trait AllProgramAttachments extends GraphQLOperation[ObservationDB] {
+    val document: String = s"""
+      query($$programId: ProgramId!) {
+        program(programId: $$programId) {
+          obsAttachments $ObsAttachmentSubquery
+          proposalAttachments $ProposalAttachmentSubquery
+        }
+      }
+    """
+  }
 }

--- a/common-queries/src/clue/scala/queries/common/ProposalAttachmentSubquery.scala
+++ b/common-queries/src/clue/scala/queries/common/ProposalAttachmentSubquery.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLSubquery
+import explore.model.ProposalAttachment
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.odb.*
+import clue.annotation.GraphQL
+
+@GraphQL
+object ProposalAttachmentSubquery
+    extends GraphQLSubquery.Typed[ObservationDB, ProposalAttachment]("ProposalAttachment"):
+  override val subquery: String = s"""
+    {
+      attachmentType
+      fileName
+      description
+      checked
+      fileSize
+      updatedAt
+    }
+  """

--- a/common/src/main/public/development.conf.json
+++ b/common/src/main/public/development.conf.json
@@ -1,6 +1,7 @@
 {
   "environment": "DEVELOPMENT",
   "odbURI": "wss://lucuma-postgres-odb-dev.herokuapp.com/ws",
+  "odbRestURI": "https://lucuma-postgres-odb-dev.herokuapp.com",
   "preferencesDBURI": "wss://user-prefs-development.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-development.herokuapp.com/itc",
   "sso": {

--- a/common/src/main/public/production.conf.json
+++ b/common/src/main/public/production.conf.json
@@ -1,6 +1,7 @@
 {
   "environment": "PRODUCTION",
   "odbURI": "wss://lucuma-odb.herokuapp.com/ws",
+  "odbRestURI": "https://lucuma-odb.herokuapp.com",
   "preferencesDBURI": "wss://user-prefs.herokuapp.com/v1/graphql",
   "itcURI": "https://itc.gpp.gemini.edu/itc",
   "sso": {

--- a/common/src/main/public/staging.conf.json
+++ b/common/src/main/public/staging.conf.json
@@ -1,6 +1,7 @@
 {
   "environment": "STAGING", 
   "odbURI": "wss://lucuma-postgres-odb-staging.herokuapp.com/ws",
+  "odbRestURI": "https://lucuma-postgres-odb-staging.herokuapp.com",
   "preferencesDBURI": "wss://user-prefs-staging.herokuapp.com/v1/graphql",
   "itcURI": "https://itc-staging.lucuma.xyz/itc",
   "sso": {

--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -251,6 +251,10 @@ object Icons {
   val faFileArrowUp: FAIcon = js.native
 
   @js.native
+  @JSImport("@fortawesome/pro-light-svg-icons", "faFileArrowDown")
+  val faFileArrowDown: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-thin-svg-icons", "faArrowUpRightAndArrowDownLeftFromCenter")
   val faExpandDiagonal: FAIcon = js.native
 
@@ -334,6 +338,7 @@ object Icons {
     faCircleSmall,
     faBahai,
     faFileArrowUp,
+    faFileArrowDown,
     faFileCirclePlus,
     faExpandDiagonal,
     faContractDiagonal,
@@ -403,6 +408,7 @@ object Icons {
   val Bahai               = FontAwesomeIcon(faBahai)
   val FileCirclePlus      = FontAwesomeIcon(faFileCirclePlus)
   val FileArrowUp         = FontAwesomeIcon(faFileArrowUp)
+  val FileArrowDown       = FontAwesomeIcon(faFileArrowDown)
   val ExpandDiagonal      = FontAwesomeIcon(faExpandDiagonal)
   val ContractDiagonal    = FontAwesomeIcon(faContractDiagonal)
   val Clone               = FontAwesomeIcon(faClone)

--- a/common/src/main/scala/explore/common/ProgramQueries.scala
+++ b/common/src/main/scala/explore/common/ProgramQueries.scala
@@ -10,6 +10,7 @@ import clue.data.syntax.*
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.DefaultErrorPolicy
 import japgolly.scalajs.react.*
+import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Program
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Enums.*
@@ -76,6 +77,36 @@ object ProgramQueries:
         UpdateProgramsInput(
           WHERE = id.toWhereProgram.assign,
           SET = ProgramPropertiesInput(name = name.orUnassign)
+        )
+      )
+      .void
+
+  def updateObsAttachmentDescription[F[_]: Async](
+    pid:  Program.Id,
+    oid:  ObsAttachment.Id,
+    desc: Option[NonEmptyString]
+  )(using FetchClient[F, ObservationDB]): F[Unit] =
+    UpdateObsAttachmentMutation[F]
+      .execute(
+        UpdateObsAttachmentsInput(
+          programId = pid,
+          WHERE = WhereObsAttachment(id = WhereOrderObsAttachmentId(EQ = oid.assign).assign).assign,
+          SET = ObsAttachmentPropertiesInput(description = desc.orUnassign)
+        )
+      )
+      .void
+
+  def updateObsAttachmentChecked[F[_]: Async](
+    pid:     Program.Id,
+    oid:     ObsAttachment.Id,
+    checked: Boolean
+  )(using FetchClient[F, ObservationDB]): F[Unit] =
+    UpdateObsAttachmentMutation[F]
+      .execute(
+        UpdateObsAttachmentsInput(
+          programId = pid,
+          WHERE = WhereObsAttachment(id = WhereOrderObsAttachmentId(EQ = oid.assign).assign).assign,
+          SET = ObsAttachmentPropertiesInput(checked = checked.assign)
         )
       )
       .void

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -295,6 +295,13 @@ object ExploreStyles:
   val BrightnessesTableDeletButtonWrapper: Css = Css("explore-brightnesses-delete-button-wrapper")
   val EmptyTreeContent: Css                    = Css("explore-empty-tree-content")
 
+  val AttachmentsTable: Css       = Css("explore-attachments-table")
+  val AttachmentsTableFooter: Css = Css("explore-attachments-footer")
+  val AttachmentName: Css         = Css("explore-attachment-name")
+  val AttachmentNameInput: Css    = Css("explore-attachment-name-input")
+
+  val FileUpload: Css = Css("explore-fileupload")
+
   // This is rendered without React, so we include SUI classes.
   val CrashMessage: Css = Css(List("ui", "large", "label", "crash-message"))
 

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -57,6 +57,8 @@ object reusability:
   given Reusability[ConstraintGroup]         = Reusability.byEq
   given Reusability[ObsSummary]              = Reusability.byEq
   given Reusability[ExploreLocalPreferences] = Reusability.byEq
+  given Reusability[ObsAttachment]           = Reusability.byEq
+  given Reusability[ProposalAttachment]      = Reusability.byEq
 
   /**
    */

--- a/common/src/main/scala/explore/utils/OdbRestClient.scala
+++ b/common/src/main/scala/explore/utils/OdbRestClient.scala
@@ -1,0 +1,157 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.utils
+
+import cats.effect.Async
+import cats.effect.Resource
+import cats.syntax.all.*
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.model.AppConfig
+import fs2.Stream
+import fs2.text.utf8
+import lucuma.core.model.ObsAttachment
+import lucuma.core.model.Program
+import lucuma.core.syntax.string.*
+import lucuma.schemas.ObservationDB.Enums.ObsAttachmentType
+import org.http4s.*
+import org.http4s.client.Client
+import org.http4s.dom.FetchClientBuilder
+import org.http4s.headers.Authorization
+import org.scalajs.dom
+
+import scala.concurrent.duration.*
+import scala.util.control.NoStackTrace
+
+trait OdbRestClient[F[_]] {
+  def getObsAttachment(programId: Program.Id, attachmentId: ObsAttachment.Id): F[Stream[F, Byte]]
+
+  def insertObsAttachment(
+    programId:      Program.Id,
+    attachmentType: ObsAttachmentType,
+    fileName:       NonEmptyString,
+    description:    Option[NonEmptyString],
+    data:           Stream[F, Byte]
+  ): F[ObsAttachment.Id]
+
+  def updateObsAttachment(
+    programId:    Program.Id,
+    attachmentId: ObsAttachment.Id,
+    fileName:     NonEmptyString,
+    description:  Option[NonEmptyString],
+    data:         Stream[F, Byte]
+  ): F[Unit]
+
+  def deleteAttachment(programId: Program.Id, attachmentId: ObsAttachment.Id): F[Unit]
+}
+
+object OdbRestClient {
+  def apply[F[_]: Async](authToken: NonEmptyString): OdbRestClient[F] = {
+
+    val authHeader = Headers(
+      Authorization(Credentials.Token(AuthScheme.Bearer, authToken.value))
+    )
+
+    given QueryParamEncoder[NonEmptyString]    = QueryParamEncoder[String].contramap(_.value)
+    given QueryParamEncoder[ObsAttachmentType] = QueryParamEncoder[String].contramap(_.show)
+
+    def getURI: F[Uri] =
+      AppConfig
+        .fetchConfig(
+          FetchClientBuilder[F]
+            .withRequestTimeout(5.seconds)
+            .withCache(dom.RequestCache.`no-store`)
+            .create
+        )
+        .map(_.odbRestURI / "attachment")
+
+    def client: Client[F] = FetchClientBuilder[F].withRequestTimeout(60.seconds).create
+
+    def mkError[A](msg: String): F[A] = Async[F].raiseError(new Exception(msg) with NoStackTrace)
+
+    def runRequest(action: String)(f: Uri => Request[F]): Resource[F, Response[F]] =
+      val resource = for {
+        uri <- Resource.eval(getURI)
+        res <- client.run(f(uri))
+      } yield res
+      resource.evalMap(res =>
+        if (res.status === Status.Ok) Async[F].pure(res)
+        else res.error(action)
+      )
+
+    extension (response: Response[F])
+      def getBody: F[String]             = response.body.through(utf8.decode).compile.string
+      def error[A](action: String): F[A] =
+        getBody.flatMap { b =>
+          val bodyMsg = if (b.isEmpty) "" else s": $b"
+          mkError(s"Error $action Attachment: ${response.status.reason}$bodyMsg")
+        }
+
+    new OdbRestClient[F] {
+      def getObsAttachment(
+        programId:    Program.Id,
+        attachmentId: ObsAttachment.Id
+      ): F[Stream[F, Byte]] =
+        runRequest("Getting")(baseUri =>
+          Request[F](
+            method = Method.GET,
+            uri = baseUri / "obs" / programId.show / attachmentId.show,
+            headers = authHeader
+          )
+        ).use(r => Async[F].pure(r.body))
+
+      def insertObsAttachment(
+        programId:      Program.Id,
+        attachmentType: ObsAttachmentType,
+        fileName:       NonEmptyString,
+        description:    Option[NonEmptyString],
+        data:           Stream[F, Byte]
+      ): F[ObsAttachment.Id] =
+        runRequest("Adding") { baseUri =>
+          val uri = (baseUri / "obs" / programId.show)
+            .withQueryParam("fileName", fileName)
+            .withQueryParam("attachmentType", attachmentType.toString.toScreamingSnakeCase)
+            .withOptionQueryParam("description", description)
+          Request[F](
+            method = Method.POST,
+            uri = uri,
+            headers = authHeader,
+            body = data
+          )
+        }.use(
+          _.getBody.flatMap(
+            ObsAttachment.Id.parse(_).fold(mkError("Invalid Attachment Id returned"))(Async[F].pure)
+          )
+        )
+
+      def updateObsAttachment(
+        programId:    Program.Id,
+        attachmentId: ObsAttachment.Id,
+        fileName:     NonEmptyString,
+        description:  Option[NonEmptyString],
+        data:         Stream[F, Byte]
+      ): F[Unit] =
+        runRequest("Updating") { baseUri =>
+          val uri = (baseUri / "obs" / programId.show / attachmentId.show)
+            .withQueryParam("fileName", fileName)
+            .withOptionQueryParam("description", description)
+          Request[F](
+            method = Method.PUT,
+            uri = uri,
+            headers = authHeader,
+            body = data
+          )
+        }.use(_ => Async[F].unit)
+
+      def deleteAttachment(programId: Program.Id, attachmentId: ObsAttachment.Id): F[Unit] =
+        runRequest("Deleting") { baseUri =>
+          val uri = baseUri / "obs" / programId.show / attachmentId.show
+          Request[F](
+            method = Method.DELETE,
+            uri = uri,
+            headers = authHeader
+          )
+        }.use(_ => Async[F].unit)
+    }
+  }
+}

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -18,6 +18,7 @@ import crystal.react.View
 import crystal.react.implicits.*
 import crystal.react.reuse.*
 import eu.timepit.refined.*
+import eu.timepit.refined.types.numeric.NonNegLong
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.BuildInfo
 import explore.Icons
@@ -176,6 +177,19 @@ extension [A](value: js.UndefOr[DateOrRange])
 
   def fromDatePickerToZDTOpt(using ev: A <:< js.Date): Option[ZonedDateTime] =
     fromDatePickerToInstantOpt.map(i => ZonedDateTime.ofInstant(i, ZoneOffset.UTC))
+
+extension (bytes: NonNegLong)
+  // modified from: https://gist.github.com/BlinkoWang/38b706cb24fa91b1d761
+  def toHumanReadableByteCount: String = {
+    val base = 1000
+    if (bytes.value < base) s"$bytes B"
+    else {
+      val exp   = (Math.log(bytes.value.toDouble) / Math.log(base)).toInt
+      val pre   = "kMGTPE".charAt(exp - 1)
+      val value = bytes.value / Math.pow(base, exp)
+      f"$value%.2f ${pre}B"
+    }
+  }
 
 object IsExpanded extends NewType[Boolean]
 type IsExpanded = IsExpanded.Type

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -577,6 +577,7 @@ a:hover {
   }
 }
 
+.explore-attachments-footer,
 .explore-brightnesses-footer {
   padding: 0.2em;
   border-top: 0.2px solid var(--under-tab-border-color);
@@ -593,7 +594,14 @@ a:hover {
 
   .p-button {
     margin-left: 5px;
+    margin-bottom: 1px;
     flex-shrink: 0;
+  }
+}
+
+.explore-attachments-footer {
+  .p-dropdown {
+    width: 15em;
   }
 }
 
@@ -1166,6 +1174,21 @@ $search-preview-margin: 5px;
 }
 
 // ------
+// Attachment Tables
+// ------
+.explore-attachments-table {
+  .explore-attachment-name {
+    @include common.text-ellipsis;
+
+    width: 100%;
+  }
+
+  .explore-attachment-name-input {
+    width: 100%;
+  }
+}
+
+// ------
 // Programs Popup
 // ------
 .api-keys-popup.p-dialog,
@@ -1535,10 +1558,15 @@ table.explore-border-table {
   padding: 0.25rem;
 }
 
-.p-button.p-fileupload {
+
+.p-button.explore-fileupload {
   +input[type="file"] {
     display: none;
   }
+}
+
+input[type="file"].explore-fileupload {
+  display: none;
 }
 
 // ----

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -37,8 +37,6 @@ case object LabelsElement extends ElementItem
 
 object Routing:
 
-  private def homeTab(): VdomElement = UnderConstruction()
-
   private def withProgramSummaries(model: View[RootModel])(
     render: View[ProgramSummaries] => VdomNode
   ): VdomElement =
@@ -50,6 +48,16 @@ object Routing:
       .asInstanceOf[VdomElement]
     // Not sure why the router's renderer requires VdomElement instead of VdomNode
     // In any case, in all of our uses here we are returning a valid VdomElement.
+
+  private def overviewTab(page: Page, model: View[RootModel]): VdomElement =
+    withProgramSummaries(model)(programSummaries =>
+      val routingInfo = RoutingInfo.from(page)
+
+      OverviewTabContents(routingInfo.programId,
+                          model.zoom(RootModel.vault).get,
+                          programSummaries.zoom(ProgramSummaries.obsAttachments)
+      )
+    )
 
   private def targetTab(page: Page, model: View[RootModel]): VdomElement =
     withProgramSummaries(model)(programSummaries =>
@@ -137,7 +145,7 @@ object Routing:
           | staticRoute(root, NoProgramPage) ~> renderP(showProgramSelectionPopup _)
 
           | dynamicRouteCT((root / id[Program.Id]).xmapL(HomePage.iso)) ~> dynRenderP {
-            case (_, _) => homeTab()
+            case (p, m) => overviewTab(p, m)
           }
 
           | dynamicRouteCT(

--- a/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
+++ b/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
@@ -1,0 +1,407 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.attachments
+
+import cats.Order.*
+import cats.effect.IO
+import cats.syntax.all.*
+import crystal.react.*
+import crystal.react.hooks.*
+import crystal.react.implicits.*
+import crystal.react.reuse.*
+import eu.timepit.refined.types.numeric.NonNegLong
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.EditableLabel
+import explore.Icons
+import explore.common.ProgramQueries
+import explore.components.ui.ExploreStyles
+import explore.model.AppContext
+import explore.model.Constants
+import explore.model.ObsAttachment
+import explore.model.reusability.given
+import explore.syntax.ui.*
+import explore.utils.OdbRestClient
+import explore.utils.*
+import fs2.dom
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.model.Program
+import lucuma.core.model.{ObsAttachment => ObsAtt}
+import lucuma.core.syntax.all.*
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
+import lucuma.core.util.NewType
+import lucuma.core.util.Timestamp
+import lucuma.react.syntax.*
+import lucuma.react.table.*
+import lucuma.refined.*
+import lucuma.schemas.ObservationDB.Enums.ObsAttachmentType
+import lucuma.ui.primereact.CheckboxView
+import lucuma.ui.primereact.EnumDropdownView
+import lucuma.ui.primereact.LucumaStyles
+import lucuma.ui.primereact.given
+import lucuma.ui.syntax.all.*
+import lucuma.ui.syntax.all.given
+import lucuma.ui.table.*
+import lucuma.ui.utils.*
+import monocle.Iso
+import monocle.Lens
+import org.scalajs.dom.{File => DomFile}
+import org.typelevel.log4cats.Logger
+import react.common.ReactFnProps
+import react.common.style.Css
+import react.floatingui.Placement
+import react.floatingui.syntax.*
+import react.primereact.Button
+import react.primereact.ConfirmPopup
+import react.primereact.Dialog
+import react.primereact.Message
+import react.primereact.PrimeStyles
+
+import java.time.Instant
+import java.time.ZoneId
+
+case class ObsAttachmentsTable(
+  pid:            Program.Id,
+  client:         OdbRestClient[IO],
+  obsAttachments: View[List[ObsAttachment]]
+) extends ReactFnProps(ObsAttachmentsTable.component)
+
+object ObsAttachmentsTable extends TableHooks:
+  private type Props = ObsAttachmentsTable
+
+  private enum Action:
+    case None, Insert, Replace, Download
+
+  private val ColDef = ColumnDef[View[ObsAttachment]]
+
+  private val ActionsColumnId: ColumnId        = ColumnId("actions")
+  private val FileNameColumnId: ColumnId       = ColumnId("filename")
+  private val AttachmentTypeColumnId: ColumnId = ColumnId("attachment-type")
+  private val SizeColumnId                     = ColumnId("filesize")
+  private val LastUpdateColumnId               = ColumnId("last-update")
+  private val DescriptionColumnId: ColumnId    = ColumnId("description")
+  private val CheckedColumnId: ColumnId        = ColumnId("checked")
+
+  private val columnNames: Map[ColumnId, String] = Map(
+    ActionsColumnId        -> "Actions",
+    FileNameColumnId       -> "File",
+    AttachmentTypeColumnId -> "Type",
+    SizeColumnId           -> "Size",
+    LastUpdateColumnId     -> "LastUpdate",
+    DescriptionColumnId    -> "Description",
+    CheckedColumnId        -> "Checked"
+  )
+
+  private val labelButtonClasses =
+    PrimeStyles.Component |+| PrimeStyles.Button |+| PrimeStyles.ButtonIconOnly
+      |+| PrimeStyles.ButtonSecondary |+| LucumaStyles.Tiny |+| LucumaStyles.Compact
+
+  // TEMPORARY until we get the graphql enums worked out
+  given Enumerated[ObsAttachmentType] =
+    Enumerated
+      .from(ObsAttachmentType.Finder, ObsAttachmentType.MosMask, ObsAttachmentType.PreImaging)
+      .withTag(_.toString)
+  given Display[ObsAttachmentType]    = Display.byShortName(_.toString)
+
+  // TODO: Maybe we can have a graphql query for getting information such as this? This is a config var in ODB.
+  private val maxFileSize: NonNegLong = 10000000.refined
+
+  def checkFileSize(file: DomFile)(f: => IO[Unit])(using tx: ToastCtx[IO]): IO[Unit] =
+    if (file.size.toLong === 0)
+      tx.showToast("Attachment files cannot be empty", Message.Severity.Error, true)
+    else if (file.size.toLong > maxFileSize.value)
+      tx.showToast(
+        s"Attachment files cannot be larger than ${maxFileSize.toHumanReadableByteCount}",
+        Message.Severity.Error,
+        true
+      )
+    else f
+
+  def insertAttachment(props: Props, attType: ObsAttachmentType, files: List[DomFile])(using
+    ToastCtx[IO]
+  ): IO[Unit] =
+    files.headOption
+      .map(f =>
+        checkFileSize(f) {
+          val name = NonEmptyString.unsafeFrom(f.name)
+          props.client
+            .insertObsAttachment(props.pid,
+                                 attType,
+                                 name,
+                                 None,
+                                 dom.readReadableStream(IO(f.stream()))
+            )
+            .flatMap(id =>
+              props.obsAttachments
+                .mod(
+                  _ :+ ObsAttachment(
+                    id,
+                    attType,
+                    name,
+                    None,
+                    false,
+                    f.size.toLong,
+                    Timestamp.unsafeFromInstantTruncated(Instant.now())
+                  )
+                )
+                .to[IO]
+            )
+            .toastErrors
+        }
+      )
+      .orEmpty
+
+  def updateAttachment(props: Props, oa: ObsAttachment, files: List[DomFile])(using
+    ToastCtx[IO]
+  ): IO[Unit] =
+    files.headOption
+      .map(f =>
+        checkFileSize(f) {
+          val name = NonEmptyString.unsafeFrom(f.name)
+          props.client
+            .updateObsAttachment(props.pid,
+                                 oa.id,
+                                 name,
+                                 oa.description,
+                                 dom.readReadableStream(IO(f.stream()))
+            ) *>
+            props.obsAttachments
+              .mod(
+                _.map(o =>
+                  if (o.id === oa.id)
+                    o.copy(fileName = name,
+                           updatedAt = Timestamp.unsafeFromInstantTruncated(Instant.now()),
+                           checked = false
+                    )
+                  else o
+                )
+              )
+              .to[IO]
+              .toastErrors
+        }
+      )
+      .orEmpty
+
+  def deleteAttachment(
+    props: Props,
+    aid:   ObsAtt.Id
+  )(using ToastCtx[IO]): IO[Unit] =
+    props.obsAttachments.mod(_.filter(_.id =!= aid)).to[IO] *>
+      props.client.deleteAttachment(props.pid, aid).toastErrors
+
+  def deletePrompt(props: Props, aid: ObsAtt.Id)(
+    e: ReactMouseEvent
+  )(using Logger[IO], ToastCtx[IO]): Callback =
+    ConfirmPopup
+      .confirmPopup(
+        e.currentTarget.domAsHtml,
+        "Delete attachment? This action is not undoable.",
+        acceptLabel = "Delete",
+        rejectLabel = "Cancel",
+        accept = deleteAttachment(props, aid).runAsync
+      )
+      .show
+
+  private val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      .useContext(AppContext.ctx)
+      .useStateView(Action.None)
+      // Columns
+      .useMemoBy((_, _, _) => ())((props, ctx, action) =>
+        _ =>
+          import ctx.given
+
+          def column[V](id: ColumnId, accessor: ObsAttachment => V)
+            : ColumnDef.Single[View[ObsAttachment], V] =
+            ColDef(id, v => accessor(v.get), columnNames(id))
+
+          List(
+            column(ActionsColumnId, identity)
+              .setCell(cell =>
+                val thisOa = cell.value
+                val id     = thisOa.id
+
+                def onUpdateFileSelected(e: ReactEventFromInput): Callback =
+                  val files = e.target.files.toList
+                  (Callback(e.target.value = null) *>
+                    action.set(Action.Replace) *>
+                    updateAttachment(props, thisOa, files)
+                      .guarantee(action.async.set(Action.None))
+                      .runAsync())
+                    .when_(files.nonEmpty)
+
+                <.div(
+                  // The upload "button" needs to be a label. In order to make
+                  // the styling consistent they're all labels.
+                  <.label(
+                    labelButtonClasses,
+                    Icons.Trash,
+                    ^.onClick ==> deletePrompt(props, id)
+                  ).withTooltip("Delete attachment"),
+                  <.label(
+                    labelButtonClasses,
+                    ^.htmlFor := s"attachment-replace-$id",
+                    Icons.FileArrowUp
+                  ).withTooltip(
+                    tooltip = s"Upload replacement file",
+                    placement = Placement.Right
+                  ),
+                  <.input(
+                    ExploreStyles.FileUpload |+| ExploreStyles.FileUpload,
+                    ^.tpe  := "file",
+                    ^.onChange ==> onUpdateFileSelected,
+                    ^.id   := s"attachment-replace-$id",
+                    ^.name := "file"
+                  )
+                  // TODO: Implement file download...
+                  // <.label(
+                  // labelButtonClasses,
+                  //   ^.cls := labelButtonClasses,
+                  //   Icons.FileArrowDown
+                  // ).withTooltip("Download attachment")
+                )
+              )
+              .setEnableSorting(false),
+            column(FileNameColumnId, ObsAttachment.fileName.get)
+              .setCell(_.value.value)
+              .sortableBy(_.value.toUpperCase),
+            column(AttachmentTypeColumnId, ObsAttachment.attachmentType.get)
+              .setCell(_.value.shortName),
+            column(SizeColumnId, ObsAttachment.fileSize.get)
+              .setCell(cell =>
+                // The fileSize will always be > 0, the api should be changed to reflect this
+                NonNegLong.from(cell.value).toOption.map(_.toHumanReadableByteCount).orEmpty
+              ),
+            column(LastUpdateColumnId, ObsAttachment.updatedAt.get)
+              .setCell(cell =>
+                Constants.GppDateFormatter
+                  .withZone(ZoneId.systemDefault())
+                  .format(cell.value.toInstant)
+              ),
+            ColDef(
+              DescriptionColumnId,
+              _.withOnMod(oa =>
+                ProgramQueries
+                  .updateObsAttachmentDescription[IO](props.pid, oa.id, oa.description)
+                  .runAsync
+              )
+                .zoom(ObsAttachment.description),
+              columnNames(DescriptionColumnId),
+              cell =>
+                EditableLabel.fromView(
+                  value = cell.value,
+                  addButtonLabel = ("Add description": VdomNode).reuseAlways,
+                  textClass = ExploreStyles.AttachmentName,
+                  inputClass = ExploreStyles.AttachmentNameInput,
+                  editButtonTooltip = "Edit description".some,
+                  deleteButtonTooltip = "Delete description".some,
+                  okButtonTooltip = "Accept".some,
+                  discardButtonTooltip = "Discard".some
+                )
+            )
+              .sortableBy(_.get.map(_.value.toUpperCase).orEmpty),
+            ColDef(
+              CheckedColumnId,
+              identity,
+              columnNames(CheckedColumnId),
+              cell =>
+                CheckboxView(
+                  id = NonEmptyString.unsafeFrom(s"checked-${cell.value.get.id}"),
+                  value = cell.value
+                    .withOnMod(oa =>
+                      ProgramQueries
+                        .updateObsAttachmentChecked[IO](props.pid, oa.id, oa.checked)
+                        .runAsync
+                    )
+                    .zoom(ObsAttachment.checked),
+                  label = ""
+                )
+            ).sortableBy(_.get.checked)
+          )
+      )
+      // Rows
+      .useMemoBy((props, _, _, _) => props.obsAttachments.reuseByValue)((_, _, _, _) =>
+        _.value.toListOfViews.sortBy(_.get.id)
+      )
+      .useReactTableBy((prop, ctx, _, cols, rows) =>
+        TableOptions(
+          cols,
+          rows,
+          getRowId = (row, _, _) => RowId(row.get.id.toString)
+        )
+      )
+      .useStateView(Enumerated[ObsAttachmentType].all.head)
+      .render { (props, ctx, action, _, _, table, newAttType) =>
+        import ctx.given
+
+        val dialogHeader = action.get match
+          case Action.None     => ""
+          case Action.Insert   => "Uploading Attachment"
+          case Action.Replace  => "Uploading Replacement"
+          case Action.Download => "Downloading Attachment"
+
+        def onInsertFileSelected(e: ReactEventFromInput): Callback =
+          val files = e.target.files.toList
+          (Callback(e.target.value = null) *>
+            action.set(Action.Insert) *>
+            insertAttachment(props, newAttType.get, files)
+              .guarantee(action.async.set(Action.None))
+              .runAsync)
+            .when_(files.nonEmpty)
+
+        val footer =
+          <.tr(
+            <.td(
+              ^.colSpan := 7,
+              <.div(
+                ExploreStyles.AttachmentsTableFooter,
+                EnumDropdownView(
+                  id = "attachment-type".refined,
+                  value = newAttType,
+                  clazz = ExploreStyles.FlatFormField
+                ),
+                <.label(
+                  labelButtonClasses,
+                  ^.htmlFor := "attachment-upload",
+                  Icons.FileArrowUp
+                ).withTooltip(
+                  tooltip = s"Upload new ${newAttType.get.shortName} attachment",
+                  placement = Placement.Right
+                ),
+                <.input(
+                  ExploreStyles.FileUpload,
+                  ^.tpe  := "file",
+                  ^.onChange ==> onInsertFileSelected,
+                  ^.id   := "attachment-upload",
+                  ^.name := "file"
+                )
+              )
+            )
+          )
+
+        <.div(
+          PrimeTable(
+            table,
+            striped = true,
+            compact = Compact.Very,
+            footerMod = footer,
+            emptyMessage = <.div("No observation attachments uploaded"),
+            tableMod = ExploreStyles.AttachmentsTable
+          ),
+          ConfirmPopup(),
+          Dialog(
+            onHide = Callback.empty,
+            visible = action.get != Action.None,
+            header = dialogHeader,
+            blockScroll = true,
+            modal = true,
+            dismissableMask = false,
+            closable = false,
+            closeOnEscape = false,
+            showHeader = true
+          )("Please wait...")
+        )
+      }

--- a/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
@@ -1,0 +1,148 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.tabs
+
+import cats.effect.IO
+import cats.syntax.all.*
+import crystal.Pot
+import crystal.react.*
+import crystal.react.hooks.*
+import crystal.react.implicits.*
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.types.numeric.NonNegInt
+import explore.UnderConstruction
+import explore.attachments.ObsAttachmentsTable
+import explore.components.Tile
+import explore.components.TileController
+import explore.model.AppContext
+import explore.model.ObsAttachment
+import explore.model.UserVault
+import explore.model.enums.GridLayoutSection
+import explore.model.layout.*
+import explore.utils.OdbRestClient
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.model.Program
+import lucuma.refined.*
+import lucuma.ui.reusability.given
+import lucuma.ui.syntax.all.*
+import lucuma.ui.syntax.all.given
+import react.common.ReactFnProps
+import react.gridlayout.*
+import react.primereact.Button
+import react.resizeDetector.hooks.*
+case class OverviewTabContents(
+  programId:      Program.Id,
+  userVault:      Option[UserVault],
+  obsAttachments: View[List[ObsAttachment]]
+) extends ReactFnProps(OverviewTabContents.component)
+
+object OverviewTabContents {
+  private type Props = OverviewTabContents
+
+  private val WarningsAndErrorsHeight: NonNegInt      = 8.refined
+  private val WarningsAndErrorsMinHeight: NonNegInt   = 6.refined
+  private val ObsAttachmentsHeight: NonNegInt         = 8.refined
+  private val ObsAttachmentsMinHeight: NonNegInt      = 6.refined
+  private val ProposalAttachmentsHeight: NonNegInt    = 6.refined
+  private val ProposalAttachmentsMinHeight: NonNegInt = 4.refined
+  private val TileMinWidth: NonNegInt                 = 4.refined
+  private val DefaultWidth: NonNegInt                 = 10.refined
+  private val DefaultLargeWidth: NonNegInt            = 12.refined
+
+  private val layoutMedium: Layout = Layout(
+    List(
+      LayoutItem(
+        i = ObsTabTilesIds.WarningsAndErrorsId.id.value,
+        x = 0,
+        y = 0,
+        w = DefaultWidth.value,
+        h = WarningsAndErrorsHeight.value,
+        minH = WarningsAndErrorsMinHeight.value,
+        minW = TileMinWidth.value
+      ),
+      LayoutItem(
+        i = ObsTabTilesIds.ObsAttachmentsId.id.value,
+        x = 0,
+        y = WarningsAndErrorsHeight.value,
+        w = DefaultWidth.value,
+        h = ObsAttachmentsHeight.value,
+        minH = ObsAttachmentsMinHeight.value,
+        minW = TileMinWidth.value
+      ),
+      LayoutItem(
+        i = ObsTabTilesIds.ProposalAttachmentsId.id.value,
+        x = 0,
+        y = WarningsAndErrorsHeight.value + ObsAttachmentsHeight.value,
+        w = DefaultWidth.value,
+        h = ProposalAttachmentsHeight.value,
+        minH = ProposalAttachmentsMinHeight.value,
+        minW = TileMinWidth.value
+      )
+    )
+  )
+
+  private val defaultLayouts = defineStdLayouts(
+    Map(
+      (BreakpointName.lg,
+       layoutItems.andThen(layoutItemWidth).replace(DefaultLargeWidth)(layoutMedium)
+      ),
+      (BreakpointName.md, layoutMedium)
+    )
+  )
+
+  private val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      .useMemoBy(_.userVault.map(_.token))(_ => _.map(OdbRestClient[IO]))
+      .useContext(AppContext.ctx)
+      // TODO: Save/restore the layout in user prefs.
+      .useStateView(Pot(defaultLayouts))
+      .useResizeDetector()
+      .render { (props, oRestClient, ctx, layouts, resize) =>
+
+        import ctx.given
+
+        oRestClient.value.map(client =>
+          layouts.renderPotView { l =>
+
+            val warningsAndErrorsTile = Tile(
+              ObsTabTilesIds.WarningsAndErrorsId.id,
+              "Warnings And Errors",
+              none,
+              canMinimize = true
+            )(_ => UnderConstruction())
+
+            val obsAttachmentsTile = Tile(
+              ObsTabTilesIds.ObsAttachmentsId.id,
+              "Observation Attachments",
+              none,
+              canMinimize = true
+            )(_ =>
+              <.div(
+                ObsAttachmentsTable(props.programId, client, props.obsAttachments)
+              )
+            )
+
+            val proposalAttachmentsTile = Tile(
+              ObsTabTilesIds.ProposalAttachmentsId.id,
+              "Warnings And Errors",
+              none,
+              canMinimize = true
+            )(_ => UnderConstruction())
+
+            TileController(
+              props.userVault.map(_.user.id),
+              resize.width.getOrElse(1),
+              defaultLayouts,
+              l,
+              List(warningsAndErrorsTile, obsAttachmentsTile, proposalAttachmentsTile),
+              GridLayoutSection.OverviewLayout,
+              storeLayout = false
+            )
+
+          }
+        )
+      }
+}

--- a/explore/src/main/scala/explore/tabs/package.scala
+++ b/explore/src/main/scala/explore/tabs/package.scala
@@ -8,14 +8,17 @@ import lucuma.refined.*
 
 enum ObsTabTilesIds:
   case NotesId, TargetSummaryId, TargetId, PlotId, ConstraintsId, ConfigurationId, ItcId,
-    TimingWindowsId
+    TimingWindowsId, WarningsAndErrorsId, ObsAttachmentsId, ProposalAttachmentsId
 
   def id: NonEmptyString = this match
-    case NotesId         => "notes".refined
-    case TargetSummaryId => "targetSummary".refined
-    case TargetId        => "target".refined
-    case PlotId          => "elevationPlot".refined
-    case ConstraintsId   => "constraints".refined
-    case ConfigurationId => "configuration".refined
-    case ItcId           => "itc".refined
-    case TimingWindowsId => "timingWindows".refined
+    case NotesId               => "notes".refined
+    case TargetSummaryId       => "targetSummary".refined
+    case TargetId              => "target".refined
+    case PlotId                => "elevationPlot".refined
+    case ConstraintsId         => "constraints".refined
+    case ConfigurationId       => "configuration".refined
+    case ItcId                 => "itc".refined
+    case TimingWindowsId       => "timingWindows".refined
+    case WarningsAndErrorsId   => "warningsAndErrors".refined
+    case ObsAttachmentsId      => "obsAttachments".refined
+    case ProposalAttachmentsId => "proposalAttachments".refined

--- a/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryTable.scala
@@ -288,7 +288,7 @@ object TargetSummaryTable extends TableHooks:
                 ExploreStyles.TableSelectionToolbar,
                 HelpIcon("target/main/target-import.md".refined),
                 <.label(
-                  ^.cls     := "pl-compact p-component p-button p-fileupload",
+                  PrimeStyles.Component |+| PrimeStyles.Button |+| LucumaStyles.Compact |+| ExploreStyles.FileUpload,
                   ^.htmlFor := "target-import",
                   Icons.FileArrowUp
                 ),

--- a/model/shared/src/main/scala/explore/model/AppConfig.scala
+++ b/model/shared/src/main/scala/explore/model/AppConfig.scala
@@ -41,6 +41,7 @@ case class AppConfig(
   environment:      ExecutionEnvironment,
   preferencesDBURI: Uri,
   odbURI:           Uri,
+  odbRestURI:       Uri,
   itcURI:           Uri,
   sso:              SSOConfig
 )

--- a/model/shared/src/main/scala/explore/model/ObsAttachment.scala
+++ b/model/shared/src/main/scala/explore/model/ObsAttachment.scala
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Decoder
+import io.circe.generic.semiauto.*
+import io.circe.refined.given
+import lucuma.core.model
+import lucuma.core.util.Timestamp
+import lucuma.schemas.ObservationDB.Enums.ObsAttachmentType
+import monocle.Focus
+import monocle.Lens
+
+case class ObsAttachment(
+  id:             model.ObsAttachment.Id,
+  attachmentType: ObsAttachmentType,
+  fileName:       NonEmptyString,
+  description:    Option[NonEmptyString],
+  checked:        Boolean,
+  fileSize:       Long,
+  updatedAt:      Timestamp
+) derives Eq
+
+object ObsAttachment:
+  val id: Lens[ObsAttachment, model.ObsAttachment.Id]          = Focus[ObsAttachment](_.id)
+  val attachmentType: Lens[ObsAttachment, ObsAttachmentType]   =
+    Focus[ObsAttachment](_.attachmentType)
+  val fileName: Lens[ObsAttachment, NonEmptyString]            = Focus[ObsAttachment](_.fileName)
+  val description: Lens[ObsAttachment, Option[NonEmptyString]] = Focus[ObsAttachment](_.description)
+  val checked: Lens[ObsAttachment, Boolean]                    = Focus[ObsAttachment](_.checked)
+  val fileSize: Lens[ObsAttachment, Long]                      = Focus[ObsAttachment](_.fileSize)
+  val updatedAt: Lens[ObsAttachment, Timestamp]                = Focus[ObsAttachment](_.updatedAt)
+
+  given Decoder[ObsAttachment] = deriveDecoder

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -20,9 +20,11 @@ import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 
 case class ProgramSummaries(
-  targets:      TargetList,
-  observations: ObservationList,
-  groups:       GroupList
+  targets:             TargetList,
+  observations:        ObservationList,
+  groups:              GroupList,
+  obsAttachments:      List[ObsAttachment],
+  proposalAttachments: List[ProposalAttachment]
 ) derives Eq:
   lazy val asterismGroups: AsterismGroupList =
     SortedMap.from(
@@ -74,18 +76,26 @@ case class ProgramSummaries(
     ProgramSummaries.observations.modify(_.removed(obsId))(this)
 
 object ProgramSummaries:
-  val targets: Lens[ProgramSummaries, TargetList]           = Focus[ProgramSummaries](_.targets)
-  val observations: Lens[ProgramSummaries, ObservationList] =
+  val targets: Lens[ProgramSummaries, TargetList]                           = Focus[ProgramSummaries](_.targets)
+  val observations: Lens[ProgramSummaries, ObservationList]                 =
     Focus[ProgramSummaries](_.observations)
-  val groups: Lens[ProgramSummaries, GroupList]             = Focus[ProgramSummaries](_.groups)
+  val groups: Lens[ProgramSummaries, GroupList]                             = Focus[ProgramSummaries](_.groups)
+  val obsAttachments: Lens[ProgramSummaries, List[ObsAttachment]]           =
+    Focus[ProgramSummaries](_.obsAttachments)
+  val proposalAttachments: Lens[ProgramSummaries, List[ProposalAttachment]] =
+    Focus[ProgramSummaries](_.proposalAttachments)
 
   def fromLists(
-    targetList: List[TargetWithId],
-    obsList:    List[ObsSummary],
-    groups:     List[GroupElement]
+    targetList:          List[TargetWithId],
+    obsList:             List[ObsSummary],
+    groups:              List[GroupElement],
+    obsAttachments:      List[ObsAttachment],
+    proposalAttachments: List[ProposalAttachment]
   ): ProgramSummaries =
     ProgramSummaries(
       targetList.toSortedMap(_.id, _.target),
       KeyedIndexedList.fromList(obsList, ObsSummary.id.get),
-      groups
+      groups,
+      obsAttachments,
+      proposalAttachments
     )

--- a/model/shared/src/main/scala/explore/model/ProposalAttachment.scala
+++ b/model/shared/src/main/scala/explore/model/ProposalAttachment.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Decoder
+import io.circe.generic.semiauto.*
+import io.circe.refined.given
+import lucuma.core.util.Timestamp
+import lucuma.schemas.ObservationDB.Enums.ProposalAttachmentType
+import monocle.Focus
+import monocle.Lens
+
+case class ProposalAttachment(
+  attachmentType: ProposalAttachmentType,
+  fileName:       NonEmptyString,
+  description:    Option[NonEmptyString],
+  checked:        Boolean,
+  fileSize:       Long,
+  updatedAt:      Timestamp
+) derives Eq
+
+object ProposalAttachment:
+  val attachmentType: Lens[ProposalAttachment, ProposalAttachmentType] =
+    Focus[ProposalAttachment](_.attachmentType)
+  val fileName: Lens[ProposalAttachment, NonEmptyString]               = Focus[ProposalAttachment](_.fileName)
+  val description: Lens[ProposalAttachment, Option[NonEmptyString]]    =
+    Focus[ProposalAttachment](_.description)
+  val checked: Lens[ProposalAttachment, Boolean]                       = Focus[ProposalAttachment](_.checked)
+  val fileSize: Lens[ProposalAttachment, Long]                         = Focus[ProposalAttachment](_.fileSize)
+  val updatedAt: Lens[ProposalAttachment, Timestamp]                   = Focus[ProposalAttachment](_.updatedAt)
+
+  given Decoder[ProposalAttachment] = deriveDecoder

--- a/model/shared/src/main/scala/explore/model/enums/GridLayoutSection.scala
+++ b/model/shared/src/main/scala/explore/model/enums/GridLayoutSection.scala
@@ -9,5 +9,6 @@ enum GridLayoutSection(val value: String) derives Enumerated:
   case ObservationsLayout extends GridLayoutSection("observations")
   case TargetLayout       extends GridLayoutSection("targets")
   case ConstraintsLayout  extends GridLayoutSection("constraints")
+  case OverviewLayout     extends GridLayoutSection("overview")
 
   private val tag = value

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -23,7 +23,7 @@ object Versions {
   val lucumaBC               = "0.4.0"
   val lucumaCore             = "0.76.0"
   val lucumaCatalog          = "0.40.5"
-  val lucumaReact            = "0.35.0"
+  val lucumaReact            = "0.36.0"
   val lucumaRefined          = "0.1.1"
   val lucumaSchemas          = "0.52.1"
   val lucumaSSO              = "0.5.10"


### PR DESCRIPTION
This creates an `Observation Attachments` tile on the overview tab, with a table of observations and allows uploading, updating and deleting of attachments. It also adds placeholder tabs for the Proposal Attachments and the Warnings And Errors. There are still things that need to be done that will be handled in other PRs.

- Make the editing of descriptions and the checked column actually update the attachment via graphql. (See comment in ObsAttachmentsTable.scala.) This could be handled in this PR if a solution is found.
- Save/restore the tile layout for the overview tab to/from the user preferences.
- Add the ability to download an attachment.
- The table should probably be a virtualized table.