### PR TITLE
Revert "Bump react-resize-detector from 8.0.4 to 9.1.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "react-hotkeys-hook": "4.4.1",
         "react-is": "17.0.2",
         "react-markdown": "^8.0.7",
-        "react-resize-detector": "9.1.1",
+        "react-resize-detector": "8.0.4",
         "rehype-katex": "^6.0.3",
         "remark-gfm": "^4.0.0",
         "remark-math": "^5.1.1",
@@ -11096,9 +11096,9 @@
       }
     },
     "node_modules/react-resize-detector": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-9.1.1.tgz",
-      "integrity": "sha512-siLzop7i4xIvZIACE/PHTvRegA8QRCEt0TfmvJ/qCIFQJ4U+3NuYcF8tNDmDWxfIn+X1eNCyY2rauH4KRxge8w==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.0.4.tgz",
+      "integrity": "sha512-ln9pMAob8y8mc9UI4aZuuWFiyMqBjnTs/sxe9Vs9dPXUjwCTeKK1FP8I75ufnb/2mEEZXG6wOo/fjMcBRRuAXw==",
       "dependencies": {
         "lodash": "^4.17.21"
       },
@@ -21287,9 +21287,9 @@
       }
     },
     "react-resize-detector": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-9.1.1.tgz",
-      "integrity": "sha512-siLzop7i4xIvZIACE/PHTvRegA8QRCEt0TfmvJ/qCIFQJ4U+3NuYcF8tNDmDWxfIn+X1eNCyY2rauH4KRxge8w==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.0.4.tgz",
+      "integrity": "sha512-ln9pMAob8y8mc9UI4aZuuWFiyMqBjnTs/sxe9Vs9dPXUjwCTeKK1FP8I75ufnb/2mEEZXG6wOo/fjMcBRRuAXw==",
       "requires": {
         "lodash": "^4.17.21"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-hotkeys-hook": "4.4.1",
     "react-is": "17.0.2",
     "react-markdown": "^8.0.7",
-    "react-resize-detector": "9.1.1",
+    "react-resize-detector": "8.0.4",
     "rehype-katex": "^6.0.3",
     "remark-gfm": "^4.0.0",
     "remark-math": "^5.1.1",


### PR DESCRIPTION
Reverts gemini-hlsw/explore#3496

Breaks obs tab contents 

<img width="3008" alt="afbeelding" src="https://github.com/gemini-hlsw/explore/assets/10114577/16a152f8-b0a2-4a42-98d0-b86b183d931e">
