### PR TITLE
Remove deprecated field on ObservationEditSubscription

### DIFF
--- a/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -149,7 +149,6 @@ object ObsQueriesGQL:
     val document = """
       subscription($obsId: ObservationId!) {
         observationEdit(input: {observationId: $obsId}) {
-          id
           value {
             id
           }


### PR DESCRIPTION
```
  id: Long! @deprecated(reason: "id is no longer computed; a constant value is returned")
```