### PR TITLE
Update crystal to fix View bug

### DIFF
--- a/explore/src/main/scala/explore/EditableLabel.scala
+++ b/explore/src/main/scala/explore/EditableLabel.scala
@@ -117,7 +117,7 @@ object EditableLabel {
           severity = Button.Severity.Secondary,
           clazz = props.rightButtonClass,
           onClickE = e => e.stopPropagationCB >> e.preventDefaultCB >> props.mod(none),
-          tooltip = props.leftButtonTooltip.orUndefined
+          tooltip = props.rightButtonTooltip.orUndefined
         ).mini.compact
 
         val acceptButton: VdomNode = Button(

--- a/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
+++ b/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
@@ -278,8 +278,7 @@ object ObsAttachmentsTable extends TableHooks:
             column(LastUpdateColumnId, ObsAttachment.updatedAt.get)
               .setCell(cell =>
                 Constants.GppDateFormatter
-                  .withZone(ZoneId.systemDefault())
-                  .format(cell.value.toInstant)
+                  .format(cell.value.toLocalDateTime)
               ),
             ColDef(
               DescriptionColumnId,

--- a/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
@@ -127,7 +127,7 @@ object OverviewTabContents {
 
             val proposalAttachmentsTile = Tile(
               ObsTabTilesIds.ProposalAttachmentsId.id,
-              "Warnings And Errors",
+              "Proposal Attachments",
               none,
               canMinimize = true
             )(_ => UnderConstruction())

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   val circeGolden            = "0.3.0"
   val coulomb                = "0.7.3"
   val clue                   = "0.30.0"
-  val crystal                = "0.33.11"
+  val crystal                = "0.33.12"
   val discipline             = "1.5.1"
   val disciplineMUnit        = "1.0.9"
   val fs2                    = "3.6.1"


### PR DESCRIPTION
Fixes bug where edits to obs attachment description and checked were not propagated to the ODB (Thanks Raul!)

Some unrelated fixes:

- Uses UTC for modified date to solve some issues with ZoneIds
- Incorrect tooltip being used for EditableLabel delete button
- Incorrect name for Proposal Attachments tile