### PR TITLE
Put the back button on the first tile always

### DIFF
--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -107,12 +107,11 @@ object Tile {
           )(
             React.Fragment(
               <.div(
-                p.back.map(b => <.div(ExploreStyles.TileButton, b)),
                 ExploreStyles.TileTitleMenu,
-                p.title
+                p.back.map(b => <.div(ExploreStyles.TileButton, b)),
+                <.span(ExploreStyles.TileTitleControlArea, p.title)
               ),
               <.div(
-                ExploreStyles.TileTitleControlArea,
                 p.control(p.state)
                   .map(b => <.div(ExploreStyles.TileControl, b)),
                 <.div(^.key := "tileTitle", ^.untypedRef(setInfoRef).when(infoRef.value.isEmpty))(

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -168,6 +168,8 @@ a:hover {
   padding: 0.5em;
   letter-spacing: 2px;
   min-width: min-content;
+  display: flex;
+  align-items: center;
 }
 
 .explore-tile-title-control-area {

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -315,7 +315,6 @@ object ObsTabTiles:
             Tile(
               ObsTabTilesIds.NotesId.id,
               s"Note for Observer",
-              props.backButton.some,
               canMinimize = true
             )(_ =>
               <.div(
@@ -421,8 +420,7 @@ object ObsTabTiles:
               setCurrentTarget(props.programId, props.obsId.some),
               otherObsCount(props.obsId, _),
               props.searching,
-              "Targets",
-              backButton = none
+              "Targets"
             )
 
           // The ExploreStyles.ConstraintsTile css adds a z-index to the constraints tile react-grid wrapper
@@ -485,6 +483,7 @@ object ObsTabTiles:
                 itcTile
               ),
               GridLayoutSection.ObservationsLayout,
+              props.backButton.some,
               clazz = ExploreStyles.ObservationTiles.some
             )
           )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -359,8 +359,7 @@ object TargetTabContents extends TwoPanels:
           setCurrentTarget(props.programId, idsToEdit) _,
           otherObsCount(idsToEdit) _,
           props.searching,
-          title,
-          backButton.some
+          title
         )
 
       val selectedCoordinates: Option[Coordinates] =
@@ -408,8 +407,7 @@ object TargetTabContents extends TwoPanels:
         props.targets.zoom(getTarget, modTarget),
         props.searching,
         title,
-        fullScreen,
-        backButton.some
+        fullScreen
       )
 
       val skyPlotTile =
@@ -465,6 +463,7 @@ object TargetTabContents extends TwoPanels:
           tileList.fold(defaultSingleLayouts)(_ => l),
           tileList.getOrElse(List(renderSummary(true))),
           GridLayoutSection.TargetLayout,
+          backButton.some,
           Option.when(tileList.isEmpty)(ExploreStyles.SingleTileMaximized),
           storeLayout = tileList.nonEmpty
         ).withKey(if (obsSelected) "target-obs-controller" else "target-summary-controller")


### PR DESCRIPTION
In small screens we have a back  button but it is always on the first tile as defined statically
This PR changes the logic to dynamically select the first tile in case the user changes the order