### PR TITLE
Use common exposure time for all targets when calculating the itc chart

### DIFF
--- a/model/shared/src/main/scala/explore/events/ItcMessage.scala
+++ b/model/shared/src/main/scala/explore/events/ItcMessage.scala
@@ -5,6 +5,7 @@ package explore.events
 
 import boopickle.DefaultBasic.*
 import cats.data.*
+import eu.timepit.refined.types.numeric.PosInt
 import explore.model.boopickle.ItcPicklers
 import explore.model.itc.ItcChartResult
 import explore.model.itc.ItcQueryProblems
@@ -17,6 +18,7 @@ import explore.modes.SpectroscopyModesMatrix
 import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
+import lucuma.core.util.TimeSpan
 import lucuma.schemas.model.CentralWavelength
 import org.http4s.Uri
 import workers.WorkerRequest
@@ -45,7 +47,8 @@ object ItcMessage extends ItcPicklers:
 
   case class GraphQuery(
     wavelength:      CentralWavelength,
-    signalToNoise:   SignalToNoise,
+    exposureTime:    TimeSpan,
+    exposures:       PosInt,
     signalToNoiseAt: Wavelength,
     constraints:     ConstraintSet,
     targets:         NonEmptyList[ItcTarget],

--- a/model/shared/src/main/scala/explore/model/itc/ItcRequestParams.scala
+++ b/model/shared/src/main/scala/explore/model/itc/ItcRequestParams.scala
@@ -4,11 +4,13 @@
 package explore.model.itc
 
 import cats.data.*
+import eu.timepit.refined.types.numeric.PosInt
 import explore.model.itc.*
 import explore.modes.InstrumentRow
 import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
+import lucuma.core.util.TimeSpan
 import lucuma.schemas.model.CentralWavelength
 
 case class ItcRequestParams(
@@ -22,7 +24,8 @@ case class ItcRequestParams(
 
 case class ItcGraphRequestParams(
   wavelength:      CentralWavelength,
-  signalToNoise:   SignalToNoise,
+  exposureTime:    TimeSpan,
+  exposures:       PosInt,
   signalToNoiseAt: Wavelength,
   constraints:     ConstraintSet,
   target:          NonEmptyList[ItcTarget],

--- a/workers/src/main/scala/workers/ItcServer.scala
+++ b/workers/src/main/scala/workers/ItcServer.scala
@@ -96,7 +96,8 @@ object ItcServer extends WorkerServer[IO, ItcMessage.Request] with ItcPicklers {
           )
 
         case ItcMessage.GraphQuery(wavelength,
-                                   signalToNoise,
+                                   exposureTime,
+                                   exposures,
                                    signalToNoiseAt,
                                    constraint,
                                    targets,
@@ -107,7 +108,8 @@ object ItcServer extends WorkerServer[IO, ItcMessage.Request] with ItcPicklers {
             ITCGraphRequests
               .queryItc[IO](
                 wavelength,
-                signalToNoise,
+                exposureTime,
+                exposures,
                 signalToNoiseAt,
                 constraint,
                 targets,

--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -8,18 +8,19 @@ import cats.*
 import cats.data.*
 import cats.effect.*
 import cats.syntax.all.*
+import eu.timepit.refined.types.numeric.PosInt
 import explore.model.boopickle.ItcPicklers.given
 import explore.model.itc.*
 import explore.model.itc.math.*
 import explore.modes.GmosNorthSpectroscopyRow
 import explore.modes.GmosSouthSpectroscopyRow
 import explore.modes.InstrumentRow
-import lucuma.core.math.SignalToNoise
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
+import lucuma.core.util.TimeSpan
 import lucuma.itc.client.ItcClient
+import lucuma.itc.client.OptimizedSpectroscopyGraphInput
 import lucuma.itc.client.SignificantFiguresInput
-import lucuma.itc.client.SpectroscopyIntegrationTimeAndGraphInput
 import lucuma.refined.*
 import lucuma.schemas.model.CentralWavelength
 import org.typelevel.log4cats.Logger
@@ -32,7 +33,8 @@ object ITCGraphRequests:
 
   def queryItc[F[_]: Concurrent: Parallel: Logger](
     wavelength:      CentralWavelength,
-    signalToNoise:   SignalToNoise,
+    exposureTime:    TimeSpan,
+    exposures:       PosInt,
     signalToNoiseAt: Wavelength,
     constraints:     ConstraintSet,
     targets:         NonEmptyList[ItcTarget],
@@ -44,7 +46,8 @@ object ITCGraphRequests:
     val itcRowsParams = mode match // Only handle known modes
       case m: GmosNorthSpectroscopyRow =>
         ItcGraphRequestParams(wavelength,
-                              signalToNoise,
+                              exposureTime,
+                              exposures,
                               signalToNoiseAt,
                               constraints,
                               targets,
@@ -52,7 +55,8 @@ object ITCGraphRequests:
         ).some
       case m: GmosSouthSpectroscopyRow =>
         ItcGraphRequestParams(wavelength,
-                              signalToNoise,
+                              exposureTime,
+                              exposures,
                               signalToNoiseAt,
                               constraints,
                               targets,
@@ -71,11 +75,12 @@ object ITCGraphRequests:
           )
             .traverseN { (band, mode) =>
               ItcClient[F]
-                .spectroscopyIntegrationTimeAndGraph(
-                  SpectroscopyIntegrationTimeAndGraphInput(
+                .optimizedSpectroscopyGraph(
+                  OptimizedSpectroscopyGraphInput(
                     wavelength = request.wavelength.value,
                     signalToNoiseAt = request.signalToNoiseAt.some,
-                    signalToNoise = request.signalToNoise,
+                    exposureTime = request.exposureTime,
+                    exposures = request.exposures,
                     sourceProfile = t.profile,
                     band = band,
                     radialVelocity = t.rv,
@@ -89,8 +94,8 @@ object ITCGraphRequests:
                   t -> ItcChartResult(
                     t,
                     ItcExposureTime(OverridenExposureTime.FromItc,
-                                    chartResult.exposureTime,
-                                    chartResult.exposures
+                                    request.exposureTime,
+                                    request.exposures
                     ),
                     chartResult.ccds,
                     chartResult.charts,


### PR DESCRIPTION
This is relevant for asterisms such that graphs use the same exposure time even though it will produce different S/N results