### PR TITLE
Check itc version and cleanup if data version changes

### DIFF
--- a/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
+++ b/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
@@ -51,6 +51,7 @@ import lucuma.itc.ItcAxis
 import lucuma.itc.ItcCcd
 import lucuma.itc.ItcWarning
 import lucuma.itc.SingleSN
+import lucuma.itc.client.ItcVersions
 import lucuma.itc.client.OptimizedChartResult
 import lucuma.itc.client.OptimizedSeriesResult
 import lucuma.itc.client.OptimizedSpectroscopyGraphResult
@@ -229,6 +230,8 @@ trait ItcPicklers extends CommonPicklers {
   given Pickler[ItcCcd] = generatePickler
 
   given Pickler[OptimizedSpectroscopyGraphResult] = generatePickler
+
+  given Pickler[ItcVersions] = generatePickler
 }
 
 object ItcPicklers extends ItcPicklers

--- a/workers/src/main/scala/workers/itc/ITCVersionsRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCVersionsRequests.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.itc
+
+import boopickle.DefaultBasic.*
+import cats.*
+import cats.effect.*
+import cats.syntax.all.*
+import explore.model.boopickle.ItcPicklers.given
+import lucuma.itc.client.ItcClient
+import lucuma.itc.client.ItcVersions
+import org.typelevel.log4cats.Logger
+import workers.*
+
+object ITCVersionsRequests {
+
+  def queryItc[F[_]: Concurrent: Parallel: Logger](
+    cache:     Cache[F],
+    itcClient: ItcClient[F]
+  ): F[Unit] =
+
+    val cacheName                                         = CacheName("itcVersions")
+    val cacheVersion                                      = CacheVersion(1)
+    val cacheableRequest: Cacheable[F, Unit, ItcVersions] =
+      Cacheable(
+        cacheName,
+        cacheVersion,
+        _ => itcClient.versions
+      )
+
+    for {
+      _        <- Logger[F].debug(s"ITC: Request version")
+      existing <- cache.get[Unit, ItcVersions](cacheName, cacheVersion, ())
+      remote   <- itcClient.versions.attempt
+      _        <- (existing, remote.toOption) match {
+                    case (Some(ItcVersions(_, a)), Some(ItcVersions(_, b))) if a =!= b =>
+                      Logger[F].info("ITC data version mismatch, clear the cache") *> cache.clear
+                    case _                                                             =>
+                      Applicative[F].unit
+                  }
+      _        <- cache
+                    .eval(cacheableRequest)
+                    .apply(())
+                    .attempt // Ignore errors
+    } yield ()
+}


### PR DESCRIPTION
This PR adds a task to check  every 1h if the data on ITC has changed and if so the local itc cache is cleared