### PR TITLE
Provide sensible roi and ccd to ITC queries

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -39,15 +39,13 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.ags.AgsAnalysis
-import lucuma.core.enums.Site
 import lucuma.core.math.Angle
 import lucuma.core.math.Coordinates
 import lucuma.core.math.Offset
-import lucuma.core.math.skycalc.ImprovedSkyCalc
 import lucuma.core.math.skycalc.averageParallacticAngle
+import lucuma.core.math.skycalc.parallacticAngle
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.CoordinatesAtVizTime
-import lucuma.core.model.ObjectTracking
 import lucuma.core.model.Observation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
@@ -311,20 +309,6 @@ object ObsTabTiles:
             props.observation.model.zoom(ObsSummary.attachmentIds).withOnMod { ids =>
               obsEditAttachments(props.programId, props.obsId, ids).runAsync
             }
-
-          // TODO Move to lucuma-core
-          def parallacticAngle(
-            site:     Site,
-            tracking: ObjectTracking,
-            vizTime:  Instant
-          ): Angle = {
-            val skycalc = new ImprovedSkyCalc(site.place)
-            val c       = tracking
-              .at(vizTime)
-              .map(_.value)
-              .getOrElse(tracking.baseCoordinates)
-            skycalc.calculate(c, vizTime, false).parallacticAngle
-          }
 
           val pa: Option[Angle] =
             (basicConfiguration.map(_.siteFor), asterismAsNel, vizTime)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -21,7 +21,7 @@ object Versions {
   val log4Cats               = "2.6.0"
   val log4CatsLogLevel       = "0.3.1"
   val lucumaBC               = "0.4.0"
-  val lucumaCore             = "0.84.0"
+  val lucumaCore             = "0.84.1"
   val lucumaCatalog          = "0.43.0"
   val lucumaReact            = "0.41.0"
   val lucumaRefined          = "0.1.2"

--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -67,7 +67,9 @@ object ITCGraphRequests:
     ): F[Map[ItcTarget, Either[ItcQueryProblems, ItcChartResult]]] =
       request.target
         .traverse(t =>
-          (selectedBand(t.profile, request.wavelength.value), request.mode.toItcClientMode)
+          (selectedBand(t.profile, request.wavelength.value),
+           request.mode.toItcClientMode(t.profile, request.constraints.imageQuality)
+          )
             .traverseN { (band, mode) =>
               ItcClient[F]
                 .spectroscopyIntegrationTimeAndGraph(
@@ -117,7 +119,7 @@ object ITCGraphRequests:
     val cacheableRequest =
       Cacheable(
         CacheName("itcGraphQuery"),
-        CacheVersion(10),
+        CacheVersion(11),
         doRequest,
         (r, g) =>
           r.target.forall(t =>

--- a/workers/src/main/scala/workers/itc/ITCRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCRequests.scala
@@ -62,7 +62,7 @@ object ITCRequests:
         .debug(
           s"ITC: Request for mode: ${params.mode}, centralWavelength: ${params.wavelength} and target count: ${params.target.name.value}"
         ) *> (selectedBand(params.target.profile, params.wavelength.value),
-              params.mode.toItcClientMode
+              params.mode.toItcClientMode(params.target.profile, params.constraints.imageQuality)
       )
         .traverseN { (band, mode) =>
           ItcClient[F]
@@ -92,7 +92,7 @@ object ITCRequests:
             }
         }
 
-    val cacheVersion = CacheVersion(9)
+    val cacheVersion = CacheVersion(10)
 
     val cacheableRequest =
       Cacheable(


### PR DESCRIPTION
There is a mismatch between the exposure time shown in the modes table and what we get from the odb.
The reason is that we are not providing roi nor ccd and the odb sets them depending on the mode an image quality

this PR replicates this logic in explore