### PR TITLE
Fix partner splits layout

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -213,11 +213,11 @@ object ExploreStyles:
   val ProposalDetailsGrid: Css = Css("explore-proposal-details-grid")
   val ProposalAbstract: Css    = Css("explore-proposal-abstract")
 
-  val MinimumPercent: Css = Css("minimum-percent") |+| FlexEnd
-
-  val PartnerSplitTotal: Css = Css("partner-split-total")
-  val PartnerSplitData: Css  = Css("partner-split-data")
-  val PartnerSplitFlag: Css  = Css("partner-split-flag")
+  val PartnerSplitsGrid: Css       = Css("partner-splits-grid")
+  val PartnerSplitsGridMinPct: Css = Css("partner-splits-grid-min-pct")
+  val PartnerSplitsGridTotal: Css  = Css("partner-splits-grid-total")
+  val PartnerSplitData: Css        = Css("partner-split-data")
+  val PartnerSplitFlag: Css        = Css("partner-split-flag")
 
   val PartnerSplitsEditorDialog: Css = Css("partner-splits-editor-dialog")
 

--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -303,51 +303,6 @@ tfoot {
   margin-left: 0.25em;
 }
 
-.minimum-percent {
-  width: 5.5em;
-  padding-left: 0.5em !important;
-
-  span& {
-    text-align: end;
-  }
-}
-
-// The split edit button and the band totals
-.partner-split-data {
-  &,
-  div& data {
-    width: 6em;
-  }
-
-  // the text only "hours".
-  span& {
-    text-align: end;
-    padding-right: 6px; // determined empirically from dev tools
-  }
-
-  // The div containing the flag and percent text.
-  data > div {
-    display: flex;
-
-    // The percent text
-    span {
-      flex: 1;
-      text-align: end;
-    }
-  }
-}
-
-div.partner-split-total {
-  &,
-  & > div > data {
-    width: 5.5em;
-  }
-
-  & > div > data {
-    text-align: end;
-  }
-}
-
 .explore-input-error-mixin() {
   left: 30%;
   z-index: 3;

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1375,6 +1375,50 @@ table.pl-react-table.explore-sequence-table {
 // ------
 // Proposals and Partner Splits
 // ------
+.partner-splits-grid {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  column-gap: 0.5dvw;
+  row-gap: 0.5em;
+  width: 100%;
+
+  .partner-splits-grid-min-pct,
+  .partner-splits-grid-total {
+    width: 3em;
+  }
+
+  // only applies to the text field, not the input - pushes text to bottom
+  & > .partner-splits-grid-min-pct {
+    display: flex;
+    flex-direction: column-reverse;
+  }
+
+  & > .explore-flex-container {
+    align-items: flex-end;
+  }
+
+  // align the partner split hours to the end to align with the percents
+  span.partner-split-data {
+    text-align: end;
+  }
+
+  .partner-split-data {
+    margin-right: 2em;
+    width: 4.5em;
+
+    // The div containing the flag and percent text.
+    data > div {
+      display: flex;
+
+      // The percent text
+      span {
+        flex: 1;
+        text-align: end;
+      }
+    }
+  }
+}
+
 img.partner-split-flag {
   height: 16px;
   width: 32px;

--- a/explore/src/clue/scala/queries/common/ExecutionSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ExecutionSubquery.scala
@@ -1,3 +1,6 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
 package queries.common
 
 import clue.GraphQLSubquery

--- a/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -85,8 +85,7 @@ object ProposalTabContents:
               programId,
               proposalView,
               undoStacks,
-              executionTime,
-              TimeSpan.Zero // Will come from API eventually
+              executionTime
             ): VdomNode
           )
           .getOrElse(user match {


### PR DESCRIPTION
Somehow, since proposals were last worked on, the partner splits suffered terrible bit-rot for the large program and intensive proposal classes. This PR just fixes the layout. I thought I'd do it separately from the other proposal stuff I'm working on.

Oh, and it also removes band 3 time as discussed a week ago in the gpp meeting.