### PR TITLE
Implement cache for user preferences

### DIFF
--- a/common/src/clue/scala/queries/common/UserPreferencesQueriesGQL.scala
+++ b/common/src/clue/scala/queries/common/UserPreferencesQueriesGQL.scala
@@ -64,20 +64,38 @@ object UserPreferencesQueriesGQL {
   }
 
   /**
-   * Read the grid layout for a given section
+   * Read the grid layout or a given section
    */
   @GraphQL
   trait UserGridLayoutQuery extends GraphQLOperation[UserPreferencesDB] {
     val document = """
-      query tabPositions($userId: String!, $section: LucumaGridLayoutIdEnum!){
-        lucumaGridLayoutPositions(where: {section: {_eq: $section}, userId: {_eq: $userId}}) {
+      query tabPositions($userId: String!){
+        lucumaGridLayoutPositions(where: {userId: {_eq: $userId}}) {
           breakpointName
+          section
           height
           width
           x
           y
           tile
           userId
+        }
+      }
+    """
+  }
+
+  @GraphQL
+  trait UserGridLayoutUpdates extends GraphQLOperation[UserPreferencesDB] {
+    val document = """
+      subscription gridLayoutPositions($userId: String!) {
+        lucumaGridLayoutPositions(where: {userId: {_eq: $userId}}) {
+          breakpointName
+          height
+          section
+          tile
+          width
+          x
+          y
         }
       }
     """

--- a/common/src/main/scala/explore/cache/PreferencesCache.scala
+++ b/common/src/main/scala/explore/cache/PreferencesCache.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.cache
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.syntax.all.*
+import clue.StreamingClient
+import explore.DefaultErrorPolicy
+import explore.common.UserPreferencesQueries.GridLayouts
+import explore.model.ExploreGridLayouts
+import explore.model.UserPreferences
+import explore.model.enums.GridLayoutSection
+import explore.model.layout.LayoutsMap
+import japgolly.scalajs.react.*
+import lucuma.core.model.User
+import lucuma.ui.reusability.given
+import queries.common.UserPreferencesQueriesGQL.UserGridLayoutUpdates
+import queries.schemas.UserPreferencesDB
+import react.common.ReactFnProps
+
+case class PreferencesCache(
+  userId:            User.Id,
+  setUserPrefrences: Option[UserPreferences] => IO[Unit]
+)(using client: StreamingClient[IO, UserPreferencesDB])
+    extends ReactFnProps[PreferencesCache](PreferencesCache.component)
+    with CacheComponent.Props[UserPreferences]:
+  val setState                                 = setUserPrefrences
+  given StreamingClient[IO, UserPreferencesDB] = client
+
+object PreferencesCache extends CacheComponent[UserPreferences, PreferencesCache]:
+  given Reusability[PreferencesCache] = Reusability.by(_.userId)
+
+  override protected val initial: PreferencesCache => IO[UserPreferences] = props =>
+    import props.given
+
+    val grids: IO[Map[GridLayoutSection, LayoutsMap]] =
+      GridLayouts.queryWithDefault[IO](props.userId.some, ExploreGridLayouts.DefaultLayouts)
+
+    grids.map(UserPreferences.apply)
+
+  override protected val updateStream: PreferencesCache => Resource[
+    cats.effect.IO,
+    fs2.Stream[cats.effect.IO, UserPreferences => UserPreferences]
+  ] = props =>
+    import props.given
+
+    Resource.eval(IO(fs2.Stream.eval(IO(identity))))
+
+    val updateLayouts =
+      UserGridLayoutUpdates
+        .subscribe[IO](props.userId.show)
+        .map(
+          _.map(data =>
+            UserPreferences.gridLayouts
+              .modify(GridLayouts.updateLayouts(data.lucumaGridLayoutPositions))
+          )
+        )
+
+    List(updateLayouts).sequence.map(_.reduceLeft(_.merge(_)))

--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -1,0 +1,281 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Order
+import cats.implicits.catsKernelOrderingForOrder
+import cats.syntax.all.*
+import eu.timepit.refined.auto.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.numeric.NonNegInt
+import explore.model.enums.GridLayoutSection
+import explore.model.layout.LayoutsMap
+import explore.model.layout.*
+import lucuma.refined.*
+import react.gridlayout.BreakpointName
+import react.gridlayout.Layout
+import react.gridlayout.LayoutItem
+
+import scala.collection.immutable.SortedMap
+
+/**
+ * Default grid layout defiinitions
+ */
+object ExploreGridLayouts:
+  private given Order[BreakpointName] = Order.by(_.name)
+
+  def sectionLayout: GridLayoutSection => LayoutsMap = _ match {
+    case GridLayoutSection.ConstraintsLayout  => constraints.defaultConstraintsLayouts
+    case GridLayoutSection.SchedulingLayout   => scheduling.defaultSchedulingLayouts
+    case GridLayoutSection.TargetLayout       => targets.defaultTargetLayouts
+    case GridLayoutSection.ObservationsLayout => observations.defaultObsLayouts
+    case _                                    => SortedMap.empty
+  }
+
+  val DefaultLayouts: Map[GridLayoutSection, LayoutsMap] =
+    SortedMap(GridLayoutSection.values.map(l => l -> sectionLayout(l)): _*)
+
+  object constraints:
+    private val ConstraintsHeight: NonNegInt   = 4.refined
+    private val TimingWindowsHeight: NonNegInt = 14.refined
+    private val DefaultWidth: NonNegInt        = 10.refined
+    private val DefaultLargeWidth: NonNegInt   = 12.refined
+
+    private val layoutMedium: Layout = Layout(
+      List(
+        LayoutItem(
+          i = ObsTabTilesIds.ConstraintsId.id.value,
+          x = 0,
+          y = 0,
+          w = DefaultWidth.value,
+          h = ConstraintsHeight.value,
+          isResizable = false
+        ),
+        LayoutItem(
+          i = ObsTabTilesIds.TimingWindowsId.id.value,
+          x = 0,
+          y = ConstraintsHeight.value,
+          w = DefaultWidth.value,
+          h = TimingWindowsHeight.value,
+          isResizable = false
+        )
+      )
+    )
+
+    val defaultConstraintsLayouts = defineStdLayouts(
+      Map(
+        (BreakpointName.lg,
+         layoutItems.andThen(layoutItemWidth).replace(DefaultLargeWidth)(layoutMedium)
+        ),
+        (BreakpointName.md, layoutMedium)
+      )
+    )
+
+  object scheduling:
+    private val SchedulingHeight: NonNegInt  = 14.refined
+    private val DefaultWidth: NonNegInt      = 10.refined
+    private val DefaultLargeWidth: NonNegInt = 12.refined
+
+    private val layoutMedium: Layout = Layout(
+      List(
+        LayoutItem(
+          i = ObsTabTilesIds.TimingWindowsId.id.value,
+          x = 0,
+          y = 0,
+          w = DefaultWidth.value,
+          h = SchedulingHeight.value,
+          isResizable = false
+        )
+      )
+    )
+
+    val defaultSchedulingLayouts = defineStdLayouts(
+      Map(
+        (BreakpointName.lg,
+         layoutItems.andThen(layoutItemWidth).replace(DefaultLargeWidth)(layoutMedium)
+        ),
+        (BreakpointName.md, layoutMedium)
+      )
+    )
+
+  object targets:
+    private val SummaryHeight: NonNegInt     = 6.refined
+    private val SummaryMinHeight: NonNegInt  = 4.refined
+    private val TargetHeight: NonNegInt      = 18.refined
+    private val TargetMinHeight: NonNegInt   = 15.refined
+    private val SkyPlotHeight: NonNegInt     = 9.refined
+    private val SkyPlotMinHeight: NonNegInt  = 6.refined
+    private val TileMinWidth: NonNegInt      = 5.refined
+    private val DefaultWidth: NonNegInt      = 10.refined
+    private val DefaultLargeWidth: NonNegInt = 12.refined
+
+    private val layoutMedium: Layout = Layout(
+      List(
+        LayoutItem(
+          i = ObsTabTilesIds.TargetSummaryId.id.value,
+          x = 0,
+          y = 0,
+          w = DefaultWidth.value,
+          h = SummaryHeight.value,
+          minH = SummaryMinHeight.value,
+          minW = TileMinWidth.value
+        ),
+        LayoutItem(
+          i = ObsTabTilesIds.TargetId.id.value,
+          x = 0,
+          y = SummaryHeight.value,
+          w = DefaultWidth.value,
+          h = TargetHeight.value,
+          minH = TargetMinHeight.value,
+          minW = TileMinWidth.value
+        ),
+        LayoutItem(
+          i = ObsTabTilesIds.PlotId.id.value,
+          x = 0,
+          y = SummaryHeight.value + TargetHeight.value,
+          w = DefaultWidth.value,
+          h = SkyPlotHeight.value,
+          minH = SkyPlotMinHeight.value,
+          minW = TileMinWidth.value
+        )
+      )
+    )
+
+    val defaultTargetLayouts = defineStdLayouts(
+      Map(
+        (BreakpointName.lg,
+         layoutItems.andThen(layoutItemWidth).replace(DefaultLargeWidth)(layoutMedium)
+        ),
+        (BreakpointName.md, layoutMedium)
+      )
+    )
+
+    private val singleLayoutMedium: Layout = Layout(
+      List(
+        LayoutItem(
+          i = ObsTabTilesIds.TargetSummaryId.id.value,
+          x = 0,
+          y = 0,
+          w = DefaultWidth.value,
+          h = 0, // This doesn't matter, we are forcing 100%.
+          minH = SummaryMinHeight.value,
+          minW = TileMinWidth.value,
+          static = true
+        )
+      )
+    )
+
+    val defaultSingleLayouts = defineStdLayouts(
+      Map(
+        (BreakpointName.lg,
+         layoutItems.andThen(layoutItemWidth).replace(DefaultLargeWidth)(singleLayoutMedium)
+        ),
+        (BreakpointName.md, singleLayoutMedium)
+      )
+    )
+
+  object observations:
+    private val NotesMaxHeight: NonNegInt         = 3.refined
+    private val TargetHeight: NonNegInt           = 18.refined
+    private val TargetMinHeight: NonNegInt        = 15.refined
+    private val SkyPlotHeight: NonNegInt          = 9.refined
+    private val SkyPlotMinHeight: NonNegInt       = 6.refined
+    private val ConstraintsMinHeight: NonNegInt   = 4.refined
+    private val ConstraintsMaxHeight: NonNegInt   = 7.refined
+    private val TimingWindowsMinHeight: NonNegInt = 8.refined
+    private val TimingWindowsMaxHeight: NonNegInt = 12.refined
+    private val ConfigurationMaxHeight: NonNegInt = 10.refined
+    private val ItcMaxHeight: NonNegInt           = 9.refined
+    private val FinderChartMinHeight: NonNegInt   = 6.refined
+    private val FinderChartHeight: NonNegInt      = 9.refined
+    private val DefaultWidth: NonNegInt           = 10.refined
+    private val TileMinWidth: NonNegInt           = 6.refined
+    private val DefaultLargeWidth: NonNegInt      = 12.refined
+
+    private val layoutMedium: Layout = Layout(
+      List(
+        LayoutItem(
+          x = 0,
+          y = 0,
+          w = DefaultWidth.value,
+          h = NotesMaxHeight.value,
+          i = ObsTabTilesIds.NotesId.id.value,
+          isResizable = false
+        ),
+        LayoutItem(
+          x = 0,
+          y = NotesMaxHeight.value,
+          w = DefaultWidth.value,
+          h = TargetHeight.value,
+          minH = TargetMinHeight.value,
+          minW = TileMinWidth.value,
+          i = ObsTabTilesIds.TargetId.id.value
+        ),
+        LayoutItem(
+          x = 0,
+          y = (NotesMaxHeight |+| TargetHeight).value,
+          w = DefaultWidth.value,
+          h = FinderChartHeight.value,
+          minH = FinderChartMinHeight.value,
+          minW = TileMinWidth.value,
+          i = ObsTabTilesIds.FinderChartsId.id.value
+        ),
+        LayoutItem(
+          x = 0,
+          y = (NotesMaxHeight |+| TargetHeight |+| FinderChartHeight).value,
+          w = DefaultWidth.value,
+          h = SkyPlotHeight.value,
+          minH = SkyPlotMinHeight.value,
+          minW = TileMinWidth.value,
+          i = ObsTabTilesIds.PlotId.id.value
+        ),
+        LayoutItem(
+          x = 0,
+          y = (NotesMaxHeight |+| TargetHeight |+| FinderChartHeight |+| SkyPlotHeight).value,
+          w = DefaultWidth.value,
+          h = ConstraintsMaxHeight.value,
+          minH = ConstraintsMinHeight.value,
+          maxH = ConstraintsMaxHeight.value,
+          minW = TileMinWidth.value,
+          i = ObsTabTilesIds.ConstraintsId.id.value
+        ),
+        LayoutItem(
+          x = 0,
+          y =
+            (NotesMaxHeight |+| TargetHeight |+| FinderChartHeight |+| SkyPlotHeight |+| ConstraintsMaxHeight).value,
+          w = DefaultWidth.value,
+          h = TimingWindowsMaxHeight.value,
+          minH = TimingWindowsMinHeight.value,
+          maxH = TimingWindowsMaxHeight.value,
+          minW = TileMinWidth.value,
+          i = ObsTabTilesIds.TimingWindowsId.id.value
+        ),
+        LayoutItem(
+          x = 0,
+          y =
+            (NotesMaxHeight |+| TargetHeight |+| FinderChartHeight |+| SkyPlotHeight |+| ConstraintsMaxHeight |+| TimingWindowsMaxHeight).value,
+          w = DefaultWidth.value,
+          h = ConfigurationMaxHeight.value,
+          i = ObsTabTilesIds.ConfigurationId.id.value
+        ),
+        LayoutItem(
+          x = 0,
+          y =
+            (NotesMaxHeight |+| TargetHeight |+| FinderChartHeight |+| SkyPlotHeight |+| ConstraintsMaxHeight |+| TimingWindowsMaxHeight |+| ConfigurationMaxHeight).value,
+          w = DefaultWidth.value,
+          h = ItcMaxHeight.value,
+          i = ObsTabTilesIds.ItcId.id.value
+        )
+      )
+    )
+
+    val defaultObsLayouts: LayoutsMap =
+      defineStdLayouts(
+        Map(
+          (BreakpointName.lg,
+           layoutItems.andThen(layoutItemWidth).replace(DefaultLargeWidth)(layoutMedium)
+          ),
+          (BreakpointName.md, layoutMedium)
+        )
+      )

--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -27,6 +27,7 @@ case class RootModel(
   searchingTarget:      Set[Target.Id] = HashSet.empty,
   userSelectionMessage: Option[NonEmptyString] = none,
   programSummaries:     Option[ProgramSummaries] = none,
+  userPreferences:      Option[UserPreferences] = none,
   undoStacks:           UndoStacks[IO, ProgramSummaries] = UndoStacks.empty[IO, ProgramSummaries],
   otherUndoStacks:      ModelUndoStacks[IO] = ModelUndoStacks[IO]()
 ) derives Eq
@@ -38,6 +39,7 @@ object RootModel:
   val searchingTarget      = Focus[RootModel](_.searchingTarget)
   val userSelectionMessage = Focus[RootModel](_.userSelectionMessage)
   val programSummaries     = Focus[RootModel](_.programSummaries)
+  val userPreferences      = Focus[RootModel](_.userPreferences)
   val undoStacks           = Focus[RootModel](_.undoStacks)
   val otherUndoStacks      = Focus[RootModel](_.otherUndoStacks)
 

--- a/common/src/main/scala/explore/model/UserPreferences.scala
+++ b/common/src/main/scala/explore/model/UserPreferences.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import cats.implicits.*
+import explore.model.enums.GridLayoutSection
+import explore.model.layout.LayoutsMap
+import monocle.Focus
+
+case class UserPreferences(
+  private val gridLayouts: Map[GridLayoutSection, LayoutsMap]
+) derives Eq {
+  private def tabLayout(l: GridLayoutSection) =
+    gridLayouts.getOrElse(l, ExploreGridLayouts.sectionLayout(l))
+
+  val constraintsTabLayout =
+    tabLayout(GridLayoutSection.ConstraintsLayout)
+
+  val targetTabLayout =
+    tabLayout(GridLayoutSection.TargetLayout)
+
+  val schedulingTabLayout =
+    tabLayout(GridLayoutSection.SchedulingLayout)
+
+  val observationsTabLayout =
+    tabLayout(GridLayoutSection.ObservationsLayout)
+}
+
+object UserPreferences:
+  val Default     = UserPreferences(ExploreGridLayouts.DefaultLayouts)
+  val gridLayouts = Focus[UserPreferences](_.gridLayouts)

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -6,6 +6,7 @@ package explore
 import cats.effect.IO
 import cats.syntax.all.*
 import crystal.react.*
+import explore.cache.PreferencesCache
 import explore.cache.ProgramCache
 import explore.components.state.IfLogged
 import explore.components.ui.ExploreStyles
@@ -152,6 +153,7 @@ object ExploreLayout:
               ProgramCache(routingInfo.programId,
                            props.view.zoom(RootModel.programSummaries).async.set
               ),
+              PreferencesCache(vault.user.id, props.view.zoom(RootModel.userPreferences).async.set),
               TopBar(
                 vault,
                 routingInfo.optProgramId,

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -73,6 +73,9 @@ object Routing:
       )
     )
 
