### PR TITLE
Fix a bug when calculating the link on the targets tab

### DIFF
--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -157,8 +157,7 @@ object ExploreGridLayouts:
           x = 0,
           y = 0,
           w = DefaultWidth.value,
-          h = 0, // This doesn't matter, we are forcing 100%.
-          minH = SummaryMinHeight.value,
+          h = 100, // This doesn't matter, we are forcing 100%.
           minW = TileMinWidth.value,
           static = true
         )

--- a/common/src/main/scala/explore/model/Focused.scala
+++ b/common/src/main/scala/explore/model/Focused.scala
@@ -40,9 +40,12 @@ object Focused {
   def singleObs(obsId: Observation.Id, targetId: Option[Target.Id] = none): Focused =
     Focused(ObsIdSet.one(obsId).some, targetId)
 
-  implicit val eqFocused: Eq[Focused] = Eq.by(x => (x.obsSet, x.target))
+  def fromAsterismGroup(group: AsterismGroup): Focused =
+    Focused(group.obsIds.some, group.targetIds.headOption)
 
-  implicit val reuseFocused: Reusability[Focused] = Reusability.byEq
+  given Eq[Focused] = Eq.by(x => (x.obsSet, x.target))
+
+  given Reusability[Focused] = Reusability.byEq
 
   val obsSet: Lens[Focused, Option[ObsIdSet]] = Focus[Focused](_.obsSet)
 

--- a/common/src/main/scala/explore/model/RoutingInfo.scala
+++ b/common/src/main/scala/explore/model/RoutingInfo.scala
@@ -19,7 +19,7 @@ case class RoutingInfo(appTab: AppTab, optProgramId: Option[Program.Id], focused
 object RoutingInfo {
   // The only Page that doesn't have a program ID is the NoProgramPage, so instead of polluting RoutingInfo with
   // Option[Program.Id], we'll just associate a dummy id with it. NoProgramPage will need special handling, anyways.
-  val dummyProgramId = Program.Id(Long.MaxValue.refined)
+  private val dummyProgramId = Program.Id(Long.MaxValue.refined)
 
   def from(page: Page): RoutingInfo = page match
     case NoProgramPage                         => RoutingInfo(AppTab.Overview, none, Focused.None)

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -246,6 +246,8 @@ tfoot {
 }
 
 .obs-tree-group {
+  display: block;
+  color: var(--primary-color-text);
   padding-top: 0;
   padding-bottom: 0;
   padding-right: 5px;

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -322,6 +322,10 @@ object AsterismGroupObsList:
               <.span(ExploreStyles.ObsCount, s"${obsIds.size} Obs")
             )
 
+            val clickFocus = props.focused.target.fold(Focused.fromAsterismGroup(asterismGroup))(
+              _ => props.focused.withObsSet(obsIds)
+            )
+
             <.div(
               provided.innerRef,
               provided.droppableProps,
@@ -329,7 +333,7 @@ object AsterismGroupObsList:
                 snapshot.draggingOverWith.exists(id => parseDragId(id).isDefined)
               )
             )(
-              <.div(
+              <.a(
                 ExploreStyles.ObsTreeGroup |+| Option
                   .when(groupSelected)(ExploreStyles.SelectedObsTreeGroup)
                   .orElse(
@@ -338,7 +342,10 @@ object AsterismGroupObsList:
                   .orEmpty
               )(
                 ^.cursor.pointer,
-                ^.onClick --> setFocused(props.focused.withObsSet(obsIds))
+                ^.href := ctx.pageUrl(AppTab.Targets, props.programId, clickFocus),
+                ^.onClick ==> { (e: ReactEvent) =>
+                  e.preventDefaultCB *> e.stopPropagationCB *> setFocused(clickFocus)
+                }
               )(
                 csHeader,
                 TagMod.when(props.expandedIds.get.contains(obsIds))(

--- a/explore/src/main/scala/explore/observationtree/ViewCommon.scala
+++ b/explore/src/main/scala/explore/observationtree/ViewCommon.scala
@@ -53,13 +53,13 @@ trait ViewCommon {
           provided.draggableProps,
           getDraggedStyle(provided.draggableStyle, snapshot),
           (^.onClick ==> { (e: ReactMouseEvent) =>
-            e.stopPropagationCB >>
+            e.preventDefaultCB *> e.stopPropagationCB >>
               (if (e.ctrlKey || e.metaKey)
                  onCtrlClick(obs.id)
                else onSelect(obs.id))
           }).when(selectable),
           (^.onDoubleClick ==> { (e: ReactEvent) =>
-            e.stopPropagationCB >> setObs(programId, obs.id.some, ctx)
+            e.preventDefaultCB *> e.stopPropagationCB >> setObs(programId, obs.id.some, ctx)
           }).when(linkToObsTab)
         )(
           <.span(provided.dragHandleProps)(


### PR DESCRIPTION
Under some circumstances the target list may not redirect to the correct address. This fixes it and also shows where we'd jump when selecting a target