### PR TITLE
Allow logout from the Programs popup.

### DIFF
--- a/explore/src/main/scala/explore/programs/ProgramTable.scala
+++ b/explore/src/main/scala/explore/programs/ProgramTable.scala
@@ -45,7 +45,8 @@ case class ProgramTable(
   programInfos:     View[ProgramInfoList],
   selectProgram:    Program.Id => Callback,
   isRequired:       Boolean,
-  onClose:          Option[Callback]
+  onClose:          Option[Callback],
+  onLogout:         Option[IO[Unit]]
 ) extends ReactFnProps(ProgramTable.component)
 
 object ProgramTable:
@@ -194,6 +195,16 @@ object ProgramTable:
           ).small.compact.some
         )
 
+      val logoutButton =
+        props.onLogout.fold(none)(io =>
+          Button(
+            label = "Logout",
+            icon = Icons.Logout,
+            severity = Button.Severity.Danger,
+            onClick = (ctx.sso.logout >> io).runAsync
+          ).small.compact.some
+        )
+
       <.div(
         React.Fragment(
           <.div(ExploreStyles.ProgramTable)(
@@ -220,7 +231,8 @@ object ProgramTable:
                          value = showDeleted.zoom(ShowDeleted.value.asLens),
                          label = "Show deleted"
             ),
-            closeButton
+            closeButton,
+            logoutButton
           )
         )
       )

--- a/explore/src/main/scala/explore/programs/ProgramsPopup.scala
+++ b/explore/src/main/scala/explore/programs/ProgramsPopup.scala
@@ -34,6 +34,7 @@ case class ProgramsPopup(
   programInfos:     ViewOpt[ProgramInfoList],
   undoStacks:       View[UndoStacks[IO, ProgramSummaries]],
   onClose:          Option[Callback] = none,
+  onLogout:         Option[IO[Unit]] = none,
   message:          Option[String] = none
 ) extends ReactFnProps(ProgramsPopup.component)
 
@@ -78,7 +79,8 @@ object ProgramsPopup {
                 pis,
                 selectProgram = selectProgram(props.onClose, props.undoStacks, ctx),
                 props.onClose.isEmpty,
-                onHide
+                onHide,
+                props.onLogout
               )
             )
             .toPot


### PR DESCRIPTION
This PR adds a `Logout` button the the Programs popup if you reached the popup due to a missing or invalid program id in the url. 
<img width="757" alt="image" src="https://github.com/gemini-hlsw/explore/assets/6035943/df88bd33-33c9-4f8d-89ec-1f47ac801dba">
It also moves the popup code for missing or invalid programs out of the routing code and into ExploreLayout.