### PR TITLE
Fix configuration input selection not sticking during input changes

### DIFF
--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -66,17 +66,25 @@ extension [F[_]: ApplicativeThrow: ToastCtx, A](f: F[A])
     }
 
 extension [F[_]: MonadCancelThrow, A](f: F[A])
+
   /**
    * Switch the value of a ViewF to true while executing the given effect, then switch it back to
    * false when the effect is finished
    */
   def switching(
     view: ViewF[F, Boolean]
-  ): F[A] = switching(view, identity)
+  ): F[A] = switching(view, true, false)
 
   /**
    * Switch the value of a ViewF to true-ish (by the function) while executing the given effect,
    * then switch it back to false when the effect is finished
    */
   def switching[B](view: ViewF[F, B], boolToB: Boolean => B): F[A] =
-    MonadCancelThrow[F].bracket(view.set(boolToB(true)))(_ => f)(_ => view.set(boolToB(false)))
+    switching(view, boolToB(true), boolToB(false))
+
+  /**
+   * Switch the value of a ViewF to the @param acquire value while executing the given effect, then
+   * switch it back to @param release when the effect is finished
+   */
+  def switching[B](view: ViewF[F, B], acquire: B, release: B): F[A] =
+    MonadCancelThrow[F].bracket(view.set(acquire))(_ => f)(_ => view.set(release))

--- a/common/src/test/scala/explore/syntax/ui/SwitchingSpec.scala
+++ b/common/src/test/scala/explore/syntax/ui/SwitchingSpec.scala
@@ -32,6 +32,16 @@ class SwitchingSpec extends munit.CatsEffectSuite {
     }
   }
 
+  test("should switch between two given values") {
+    mkView.flatMap { (ref, view) =>
+      for {
+        _ <- ref.get.assertEquals(false)
+        _ <- ref.get.assertEquals(true).switching(view, true, false)
+        _ <- ref.get.assertEquals(false)
+      } yield ()
+    }
+  }
+
   /**
    * Make a ViewF[IO, Boolean], backed by a `Ref`
    */

--- a/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
+++ b/explore/src/main/scala/explore/attachments/ObsAttachmentsTable.scala
@@ -212,9 +212,8 @@ object ObsAttachmentsTable extends TableHooks with ObsAttachmentUtils:
                 def onUpdateFileSelected(e: ReactEventFromInput): Callback =
                   val files = e.target.files.toList
                   (Callback(e.target.value = null) *>
-                    action.set(Action.Replace) *>
                     updateAttachment(props, client, thisOa, files)
-                      .guarantee(action.async.set(Action.None))
+                      .switching(action.async, Action.Replace, Action.None)
                       .runAsync)
                     .when_(files.nonEmpty)
 

--- a/explore/src/main/scala/explore/attachments/package.scala
+++ b/explore/src/main/scala/explore/attachments/package.scala
@@ -154,9 +154,8 @@ trait ObsAttachmentUtils:
   ): Callback =
     val files = e.target.files.toList
     (Callback(e.target.value = null) *>
-      action.set(Action.Insert) *>
       insertAttachment(programId, obsAttachments, client, newAttType.gql, files, onSuccess)
-        .guarantee(action.async.set(Action.None))
+        .switching(action.async, Action.Insert, Action.None)
         .runAsync)
       .when_(files.nonEmpty)
 

--- a/explore/src/main/scala/explore/shortcuts.scala
+++ b/explore/src/main/scala/explore/shortcuts.scala
@@ -4,6 +4,7 @@
 package explore.shortcuts
 
 import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.*
 import lucuma.core.util.NewType
 import react.hotkeys.HotkeysCallback
 import react.hotkeys.HotkeysEvent
@@ -40,7 +41,7 @@ given Conversion[PartialFunction[Shortcut, Callback], HotkeysCallback] with
             p.applyOrElse(s, _ => Callback.empty)
         }
         .headOption
-        .getOrElse(Callback.empty)
+        .getOrEmpty
 
 val GoToObs         = Shortcut("o")
 val GoToTargets     = Shortcut("t")

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -256,9 +256,9 @@ object ObsTabTiles:
             props.observation.model
               .zoom(ObsSummary.posAngleConstraint)
               .withOnMod(pa =>
-                agsState.set(AgsState.Saving) *> ObsQueries
+                ObsQueries
                   .updatePosAngle[IO](props.programId, List(props.obsId), pa)
-                  .guarantee(agsState.async.set(AgsState.Idle))
+                  .switching(agsState.async, AgsState.Saving, AgsState.Idle)
                   .runAsync
               )
 

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -34,6 +34,7 @@ import explore.model.itc.ItcChartResult
 import explore.model.itc.ItcTarget
 import explore.model.layout.*
 import explore.observationtree.obsEditAttachments
+import explore.syntax.ui.*
 import explore.timingwindows.TimingWindowsPanel
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*


### PR DESCRIPTION
Now uses a `selectedRow` instead of `selectedIndex` (which is still there, but a memo). Sorting changing during selection changes will follow the selected row

Video:

https://github.com/gemini-hlsw/explore/assets/10114577/3049ba93-5224-4dbe-bf4b-967f7ce683c4


