### PR TITLE
API changes

### DIFF
--- a/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -147,8 +147,8 @@ object ObsQueriesGQL:
   trait ObservationEditSubscription extends GraphQLOperation[ObservationDB]:
     // We need to include the `value {id}` to avoid a bug in grackle.
     val document = """
-      subscription($obsId: ObservationId!) {
-        observationEdit(input: {observationId: $obsId}) {
+      subscription($input: ObservationEditInput!) {
+        observationEdit(input: $input) {
           value {
             id
           }
@@ -193,8 +193,8 @@ object ObsQueriesGQL:
   @GraphQL
   trait ProgramObservationsDelta extends GraphQLOperation[ObservationDB] {
     val document = s"""
-      subscription($$programId: ProgramId!) {
-        observationEdit(input: {programId: $$programId}) {
+      subscription($$input: ObservationEditInput!) {
+        observationEdit(input: $$input) {
           value $ObservationSummarySubquery
           meta:value {
             existence

--- a/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -57,23 +57,10 @@ object ProgramQueriesGQL {
   }
 
   @GraphQL
-  trait ProgramEditSubscription extends GraphQLOperation[ObservationDB] {
-    val document: String = """
-      subscription($programId: ProgramId) {
-        programEdit(input: {programId: $programId}) {
-          value {
-            id
-          }
-        }
-      }
-    """
-  }
-
-  @GraphQL
   trait GroupEditSubscription extends GraphQLOperation[ObservationDB] {
     val document: String = s"""
-      subscription($$programId: ProgramId!) {
-        groupEdit(input: { programId: $$programId }) {
+      subscription($$input: ProgramEditInput!) {
+        groupEdit(input: $$input) {
           value ${GroupQueriesGQL.GroupSubQuery}
           editType
         }
@@ -84,8 +71,8 @@ object ProgramQueriesGQL {
   @GraphQL
   trait ProgramEditAttachmentSubscription extends GraphQLOperation[ObservationDB] {
     val document: String = s"""
-      subscription($$programId: ProgramId!) {
-        programEdit(input: {programId: $$programId}) {
+      subscription($$input: ProgramEditInput!) {
+        programEdit(input: $$input) {
           value {
             obsAttachments $ObsAttachmentSubquery
             proposalAttachments $ProposalAttachmentSubquery
@@ -102,8 +89,8 @@ object ProgramQueriesGQL {
   @GraphQL
   trait ProgramEditDetailsSubscription extends GraphQLOperation[ObservationDB] {
     val document: String = s"""
-      subscription($$programId: ProgramId!) {
-        programEdit(input: {programId: $$programId}) {
+      subscription($$input: ProgramEditInput!) {
+        programEdit(input: $$input) {
           value $ProgramDetailsSubquery
         }
       }

--- a/explore/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
@@ -13,8 +13,8 @@ object ProgramSummaryQueriesGQL {
   @GraphQL
   trait AllProgramObservations extends GraphQLOperation[ObservationDB] {
     val document: String = s"""
-      query($$programId: ProgramId!, $$OFFSET: ObservationId) {
-        observations(programId: $$programId, OFFSET: $$OFFSET) {
+      query($$where: WhereObservation!, $$OFFSET: ObservationId) {
+        observations(WHERE: $$where, OFFSET: $$OFFSET) {
           matches $ObservationSummarySubquery
           hasMore
         }
@@ -24,8 +24,8 @@ object ProgramSummaryQueriesGQL {
   @GraphQL
   trait AllProgramTargets      extends GraphQLOperation[ObservationDB] {
     val document: String = s"""
-      query($$programId: ProgramId!, $$OFFSET: TargetId) {
-        targets(WHERE: { programId: { EQ: $$programId } }, OFFSET: $$OFFSET) {
+      query($$where: WhereTarget!, $$OFFSET: TargetId) {
+        targets(WHERE: $$where, OFFSET: $$OFFSET) {
           matches $TargetWithIdSubquery
           hasMore
         }

--- a/explore/src/clue/scala/queries/common/TargetQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/TargetQueriesGQL.scala
@@ -24,14 +24,6 @@ object TargetQueriesGQL {
         }
       }
     """
-
-    object Data {
-      object TargetGroup {
-        object Matches {
-          type Target = schemasModel.TargetWithId
-        }
-      }
-    }
   }
 
   @GraphQL
@@ -108,8 +100,8 @@ object TargetQueriesGQL {
   // how to do. Is it worth it?
   trait AllProgramTargets extends GraphQLOperation[ObservationDB] {
     val document = s"""
-      query($$programId: ProgramId!) {
-        targets(WHERE: {programId: {EQ: $$programId}}) {
+      query($$where: WhereTarget!) {
+        targets(WHERE: $$where) {
           matches $TargetWithIdSubquery
         }
       }
@@ -119,8 +111,8 @@ object TargetQueriesGQL {
   @GraphQL
   trait ProgramTargetsDelta extends GraphQLOperation[ObservationDB] {
     val document = s"""
-      subscription($$programId: ProgramId!) {
-        targetEdit(input: {programId: $$programId}) {
+      subscription($$input: TargetEditInput!) {
+        targetEdit(input: $$input) {
           value $TargetWithIdSubquery
           meta:value {
             existence

--- a/explore/src/main/scala/explore/config/sequence/GeneratedSequenceViewer.scala
+++ b/explore/src/main/scala/explore/config/sequence/GeneratedSequenceViewer.scala
@@ -23,6 +23,7 @@ import lucuma.core.model.sequence.InstrumentExecutionConfig
 import lucuma.react.common.ReactFnProps
 import lucuma.react.primereact.Message
 import lucuma.schemas.odb.SequenceSQL.*
+import lucuma.schemas.odb.input.*
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import queries.common.ObsQueriesGQL
@@ -58,7 +59,8 @@ object GeneratedSequenceViewer:
           .attemptPot
           .resetOnResourceSignals(
             for {
-              o <- ObsQueriesGQL.ObservationEditSubscription.subscribe[IO](props.obsId)
+              o <- ObsQueriesGQL.ObservationEditSubscription
+                     .subscribe[IO](props.obsId.toObservationEditInput)
               t <- targetChanges
             } yield o.merge(t.sequence)
           )

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -65,6 +65,7 @@ import lucuma.react.resizeDetector.*
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.model.BasicConfiguration
 import lucuma.schemas.model.TargetWithId
+import lucuma.schemas.odb.input.*
 import lucuma.ui.reusability.given
 import lucuma.ui.sso.UserVault
 import lucuma.ui.syntax.all.*
@@ -170,7 +171,9 @@ object ObsTabTiles:
             )
           )
           // TODO Could we get the edit signal from ProgramCache instead of doing another subscritpion??
-          .reRunOnResourceSignals(ObservationEditSubscription.subscribe[IO](props.obsId))
+          .reRunOnResourceSignals(
+            ObservationEditSubscription.subscribe[IO](props.obsId.toObservationEditInput)
+          )
       }
       .useStreamResourceOnMountBy { (props, ctx, _) =>
         import ctx.given
@@ -192,7 +195,9 @@ object ObsTabTiles:
             )
           )
           // TODO Could we get the edit signal from ProgramCache instead of doing another subscritpion??
-          .reRunOnResourceSignals(ObservationEditSubscription.subscribe[IO](props.obsId))
+          .reRunOnResourceSignals(
+            ObservationEditSubscription.subscribe[IO](props.obsId.toObservationEditInput)
+          )
       }
       // Ags state
       .useStateView[AgsState](AgsState.Idle)

--- a/explore/src/main/scala/explore/targets/TargetAddDeleteActions.scala
+++ b/explore/src/main/scala/explore/targets/TargetAddDeleteActions.scala
@@ -47,7 +47,7 @@ object TargetAddDeleteActions {
       .execute(
         UpdateTargetsInput(
           WHERE = targetIds.toWhereTargets
-            .copy(programId = WhereOrderProgramId(programId.assign).assign)
+            .copy(program = programId.toWhereProgram.assign)
             .assign,
           SET = TargetPropertiesInput(existence = Existence.Deleted.assign)
         )
@@ -62,7 +62,7 @@ object TargetAddDeleteActions {
       .execute(
         UpdateTargetsInput(
           WHERE = targetIds.toWhereTargets
-            .copy(programId = WhereOrderProgramId(programId.assign).assign)
+            .copy(program = programId.toWhereProgram.assign)
             .assign,
           SET = TargetPropertiesInput(existence = Existence.Present.assign),
           includeDeleted = true.assign

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -25,7 +25,7 @@ object Versions {
   val lucumaCatalog          = "0.44.5"
   val lucumaReact            = "0.47.2"
   val lucumaRefined          = "0.1.2"
-  val lucumaSchemas          = "0.71.0"
+  val lucumaSchemas          = "0.72.0"
   val lucumaOdbSchema        = "0.10.0"
   val lucumaSSO              = "0.6.11"
   val lucumaUI               = "0.88.1"


### PR DESCRIPTION
I changed all the places where we were building `input` or `WHERE' objects within the graphql documents, since this makes it less likely we'll catch API changes such as the ones here. It is a tradeoff for convenience, though.