### PR TITLE
Better sorting of the modes table

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -332,6 +332,7 @@ object ExploreStyles:
   val SeqGenParametersForm: Css    = Css("seq-gen-parameters-form")
 
   // Configuration tile
+  val ConfigurationTileBody: Css        = Css("explore-configuration-tile-body")
   val PAConfigurationForm: Css          = Css("explore-pa-configuration-form")
   val PAConfigurationAngle: Css         = Css("explore-pa-configuration-angle")
   val ObsInstantTileTitle: Css          = Css("explore-obs-instant-tile-title")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -2293,7 +2293,6 @@ $help-title-height: 40px;
   align-self: stretch;
   align-items: baseline;
   gap: 0.3em;
-
   display: flex;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--site-border-color);

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1077,6 +1077,22 @@ $search-preview-margin: 5px;
 }
 
 // ------
+// Configuration Tile
+// ------
+.explore-configuration-grid {
+  padding: 0.5em;
+  width: 100%;
+  gap: 0.3em;
+  display: flex;
+  flex-direction: column;
+}
+
+.explore-configuration-tile-body {
+  display: flex;
+  background-color: var(--surface-card);
+}
+
+// ------
 // Imaging Configuration
 // ------
 .explore-configuration-filter .p-multiselect-item>span {
@@ -1101,10 +1117,6 @@ $search-preview-margin: 5px;
 // ------
 // Advanced Configuration
 // ------
-
-.explore-configuration-grid {
-  padding: 0.5em;
-}
 
 .explore-advanced-configuration-buttons {
   grid-area: buttons;
@@ -2252,9 +2264,10 @@ $help-title-height: 40px;
 }
 
 .explore-basic-configuration-grid {
+  flex-grow: 1;
   min-height: 0;
-  height: 100%;
   display: grid;
+  max-height: 100%;
   gap: 0.5em;
   grid-template:
     "form table-header" auto
@@ -2276,13 +2289,14 @@ $help-title-height: 40px;
 // Pos angle form
 // -----------------
 .explore-pa-configuration-form {
-  grid-area: obs-props;
-  display: flex;
-  gap: 0.3em;
+  flex-shrink: 1;
+  align-self: stretch;
   align-items: baseline;
+  gap: 0.3em;
+
+  display: flex;
   padding-bottom: 0.3em;
   border-bottom: 1px solid var(--site-border-color);
-  align-self: stretch;
 
   .explore-pa-configuration-angle {
     input {

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -516,7 +516,7 @@ private object SpectroscopyModesTable extends TableHooks:
       }
       .useMemoBy((_, _, _, rows, _, _, timeSort, _, table, _) =>
         (rows, timeSort.value, table.getState().sorting)
-      ) { (_, _, _, _, _, _, sorting, _, table, _) => (_, s, _) =>
+      ) { (_, _, _, _, _, _, sorting, _, table, _) => (_, _, _) =>
         table.getSortedRowModel().rows.map(_.original).toList
       }
       // selectedIndex
@@ -541,7 +541,7 @@ private object SpectroscopyModesTable extends TableHooks:
       }
       // Set the selected config if the rows change because it might have different itc data.
       // Note, we use rows for the dependency, not sorted rows, because sorted rows also changes with sort.
-      .useEffectWithDepsBy((_, _, _, rows, _, _, timeSort, _, _, _, _, _) => rows) {
+      .useEffectWithDepsBy((_, _, _, rows, _, _, _, _, _, _, _, _) => rows) {
         (props, _, _, _, _, _, _, _, _, _, sortedRows, selectedIndex) => _ =>
           val optRow = selectedIndex.value.flatMap(idx => sortedRows.lift(idx))
           val conf   = optRow.flatMap(_.rowToConf(props.spectroscopyRequirements.wavelength))

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -4,11 +4,13 @@
 package explore.tabs
 
 import cats.effect.IO
+import cats.syntax.all.*
 import crystal.Pot
 import crystal.react.View
 import eu.timepit.refined.auto.*
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.Tile
+import explore.components.ui.ExploreStyles
 import explore.config.ConfigurationPanel
 import explore.model.AsterismIds
 import explore.model.BasicConfigAndItc

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -5,6 +5,7 @@ package explore.tabs
 
 import cats.effect.IO
 import cats.syntax.all.*
+import cats.syntax.all.*
 import crystal.Pot
 import crystal.react.View
 import eu.timepit.refined.auto.*
@@ -54,6 +55,7 @@ object ConfigurationTile {
     Tile(
       ObsTabTilesIds.ConfigurationId.id,
       "Configuration",
+      bodyClass = ExploreStyles.ConfigurationTileBody.some,
       canMinimize = true
     )(_ =>
       ConfigurationPanel(

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@fortawesome/pro-solid-svg-icons": "^6.4.0",
         "@fortawesome/pro-thin-svg-icons": "^6.4.0",
         "@fortawesome/react-fontawesome": "^0.1.18",
-        "@tanstack/react-table": "^8.9.1",
+        "@tanstack/react-table": "^8.9.2",
         "@tanstack/react-virtual": "v3.0.0-beta.54",
         "broadcast-channel": "5.1.0",
         "copy-to-clipboard": "3.3.3",
@@ -2275,11 +2275,11 @@
       }
     },
     "node_modules/@tanstack/react-table": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.9.1.tgz",
-      "integrity": "sha512-yHs2m6lk5J5RNcu2dNtsDGux66wNXZjEgzxos6MRCX8gL+nqxeW3ZglqP6eANN0bGElPnjvqiUHGQvdACOr3Cw==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.9.2.tgz",
+      "integrity": "sha512-Irvw4wqVF9hhuYzmNrlae4IKdlmgSyoRWnApSLebvYzqHoi5tEsYzBj6YPd0hX78aB/L+4w/jgK2eBQVpGfThQ==",
       "dependencies": {
-        "@tanstack/table-core": "8.9.1"
+        "@tanstack/table-core": "8.9.2"
       },
       "engines": {
         "node": ">=12"
@@ -2309,9 +2309,9 @@
       }
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.9.1.tgz",
-      "integrity": "sha512-2+R83n8vMZND0q3W1lSiF7co9nFbeWbjAErFf27xwbeA9E0wtUu5ZDfgj+TZ6JzdAEQAgfxkk/QNFAKiS8E4MA==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.9.2.tgz",
+      "integrity": "sha512-ajc0OF+karBAdaSz7OK09rCoAHB1XI1+wEhu+tDNMPc+XcO+dTlXXN/Vc0a8vym4kElvEjXEDd9c8Zfgt4bekA==",
       "engines": {
         "node": ">=12"
       },
@@ -3244,9 +3244,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.30.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
-      "integrity": "sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.31.0.tgz",
+      "integrity": "sha512-hM7YCu1cU6Opx7MXNu0NuumM0ezNeAeRKadixyiQELWY3vT3De9S4J5ZBMraWV2vZnrE1Cirl0GtFtDtMUXzPw==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.21.5"
@@ -11271,11 +11271,11 @@
       }
     },
     "@tanstack/react-table": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.9.1.tgz",
-      "integrity": "sha512-yHs2m6lk5J5RNcu2dNtsDGux66wNXZjEgzxos6MRCX8gL+nqxeW3ZglqP6eANN0bGElPnjvqiUHGQvdACOr3Cw==",
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-table/-/react-table-8.9.2.tgz",
+      "integrity": "sha512-Irvw4wqVF9hhuYzmNrlae4IKdlmgSyoRWnApSLebvYzqHoi5tEsYzBj6YPd0hX78aB/L+4w/jgK2eBQVpGfThQ==",
       "requires": {
-        "@tanstack/table-core": "8.9.1"
+        "@tanstack/table-core": "8.9.2"
       }
     },
     "@tanstack/react-virtual": {
@@ -11287,9 +11287,9 @@
       }
     },
     "@tanstack/table-core": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.9.1.tgz",
-      "integrity": "sha512-2+R83n8vMZND0q3W1lSiF7co9nFbeWbjAErFf27xwbeA9E0wtUu5ZDfgj+TZ6JzdAEQAgfxkk/QNFAKiS8E4MA=="
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.9.2.tgz",
+      "integrity": "sha512-ajc0OF+karBAdaSz7OK09rCoAHB1XI1+wEhu+tDNMPc+XcO+dTlXXN/Vc0a8vym4kElvEjXEDd9c8Zfgt4bekA=="
     },
     "@tanstack/virtual-core": {
       "version": "3.0.0-beta.54",
@@ -11999,9 +11999,9 @@
       }
     },
     "core-js-compat": {
-      "version": "3.30.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.30.2.tgz",
-      "integrity": "sha512-nriW1nuJjUgvkEjIot1Spwakz52V9YkYHZAQG6A1eCgC8AA1p0zngrQEP9R0+V6hji5XilWKG1Bd0YRppmGimA==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.31.0.tgz",
+      "integrity": "sha512-hM7YCu1cU6Opx7MXNu0NuumM0ezNeAeRKadixyiQELWY3vT3De9S4J5ZBMraWV2vZnrE1Cirl0GtFtDtMUXzPw==",
       "dev": true,
       "requires": {
         "browserslist": "^4.21.5"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@fortawesome/pro-solid-svg-icons": "^6.4.0",
     "@fortawesome/pro-thin-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.1.18",
-    "@tanstack/react-table": "^8.9.1",
+    "@tanstack/react-table": "^8.9.2",
     "@tanstack/react-virtual": "v3.0.0-beta.54",
     "broadcast-channel": "5.1.0",
     "copy-to-clipboard": "3.3.3",


### PR DESCRIPTION
With the update of react table of 8.9.2 the logic of sorting undefined changed a bit.
After some experiments I thought it maybe be better to take full control defining different orderings for each direction in code.
Now the times are sorted such that all the non available values go to the end regardless if we are ascending or descending.
There are also some small ui touches for the configuration tile