### PR TITLE
Improve saving/restoring of tile layouts in user preferences

### DIFF
--- a/common/src/clue/scala/queries/common/UserPreferencesQueriesGQL.scala
+++ b/common/src/clue/scala/queries/common/UserPreferencesQueriesGQL.scala
@@ -78,7 +78,6 @@ object UserPreferencesQueriesGQL {
           x
           y
           tile
-          userId
         }
       }
     """
@@ -90,12 +89,12 @@ object UserPreferencesQueriesGQL {
       subscription gridLayoutPositions($userId: String!) {
         lucumaGridLayoutPositions(where: {userId: {_eq: $userId}}) {
           breakpointName
-          height
           section
-          tile
+          height
           width
           x
           y
+          tile
         }
       }
     """

--- a/common/src/main/scala/explore/cache/PreferencesCache.scala
+++ b/common/src/main/scala/explore/cache/PreferencesCache.scala
@@ -12,6 +12,7 @@ import explore.common.UserPreferencesQueries.GridLayouts
 import explore.model.ExploreGridLayouts
 import explore.model.UserPreferences
 import explore.model.enums.GridLayoutSection
+import explore.model.layout
 import explore.model.layout.LayoutsMap
 import japgolly.scalajs.react.*
 import lucuma.core.model.User
@@ -36,7 +37,13 @@ object PreferencesCache extends CacheComponent[UserPreferences, PreferencesCache
     import props.given
 
     val grids: IO[Map[GridLayoutSection, LayoutsMap]] =
-      GridLayouts.queryWithDefault[IO](props.userId.some, ExploreGridLayouts.DefaultLayouts)
+      GridLayouts
+        .queryLayouts[IO](props.userId.some)
+        .map(
+          _.fold(ExploreGridLayouts.DefaultLayouts)(l =>
+            layout.mergeSectionLayoutsMaps(ExploreGridLayouts.DefaultLayouts, l)
+          )
+        )
 
     grids.map(UserPreferences.apply)
 

--- a/common/src/main/scala/explore/components/TileController.scala
+++ b/common/src/main/scala/explore/components/TileController.scala
@@ -27,7 +27,6 @@ import lucuma.ui.syntax.all.given
 import monocle.Traversal
 import queries.schemas.UserPreferencesDB
 import react.common.ReactFnProps
-import react.common.implicits.given
 import react.common.style.Css
 import react.gridlayout.*
 
@@ -61,7 +60,7 @@ object TileController:
     tileId:     Tile.TileId
   ): TileSizeState = {
     val k = allTiles
-      .filter(s => s.i.forall(_ === tileId.value))
+      .filter(s => s.i === tileId.value)
       .getAll(layoutsMap)
       .headOption
 
@@ -74,12 +73,12 @@ object TileController:
 
   private def unsafeTileHeight(id: Tile.TileId): Traversal[LayoutsMap, Int] =
     allTiles
-      .filter(_.i.forall(_ === id.value))
+      .filter(_.i === id.value)
       .andThen(layoutItemHeight)
 
   private def tileResizable(id: Tile.TileId): Traversal[LayoutsMap, Boolean | Unit] =
     allTiles
-      .filter(_.i.forall(_ === id.value))
+      .filter(_.i === id.value)
       .andThen(layoutItemResizable)
 
   private def updateResizableState(p: LayoutsMap): LayoutsMap =
@@ -111,7 +110,7 @@ object TileController:
           currentLayout
             .zoom(allTiles)
             .mod {
-              case l if l.i.forall(_ === id.value) =>
+              case l if l.i === id.value =>
                 if (st === TileSizeState.Minimized) l.copy(h = 1, minH = 1, isResizable = false)
                 else if (st === TileSizeState.Normal) {
                   val defaultHeight =
@@ -125,19 +124,19 @@ object TileController:
                          minH = scala.math.max(l.minH.getOrElse(1), defaultHeight)
                   )
                 } else l
-              case l                               => l
+              case l                     => l
             }
 
         def addBackButton: List[Tile] = {
           val topTile =
-            currentLayout.get.get(breakpoint.value).flatMap(_._3.l.sortBy(_.y).headOption)
+            currentLayout.get.get(breakpoint.value).flatMap(_._3.asList.sortBy(_.y).headOption)
           (topTile, p.backButton)
             .mapN((t, b) =>
               p.tiles
                 .map {
-                  case ti if t.i.toOption.exists(_ === ti.id.value) =>
+                  case ti if t.i === ti.id.value =>
                     ti.copy(back = p.backButton)(ti.render)
-                  case ti                                           => ti
+                  case ti                        => ti
                 }
             )
             .getOrElse(p.tiles)
@@ -169,7 +168,7 @@ object TileController:
               currentLayout.get
                 .get(breakpoint.value)
                 .flatMap { case (_, _, l) =>
-                  l.l
+                  l.asList
                     .find(_.i === t.id.value)
                     .flatMap { i =>
                       TagMod

--- a/common/src/test/scala/explore/model/LayoutSuite.scala
+++ b/common/src/test/scala/explore/model/LayoutSuite.scala
@@ -1,0 +1,116 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import explore.model.enums.GridLayoutSection
+import explore.model.layout.*
+import munit.FunSuite
+import react.gridlayout.*
+
+import scala.collection.immutable.SortedMap
+
+class LayoutSuite extends FunSuite {
+
+  val observationMdXLayoutItem =
+    LayoutItem(i = "X", x = 0, y = 0, w = 8, h = 5, minH = 3, maxH = 10, minW = 2, maxW = 12)
+
+  val dbObservationMdXLayoutItem =
+    LayoutItem(i = "X", x = 1, y = 2, w = 7, h = 9, minH = 0, maxH = 15, minW = 5, maxW = 11)
+
+  val expectedObservationMdXLayoutItem =
+    observationMdXLayoutItem.copy(x = 1, y = 2, w = 7, h = 9)
+
+  val observationMdLayout = Layout(
+    List[LayoutItem](
+      observationMdXLayoutItem,
+      LayoutItem(i = "Y", x = 5, y = 9, w = 7, h = 8, minH = 6, maxH = 9, minW = 4, maxW = 11),
+      LayoutItem(i = "Z", x = 9, y = 15, w = 8, h = 9, minH = 5, maxH = 7, minW = 7, maxW = 9)
+    )
+  )
+
+  val dbObservationMdLayout = Layout(
+    List[LayoutItem](
+      dbObservationMdXLayoutItem,
+      LayoutItem(i = "Y", x = 3, y = 2, w = 8, h = 6, minH = 5, maxH = 11, minW = 3, maxW = 12),
+      LayoutItem(i = "Q", x = 7, y = 14, w = 8, h = 9, minH = 5, maxH = 7, minW = 7, maxW = 9)
+    )
+  )
+
+  val expectedObservationMdLayout = Layout(
+    List[LayoutItem](
+      expectedObservationMdXLayoutItem,
+      LayoutItem(i = "Y", x = 3, y = 2, w = 8, h = 6, minH = 6, maxH = 9, minW = 4, maxW = 11),
+      LayoutItem(i = "Z", x = 9, y = 15, w = 8, h = 9, minH = 5, maxH = 7, minW = 7, maxW = 9)
+    )
+  )
+
+  val originalMap: SectionLayoutsMap = Map(
+    GridLayoutSection.ObservationsLayout -> SortedMap(
+      BreakpointName.md -> (8, 10, observationMdLayout),
+      BreakpointName.lg -> (7, 11, Layout(
+        List[LayoutItem](
+          LayoutItem(i = "X", x = 2, y = 1, w = 6, h = 6, minH = 5, maxH = 11, minW = 3, maxW = 10)
+        )
+      ))
+    ),
+    GridLayoutSection.ConstraintsLayout  -> SortedMap(
+      BreakpointName.md -> (9, 13, Layout(
+        List[LayoutItem](
+          LayoutItem(i = "Z", x = 0, y = 0, w = 8, h = 5, minH = 3, maxH = 10, minW = 2, maxW = 12)
+        )
+      ))
+    )
+  )
+
+  val dbMap: SectionLayoutsMap = Map(
+    GridLayoutSection.ObservationsLayout -> SortedMap(
+      BreakpointName.md  -> (9, 20, dbObservationMdLayout),
+      BreakpointName.xxs -> (7, 12, Layout(
+        List[LayoutItem](
+          LayoutItem(i = "X", x = 5, y = 1, w = 6, h = 6, minH = 5, maxH = 11, minW = 3, maxW = 10)
+        )
+      ))
+    ),
+    GridLayoutSection.SchedulingLayout   -> SortedMap(
+      BreakpointName.md -> (8, 10, Layout(
+        List[LayoutItem](
+          LayoutItem(i = "Y", x = 5, y = 9, w = 9, h = 7, minH = 4, maxH = 9, minW = 4, maxW = 11)
+        )
+      ))
+    )
+  )
+
+  val expectedMap: SectionLayoutsMap = Map(
+    GridLayoutSection.ObservationsLayout -> SortedMap(
+      BreakpointName.md -> (8, 10, expectedObservationMdLayout),
+      BreakpointName.lg -> (7, 11, Layout(
+        List[LayoutItem](
+          LayoutItem(i = "X", x = 2, y = 1, w = 6, h = 6, minH = 5, maxH = 11, minW = 3, maxW = 10)
+        )
+      ))
+    ),
+    GridLayoutSection.ConstraintsLayout  -> SortedMap(
+      BreakpointName.md -> (9, 13, Layout(
+        List[LayoutItem](
+          LayoutItem(i = "Z", x = 0, y = 0, w = 8, h = 5, minH = 3, maxH = 10, minW = 2, maxW = 12)
+        )
+      ))
+    )
+  )
+
+  test("LayoutItems merge correctly") {
+    val mergedLayoutItem = mergeLayoutItems(observationMdXLayoutItem, dbObservationMdXLayoutItem)
+    assertEquals(mergedLayoutItem, expectedObservationMdXLayoutItem)
+  }
+
+  test("Layouts merge correctly") {
+    val mergedLayout = mergeLayouts(observationMdLayout, dbObservationMdLayout)
+    assertEquals(mergedLayout, expectedObservationMdLayout)
+  }
+
+  test("SectionLayoutsMaps merge correctly") {
+    val mergedMap = mergeSectionLayoutsMaps(originalMap, dbMap)
+    assertEquals(mergedMap, expectedMap)
+  }
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -23,7 +23,7 @@ object Versions {
   val lucumaBC               = "0.4.0"
   val lucumaCore             = "0.80.2"
   val lucumaCatalog          = "0.41.0"
-  val lucumaReact            = "0.38.0"
+  val lucumaReact            = "0.40.0"
   val lucumaRefined          = "0.1.2"
   val lucumaSchemas          = "0.55.0"
   val lucumaSSO              = "0.6.0"


### PR DESCRIPTION
The min/max values width/height for the tiles were being lost because we were directly using the data from User Preferences, where only x, y, width and height are saved. This PR restores merging of the user preferences data back onto the current values.