### PR TITLE
Extend the staging banner to all non-production instances

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -383,7 +383,7 @@ div.inline.field.explore-warning-input {
   box-shadow: -0 0 2px 1px var(--warning-background-color);
 }
 
-#staging-banner {
+#non-prod-banner {
   @spacing: 20;
 
   z-index: 2000;

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -84,12 +84,12 @@ object ExploreMain {
 
   def showEnvironment[F[_]: Sync](env: ExecutionEnvironment): F[Unit] = Sync[F]
     .delay {
-      val stagingBanner = dom.document.createElement("div")
-      stagingBanner.id = "staging-banner"
-      stagingBanner.textContent = "Staging"
-      dom.document.body.appendChild(stagingBanner)
+      val nonProdBanner = dom.document.createElement("div")
+      nonProdBanner.id = "non-prod-banner"
+      nonProdBanner.textContent = env.tag
+      dom.document.body.appendChild(nonProdBanner)
     }
-    .whenA(env === ExecutionEnvironment.Staging)
+    .whenA(env =!= ExecutionEnvironment.Production)
 
   def crash[F[_]: Sync](msg: String): F[Unit] =
     setupDOM[F].map { element =>


### PR DESCRIPTION
Because we now have a dev instance on firebase, I thought we should have a banner to differentiate it, too.