### PR TITLE
Revert "Try to config fortawesome registry"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,10 @@
 version: 2
-registries:
-  fortawesome:
-    type: npm-registry
-    url: https://npm.fontawesome.com/
-    token: ${{secrets.FONTAWESOME_NPM_AUTH_TOKEN}}
-    replaces-base: true
 updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'monthly'
   - package-ecosystem: 'npm'
-    registries:
-      - fortawesome
     directory: '/'
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
This _did_ fix dependabot updates for FontAwesome. But also I think it caused us to go over our quota 🤔 hard to be certain. So let's revert for now.