### PR TITLE
Update config files sent to firebase

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -6,7 +6,7 @@
     "explore-gemini": {
       "hosting": {
         "dev": ["explore-gemini-dev"],
-        "staging": ["explore-gemini"],
+        "staging": ["explore-gemini-stage"],
         "production": ["explore-gemini-prod"]
       }
     }

--- a/common/src/main/public/README.txt
+++ b/common/src/main/public/README.txt
@@ -1,10 +1,7 @@
-The "conf.json" and "staging.conf.json" files are deprecated. They
-are only here so that old serviceWorkers won't fail when they can't
-find the config file they are expecting.
+The "conf.json" files is deprecated. It is only here so that old serviceWorkers 
+won't fail when they can't find the config file they are expecting. The working
+assumption is that everyone who uses staging has updated in the 5 months
+since the change was made to "environments.conf.json", so the only issue will be
+with production.
 
-"staging.conf.json" is only needed by serviceWorkers that were loaded
-during a short transition of 1 day on 19 June 2023 and is probably only 
-needed by developers and Andy. It can be deleted soon.
-
-"conf.json" is expected by serviceWorkers that stretch back for many
-months so probably should be kept longer. 
+Eventually, this file and conf.json should be deleted.

--- a/common/src/main/public/conf.json
+++ b/common/src/main/public/conf.json
@@ -1,11 +1,11 @@
 {
-  "environment": "STAGING",
-  "odbURI": "wss://lucuma-postgres-odb-staging.herokuapp.com/ws",
-  "odbRestURI": "https://lucuma-postgres-odb-staging.herokuapp.com",
-  "preferencesDBURI": "wss://user-prefs-staging.herokuapp.com/v1/graphql",
-  "itcURI": "https://itc-staging.lucuma.xyz/itc",
+  "environment": "PRODUCTION",
+  "odbURI": "wss://lucuma-postgres-odb-production.herokuapp.com/ws",
+  "odbRestURI": "https://lucuma-postgres-odb-production.herokuapp.com",
+  "preferencesDBURI": "wss://user-prefs.herokuapp.com/v1/graphql",
+  "itcURI": "https://itc.gpp.gemini.edu/itc",
   "sso": {
-    "uri": "https://sso.gpp.lucuma.xyz",
+    "uri": "https://sso.gpp.gemini.edu",
     "readTimeoutSeconds": 10,
     "refreshTimeoutDeltaSeconds": 10,
     "refreshIntervalFactor": 1

--- a/explore/src/clue/scala/queries/common/ExecutionSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ExecutionSubquery.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package queries.common
 
 import clue.GraphQLSubquery


### PR DESCRIPTION
When we changed to a single config file, we put a mechanism in place to allow the old service workers in staging to update themselves. Now we need to change that to deal with production explore instead.