+  def userPreferences(model: View[RootModel]): UserPreferences =
+    model.zoom(RootModel.userPreferences).get.getOrElse(UserPreferences.Default)
+
   private def targetTab(page: Page, model: View[RootModel]): VdomElement =
     val routingInfo = RoutingInfo.from(page)
     withProgramSummaries(routingInfo.programId.some, model)(programSummaries =>
@@ -80,6 +83,7 @@ object Routing:
         model.zoom(RootModel.userId).get,
         routingInfo.programId,
         programSummaries,
+        userPreferences(model),
         routingInfo.focused,
         model.zoom(RootModel.searchingTarget),
         model.zoom(RootModel.expandedIds.andThen(ExpandedIds.asterismObsIds))
@@ -94,6 +98,7 @@ object Routing:
         model.zoom(RootModel.userId).get,
         routingInfo.programId,
         programSummaries,
+        userPreferences(model),
         routingInfo.focused,
         model.zoom(RootModel.searchingTarget),
         model.zoom(RootModel.expandedIds.andThen(ExpandedIds.obsListGroupIds))
@@ -107,6 +112,7 @@ object Routing:
         model.zoom(RootModel.userId).get,
         routingInfo.programId,
         programSummaries,
+        userPreferences(model),
         routingInfo.focused.obsSet,
         model.zoom(RootModel.expandedIds.andThen(ExpandedIds.constraintSetObsIds))
       )
