### PR TITLE
Improve the way tile resizing is enabled/disabled

### DIFF
--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -12,11 +12,15 @@ import explore.model.enums.TileSizeState
 import explore.model.layout
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.util.NewType
 import lucuma.react.common.ReactFnProps
 import lucuma.react.common.style.*
 import lucuma.react.primereact.Button
 import lucuma.ui.syntax.all.given
 import org.scalajs.dom
+
+object TileResizing extends NewType[Boolean]
+type TileResizing = TileResizing.Type
 
 case class Tile(
   id:                 Tile.TileId,
@@ -26,6 +30,7 @@ case class Tile(
   canMinimize:        Boolean = false,
   canMaximize:        Boolean = false,
   hidden:             Boolean = false,
+  isResizing:         TileResizing = TileResizing(false),
   state:              TileSizeState = TileSizeState.Normal,
   sizeStateCallback:  TileSizeState => Callback = _ => Callback.empty,
   controllerClass:    Css = Css.Empty, // applied to wrapping div when in a TileController.
@@ -41,11 +46,15 @@ case class Tile(
   def showMinimize: Boolean =
     state === TileSizeState.Maximized || (canMinimize && state === TileSizeState.Normal)
 
-  def withState(state: TileSizeState, sizeStateCallback: TileSizeState => Callback): Tile =
-    copy(state = state, sizeStateCallback = sizeStateCallback)(render)
+  def withState(
+    state:             TileSizeState,
+    isResizing:        TileResizing,
+    sizeStateCallback: TileSizeState => Callback
+  ): Tile =
+    copy(state = state, isResizing = isResizing, sizeStateCallback = sizeStateCallback)(render)
 }
 
-object Tile {
+object Tile:
   type TileId        = NonEmptyString
   type RenderInTitle = VdomNode => VdomNode
 
@@ -72,6 +81,7 @@ object Tile {
             text = true,
             clazz = ExploreStyles.TileStateButton,
             icon = Icons.Maximize,
+            disabled = p.isResizing.value,
             onClick = p
               .sizeStateCallback(TileSizeState.Normal)
               .when_(p.state === TileSizeState.Minimized) *> p
@@ -84,6 +94,7 @@ object Tile {
             text = true,
             clazz = ExploreStyles.TileStateButton,
             icon = Icons.Minimize,
+            disabled = p.isResizing.value,
             onClick = p
               .sizeStateCallback(TileSizeState.Normal)
               .when_(p.state === TileSizeState.Maximized) *> p
@@ -142,4 +153,3 @@ object Tile {
           )
         } else EmptyVdom
       }
-}

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -209,6 +209,7 @@ body.hide-reusability {
     transform 0.25s,
     filter 0.25s ease-in;
 
+  &:enabled:focus,
   &:enabled:focus-visible {
     border: none;
     box-shadow: none;


### PR DESCRIPTION
on layouts with multiple tiles it may take a while to maximize/minimize a tile and you can (if you click multiple times) end on a weird loop while minimizing and maximizing

This PR adds a state so the buttons are disabled until the size change gets completed