### PR TITLE
Update browserslist configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode", "scalameta.metals", "stylelint.vscode-stylelint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,11 @@
     "**/target": true
   },
   "[scss]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": true
+    }
   },
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "stylelint.validate": ["css", "scss"]
 }

--- a/package.json
+++ b/package.json
@@ -67,9 +67,14 @@
     "build": "node --unhandled-rejections=strict build.mjs",
     "serve": "vite preview"
   },
-  "browserslist": [
-    "supports es6-module",
-    "last 2 versions",
-    "Firefox ESR"
-  ]
+  "browserslist": {
+    "production": [
+      "defaults and supports es6-module"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
 }


### PR DESCRIPTION
Browserslist is used to generate browser compatibility polyfills for JS and CSS.
The previous configuration was very wide and [included browsers like IE10](https://browsersl.ist/#q=supports+es6-module%0Alast+2+versions%0AFirefox+ESR). This splits the configuration into 2 parts:
- Production: [defaults](https://browsersl.ist/#q=defaults) splits into `> 0.5%, last 2 versions, Firefox ESR, not dead`. We include `supports es6-module` into it. This uses the sane default that doesn't try to support very old browsers.
- Development: We want working code, with as little transpilation as possible for speed. So this just targets the last version of each development browser.

Also fixes the stylelint plugin not working in VS Code.
