### PR TITLE
Fix tile controller when `storeLayout` is false

### DIFF
--- a/explore/src/main/scala/explore/components/TileController.scala
+++ b/explore/src/main/scala/explore/components/TileController.scala
@@ -135,7 +135,7 @@ object TileController:
                     )
                   } else l
                 case l                     => l
-              }
+              } *> resizing.setState(TileResizing(false)).when(p.storeLayout === false).void
 
         def addBackButton: List[Tile] = {
           val topTile =


### PR DESCRIPTION
I'm not sure exactly why the tilecontroller waits for a update from user preferences before saying it isn't resizing. However, if `storeLayout` is false, that means it always thinks it is resizing after any minimizing or mazimizing. This was making it very hard to test out layouts before going to the effort of adding the layouts to the user preferences. 