### PR TITLE
Downgrade primereact to 10.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "highcharts": "11.2.0",
         "loglevel": "1.8.1",
         "primeicons": "^6.0.1",
-        "primereact": "^10.3.0",
+        "primereact": "^10.2.1",
         "prop-types": "15.8.1",
         "react": "17.0.2",
         "react-beautiful-dnd": "13.1.1",
@@ -10739,9 +10739,9 @@
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
     },
     "node_modules/primereact": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.3.0.tgz",
-      "integrity": "sha512-eLIOJZKzrRIqxhLLmI0LPdfzdODK/OESX3Heh1DlgBDahxUgnFNYjnctbriDje51DW+NE8/xX3JQazUszH6McA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.2.1.tgz",
+      "integrity": "sha512-F25053E1z+fod6V7AJ1Ix/DwSPkFQotk2+Idm0XkFsN+gQEywH7DgtbvNKpUA+LEq48h2+/WVK3D0V8IAm1Npg==",
       "dependencies": {
         "@types/react-transition-group": "^4.4.1",
         "react-transition-group": "^4.4.1"
@@ -21036,9 +21036,9 @@
       "integrity": "sha512-KDeO94CbWI4pKsPnYpA1FPjo79EsY9I+M8ywoPBSf9XMXoe/0crjbUK7jcQEDHuc0ZMRIZsxH3TYLv4TUtHmAA=="
     },
     "primereact": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.3.0.tgz",
-      "integrity": "sha512-eLIOJZKzrRIqxhLLmI0LPdfzdODK/OESX3Heh1DlgBDahxUgnFNYjnctbriDje51DW+NE8/xX3JQazUszH6McA==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.2.1.tgz",
+      "integrity": "sha512-F25053E1z+fod6V7AJ1Ix/DwSPkFQotk2+Idm0XkFsN+gQEywH7DgtbvNKpUA+LEq48h2+/WVK3D0V8IAm1Npg==",
       "requires": {
         "@types/react-transition-group": "^4.4.1",
         "react-transition-group": "^4.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "highcharts": "11.2.0",
         "loglevel": "1.8.1",
         "primeicons": "^6.0.1",
-        "primereact": "^10.2.1",
+        "primereact": "~10.2.1",
         "prop-types": "15.8.1",
         "react": "17.0.2",
         "react-beautiful-dnd": "13.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "highcharts": "11.2.0",
     "loglevel": "1.8.1",
     "primeicons": "^6.0.1",
-    "primereact": "^10.2.1",
+    "primereact": "~10.2.1",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-beautiful-dnd": "13.1.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "highcharts": "11.2.0",
     "loglevel": "1.8.1",
     "primeicons": "^6.0.1",
-    "primereact": "^10.3.0",
+    "primereact": "^10.2.1",
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-beautiful-dnd": "13.1.1",


### PR DESCRIPTION
Downgrade primereact because the `TieredMenu` that we use in the popup menu in the upper right of explore is broken in 10.3.*. A fix has been merged and will be released in `10.4.*`. At that point, we will also need to switch our lucuma themes to the ones for the new `lucuma-primereact-sass-theme` repo due to changes in the the theming for (at least) the menus. These themes are brought in via `lucuma-ui`.