### PR TITLE
Allow filtering of cacheable items, e.g. to not cache errors

### DIFF
--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -121,7 +121,20 @@ object ITCGraphRequests:
         .map(_.toList.flattenOption.toMap)
 
     // We cache unexpanded results, exactly as received from server.
-    val cacheableRequest = Cacheable(CacheName("itcGraphQuery"), CacheVersion(5), doRequest)
+    val cacheableRequest =
+      Cacheable(
+        CacheName("itcGraphQuery"),
+        CacheVersion(5),
+        doRequest,
+        (r, g) =>
+          r.target.forall(t =>
+            g.get(t).forall {
+              case Right(_)                               => true
+              case Left(ItcQueryProblems.GenericError(_)) => false
+              case Left(_)                                => false
+            }
+          )
+      )
 
     itcRowsParams
       .traverse { request =>

--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -131,7 +131,7 @@ object ITCGraphRequests:
             g.get(t).forall {
               case Right(_)                               => true
               case Left(ItcQueryProblems.GenericError(_)) => false
-              case Left(_)                                => false
+              case Left(_)                                => true
             }
           )
       )

--- a/workers/src/main/scala/workers/itc/ITCRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCRequests.scala
@@ -110,7 +110,18 @@ object ITCRequests:
 
     val cacheVersion = CacheVersion(3)
 
-    val cacheableRequest = Cacheable(CacheName("itcQuery"), cacheVersion, doRequest)
+    val cacheableRequest =
+      Cacheable(
+        CacheName("itcQuery"),
+        cacheVersion,
+        doRequest,
+        (r, g) =>
+          g.exists(_.get(r).forall {
+            case Right(_)                               => true
+            case Left(ItcQueryProblems.GenericError(_)) => false
+            case Left(_)                                => false
+          })
+      )
 
     val itcRowsParams = modes
       .map(x => (x.intervalCenter(wavelength), x.instrument))

--- a/workers/src/main/scala/workers/itc/ITCRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCRequests.scala
@@ -119,7 +119,7 @@ object ITCRequests:
           g.exists(_.get(r).forall {
             case Right(_)                               => true
             case Left(ItcQueryProblems.GenericError(_)) => false
-            case Left(_)                                => false
+            case Left(_)                                => true
           })
       )
 


### PR DESCRIPTION
This adds a feature to the cache to make it optional no a per request basis
On ITC we are storing error cases but we may not want to do that in all cases. In particular if the server is unreachable we want to retry.