### PR TITLE
Restore ability to hide the obs toolbar

### DIFF
--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -19,7 +19,7 @@ object Icons {
   val faArrowDownLeft: FAIcon = js.native
 
   @js.native
-  @JSImport("@fortawesome/pro-thin-svg-icons", "faArrowLeftFromLine")
+  @JSImport("@fortawesome/pro-regular-svg-icons", "faArrowLeftFromLine")
   val faArrowLeftFromLine: FAIcon = js.native
 
   @js.native
@@ -27,7 +27,7 @@ object Icons {
   val faArrowRight: FAIcon = js.native
 
   @js.native
-  @JSImport("@fortawesome/pro-thin-svg-icons", "faArrowRightFromLine")
+  @JSImport("@fortawesome/pro-regular-svg-icons", "faArrowRightFromLine")
   val faArrowRightFromLine: FAIcon = js.native
 
   @js.native

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1659,6 +1659,12 @@ input[type='file'].explore-fileupload {
 .tree-body {
   width: 100vw;
 
+  &.obs-tree-hidden-toolbar {
+    @media (min-width: lucumaUICommon.$mobile-responsive-cutoff) {
+      width: unset;
+    }
+  }
+
   @media (min-width: lucumaUICommon.$mobile-responsive-cutoff) {
     width: $tree-section-width;
 
@@ -1694,6 +1700,10 @@ input[type='file'].explore-fileupload {
 
 .obs-hide-show-button {
   display: none;
+
+  &.p-button-secondary.p-button-outlined.p-button {
+    color: var(--site-text-color);
+  }
 
   @media (min-width: lucumaUICommon.$mobile-responsive-cutoff) {
     display: flex;

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -112,6 +112,7 @@ object ObsTabContents extends TwoPanels:
             outlined = true,
             disabled = false,
             icon = Icons.ArrowRightFromLine,
+            clazz = ExploreStyles.ObsTreeHideShow,
             onClick = deckShown.mod(_.flip)
           ).mini.compact
         )
@@ -171,7 +172,7 @@ object ObsTabContents extends TwoPanels:
       rightSide,
       RightSideCardinality.Multi,
       resize,
-      ExploreStyles.ObsHiddenToolbar
+      ExploreStyles.ObsHiddenToolbar.when_(deckShown.get === DeckShown.Hidden)
     )
   }
 


### PR DESCRIPTION
It seems this was lost in one of the refactorings