### PR TITLE
Change staging hostName in environments.conf.json

### DIFF
--- a/common/src/main/public/environments.conf.json
+++ b/common/src/main/public/environments.conf.json
@@ -14,7 +14,7 @@
     }
   },
   {
-    "hostName": "explore.lucuma.xyz",
+    "hostName": "explore-staging.lucuma.xyz",
     "environment": "STAGING",
     "odbURI": "wss://lucuma-postgres-odb-staging.herokuapp.com/ws",
     "odbRestURI": "https://lucuma-postgres-odb-staging.herokuapp.com",


### PR DESCRIPTION
Merge AFTER the migration to Firebase.

The host name `explore-staging.lucuma.xyz` points to the staging app on Firebase. This change will be needed to allow explore to get the correct config.

The slack #gpp group should probably be notified when staging changes over, and the staging environment on Heroku could be shut down?