### PR TITLE
Button for deleting grid layouts from user preferences

### DIFF
--- a/explore/src/clue/scala/queries/common/UserPreferencesQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/UserPreferencesQueriesGQL.scala
@@ -130,6 +130,17 @@ object UserPreferencesQueriesGQL {
   }
 
   @GraphQL
+  trait UserGridLayoutsDelete extends GraphQLOperation[UserPreferencesDB] {
+    val document = """
+      mutation deleteLayoutPositions($userId: String!) {
+        deleteLucumaGridLayoutPositions(where : {userId: {_eq: $userId}}) {
+          affected_rows
+        }
+      }
+    """
+  }
+
+  @GraphQL
   trait AsterismPreferencesQuery extends GraphQLOperation[UserPreferencesDB] {
     val document = """
     query asterismPreferences($userId: String!, $targetIds: [String!] = "") {

--- a/explore/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/explore/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -203,6 +203,12 @@ object UserPreferencesQueries:
           )
           .attempt
       }.void
+
+    def deleteLayoutsPreference[F[_]: ApplicativeThrow](userId: User.Id)(using
+      FetchClient[F, UserPreferencesDB]
+    ): F[Unit] =
+      UserGridLayoutsDelete[F].execute(userId.show).void
+
   end GridLayouts
 
   object AsterismPreferences:

--- a/explore/src/main/scala/explore/users/UserPreferencesPopup.scala
+++ b/explore/src/main/scala/explore/users/UserPreferencesPopup.scala
@@ -11,6 +11,7 @@ import crystal.react.*
 import crystal.react.hooks.*
 import explore.DefaultErrorPolicy
 import explore.Icons
+import explore.common.UserPreferencesQueries.GridLayouts
 import explore.components.ui.ExploreStyles
 import explore.model.ApiKey
 import explore.model.AppContext
@@ -80,6 +81,7 @@ object UserPreferencesContent:
   private type IsActive = IsActive.Type
 
   private object IsCleaningTheCache extends NewType[Boolean]
+  private object IsDeletingLayouts  extends NewType[Boolean]
 
   private object NewKey extends NewType[Option[String]]
   private type NewKey = NewKey.Type
@@ -185,91 +187,122 @@ object UserPreferencesContent:
     )
     .useStateView(RoleType.Pi)
     .useState(IsCleaningTheCache(false))
-    .render { (props, ctx, active, user, newKey, _, _, table, newRoleType, isCleaningTheCache) =>
-      import ctx.given
+    .useStateView(IsDeletingLayouts(false))
+    .render {
+      (
+        props,
+        ctx,
+        active,
+        user,
+        newKey,
+        _,
+        _,
+        table,
+        newRoleType,
+        isCleaningTheCache,
+        isDeletingLayouts
+      ) =>
+        import ctx.given
 
-      user.renderPot { ssoUser =>
-        val id   = ssoUser.user.id
-        val name = s"${ssoUser.user.givenName.orEmpty} ${ssoUser.user.familyName.orEmpty}"
-        val role = ssoUser.role.`type`.shortName
+        user.renderPot { ssoUser =>
+          val id   = ssoUser.user.id
+          val name = s"${ssoUser.user.givenName.orEmpty} ${ssoUser.user.familyName.orEmpty}"
+          val role = ssoUser.role.`type`.shortName
 
-        val allRoles = ssoUser.user.roles
+          val allRoles = ssoUser.user.roles
 
-        val requestCacheClean =
-          for {
-            _ <- isCleaningTheCache.setState(IsCleaningTheCache(true)).toAsync
-            _ <- ctx.workerClients.clearAll(
-                   isCleaningTheCache.setState(IsCleaningTheCache(false)).toAsync
-                 )
-          } yield ()
+          val requestCacheClean =
+            for {
+              _ <- isCleaningTheCache.setState(IsCleaningTheCache(true)).toAsync
+              _ <- ctx.workerClients.clearAll(
+                     isCleaningTheCache.setState(IsCleaningTheCache(false)).toAsync
+                   )
+            } yield ()
 
-        val cleanCacheButton =
-          Button(
-            label = "Clean local cache",
-            disabled = isCleaningTheCache.value.value,
-            icon = Icons.Trash,
-            onClick = requestCacheClean.runAsyncAndForget
-          ).small.compact
-
-        val unsupportedRoles = Enumerated[RoleType].all.filterNot { rt =>
-          allRoles.exists(r => r.`type` === rt)
-        }
-        val currentKeyRoleId = allRoles.find(_.`type` === newRoleType.get).map(_.id)
-
-        React.Fragment(
-          Divider(),
-          <.div(LucumaPrimeStyles.FormColumnCompact)(
-            <.label(LucumaPrimeStyles.FormFieldLabel, "ID: "),
-            <.label(LucumaPrimeStyles.FormField, id.show),
-            <.label(LucumaPrimeStyles.FormFieldLabel, "Name: "),
-            <.label(LucumaPrimeStyles.FormField, name),
-            <.label(LucumaPrimeStyles.FormFieldLabel, "Role: "),
-            <.label(LucumaPrimeStyles.FormField, role)
-          ),
-          Divider(),
-          <.h4("API Keys:"),
-          <.div(ExploreStyles.ApiKeysTable)(
-            PrimeAutoHeightVirtualizedTable(
-              table,
-              estimateSize = _ => 32.toPx,
-              striped = true,
-              compact = Compact.Very,
-              tableMod =
-                ExploreStyles.ApiKeysTableMod |+| ExploreStyles.ExploreTable |+| ExploreStyles.ExploreBorderTable,
-              emptyMessage = "No keys available"
-            )
-          ),
-          Divider(),
-          newKey.get.value.map { k =>
-            <.div(LucumaPrimeStyles.FormColumnCompact)(
-              <.label(LucumaPrimeStyles.FormFieldLabel, "Key: "),
-              <.label(ExploreStyles.NewApiKey, k),
-              CopyControl("", k),
-              <.label(ExploreStyles.NewApiKeyLabel, "This API key won't be displayed again.")
-            )
-          },
-          <.div(ExploreStyles.ProgramsPopupFauxFooter)(
+          val cleanCacheButton =
             Button(
-              label = "New Key with role: ",
-              icon = Icons.New,
-              severity = Button.Severity.Success,
-              disabled = active.get.value,
-              loading = active.get.value,
-              onClick = currentKeyRoleId
-                .map(createNewKey(_, active, newKey, props.vault))
-                .map(_.runAsync)
-                .getOrEmpty
-            ).small.compact,
-            EnumDropdownView(
-              id = "new-key-role".refined,
-              exclude = unsupportedRoles.toSet,
-              value = newRoleType,
-              disabled = active.get.value
-            )
-          ),
-          Divider(),
-          cleanCacheButton,
-          ConfirmDialog()
-        )
-      }
+              label = "Clean local cache",
+              disabled = isCleaningTheCache.value.value,
+              loading = isCleaningTheCache.value.value,
+              icon = Icons.Trash,
+              onClick = requestCacheClean.runAsyncAndForget
+            ).small.compact
+
+          val deleteGridLayoutsButton =
+            Button(
+              label = "Reset Tile Layouts",
+              disabled = isDeletingLayouts.get.value,
+              loading = isDeletingLayouts.get.value,
+              icon = Icons.Trash,
+              tooltip = "Revert to the default tile layouts for the various tabs",
+              onClick = GridLayouts
+                .deleteLayoutsPreference(props.vault.user.id)
+                .switching(isDeletingLayouts.async, IsDeletingLayouts(_))
+                .runAsyncAndForget
+            ).small.compact
+
+          val unsupportedRoles = Enumerated[RoleType].all.filterNot { rt =>
+            allRoles.exists(r => r.`type` === rt)
+          }
+          val currentKeyRoleId = allRoles.find(_.`type` === newRoleType.get).map(_.id)
+
+          React.Fragment(
+            Divider(),
+            <.div(LucumaPrimeStyles.FormColumnCompact)(
+              <.label(LucumaPrimeStyles.FormFieldLabel, "ID: "),
+              <.label(LucumaPrimeStyles.FormField, id.show),
+              <.label(LucumaPrimeStyles.FormFieldLabel, "Name: "),
+              <.label(LucumaPrimeStyles.FormField, name),
+              <.label(LucumaPrimeStyles.FormFieldLabel, "Role: "),
+              <.label(LucumaPrimeStyles.FormField, role)
+            ),
+            Divider(),
+            <.h4("API Keys:"),
+            <.div(ExploreStyles.ApiKeysTable)(
+              PrimeAutoHeightVirtualizedTable(
+                table,
+                estimateSize = _ => 32.toPx,
+                striped = true,
+                compact = Compact.Very,
+                tableMod =
+                  ExploreStyles.ApiKeysTableMod |+| ExploreStyles.ExploreTable |+| ExploreStyles.ExploreBorderTable,
+                emptyMessage = "No keys available"
+              )
+            ),
+            Divider(),
+            newKey.get.value.map { k =>
+              <.div(LucumaPrimeStyles.FormColumnCompact)(
+                <.label(LucumaPrimeStyles.FormFieldLabel, "Key: "),
+                <.label(ExploreStyles.NewApiKey, k),
+                CopyControl("", k),
+                <.label(ExploreStyles.NewApiKeyLabel, "This API key won't be displayed again.")
+              )
+            },
+            <.div(ExploreStyles.ProgramsPopupFauxFooter)(
+              Button(
+                label = "New Key with role: ",
+                icon = Icons.New,
+                severity = Button.Severity.Success,
+                disabled = active.get.value,
+                loading = active.get.value,
+                onClick = currentKeyRoleId
+                  .map(createNewKey(_, active, newKey, props.vault))
+                  .map(_.runAsync)
+                  .getOrEmpty
+              ).small.compact,
+              EnumDropdownView(
+                id = "new-key-role".refined,
+                exclude = unsupportedRoles.toSet,
+                value = newRoleType,
+                disabled = active.get.value
+              )
+            ),
+            Divider(),
+            <.div(
+              cleanCacheButton,
+              deleteGridLayoutsButton
+            ),
+            ConfirmDialog()
+          )
+        }
     }

--- a/explore/src/main/scala/explore/users/UserPreferencesPopup.scala
+++ b/explore/src/main/scala/explore/users/UserPreferencesPopup.scala
@@ -19,6 +19,7 @@ import explore.model.display.given
 import explore.model.enums.RoleType
 import explore.model.reusability.given
 import explore.syntax.ui.*
+import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.StandardRole
@@ -238,6 +239,7 @@ object UserPreferencesContent:
               onClick = GridLayouts
                 .deleteLayoutsPreference(props.vault.user.id)
                 .switching(isDeletingLayouts.async, IsDeletingLayouts(_))
+                .withToast("Layouts reset. You may need to reload page for it to take effect.")
                 .runAsyncAndForget
             ).small.compact
 


### PR DESCRIPTION
I was just going to make the button available in development for helping to test default layouts, but then I thought it could be handy for users if they really mess up all the tiles on, for example, the observation tab. 

I thought the subscription would reset the tiles, but it seems to need to have a reload to take effect. Maybe I should display a toast or something to that effect when the reset is complete?

Hint: Hiding whitespace changes will make this much easier to review. 😄 