### PR TITLE
Properly assign shortcut

### DIFF
--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -62,11 +62,12 @@ val Down = Shortcut("j")
 val Up   = Shortcut("k")
 
 val CopyAlt1 = Shortcut("y")
-val CopyAlt2 = Shortcut("meta+c")
+// mod implies cmd on mac and ctrl on windows/linux
+val CopyAlt2 = Shortcut("mod+c")
 
 val CopyKeys = List(CopyAlt1, CopyAlt2)
 
 val PasteAlt1 = Shortcut("p")
-val PasteAlt2 = Shortcut("meta+v")
+val PasteAlt2 = Shortcut("mod+v")
 
 val PasteKeys = List(PasteAlt1, PasteAlt2)


### PR DESCRIPTION
Tested on Chrome/Linux, Chrome/OSX, Edge/Windows