### PR TITLE
Add assigned obs ids to obs attachments table

### DIFF
--- a/common-queries/src/clue/scala/queries/common/ObsAttachmentSubquery.scala
+++ b/common-queries/src/clue/scala/queries/common/ObsAttachmentSubquery.scala
@@ -21,10 +21,5 @@ object ObsAttachmentSubquery
       checked
       fileSize
       updatedAt
-      observations {
-        matches {
-          id
-        }
-      }
     }
   """

--- a/common-queries/src/clue/scala/queries/common/ObsAttachmentSubquery.scala
+++ b/common-queries/src/clue/scala/queries/common/ObsAttachmentSubquery.scala
@@ -21,5 +21,10 @@ object ObsAttachmentSubquery
       checked
       fileSize
       updatedAt
+      observations {
+        matches {
+          id
+        }
+      }
     }
   """

--- a/common-queries/src/clue/scala/queries/common/ObservationSummarySubquery.scala
+++ b/common-queries/src/clue/scala/queries/common/ObservationSummarySubquery.scala
@@ -32,6 +32,9 @@ object ObservationSummarySubquery
           }
           constraintSet $ConstraintSetSubquery
           timingWindows $TimingWindowSubquery
+          obsAttachments {
+            id
+          }
           scienceRequirements {
             spectroscopy {
               wavelength $WavelengthSubquery

--- a/common/src/main/scala/explore/cache/ProgramCache.scala
+++ b/common/src/main/scala/explore/cache/ProgramCache.scala
@@ -19,6 +19,7 @@ import explore.model.ObsSummary
 import explore.model.ProgramSummaries
 import explore.model.ProposalAttachment
 import explore.model.TargetWithObs
+import explore.model.syntax.all.*
 import explore.model.reusability.given
 import japgolly.scalajs.react.*
 import lucuma.core.model.Observation
@@ -197,7 +198,7 @@ object ProgramCache extends CacheComponent[ProgramSummaries, ProgramCache]:
     val updateAttachments = ProgramEditAttachmentSubscription
       .subscribe[IO](props.programId)
       .map(_.map(data =>
-        val obsAttachments      = data.programEdit.value.obsAttachments
+        val obsAttachments      = data.programEdit.value.obsAttachments.toSortedMap(_.id)
         val proposalAttachments = data.programEdit.value.proposalAttachments
         ProgramSummaries.obsAttachments
           .replace(obsAttachments)

--- a/common/src/main/scala/explore/cache/ProgramCache.scala
+++ b/common/src/main/scala/explore/cache/ProgramCache.scala
@@ -19,8 +19,8 @@ import explore.model.ObsSummary
 import explore.model.ProgramSummaries
 import explore.model.ProposalAttachment
 import explore.model.TargetWithObs
-import explore.model.syntax.all.*
 import explore.model.reusability.given
+import explore.model.syntax.all.*
 import japgolly.scalajs.react.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -304,10 +304,10 @@ object ExploreStyles:
   val BrightnessesTableDeletButtonWrapper: Css = Css("explore-brightnesses-delete-button-wrapper")
   val EmptyTreeContent: Css                    = Css("explore-empty-tree-content")
 
-  val AttachmentsTable: Css       = Css("explore-attachments-table")
-  val AttachmentsTableFooter: Css = Css("explore-attachments-footer")
-  val AttachmentName: Css         = Css("explore-attachment-name")
-  val AttachmentNameInput: Css    = Css("explore-attachment-name-input")
+  val AttachmentsTable: Css           = Css("explore-attachments-table")
+  val AttachmentsTableTypeSelect: Css = Css("explore-attachments-type-select")
+  val AttachmentName: Css             = Css("explore-attachment-name")
+  val AttachmentNameInput: Css        = Css("explore-attachment-name-input")
 
   val FileUpload: Css = Css("explore-fileupload")
 

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -13,6 +13,7 @@ import explore.model.itc.ItcExposureTime
 import explore.model.itc.ItcTarget
 import explore.modes.InstrumentRow
 import explore.undo.UndoStacks
+import explore.utils.OdbRestClient
 import japgolly.scalajs.react.ReactCats.*
 import japgolly.scalajs.react.Reusability
 import lucuma.ags.AgsAnalysis
@@ -127,3 +128,5 @@ object reusability:
   given Reusability[ScienceRequirements] = Reusability.byEq
 
   given Reusability[OdbItcResult.Success] = Reusability.byEq
+
+  given odbRestClientReuse[F[_]]: Reusability[OdbRestClient[F]] = Reusability.by(_.authToken)

--- a/common/src/main/scala/explore/utils/OdbRestClient.scala
+++ b/common/src/main/scala/explore/utils/OdbRestClient.scala
@@ -24,6 +24,9 @@ import scala.concurrent.duration.*
 import scala.util.control.NoStackTrace
 
 trait OdbRestClient[F[_]] {
+  // Allows us to have a reuse - needed for memoization, etc.
+  def authToken: NonEmptyString
+
   def getObsAttachment(programId: Program.Id, attachmentId: ObsAttachment.Id): F[Stream[F, Byte]]
 
   def getPresignedUrl(programId: Program.Id, attachmentId: ObsAttachment.Id): F[String]
@@ -90,6 +93,8 @@ object OdbRestClient {
         }
 
     new OdbRestClient[F] {
+      val authToken: NonEmptyString = authToken
+
       def getObsAttachment(
         programId:    Program.Id,
         attachmentId: ObsAttachment.Id

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -589,7 +589,6 @@ a:hover {
   }
 }
 
-.explore-attachments-footer,
 .explore-brightnesses-footer {
   padding: 0.2em;
   border-top: 0.2px solid var(--under-tab-border-color);
@@ -608,12 +607,6 @@ a:hover {
     margin-left: 5px;
     margin-bottom: 1px;
     flex-shrink: 0;
-  }
-}
-
-.explore-attachments-footer {
-  .p-dropdown {
-    width: 15em;
   }
 }
 
@@ -1228,6 +1221,10 @@ $search-preview-margin: 5px;
   .explore-attachment-name-input {
     width: 100%;
   }
+}
+
+.explore-attachments-type-select.p-dropdown {
+  width: 15em;
 }
 
 // ------

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1224,7 +1224,7 @@ $search-preview-margin: 5px;
 }
 
 .explore-attachments-type-select.p-dropdown {
-  width: 15em;
+  width: 10em;
 }
 
 // ------

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -49,9 +49,11 @@ object Routing:
     withProgramSummaries(model)(programSummaries =>
       val routingInfo = RoutingInfo.from(page)
 
-      OverviewTabContents(routingInfo.programId,
-                          model.zoom(RootModel.vault).get,
-                          programSummaries.zoom(ProgramSummaries.obsAttachments)
+      OverviewTabContents(
+        routingInfo.programId,
+        model.zoom(RootModel.vault).get,
+        programSummaries.zoom(ProgramSummaries.obsAttachments),
+        programSummaries.get.obsAttachmentAssignments
       )
     )
 

--- a/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
+++ b/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
@@ -222,16 +222,19 @@ object ObsAttachmentsTable extends TableHooks:
       }
       .flatMap(p => urlMap.mod(_.updated(oa.toMapKey, p)).to[IO])
 
-  def deletePrompt(props: Props, aid: ObsAtt.Id)(
+  def deletePrompt(props: Props, oa: ObsAttachment)(
     e: ReactMouseEvent
   )(using Logger[IO], ToastCtx[IO]): Callback =
+    val msg =
+      if (oa.observations.isEmpty) ""
+      else s"It is assigned to ${oa.observations.size} observations. "
     ConfirmPopup
       .confirmPopup(
         e.currentTarget.domAsHtml,
-        "Delete attachment? This action is not undoable.",
+        s"Delete attachment? ${msg}This action is not undoable.",
         acceptLabel = "Delete",
         rejectLabel = "Cancel",
-        accept = deleteAttachment(props, aid).runAsync
+        accept = deleteAttachment(props, oa.id).runAsync
       )
       .show
 
@@ -294,7 +297,7 @@ object ObsAttachmentsTable extends TableHooks:
                   <.label(
                     labelButtonClasses,
                     Icons.Trash,
-                    ^.onClick ==> deletePrompt(props, id)
+                    ^.onClick ==> deletePrompt(props, thisOa)
                   ).withTooltip("Delete attachment"),
                   <.label(
                     labelButtonClasses,
@@ -425,7 +428,7 @@ object ObsAttachmentsTable extends TableHooks:
         val footer =
           <.tr(
             <.td(
-              ^.colSpan := 7,
+              ^.colSpan := 8,
               <.div(
                 ExploreStyles.AttachmentsTableFooter,
                 EnumDropdownView(

--- a/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
@@ -41,15 +41,13 @@ case class OverviewTabContents(
 object OverviewTabContents {
   private type Props = OverviewTabContents
 
-  private val WarningsAndErrorsHeight: NonNegInt      = 8.refined
-  private val WarningsAndErrorsMinHeight: NonNegInt   = 6.refined
-  private val ObsAttachmentsHeight: NonNegInt         = 8.refined
-  private val ObsAttachmentsMinHeight: NonNegInt      = 6.refined
-  private val ProposalAttachmentsHeight: NonNegInt    = 6.refined
-  private val ProposalAttachmentsMinHeight: NonNegInt = 4.refined
-  private val TileMinWidth: NonNegInt                 = 4.refined
-  private val DefaultWidth: NonNegInt                 = 10.refined
-  private val DefaultLargeWidth: NonNegInt            = 12.refined
+  private val WarningsAndErrorsHeight: NonNegInt    = 8.refined
+  private val WarningsAndErrorsMinHeight: NonNegInt = 6.refined
+  private val ObsAttachmentsHeight: NonNegInt       = 8.refined
+  private val ObsAttachmentsMinHeight: NonNegInt    = 6.refined
+  private val TileMinWidth: NonNegInt               = 4.refined
+  private val DefaultWidth: NonNegInt               = 10.refined
+  private val DefaultLargeWidth: NonNegInt          = 12.refined
 
   private val layoutMedium: Layout = Layout(
     List(
@@ -69,15 +67,6 @@ object OverviewTabContents {
         w = DefaultWidth.value,
         h = ObsAttachmentsHeight.value,
         minH = ObsAttachmentsMinHeight.value,
-        minW = TileMinWidth.value
-      ),
-      LayoutItem(
-        i = ObsTabTilesIds.ProposalAttachmentsId.id.value,
-        x = 0,
-        y = WarningsAndErrorsHeight.value + ObsAttachmentsHeight.value,
-        w = DefaultWidth.value,
-        h = ProposalAttachmentsHeight.value,
-        minH = ProposalAttachmentsMinHeight.value,
         minW = TileMinWidth.value
       )
     )
@@ -125,19 +114,12 @@ object OverviewTabContents {
               )
             )
 
-            val proposalAttachmentsTile = Tile(
-              ObsTabTilesIds.ProposalAttachmentsId.id,
-              "Proposal Attachments",
-              none,
-              canMinimize = true
-            )(_ => UnderConstruction())
-
             TileController(
               props.userVault.map(_.user.id),
               resize.width.getOrElse(1),
               defaultLayouts,
               l,
-              List(warningsAndErrorsTile, obsAttachmentsTile, proposalAttachmentsTile),
+              List(warningsAndErrorsTile, obsAttachmentsTile),
               GridLayoutSection.OverviewLayout,
               storeLayout = false
             )

--- a/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
@@ -32,6 +32,7 @@ import react.common.ReactFnProps
 import react.gridlayout.*
 import react.primereact.Button
 import react.resizeDetector.hooks.*
+
 case class OverviewTabContents(
   programId:      Program.Id,
   userVault:      Option[UserVault],
@@ -108,10 +109,8 @@ object OverviewTabContents {
               "Observation Attachments",
               none,
               canMinimize = true
-            )(_ =>
-              <.div(
-                ObsAttachmentsTable(props.programId, client, props.obsAttachments)
-              )
+            )(renderInTitle =>
+              ObsAttachmentsTable(props.programId, client, props.obsAttachments, renderInTitle)
             )
 
             TileController(

--- a/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
@@ -17,6 +17,8 @@ import explore.components.Tile
 import explore.components.TileController
 import explore.model.AppContext
 import explore.model.ObsAttachment
+import explore.model.ObsAttachmentList
+import explore.model.ObsAttachmentAssignmentMap
 import explore.model.UserVault
 import explore.model.enums.GridLayoutSection
 import explore.model.layout.*
@@ -34,9 +36,10 @@ import react.primereact.Button
 import react.resizeDetector.hooks.*
 
 case class OverviewTabContents(
-  programId:      Program.Id,
-  userVault:      Option[UserVault],
-  obsAttachments: View[List[ObsAttachment]]
+  programId:                Program.Id,
+  userVault:                Option[UserVault],
+  obsAttachments:           View[ObsAttachmentList],
+  obsAttachmentAssignments: ObsAttachmentAssignmentMap
 ) extends ReactFnProps(OverviewTabContents.component)
 
 object OverviewTabContents {
@@ -110,7 +113,12 @@ object OverviewTabContents {
               none,
               canMinimize = true
             )(renderInTitle =>
-              ObsAttachmentsTable(props.programId, client, props.obsAttachments, renderInTitle)
+              ObsAttachmentsTable(props.programId,
+                                  client,
+                                  props.obsAttachments,
+                                  props.obsAttachmentAssignments,
+                                  renderInTitle
+              )
             )
 
             TileController(

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -356,6 +356,7 @@ object TargetTabContents extends TwoPanels:
                   const,
                   _,
                   _,
+                  _,
                   Some(conf),
                   _,
                   posAngle,

--- a/explore/src/main/scala/explore/tabs/package.scala
+++ b/explore/src/main/scala/explore/tabs/package.scala
@@ -8,18 +8,17 @@ import lucuma.refined.*
 
 enum ObsTabTilesIds:
   case NotesId, TargetSummaryId, TargetId, PlotId, ConstraintsId, ConfigurationId, ItcId,
-    TimingWindowsId, WarningsAndErrorsId, ObsAttachmentsId, ProposalAttachmentsId, FinderChartsId
+    TimingWindowsId, WarningsAndErrorsId, ObsAttachmentsId, FinderChartsId
 
   def id: NonEmptyString = this match
-    case NotesId               => "notes".refined
-    case TargetSummaryId       => "targetSummary".refined
-    case TargetId              => "target".refined
-    case PlotId                => "elevationPlot".refined
-    case ConstraintsId         => "constraints".refined
-    case ConfigurationId       => "configuration".refined
-    case ItcId                 => "itc".refined
-    case TimingWindowsId       => "timingWindows".refined
-    case WarningsAndErrorsId   => "warningsAndErrors".refined
-    case ObsAttachmentsId      => "obsAttachments".refined
-    case ProposalAttachmentsId => "proposalAttachments".refined
-    case FinderChartsId        => "finderChartes".refined
+    case NotesId             => "notes".refined
+    case TargetSummaryId     => "targetSummary".refined
+    case TargetId            => "target".refined
+    case PlotId              => "elevationPlot".refined
+    case ConstraintsId       => "constraints".refined
+    case ConfigurationId     => "configuration".refined
+    case ItcId               => "itc".refined
+    case TimingWindowsId     => "timingWindows".refined
+    case WarningsAndErrorsId => "warningsAndErrors".refined
+    case ObsAttachmentsId    => "obsAttachments".refined
+    case FinderChartsId      => "finderChartes".refined

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
@@ -11,6 +11,7 @@ import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
 import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbWavelength.given
+import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
@@ -57,6 +58,7 @@ trait ArbObsSummary:
         scienceTargetIds    <- arbitrary[Set[Target.Id]]
         constraints         <- arbitrary[ConstraintSet]
         timingWindows       <- arbitrary[List[TimingWindow]]
+        attachmentIds       <- arbitrary[Set[ObsAttachment.Id]]
         scienceRequirements <- arbitrary[ScienceRequirements]
         observingMode       <- arbitrary[Option[ObservingMode]]
         vizTime             <- arbitrary[Option[Instant]]
@@ -72,6 +74,7 @@ trait ArbObsSummary:
         SortedSet.from(scienceTargetIds),
         constraints,
         timingWindows,
+        SortedSet.from(attachmentIds),
         scienceRequirements,
         observingMode,
         vizTime,

--- a/model/shared/src/main/scala/explore/model/ObsAttachment.scala
+++ b/model/shared/src/main/scala/explore/model/ObsAttachment.scala
@@ -4,6 +4,7 @@
 package explore.model
 
 import cats.Eq
+import cats.Order.*
 import cats.derived.*
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
@@ -12,10 +13,13 @@ import io.circe.Decoder
 import io.circe.generic.semiauto.*
 import io.circe.refined.given
 import lucuma.core.model
+import lucuma.core.model.Observation
 import lucuma.core.util.Timestamp
 import lucuma.schemas.ObservationDB.Enums.ObsAttachmentType
 import monocle.Focus
 import monocle.Lens
+
+import scala.collection.immutable.SortedSet
 
 case class ObsAttachment(
   id:             model.ObsAttachment.Id,
@@ -24,17 +28,37 @@ case class ObsAttachment(
   description:    Option[NonEmptyString],
   checked:        Boolean,
   fileSize:       Long,
-  updatedAt:      Timestamp
+  updatedAt:      Timestamp,
+  observations:   SortedSet[Observation.Id]
 ) derives Eq
 
 object ObsAttachment:
-  val id: Lens[ObsAttachment, model.ObsAttachment.Id]          = Focus[ObsAttachment](_.id)
-  val attachmentType: Lens[ObsAttachment, ObsAttachmentType]   =
+  val id: Lens[ObsAttachment, model.ObsAttachment.Id]              = Focus[ObsAttachment](_.id)
+  val attachmentType: Lens[ObsAttachment, ObsAttachmentType]       =
     Focus[ObsAttachment](_.attachmentType)
-  val fileName: Lens[ObsAttachment, NonEmptyString]            = Focus[ObsAttachment](_.fileName)
-  val description: Lens[ObsAttachment, Option[NonEmptyString]] = Focus[ObsAttachment](_.description)
-  val checked: Lens[ObsAttachment, Boolean]                    = Focus[ObsAttachment](_.checked)
-  val fileSize: Lens[ObsAttachment, Long]                      = Focus[ObsAttachment](_.fileSize)
-  val updatedAt: Lens[ObsAttachment, Timestamp]                = Focus[ObsAttachment](_.updatedAt)
+  val fileName: Lens[ObsAttachment, NonEmptyString]                = Focus[ObsAttachment](_.fileName)
+  val description: Lens[ObsAttachment, Option[NonEmptyString]]     = Focus[ObsAttachment](_.description)
+  val checked: Lens[ObsAttachment, Boolean]                        = Focus[ObsAttachment](_.checked)
+  val fileSize: Lens[ObsAttachment, Long]                          = Focus[ObsAttachment](_.fileSize)
+  val updatedAt: Lens[ObsAttachment, Timestamp]                    = Focus[ObsAttachment](_.updatedAt)
+  val observations: Lens[ObsAttachment, SortedSet[Observation.Id]] =
+    Focus[ObsAttachment](_.observations)
 
-  given Decoder[ObsAttachment] = deriveDecoder
+  private case class ObsIdMatch(id: Observation.Id)
+  private given Decoder[ObsIdMatch] = deriveDecoder
+
+  private case class ObsIdMatches(matches: List[ObsIdMatch])
+  private given Decoder[ObsIdMatches] = deriveDecoder
+
+  given Decoder[ObsAttachment] = Decoder.instance(c =>
+    for {
+      id   <- c.get[model.ObsAttachment.Id]("id")
+      tpe  <- c.get[ObsAttachmentType]("attachmentType")
+      name <- c.get[NonEmptyString]("fileName")
+      desc <- c.get[Option[NonEmptyString]]("description")
+      chkd <- c.get[Boolean]("checked")
+      size <- c.get[Long]("fileSize")
+      updt <- c.get[Timestamp]("updatedAt")
+      oids <- c.downField("observations").as[ObsIdMatches].map(_.matches.map(_.id))
+    } yield ObsAttachment(id, tpe, name, desc, chkd, size, updt, SortedSet.from(oids))
+  )

--- a/model/shared/src/main/scala/explore/model/ObsAttachment.scala
+++ b/model/shared/src/main/scala/explore/model/ObsAttachment.scala
@@ -13,7 +13,6 @@ import io.circe.Decoder
 import io.circe.generic.semiauto.*
 import io.circe.refined.given
 import lucuma.core.model
-import lucuma.core.model.Observation
 import lucuma.core.util.Timestamp
 import lucuma.schemas.ObservationDB.Enums.ObsAttachmentType
 import monocle.Focus
@@ -28,37 +27,17 @@ case class ObsAttachment(
   description:    Option[NonEmptyString],
   checked:        Boolean,
   fileSize:       Long,
-  updatedAt:      Timestamp,
-  observations:   SortedSet[Observation.Id]
+  updatedAt:      Timestamp
 ) derives Eq
 
 object ObsAttachment:
-  val id: Lens[ObsAttachment, model.ObsAttachment.Id]              = Focus[ObsAttachment](_.id)
-  val attachmentType: Lens[ObsAttachment, ObsAttachmentType]       =
+  val id: Lens[ObsAttachment, model.ObsAttachment.Id]          = Focus[ObsAttachment](_.id)
+  val attachmentType: Lens[ObsAttachment, ObsAttachmentType]   =
     Focus[ObsAttachment](_.attachmentType)
-  val fileName: Lens[ObsAttachment, NonEmptyString]                = Focus[ObsAttachment](_.fileName)
-  val description: Lens[ObsAttachment, Option[NonEmptyString]]     = Focus[ObsAttachment](_.description)
-  val checked: Lens[ObsAttachment, Boolean]                        = Focus[ObsAttachment](_.checked)
-  val fileSize: Lens[ObsAttachment, Long]                          = Focus[ObsAttachment](_.fileSize)
-  val updatedAt: Lens[ObsAttachment, Timestamp]                    = Focus[ObsAttachment](_.updatedAt)
-  val observations: Lens[ObsAttachment, SortedSet[Observation.Id]] =
-    Focus[ObsAttachment](_.observations)
+  val fileName: Lens[ObsAttachment, NonEmptyString]            = Focus[ObsAttachment](_.fileName)
+  val description: Lens[ObsAttachment, Option[NonEmptyString]] = Focus[ObsAttachment](_.description)
+  val checked: Lens[ObsAttachment, Boolean]                    = Focus[ObsAttachment](_.checked)
+  val fileSize: Lens[ObsAttachment, Long]                      = Focus[ObsAttachment](_.fileSize)
+  val updatedAt: Lens[ObsAttachment, Timestamp]                = Focus[ObsAttachment](_.updatedAt)
 
-  private case class ObsIdMatch(id: Observation.Id)
-  private given Decoder[ObsIdMatch] = deriveDecoder
-
-  private case class ObsIdMatches(matches: List[ObsIdMatch])
-  private given Decoder[ObsIdMatches] = deriveDecoder
-
-  given Decoder[ObsAttachment] = Decoder.instance(c =>
-    for {
-      id   <- c.get[model.ObsAttachment.Id]("id")
-      tpe  <- c.get[ObsAttachmentType]("attachmentType")
-      name <- c.get[NonEmptyString]("fileName")
-      desc <- c.get[Option[NonEmptyString]]("description")
-      chkd <- c.get[Boolean]("checked")
-      size <- c.get[Long]("fileSize")
-      updt <- c.get[Timestamp]("updatedAt")
-      oids <- c.downField("observations").as[ObsIdMatches].map(_.matches.map(_.id))
-    } yield ObsAttachment(id, tpe, name, desc, chkd, size, updt, SortedSet.from(oids))
-  )
+  given Decoder[ObsAttachment] = deriveDecoder

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -19,6 +19,7 @@ import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
+import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
@@ -46,6 +47,7 @@ case class ObsSummary(
   scienceTargetIds:    AsterismIds,
   constraints:         ConstraintSet,
   timingWindows:       List[TimingWindow],
+  attachmentIds:       SortedSet[ObsAttachment.Id],
   scienceRequirements: ScienceRequirements,
   observingMode:       Option[ObservingMode],
   visualizationTime:   Option[Instant],
@@ -72,6 +74,7 @@ object ObsSummary:
   val scienceTargetIds    = Focus[ObsSummary](_.scienceTargetIds)
   val constraints         = Focus[ObsSummary](_.constraints)
   val timingWindows       = Focus[ObsSummary](_.timingWindows)
+  val attachmentIds       = Focus[ObsSummary](_.attachmentIds)
   val scienceRequirements = Focus[ObsSummary](_.scienceRequirements)
   val observingMode       = Focus[ObsSummary](_.observingMode)
   val visualizationTime   = Focus[ObsSummary](_.visualizationTime)
@@ -81,6 +84,10 @@ object ObsSummary:
   private case class TargetIdWrapper(id: Target.Id)
   private object TargetIdWrapper:
     given Decoder[TargetIdWrapper] = deriveDecoder
+
+  private case class AttachmentIdWrapper(id: ObsAttachment.Id)
+  private object AttachmentIdWrapper:
+    given Decoder[AttachmentIdWrapper] = deriveDecoder
 
   given Decoder[ObsSummary] = Decoder.instance(c =>
     for {
@@ -93,6 +100,7 @@ object ObsSummary:
       scienceTargetIds    <- c.downField("targetEnvironment").get[List[TargetIdWrapper]]("asterism")
       constraints         <- c.get[ConstraintSet]("constraintSet")
       timingWindows       <- c.get[List[TimingWindow]]("timingWindows")
+      attachmentIds       <- c.get[List[AttachmentIdWrapper]]("obsAttachments")
       scienceRequirements <- c.get[ScienceRequirements]("scienceRequirements")
       observingMode       <- c.get[Option[ObservingMode]]("observingMode")
       visualizationTime   <- c.get[Option[Timestamp]]("visualizationTime")
@@ -110,6 +118,7 @@ object ObsSummary:
       SortedSet.from(scienceTargetIds.map(_.id)),
       constraints,
       timingWindows,
+      SortedSet.from(attachmentIds.map(_.id)),
       scienceRequirements,
       observingMode,
       visualizationTime.map(_.toInstant),

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -17,13 +17,13 @@ import lucuma.core.enums.StellarLibrarySpectrum
 import lucuma.core.math.Coordinates
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Group
-import lucuma.core.model.{ObsAttachment => ObsAtt}
 import lucuma.core.model.Observation
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.SourceProfile
 import lucuma.core.model.SpectralDefinition
 import lucuma.core.model.Target
 import lucuma.core.model.UnnormalizedSED
+import lucuma.core.model.{ObsAttachment => ObsAtt}
 import lucuma.core.optics.SplitEpi
 import lucuma.core.util.NewType
 import lucuma.refined.*

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -17,6 +17,7 @@ import lucuma.core.enums.StellarLibrarySpectrum
 import lucuma.core.math.Coordinates
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Group
+import lucuma.core.model.{ObsAttachment => ObsAtt}
 import lucuma.core.model.Observation
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.SourceProfile
@@ -51,13 +52,15 @@ val EmptySiderealTarget =
 
 type AsterismIds = SortedSet[Target.Id]
 
-type AsterismGroupList   = SortedMap[ObsIdSet, AsterismIds]
-type TargetList          = SortedMap[Target.Id, Target]
-type TargetWithObsList   = SortedMap[Target.Id, TargetWithObs]
+type AsterismGroupList          = SortedMap[ObsIdSet, AsterismIds]
+type TargetList                 = SortedMap[Target.Id, Target]
+type TargetWithObsList          = SortedMap[Target.Id, TargetWithObs]
 // KeyedIndexedList is only useful is manual order is going to matter.
 // For the moment I'm keeping it because it seems it will matter at some point.
 // Otherwise, we should change to a SortedMap.
-type ObservationList     = KeyedIndexedList[Observation.Id, ObsSummary]
-type ConstraintGroupList = SortedMap[ObsIdSet, ConstraintSet]
+type ObservationList            = KeyedIndexedList[Observation.Id, ObsSummary]
+type ConstraintGroupList        = SortedMap[ObsIdSet, ConstraintSet]
+type ObsAttachmentList          = SortedMap[ObsAtt.Id, ObsAttachment]
+type ObsAttachmentAssignmentMap = Map[ObsAtt.Id, SortedSet[Observation.Id]]
 
 type GroupList = List[GroupElement]

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -27,7 +27,7 @@ object Versions {
   val lucumaRefined          = "0.1.1"
   val lucumaSchemas          = "0.52.1"
   val lucumaSSO              = "0.5.10"
-  val lucumaUI               = "0.70.0"
+  val lucumaUI               = "0.70.1"
   val lucumaITC              = "0.15.0"
   val monocle                = "3.2.0"
   val mouse                  = "1.2.1"


### PR DESCRIPTION
This also includes a number of other changes, including, but not limited to:

- Add the assigned `ObsAttachmentId`s to the `ObsSummary`
- Remove the Proposal Attachments tile from the overview tab. I discussed it with Andy and it isn't necessary.
- Move the attachment upload button and dropdown to the tile title from the table footer. It is now more like the target summary table.
- Fix issue where there would be a stale `OdbRestClient` when the auth token expired.