### PR TITLE
Use program time estimates instead of total

### DIFF
--- a/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -85,12 +85,12 @@ object ProgramQueriesGQL {
           users $ProgramUserWithRoleSubquery
           timeEstimateRange {
             minimum {
-              total {
+              program {
                 microseconds
               }
             }
             maximum {
-              total {
+              program {
                 microseconds
               }
             }
@@ -109,9 +109,9 @@ object ProgramQueriesGQL {
         type Proposal   = model.Proposal
         object TimeEstimateRange:
           object Minimum:
-            type Total = TimeSpan
+            type Program = TimeSpan
           object Maximum:
-            type Total = TimeSpan
+            type Program = TimeSpan
         type TimeCharge = exploreModel.TimeCharge
   }
 

--- a/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -155,8 +155,8 @@ object ProposalTabContents:
           data.program
             .map { prog =>
               ProposalInfo(prog.proposal,
-                           prog.timeEstimateRange.map(_.minimum.total),
-                           prog.timeEstimateRange.map(_.maximum.total),
+                           prog.timeEstimateRange.map(_.minimum.program),
+                           prog.timeEstimateRange.map(_.maximum.program),
                            prog.pi,
                            prog.users,
                            prog.timeCharge

--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -52,8 +52,8 @@ object ProgramTabContents:
           data.program
             .map(prog =>
               ProposalInfo(prog.proposal,
-                           prog.timeEstimateRange.map(_.minimum.total),
-                           prog.timeEstimateRange.map(_.maximum.total),
+                           prog.timeEstimateRange.map(_.minimum.program),
+                           prog.timeEstimateRange.map(_.maximum.program),
                            prog.pi,
                            prog.users,
                            prog.timeCharge


### PR DESCRIPTION
Everywhere time estimates are shown the  time should be used, and not include partner or nonCharged
