### PR TITLE
Fix problem with explore not loading with invalid program id

### DIFF
--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -130,28 +130,35 @@ object Routing:
   private def proposalTab(page: Page, model: View[RootModel]): VdomElement =
     withProgramSummaries(model)(programSummaries =>
       val routingInfo = RoutingInfo.from(page)
-      ProposalTabContents(
-        routingInfo.programId,
-        model.zoom(RootModel.vault).get,
-        programSummaries.model.zoom(ProgramSummaries.programDetails),
-        programSummaries.model.zoom(ProgramSummaries.proposalAttachments),
-        model.zoom(RootModel.otherUndoStacks).zoom(ModelUndoStacks.forProposal),
-        userPreferences(model).proposalTabLayout
-      )
+      // if we got this far, we will have program details
+      programSummaries.model
+        .zoom(ProgramSummaries.optProgramDetails)
+        .toOptionView
+        .map(detailsView =>
+          ProposalTabContents(
+            routingInfo.programId,
+            model.zoom(RootModel.vault).get,
+            detailsView,
+            programSummaries.model.zoom(ProgramSummaries.proposalAttachments),
+            model.zoom(RootModel.otherUndoStacks).zoom(ModelUndoStacks.forProposal),
+            userPreferences(model).proposalTabLayout
+          )
+        )
     )
 
   private def programTab(page: Page, model: View[RootModel]): VdomElement =
     withProgramSummaries(model) { programSummaries =>
-      val programTimeEstimateRange = programSummaries.get.programDetails.programTimeEstimateRange
-      val programTimeCharge        = programSummaries.get.programDetails.programTimeCharge
-      val routingInfo              = RoutingInfo.from(page)
-      ProgramTabContents(
-        routingInfo.programId,
-        model.zoom(RootModel.vault).get,
-        programTimeEstimateRange,
-        programTimeCharge,
-        userPreferences(model)
-      )
+      // if we got this far, we will have program details
+      programSummaries.get.optProgramDetails.map { details =>
+        val routingInfo = RoutingInfo.from(page)
+        ProgramTabContents(
+          routingInfo.programId,
+          model.zoom(RootModel.vault).get,
+          details.programTimeEstimateRange,
+          details.programTimeCharge,
+          userPreferences(model)
+        )
+      }
     }
 
   // The programs popup will be shown

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -20,7 +20,7 @@ import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 
 case class ProgramSummaries(
-  programDetails:      ProgramDetails,
+  optProgramDetails:   Option[ProgramDetails],
   targets:             TargetList,
   observations:        ObservationList,
   groups:              GroupList,
@@ -93,8 +93,8 @@ case class ProgramSummaries(
     ProgramSummaries.observations.modify(_.removed(obsId))(this)
 
 object ProgramSummaries:
-  val programDetails: Lens[ProgramSummaries, ProgramDetails]                =
-    Focus[ProgramSummaries](_.programDetails)
+  val optProgramDetails: Lens[ProgramSummaries, Option[ProgramDetails]]     =
+    Focus[ProgramSummaries](_.optProgramDetails)
   val targets: Lens[ProgramSummaries, TargetList]                           = Focus[ProgramSummaries](_.targets)
   val observations: Lens[ProgramSummaries, ObservationList]                 =
     Focus[ProgramSummaries](_.observations)
@@ -106,7 +106,7 @@ object ProgramSummaries:
   val programs: Lens[ProgramSummaries, ProgramInfoList]                     = Focus[ProgramSummaries](_.programs)
 
   def fromLists(
-    programDetails:      ProgramDetails,
+    optProgramDetails:   Option[ProgramDetails],
     targetList:          List[TargetWithId],
     obsList:             List[ObsSummary],
     groups:              List[GroupElement],
@@ -115,7 +115,7 @@ object ProgramSummaries:
     programs:            List[ProgramInfo]
   ): ProgramSummaries =
     ProgramSummaries(
-      programDetails,
+      optProgramDetails,
       targetList.toSortedMap(_.id, _.target),
       KeyedIndexedList.fromList(obsList, ObsSummary.id.get),
       groups,


### PR DESCRIPTION
Moving program details into the ProgramCache broke explore when trying to load with a missing or invalid program id in the URL. This is because the ProgramCache is loaded regardless and the list of program summaries within it is used to populated the program selection dialog. This makes the program details optional and deals with it downstream.