### PR TITLE
Fix a subtle bug that makes the flip angles not to converge

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,6 @@ import scala.sys.process.*
 import Dependencies.*
 
 val reactJS = "17.0.2"
-val FUILess = "2.8.7"
 
 ThisBuild / Test / bspEnabled                                        := false
 ThisBuild / ScalafixConfig / bspEnabled.withRank(KeyRanks.Invisible) := false

--- a/common/src/main/scala/explore/model/ObsConfiguration.scala
+++ b/common/src/main/scala/explore/model/ObsConfiguration.scala
@@ -34,8 +34,6 @@ case class ObsConfiguration(
   acquisitionOffsets: Option[NonEmptyList[Offset]],
   averagePA:          Option[Angle]
 ) derives Eq:
-  def posAngleConstraint: Option[PosAngleConstraint] = posAngleProperties.map(_.constraint.get)
-
   // In case there is no guide star we still want to have a posAngle equivalent
   // To draw visualization
   def fallbackPosAngle: Option[Angle] =
@@ -51,6 +49,8 @@ case class ObsConfiguration(
   def posAngleConstraintView: Option[View[PosAngleConstraint]] =
     posAngleProperties.map(_.constraint)
 
+  def posAngleConstraint: Option[PosAngleConstraint] = posAngleConstraintView.map(_.get)
+
   def agsState: Option[View[AgsState]] =
     posAngleProperties.map(_.agsState)
 
@@ -59,8 +59,4 @@ case class ObsConfiguration(
     posAngleProperties.map(_.selectedGS)
 
   def selectedPA: Option[Angle] =
-    for
-      gs  <- selectedGS
-      gsv <- gs.get
-      ang <- gsv.posAngle
-    yield ang
+    posAngleProperties.flatMap(_.selectedPA)

--- a/explore/src/main/scala/explore/config/PAConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/PAConfigurationPanel.scala
@@ -71,12 +71,6 @@ object PAConfigurationPanel:
         import ctx.given
 
         val paView = props.posAngleView
-          .withOnMod(c =>
-            (props.agsState.async.set(AgsState.Saving) >>
-              ObsQueries.updatePosAngle[IO](props.programId, List(props.obsId), c))
-              .guarantee(props.agsState.async.set(AgsState.Idle))
-              .runAsync
-          )
 
         val posAngleOptionsView: View[PosAngleOptions] =
           paView.zoom(unsafePosOptionsLens)

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -71,20 +71,6 @@ object AsterismEditorTile:
       ObsQueries.updateVisualizationTime[IO](programId, obsIds.toList, t).runAsync
     )
 
-    // Store the pos angle on the db
-    val updatableObsConf: ObsConfiguration =
-      obsConf.copy(posAngleProperties = obsConf.posAngleProperties.map {
-        case p @ PAProperties(oid, _, agsStateView, paView) =>
-          p.copy(constraint =
-            paView.withOnMod(pa =>
-              agsStateView.set(AgsState.Saving) *> ObsQueries
-                .updatePosAngle[IO](programId, List(oid), pa)
-                .guarantee(agsStateView.async.set(AgsState.Idle))
-                .runAsync
-            )
-          )
-      })
-
     val control: VdomNode = <.div(VizTimeEditor(vizTimeView))
 
     Tile(
@@ -103,7 +89,7 @@ object AsterismEditorTile:
           asterismIds,
           allTargets,
           vizTime,
-          updatableObsConf,
+          obsConf,
           currentTarget,
           setTarget,
           otherObsCount,

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -91,12 +91,10 @@ case class AladinCell(
       paConstraint  <- conf.posAngleConstraint
       angles        <-
         paConstraint.anglesToTestAt(configuration.siteFor, asterism.baseTracking, vizTime)
-    } yield {
-      // We sort the angles or we could end up in a loop where the angles are tested back and forth
-      // This is rare but can happen if each angle finds an equivalent guide star
-      given Order[Angle] = Angle.AngleOrder
-      angles.sorted
-    }
+    } yield
+    // We sort the angles or we could end up in a loop where the angles are tested back and forth
+    // This is rare but can happen if each angle finds an equivalent guide star
+    angles.sorted(using Angle.AngleOrder)
 
   val positions: Option[NonEmptyList[AgsPosition]] =
     val offsets: NonEmptyList[Offset] = obsConf.flatMap(_.scienceOffsets) match

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -91,12 +91,18 @@ case class AladinCell(
       paConstraint  <- conf.posAngleConstraint
       angles        <-
         paConstraint.anglesToTestAt(configuration.siteFor, asterism.baseTracking, vizTime)
-    } yield angles
+    } yield {
+      // We sort the angles or we could end up in a loop where the angles are tested back and forth
+      // This is rare but can happen if each angle finds an equivalent guide star
+      given Order[Angle] = Angle.AngleOrder
+      angles.sorted
+    }
 
   val positions: Option[NonEmptyList[AgsPosition]] =
     val offsets: NonEmptyList[Offset] = obsConf.flatMap(_.scienceOffsets) match
       case Some(offsets) => offsets.prepend(Offset.Zero)
       case None          => NonEmptyList.of(Offset.Zero)
+
     anglesToTest.map { anglesToTest =>
       for {
         pa  <- anglesToTest
@@ -212,7 +218,7 @@ object AladinCell extends ModelOptics with AladinCommon:
         case Some(PosAngleConstraint.AllowFlip(a)) if a =!= angle =>
           props.obsConf
             .flatMap(_.posAngleConstraintView)
-            .map(_.set(PosAngleConstraint.AllowFlip(angle)))
+            .map(_.set(PosAngleConstraint.AllowFlip(a.flip)))
             .getOrEmpty *> manualOverride.set(ManualAgsOverride(true))
         case _                                                    => Callback.empty
     case _                                         => Callback.empty

--- a/workers/src/main/scala/workers/AgsServer.scala
+++ b/workers/src/main/scala/workers/AgsServer.scala
@@ -26,7 +26,7 @@ object AgsServer extends WorkerServer[IO, AgsMessage.Request] {
   @JSExport
   def runWorker(): Unit = run.unsafeRunAndForget()
 
-  private val AgsCacheVersion: Int = 13
+  private val AgsCacheVersion: Int = 14
 
   private val CacheRetention: Duration = Duration.ofDays(60)
 


### PR DESCRIPTION
When doing allow flip mode we could endup in a loop where the selected angle jumps between the searched angles forever.
This fixes it by making sure we write to the db only once and by sorting the angles in flip mode