@@ -120,6 +126,7 @@ object Routing:
         model.zoom(RootModel.userId).get,
         routingInfo.programId,
         programSummaries,
+        userPreferences(model),
         routingInfo.focused.obsSet,
         model.zoom(RootModel.expandedIds.andThen(ExpandedIds.schedulingObsIds))
       )

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -14,6 +14,7 @@ import explore.config.VizTimeEditor
 import explore.model.AsterismIds
 import explore.model.ObsConfiguration
 import explore.model.ObsIdSet
+import explore.model.ObsTabTilesIds
 import explore.model.TargetList
 import explore.model.enums.TileSizeState
 import explore.targeteditor.AsterismEditor

--- a/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/tabs/ConfigurationTile.scala
@@ -12,6 +12,7 @@ import explore.config.ConfigurationPanel
 import explore.model.AsterismIds
 import explore.model.BasicConfigAndItc
 import explore.model.ObsConfiguration
+import explore.model.ObsTabTilesIds
 import explore.model.ScienceRequirements
 import explore.model.TargetList
 import explore.undo.*

--- a/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
+++ b/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
@@ -6,6 +6,7 @@ package explore.tabs
 import cats.syntax.all.*
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
+import explore.model.ObsTabTilesIds
 import explore.targeteditor.ElevationPlotSection
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*

--- a/explore/src/main/scala/explore/tabs/FinderChartsTile.scala
+++ b/explore/src/main/scala/explore/tabs/FinderChartsTile.scala
@@ -10,6 +10,7 @@ import explore.components.ui.ExploreStyles
 import explore.findercharts.FinderCharts
 import explore.findercharts.finderChartsSelector
 import explore.model.ObsAttachmentList
+import explore.model.ObsTabTilesIds
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Observation
 import lucuma.core.model.Program

--- a/explore/src/main/scala/explore/tabs/ItcTile.scala
+++ b/explore/src/main/scala/explore/tabs/ItcTile.scala
@@ -12,6 +12,7 @@ import explore.itc.ItcGraphPanel
 import explore.itc.ItcPanelTitle
 import explore.itc.ItcProps
 import explore.model.LoadingState
+import explore.model.ObsTabTilesIds
 import explore.model.TargetList
 import explore.model.itc.ItcChartResult
 import explore.model.itc.ItcTarget

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -64,7 +64,6 @@ import queries.schemas.odb.ObsQueries
 import queries.schemas.odb.ObsQueries.*
 
 import java.time.Instant
-import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 
 case class ObsTabTiles(
@@ -79,7 +78,7 @@ case class ObsTabTiles(
   focusedTarget:            Option[Target.Id],
   searching:                View[Set[Target.Id]],
   defaultLayouts:           LayoutsMap,
-  layouts:                  View[Pot[LayoutsMap]],
+  layouts:                  LayoutsMap,
   resize:                   UseResizeDetectorReturn,
   obsAttachments:           View[ObsAttachmentList],
   obsAttachmentAssignments: ObsAttachmentAssignmentMap
@@ -466,25 +465,23 @@ object ObsTabTiles:
               props.allTargets.get
             )
 
-          props.layouts.renderPotView(l =>
-            TileController(
-              props.userId,
-              props.resize.width.getOrElse(0),
-              props.defaultLayouts,
-              l,
-              List(
-                notesTile,
-                targetTile,
-                finderChartsTile,
-                skyPlotTile,
-                constraintsTile,
-                timingWindowsTile,
-                configurationTile,
-                itcTile
-              ),
-              GridLayoutSection.ObservationsLayout,
-              props.backButton.some,
-              clazz = ExploreStyles.ObservationTiles.some
-            )
+          TileController(
+            props.userId,
+            props.resize.width.getOrElse(0),
+            props.defaultLayouts,
+            props.layouts,
+            List(
+              notesTile,
+              targetTile,
+              finderChartsTile,
+              skyPlotTile,
+              constraintsTile,
+              timingWindowsTile,
+              configurationTile,
+              itcTile
+            ),
+            GridLayoutSection.ObservationsLayout,
+            props.backButton.some,
+            clazz = ExploreStyles.ObservationTiles.some
           )
       }

--- a/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
@@ -17,6 +17,7 @@ import explore.components.TileController
 import explore.model.AppContext
 import explore.model.ObsAttachmentAssignmentMap
 import explore.model.ObsAttachmentList
+import explore.model.ObsTabTilesIds
 import explore.model.UserVault
 import explore.model.enums.GridLayoutSection
 import explore.model.layout.*

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -9,6 +9,7 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.model.AladinFullScreen
 import explore.model.Asterism
+import explore.model.ObsTabTilesIds
 import explore.targeteditor.SiderealTargetEditor
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -25,7 +25,8 @@ import eu.timepit.refined.*
 import eu.timepit.refined.auto.*
 import explore.Icons
 import explore.aladin.AladinFullScreenControl
-import explore.common.UserPreferencesQueries.*
+import explore.common.UserPreferencesQueries.GlobalUserPreferences
+import explore.common.UserPreferencesQueries.TargetPreferences
 import explore.components.ui.ExploreStyles
 import explore.events.*
 import explore.model.WorkerClients.*
@@ -412,7 +413,7 @@ object AladinCell extends ModelOptics with AladinCommon:
             scienceOffsets:     Option[Visible] = None,
             acquisitionOffsets: Option[Visible] = None
           ): Callback =
-            UserPreferences
+            GlobalUserPreferences
               .storePreferences[IO](
                 props.uid,
                 showCatalog = showCatalog,
@@ -493,7 +494,7 @@ object AladinCell extends ModelOptics with AladinCommon:
                 Pot.readyPrism.andThen(userPrefs).andThen(UserGlobalPreferences.aladinMouseScroll)
               )
               .withOnMod(z =>
-                z.map(z => UserPreferences.storePreferences[IO](props.uid, z.some).runAsync)
+                z.map(z => GlobalUserPreferences.storePreferences[IO](props.uid, z.some).runAsync)
                   .getOrEmpty
               )
 

--- a/model/shared/src/main/scala/explore/model/TileIds.scala
+++ b/model/shared/src/main/scala/explore/model/TileIds.scala
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
 // For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
 
-package explore.tabs
+package explore.model
 
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.refined.*


### PR DESCRIPTION
We added a better client side cache for the odb and we can do something similar for the user preferences.
This lays out the ground work and uses it for the grid layout state.
The code downstream gets nicely simplified IMHO