### PR TITLE
Delay loading of execution times in ProgramCache

### DIFF
--- a/common/src/main/scala/explore/cache/CacheComponent.scala
+++ b/common/src/main/scala/explore/cache/CacheComponent.scala
@@ -16,8 +16,19 @@ import japgolly.scalajs.react.vdom.html_<^.*
 trait CacheComponent[S, P <: CacheComponent.Props[S]: Reusability]:
   private type F[T] = DefaultA[T]
 
+  // Initializes the cache.
+  // `P` is the Properties
+  // `(S => S) => F[Unit]` is a delayed update function. Things fed to this function
+  // will be merged with the main update stream. The idea is that this will be done
+  // asynchronously. BUT, it is the responsibility of the implementation to
+  // call `.start` on the IO returned by this function. This gives the implementation
+  // more control over when the IO will be started.
   protected val initial: (P, (S => S) => F[Unit]) => F[S]
 
+  // A stream of updates to the cache.
+  // See explanation of types above.
+  // Plus, in the output, the stream values must be `F[S => S]` in order to support
+  // the asnchronous updates.
   protected val updateStream: (P, (S => S) => F[Unit]) => Resource[F, fs2.Stream[F, F[S => S]]]
 
   val component =
@@ -27,15 +38,15 @@ trait CacheComponent[S, P <: CacheComponent.Props[S]: Reusability]:
         props =>
           for
             latch        <- Deferred[F, SignallingRef[F, S]]
-            effects      <- SignallingRef[F].of(identity[S])
+            delayUpdate  <- SignallingRef[F].of(identity[S])
             // Start the update fiber. We want subscriptions to start before initial query.
             // This way we don't miss updates.
             // The update fiber Will only update the cache once it is initialized (via latch).
             // TODO: RESTART CACHE IN CASE OF INTERRUPTED SUBSCRIPTION.
             _            <-
-              updateStream(props, effects.set)
+              updateStream(props, delayUpdate.set)
                 .map(
-                  _.merge(effects.discrete.map(Async[F].pure))
+                  _.merge(delayUpdate.discrete.map(Async[F].pure))
                 )
                 .evalTap(
                   _.evalTap(fmod =>
@@ -44,7 +55,7 @@ trait CacheComponent[S, P <: CacheComponent.Props[S]: Reusability]:
                 )
                 .useForever
                 .start
-            initialValue <- initial(props, effects.set)
+            initialValue <- initial(props, delayUpdate.set)
             cache        <- SignallingRef[F].of(initialValue)
             _            <- latch.complete(cache) // Allow stream updates to proceed.
           yield cache
@@ -52,8 +63,7 @@ trait CacheComponent[S, P <: CacheComponent.Props[S]: Reusability]:
       .useStreamBy((props, cache) => (props, cache.isReady))((props, cache) =>
         _ =>
           cache.toOption.map(_.discrete).orEmpty.evalTap { value =>
-            cats.effect.Async[F].delay(println("Emitting a value")) >>
-              props.setState(value.some)
+            props.setState(value.some)
           }
       )
       // .useEffectWithDepsBy((_, _, value) => value.toOption)((props, _, _) =>

--- a/common/src/main/scala/explore/cache/CacheComponent.scala
+++ b/common/src/main/scala/explore/cache/CacheComponent.scala
@@ -3,6 +3,7 @@
 
 package explore.cache
 
+import cats.effect.Async
 import cats.effect.Resource
 import cats.effect.kernel.Deferred
 import cats.syntax.all.*
@@ -15,9 +16,9 @@ import japgolly.scalajs.react.vdom.html_<^.*
 trait CacheComponent[S, P <: CacheComponent.Props[S]: Reusability]:
   private type F[T] = DefaultA[T]
 
-  protected val initial: P => F[S]
+  protected val initial: (P, (S => S) => F[Unit]) => F[S]
 
-  protected val updateStream: P => Resource[F, fs2.Stream[F, S => S]]
+  protected val updateStream: (P, (S => S) => F[Unit]) => Resource[F, fs2.Stream[F, F[S => S]]]
 
   val component =
     ScalaFnComponent
@@ -26,24 +27,34 @@ trait CacheComponent[S, P <: CacheComponent.Props[S]: Reusability]:
         props =>
           for
             latch        <- Deferred[F, SignallingRef[F, S]]
+            effects      <- SignallingRef[F].of(identity[S])
             // Start the update fiber. We want subscriptions to start before initial query.
             // This way we don't miss updates.
             // The update fiber Will only update the cache once it is initialized (via latch).
             // TODO: RESTART CACHE IN CASE OF INTERRUPTED SUBSCRIPTION.
             _            <-
-              updateStream(props)
+              updateStream(props, effects.set)
+                .map(
+                  _.merge(effects.discrete.map(Async[F].pure))
+                )
                 .evalTap(
-                  _.evalTap(mod => latch.get.flatMap(_.update(mod))).compile.drain
+                  _.evalTap(fmod =>
+                    latch.get.flatMap(ref => fmod.flatMap(mod => ref.update(mod)))
+                  ).compile.drain
                 )
                 .useForever
                 .start
-            initialValue <- initial(props)
+            initialValue <- initial(props, effects.set)
             cache        <- SignallingRef[F].of(initialValue)
             _            <- latch.complete(cache) // Allow stream updates to proceed.
           yield cache
       )
       .useStreamBy((props, cache) => (props, cache.isReady))((props, cache) =>
-        _ => cache.toOption.map(_.discrete).orEmpty.evalTap(value => props.setState(value.some))
+        _ =>
+          cache.toOption.map(_.discrete).orEmpty.evalTap { value =>
+            cats.effect.Async[F].delay(println("Emitting a value")) >>
+              props.setState(value.some)
+          }
       )
       // .useEffectWithDepsBy((_, _, value) => value.toOption)((props, _, _) =>
       //   value => props.setState(value)

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -56,6 +56,7 @@ object reusability:
   given Reusability[ProposalAttachment]      = Reusability.byEq
   given Reusability[ProgramInfo]             = Reusability.byEq
   given Reusability[ProgramDetails]          = Reusability.byEq
+  given Reusability[Execution]               = Reusability.byEq
 
   /**
    */

--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -10,12 +10,15 @@ import clue.ResponseException
 import clue.js.FetchJSRequest
 import crystal.*
 import crystal.react.*
+import explore.Icons
 import explore.model.Constants
 import explore.utils.*
 import japgolly.scalajs.react.callback.Callback
 import japgolly.scalajs.react.util.Effect
+import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.primereact.Message
 import lucuma.ui.sso.UserVault
+import lucuma.ui.syntax.all.*
 import org.scalajs.dom.Window
 import org.typelevel.log4cats.Logger
 
@@ -86,3 +89,7 @@ extension [F[_]: MonadCancelThrow, A](f: F[A])
    */
   def switching[B](view: ViewF[F, B], acquire: B, release: B): F[A] =
     MonadCancelThrow[F].bracket(view.set(acquire))(_ => f)(_ => view.set(release))
+
+extension [A](pot: Pot[A])
+  def orSpinner(f: A => VdomNode): VdomNode =
+    pot.renderPot(valueRender = f, pendingRender = Icons.Spinner.withSpin(true))

--- a/explore/src/clue/scala/queries/common/ExecutionSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ExecutionSubquery.scala
@@ -13,7 +13,7 @@ import lucuma.schemas.odb.OffsetSubquery
 
 @GraphQL
 object ExecutionSubquery extends GraphQLSubquery.Typed[ObservationDB, Execution]("Execution") {
-  override val subquery: String = s"""#gql
+  override val subquery: String = s"""
     {
       digest {
         setup {

--- a/explore/src/clue/scala/queries/common/ObservationSummarySubquery.scala
+++ b/explore/src/clue/scala/queries/common/ObservationSummarySubquery.scala
@@ -47,6 +47,5 @@ object ObservationSummarySubquery
           observingMode $ObservingModeSubquery
           groupId
           groupIndex
-          execution $ExecutionSubquery
         }
       """

--- a/explore/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
@@ -40,7 +40,7 @@ object ProgramSummaryQueriesGQL {
         program(programId: $$programId) {
           obsAttachments $ObsAttachmentSubquery
           proposalAttachments $ProposalAttachmentSubquery
-        }
+        } 
       }
     """
   }
@@ -62,6 +62,26 @@ object ProgramSummaryQueriesGQL {
     val document: String = s"""
       query($$programId: ProgramId!) {
         program(programId: $$programId) $ProgramDetailsSubquery
+      }
+    """
+  }
+
+  @GraphQL
+  trait ProgramTimesQuery extends GraphQLOperation[ObservationDB] {
+    val document: String = s"""
+      query($$programId: ProgramId!) {
+        program(programId: $$programId) $ProgramTimesSubquery
+      }
+    """
+  }
+
+  @GraphQL
+  trait ObservationExecutionQuery extends GraphQLOperation[ObservationDB] {
+    val document: String = s"""
+      query($$id: ObservationId!) {
+        observation(observationId: $$id) {
+          execution $ExecutionSubquery
+        }
       }
     """
   }

--- a/explore/src/clue/scala/queries/common/ProgramTimesSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramTimesSubquery.scala
@@ -1,0 +1,19 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQL
+import explore.model.ProgramTimes
+import lucuma.schemas.ObservationDB
+
+@GraphQL
+object ProgramTimesSubquery extends GraphQLSubquery.Typed[ObservationDB, ProgramTimes]("Program") {
+  override val subquery: String = s"""
+    {
+      timeEstimateRange $ProgramTimeRangeSubquery
+      timeCharge $ProgramTimeSubquery
+    }
+  """
+}

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -144,6 +144,7 @@ object Routing:
             routingInfo.programId,
             model.zoom(RootModel.vault).get,
             detailsView,
+            programSummaries.model.get.programTimes.map(_.timeEstimateRange),
             programSummaries.model.zoom(ProgramSummaries.proposalAttachments),
             model.zoom(RootModel.otherUndoStacks).zoom(ModelUndoStacks.forProposal),
             userPreferences(model).proposalTabLayout
@@ -153,17 +154,13 @@ object Routing:
 
   private def programTab(page: Page, model: View[RootModel]): VdomElement =
     withProgramSummaries(model) { programSummaries =>
-      // if we got this far, we will have program details
-      programSummaries.get.optProgramDetails.map { details =>
-        val routingInfo = RoutingInfo.from(page)
-        ProgramTabContents(
-          routingInfo.programId,
-          model.zoom(RootModel.vault).get,
-          details.programTimeEstimateRange,
-          details.programTimeCharge,
-          userPreferences(model)
-        )
-      }
+      val routingInfo = RoutingInfo.from(page)
+      ProgramTabContents(
+        routingInfo.programId,
+        model.zoom(RootModel.vault).get,
+        programSummaries.get.programTimes,
+        userPreferences(model)
+      )
     }
 
   // The programs popup will be shown

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -57,6 +57,7 @@ case class AsterismGroupObsList(
 ) extends ReactFnProps[AsterismGroupObsList](AsterismGroupObsList.component)
     with ViewCommon:
   val programSummaries                         = undoCtx.model
+  val obsExecutions                            = programSummaries.get.obsExecutionPots
   override val focusedObsSet: Option[ObsIdSet] = focused.obsSet
 
 object AsterismGroupObsList:

--- a/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ConstraintGroupObsList.scala
@@ -17,6 +17,7 @@ import explore.model.ConstraintGroupList
 import explore.model.Focused
 import explore.model.ObsIdSet
 import explore.model.ObsSummary
+import explore.model.ObservationExecutionMap
 import explore.model.ObservationList
 import explore.model.display.given
 import explore.model.enums.AppTab
@@ -48,6 +49,7 @@ case class ConstraintGroupObsList(
   observations:     UndoSetter[ObservationList],
   undoer:           Undoer,
   constraintGroups: ConstraintGroupList,
+  obsExecutions:    ObservationExecutionMap,
   focusedObsSet:    Option[ObsIdSet],
   setSummaryPanel:  Callback,
   expandedIds:      View[SortedSet[ObsIdSet]],

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -14,6 +14,7 @@ import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.model.ObsSummary
 import explore.model.syntax.all.*
+import explore.syntax.ui.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.ObsActiveStatus
@@ -29,7 +30,6 @@ import lucuma.react.primereact.TooltipOptions
 import lucuma.ui.primereact.EnumDropdownView
 import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given
-import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 
 case class ObsBadge(
@@ -188,10 +188,7 @@ object ObsBadge:
                 ^.onClick ==> { e => e.preventDefaultCB >> e.stopPropagationCB }
               )
             ),
-            props.executionTime.renderPot(valueRender = _.map(ts => <.span(ts.toHoursMinutes)),
-                                          pendingRender = Icons.Spinner.withSpin(true)
-                                          // pendingRender = <.span("Waiting...")
-            )
+            props.executionTime.orSpinner(_.map(ts => <.span(ts.toHoursMinutes)))
           )
         )
       )

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -6,6 +6,7 @@ package explore.observationtree
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
+import crystal.Pot
 import crystal.react.View
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.EditableLabel
@@ -20,6 +21,7 @@ import lucuma.core.enums.ObsStatus
 import lucuma.core.model.Observation
 import lucuma.core.util.Enumerated
 import lucuma.core.util.Gid
+import lucuma.core.util.TimeSpan
 import lucuma.react.common.ReactFnProps
 import lucuma.react.primereact.Button
 import lucuma.react.primereact.InputSwitch
@@ -27,10 +29,12 @@ import lucuma.react.primereact.TooltipOptions
 import lucuma.ui.primereact.EnumDropdownView
 import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given
+import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 
 case class ObsBadge(
   obs:               ObsSummary,
+  executionTime:     Pot[Option[TimeSpan]],
   layout:            ObsBadge.Layout,
   selected:          Boolean = false,
   setStatusCB:       Option[ObsStatus => Callback] = none,
@@ -184,7 +188,10 @@ object ObsBadge:
                 ^.onClick ==> { e => e.preventDefaultCB >> e.stopPropagationCB }
               )
             ),
-            obs.executionTime.map(ts => <.span(ts.toHoursMinutes))
+            props.executionTime.renderPot(valueRender = _.map(ts => <.span(ts.toHoursMinutes)),
+                                          pendingRender = Icons.Spinner.withSpin(true)
+                                          // pendingRender = <.span("Waiting...")
+            )
           )
         )
       )

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -214,7 +214,7 @@ object ObsList:
               )(
                 ObsBadge(
                   obs,
-                  props.obsExecutionTimes.getPot(id).map(_.executionTime),
+                  props.obsExecutionTimes.getPot(id).map(_.programTimeEstimate),
                   ObsBadge.Layout.ObservationsTab,
                   selected = selected,
                   setStatusCB = obsEditStatus(id)

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -19,6 +19,7 @@ import explore.model.Focused
 import explore.model.GroupElement
 import explore.model.GroupList
 import explore.model.Grouping
+import explore.model.ObservationExecutionMap
 import explore.model.enums.AppTab
 import explore.model.reusability.given
 import explore.tabs.DeckShown
@@ -53,16 +54,17 @@ import scala.scalajs.js
 import ObsQueries.*
 
 case class ObsList(
-  observations:    UndoSetter[ObservationList],
-  undoer:          Undoer,
-  programId:       Program.Id,
-  focusedObs:      Option[Observation.Id],
-  focusedTarget:   Option[Target.Id],
-  setSummaryPanel: Callback,
-  groups:          UndoSetter[GroupList],
-  expandedGroups:  View[Set[Group.Id]],
-  deckShown:       View[DeckShown],
-  readonly:        Boolean
+  observations:      UndoSetter[ObservationList],
+  obsExecutionTimes: ObservationExecutionMap,
+  undoer:            Undoer,
+  programId:         Program.Id,
+  focusedObs:        Option[Observation.Id],
+  focusedTarget:     Option[Target.Id],
+  setSummaryPanel:   Callback,
+  groups:            UndoSetter[GroupList],
+  expandedGroups:    View[Set[Group.Id]],
+  deckShown:         View[DeckShown],
+  readonly:          Boolean
 ) extends ReactFnProps(ObsList.component)
 
 object ObsList:
@@ -212,6 +214,7 @@ object ObsList:
               )(
                 ObsBadge(
                   obs,
+                  props.obsExecutionTimes.getPot(id).map(_.executionTime),
                   ObsBadge.Layout.ObservationsTab,
                   selected = selected,
                   setStatusCB = obsEditStatus(id)

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -25,6 +25,7 @@ import explore.model.enums.AppTab
 import explore.model.enums.TableId
 import explore.model.reusability.given
 import explore.model.syntax.all.*
+import explore.syntax.ui.*
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.ScalaFnComponent
 import japgolly.scalajs.react.*
@@ -47,7 +48,6 @@ import lucuma.react.table.*
 import lucuma.schemas.model.TargetWithId
 import lucuma.ui.primereact.*
 import lucuma.ui.reusability.given
-import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import lucuma.ui.table.*
 import lucuma.ui.table.hooks.*
@@ -255,9 +255,7 @@ object ObsSummaryTable:
               .map(_.executionTime)
         ).setCell(cell =>
           cell.value.map(
-            _.renderPot(valueRender = t => t.map(_.toHoursMinutes).orEmpty,
-                        pendingRender = Icons.Spinner.withSpin(true)
-            )
+            _.orSpinner(_.map(_.toHoursMinutes).orEmpty)
           )
         )
         // TODO: PriorityColumnId

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -252,7 +252,7 @@ object ObsSummaryTable:
           r =>
             obsExecutions
               .getPot(r.obs.id)
-              .map(_.executionTime)
+              .map(_.programTimeEstimate)
         ).setCell(cell =>
           cell.value.map(
             _.orSpinner(_.map(_.toHoursMinutes).orEmpty)

--- a/explore/src/main/scala/explore/observationtree/SchedulingGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/SchedulingGroupObsList.scala
@@ -17,6 +17,7 @@ import explore.model.AppContext
 import explore.model.Focused
 import explore.model.ObsIdSet
 import explore.model.ObsSummary
+import explore.model.ObservationExecutionMap
 import explore.model.ObservationList
 import explore.model.SchedulingGroupList
 import explore.model.enums.AppTab
@@ -52,6 +53,7 @@ case class SchedulingGroupObsList(
   observations:     UndoSetter[ObservationList],
   undoer:           Undoer,
   schedulingGroups: SchedulingGroupList,
+  obsExecutions:    ObservationExecutionMap,
   focusedObsSet:    Option[ObsIdSet],
   setSummaryPanel:  Callback,
   expandedIds:      View[SortedSet[ObsIdSet]],

--- a/explore/src/main/scala/explore/observationtree/ViewCommon.scala
+++ b/explore/src/main/scala/explore/observationtree/ViewCommon.scala
@@ -9,6 +9,7 @@ import explore.components.ui.ExploreStyles
 import explore.model.AppContext
 import explore.model.ObsIdSet
 import explore.model.ObsSummary
+import explore.model.ObservationExecutionMap
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.TagMod
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -20,6 +21,7 @@ import lucuma.ui.syntax.all.given
 trait ViewCommon {
   def programId: Program.Id
   def focusedObsSet: Option[ObsIdSet]
+  def obsExecutions: ObservationExecutionMap
   def readonly: Boolean
 
   def renderObsBadge(
@@ -30,6 +32,7 @@ trait ViewCommon {
   ): TagMod =
     ObsBadge(
       obs,
+      obsExecutions.getPot(obs.id).map(_.executionTime),
       layout,
       selected = forceHighlight || (highlightSelected && focusedObsSet.exists(_.contains(obs.id))),
       readonly = readonly

--- a/explore/src/main/scala/explore/observationtree/ViewCommon.scala
+++ b/explore/src/main/scala/explore/observationtree/ViewCommon.scala
@@ -32,7 +32,7 @@ trait ViewCommon {
   ): TagMod =
     ObsBadge(
       obs,
-      obsExecutions.getPot(obs.id).map(_.executionTime),
+      obsExecutions.getPot(obs.id).map(_.programTimeEstimate),
       layout,
       selected = forceHighlight || (highlightSelected && focusedObsSet.exists(_.contains(obs.id))),
       readonly = readonly

--- a/explore/src/main/scala/explore/programs/ProgramDetailsTile.scala
+++ b/explore/src/main/scala/explore/programs/ProgramDetailsTile.scala
@@ -4,18 +4,18 @@
 package explore.programs
 
 import cats.syntax.all.*
+import crystal.Pot
 import explore.components.ui.ExploreStyles
-import explore.model.ProgramTime
-import explore.model.ProgramTimeRange
+import explore.model.ProgramTimes
 import explore.model.syntax.all.toHoursMinutes
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.util.TimeSpan
 import lucuma.react.common.ReactFnProps
+import lucuma.ui.syntax.all.*
 
 case class ProgramDetailsTile(
-  programTimeEstimateRange: Option[ProgramTimeRange],
-  programTimeCharge:        ProgramTime
+  programTimes: Pot[ProgramTimes]
 ) extends ReactFnProps(ProgramDetailsTile.component)
 
 object ProgramDetailsTile:
@@ -25,31 +25,32 @@ object ProgramDetailsTile:
   def component = ScalaFnComponent
     .withHooks[Props]
     .render { props =>
-
-      val timeAccounting = for {
-        minTime     <- props.programTimeEstimateRange.map(_.minimum.value)
-        maxTime     <- props.programTimeEstimateRange.map(_.maximum.value)
-        used         = props.programTimeCharge.value
-        remain       = TimeSpan.Zero // TODO
-        isSingleTime = minTime == maxTime
-      } yield table(
-        headers = Seq("Time accounting"),
-        rows = (if (isSingleTime) Seq(Seq[TagMod]("Planned", minTime.toHoursMinutes))
-                else
-                  Seq(
-                    Seq[TagMod]("Min Time", minTime.toHoursMinutes),
-                    Seq[TagMod]("Max Time", maxTime.toHoursMinutes)
-                  )) ++
-          Seq(Seq[TagMod]("Used", used.toHoursMinutes)),
-        footer = Seq(Seq[TagMod]("Remain", remain.toHoursMinutes))
-      )
-
-      <.div(
-        ExploreStyles.ProgramDetailsTile,
-        <.div(
-          timeAccounting
+      props.programTimes.renderPot { programTimes =>
+        val timeAccounting = for {
+          minTime     <- programTimes.timeEstimateRange.map(_.minimum.value)
+          maxTime     <- programTimes.timeEstimateRange.map(_.maximum.value)
+          used         = programTimes.timeCharge.value
+          remain       = TimeSpan.Zero // TODO
+          isSingleTime = minTime == maxTime
+        } yield table(
+          headers = Seq("Time accounting"),
+          rows = (if (isSingleTime) Seq(Seq[TagMod]("Planned", minTime.toHoursMinutes))
+                  else
+                    Seq(
+                      Seq[TagMod]("Min Time", minTime.toHoursMinutes),
+                      Seq[TagMod]("Max Time", maxTime.toHoursMinutes)
+                    )) ++
+            Seq(Seq[TagMod]("Used", used.toHoursMinutes)),
+          footer = Seq(Seq[TagMod]("Remain", remain.toHoursMinutes))
         )
-      )
+
+        <.div(
+          ExploreStyles.ProgramDetailsTile,
+          <.div(
+            timeAccounting
+          )
+        )
+      }
     }
 
   private def table(

--- a/explore/src/main/scala/explore/proposal/ProposalEditor.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalEditor.scala
@@ -37,6 +37,7 @@ import explore.model.display.given
 import explore.model.enums.GridLayoutSection
 import explore.model.layout.LayoutsMap
 import explore.proposal.ProposalClassType.*
+import explore.syntax.ui.*
 import explore.undo.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -277,10 +278,6 @@ object ProposalEditor:
       val newClass        = classType.toProposalClass(minPctTime, minPctTotalTime, totalTime)
       classView.set(newClass) >> minPct2.set(minPctTotalTime) >> totalHours.set(toHours(totalTime))
     }
-
-    extension [A](pot: Pot[A])
-      def orSpinner(f: A => VdomNode): VdomNode =
-        pot.renderPot(valueRender = f, pendingRender = Icons.Spinner.withSpin(true))
 
     React.Fragment(
       renderInTitle(<.div(ExploreStyles.TitleUndoButtons)(UndoButtons(undoCtx))),

--- a/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
@@ -184,6 +184,7 @@ object ConstraintsTabContents extends TwoPanels:
             observations,
             props.programSummaries,
             props.programSummaries.get.constraintGroups,
+            props.programSummaries.get.obsExecutionPots,
             props.focusedObsSet,
             state.set(SelectedPanel.Summary),
             props.expandedIds,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -12,6 +12,7 @@ import crystal.Pot.Ready
 import crystal.*
 import crystal.react.*
 import crystal.react.hooks.*
+import explore.Icons
 import explore.*
 import explore.common.TimingWindowsQueries
 import explore.components.Tile
@@ -84,6 +85,7 @@ case class ObsTabTiles(
   programId:                Program.Id,
   backButton:               VdomNode,
   observation:              UndoSetter[ObsSummary],
+  obsExecution:             Pot[Execution],
   allTargets:               UndoSetter[TargetList],
   allConstraintSets:        Set[ConstraintSet],
   targetObservations:       Map[Target.Id, SortedSet[Observation.Id]],
@@ -371,16 +373,21 @@ object ObsTabTiles:
             SequenceEditorTile.sequenceTile(renderInTitle =>
               React.Fragment(
                 renderInTitle {
-                  val programTimeCharge = props.observation.get.execution.programTimeCharge.value
-                  props.observation.get.executionTime
-                    .map { planned =>
-                      val total = programTimeCharge +| planned
-                      <.span(
-                        <.span(ExploreStyles.SequenceTileTitle, total.toHoursMinutes),
-                        s" (${programTimeCharge.toHoursMinutes} executed, ${planned.toHoursMinutes} remaining)"
-                      )
-                    }
-                    .getOrElse(s"${programTimeCharge.toHoursMinutes} executed")
+                  props.obsExecution.renderPot(
+                    valueRender = execution => {
+                      val programTimeCharge = execution.programTimeCharge.value
+                      execution.executionTime
+                        .map { planned =>
+                          val total = programTimeCharge +| planned
+                          <.span(
+                            <.span(ExploreStyles.SequenceTileTitle, total.toHoursMinutes),
+                            s" (${programTimeCharge.toHoursMinutes} executed, ${planned.toHoursMinutes} remaining)"
+                          )
+                        }
+                        .getOrElse(s"${programTimeCharge.toHoursMinutes} executed")
+                    },
+                    pendingRender = Icons.Spinner.withSpin(true)
+                  )
                 },
                 GeneratedSequenceViewer(
                   props.programId,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -374,7 +374,7 @@ object ObsTabTiles:
                 renderInTitle {
                   props.obsExecution.orSpinner { execution =>
                     val programTimeCharge = execution.programTimeCharge.value
-                    execution.executionTime
+                    execution.programTimeEstimate
                       .map { planned =>
                         val total = programTimeCharge +| planned
                         <.span(

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -12,7 +12,6 @@ import crystal.Pot.Ready
 import crystal.*
 import crystal.react.*
 import crystal.react.hooks.*
-import explore.Icons
 import explore.*
 import explore.common.TimingWindowsQueries
 import explore.components.Tile
@@ -373,21 +372,18 @@ object ObsTabTiles:
             SequenceEditorTile.sequenceTile(renderInTitle =>
               React.Fragment(
                 renderInTitle {
-                  props.obsExecution.renderPot(
-                    valueRender = execution => {
-                      val programTimeCharge = execution.programTimeCharge.value
-                      execution.executionTime
-                        .map { planned =>
-                          val total = programTimeCharge +| planned
-                          <.span(
-                            <.span(ExploreStyles.SequenceTileTitle, total.toHoursMinutes),
-                            s" (${programTimeCharge.toHoursMinutes} executed, ${planned.toHoursMinutes} remaining)"
-                          )
-                        }
-                        .getOrElse(s"${programTimeCharge.toHoursMinutes} executed")
-                    },
-                    pendingRender = Icons.Spinner.withSpin(true)
-                  )
+                  props.obsExecution.orSpinner { execution =>
+                    val programTimeCharge = execution.programTimeCharge.value
+                    execution.executionTime
+                      .map { planned =>
+                        val total = programTimeCharge +| planned
+                        <.span(
+                          <.span(ExploreStyles.SequenceTileTitle, total.toHoursMinutes),
+                          s" (${programTimeCharge.toHoursMinutes} executed, ${planned.toHoursMinutes} remaining)"
+                        )
+                      }
+                      .getOrElse(s"${programTimeCharge.toHoursMinutes} executed")
+                  }
                 },
                 GeneratedSequenceViewer(
                   props.programId,

--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -4,6 +4,7 @@
 package explore.tabs
 
 import cats.effect.IO
+import crystal.Pot
 import explore.*
 import explore.components.Tile
 import explore.components.TileController
@@ -11,8 +12,7 @@ import explore.components.ui.ExploreStyles
 import explore.model.AppContext
 import explore.model.ExploreGridLayouts
 import explore.model.ProgramTabTileIds
-import explore.model.ProgramTime
-import explore.model.ProgramTimeRange
+import explore.model.ProgramTimes
 import explore.model.UserPreferences
 import explore.model.enums.GridLayoutSection
 import explore.programs.ProgramChangeRequestsTile
@@ -29,11 +29,10 @@ import lucuma.ui.sso.UserVault
 import lucuma.ui.syntax.all.given
 
 case class ProgramTabContents(
-  programId:                Program.Id,
-  userVault:                Option[UserVault],
-  programTimeEstimateRange: Option[ProgramTimeRange],
-  programTimeCharge:        ProgramTime,
-  userPreferences:          UserPreferences
+  programId:       Program.Id,
+  userVault:       Option[UserVault],
+  programTimes:    Pot[ProgramTimes],
+  userPreferences: UserPreferences
 ) extends ReactFnProps(ProgramTabContents.component)
 
 object ProgramTabContents:
@@ -53,7 +52,7 @@ object ProgramTabContents:
         ProgramTabTileIds.DetailsId.id,
         "Program Details",
         canMinimize = true
-      )(_ => ProgramDetailsTile(props.programTimeEstimateRange, props.programTimeCharge))
+      )(_ => ProgramDetailsTile(props.programTimes))
 
       val notesTile = Tile(
         ProgramTabTileIds.NotesId.id,

--- a/explore/src/main/scala/explore/tabs/SchedulingTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/SchedulingTabContents.scala
@@ -141,6 +141,7 @@ object SchedulingTabContents extends TwoPanels:
             observations,
             props.programSummaries,
             props.programSummaries.get.schedulingGroups,
+            props.programSummaries.get.obsExecutionPots,
             props.focusedObsSet,
             state.set(SelectedPanel.Summary),
             props.expandedIds,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -253,7 +253,6 @@ object TargetTabContents extends TwoPanels:
                   posAngle,
                   Some(wavelength),
                   _,
-                  _,
                   _
                 ) if obsId === id =>
               (const, conf.toBasicConfiguration, posAngle, wavelength)

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
@@ -4,11 +4,10 @@
 package explore.model.arb
 
 import cats.Order.given
-import eu.timepit.refined.scalacheck.numeric.*
+import eu.timepit.refined.scalacheck.numeric.given
 import eu.timepit.refined.scalacheck.string.given
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.model.Execution
 import explore.model.ObsSummary
 import explore.model.ScienceRequirements
 import lucuma.core.arb.ArbTime
@@ -41,7 +40,6 @@ trait ArbObsSummary:
   import ArbTime.given
   import ArbScienceRequirements.given
   import ArbObservingMode.given
-  import ArbExecution.given
 
   given Arbitrary[ObsSummary] =
     Arbitrary(
@@ -62,7 +60,6 @@ trait ArbObsSummary:
         wavelength          <- arbitrary[Option[Wavelength]]
         groupId             <- arbitrary[Option[Group.Id]]
         groupIndex          <- arbitrary[NonNegShort]
-        execution           <- arbitrary[Execution]
       yield ObsSummary(
         id,
         title,
@@ -79,8 +76,7 @@ trait ArbObsSummary:
         posAngleConstraint,
         wavelength,
         groupId,
-        groupIndex,
-        execution
+        groupIndex
       )
     )
 
@@ -98,7 +94,9 @@ trait ArbObsSummary:
        Option[ObservingMode],
        Option[Instant],
        PosAngleConstraint,
-       Option[Wavelength]
+       Option[Wavelength],
+       Option[Group.Id],
+       Short
       )
     ]
       .contramap(o =>
@@ -114,7 +112,9 @@ trait ArbObsSummary:
          o.observingMode,
          o.visualizationTime,
          o.posAngleConstraint,
-         o.wavelength
+         o.wavelength,
+         o.groupId,
+         o.groupIndex.value
         )
       )
 

--- a/model/shared/src/main/scala/explore/model/Execution.scala
+++ b/model/shared/src/main/scala/explore/model/Execution.scala
@@ -9,9 +9,11 @@ import cats.syntax.all.*
 import explore.model.ProgramTime
 import io.circe.Decoder
 import lucuma.core.model.sequence.ExecutionDigest
+import lucuma.core.util.TimeSpan
 import lucuma.odb.json.sequence.given
 
-case class Execution(digest: Option[ExecutionDigest], programTimeCharge: ProgramTime) derives Eq
+case class Execution(digest: Option[ExecutionDigest], programTimeCharge: ProgramTime) derives Eq:
+  lazy val executionTime: Option[TimeSpan] = digest.map(_.fullTimeEstimate.sum)
 
 object Execution {
   given Decoder[Execution] = Decoder.instance(c =>

--- a/model/shared/src/main/scala/explore/model/Execution.scala
+++ b/model/shared/src/main/scala/explore/model/Execution.scala
@@ -13,7 +13,7 @@ import lucuma.core.util.TimeSpan
 import lucuma.odb.json.sequence.given
 
 case class Execution(digest: Option[ExecutionDigest], programTimeCharge: ProgramTime) derives Eq:
-  lazy val executionTime: Option[TimeSpan] = digest.map(_.fullTimeEstimate.sum)
+  lazy val programTimeEstimate: Option[TimeSpan] = digest.map(_.fullTimeEstimate.programTime)
 
 object Execution {
   given Decoder[Execution] = Decoder.instance(c =>

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -31,7 +31,6 @@ import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.sequence.gmos.GmosCcdMode
-import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.odb.json.wavelength.decoder.given
 import lucuma.schemas.decoders.given
@@ -60,8 +59,7 @@ case class ObsSummary(
   posAngleConstraint:  PosAngleConstraint,
   wavelength:          Option[Wavelength],
   groupId:             Option[Group.Id],
-  groupIndex:          NonNegShort,
-  execution:           Execution
+  groupIndex:          NonNegShort
 ) derives Eq:
   lazy val configurationSummary: Option[String] = observingMode.map(_.toBasicConfiguration) match
     case Some(BasicConfiguration.GmosNorthLongSlit(grating, _, fpu, _)) =>
@@ -70,8 +68,6 @@ case class ObsSummary(
       s"GMOS-S ${grating.shortName} ${fpu.shortName}".some
     case _                                                              =>
       none
-
-  val executionTime: Option[TimeSpan] = execution.digest.map(_.fullTimeEstimate.sum)
 
   val toModeOverride: Option[InstrumentOverrides] = observingMode.map {
     case n: ObservingMode.GmosNorthLongSlit =>
@@ -172,7 +168,6 @@ object ObsSummary:
                                .get[Option[Wavelength]]("wavelength")
       groupId             <- c.get[Option[Group.Id]]("groupId")
       groupIndex          <- c.get[NonNegShort]("groupIndex")
-      execution           <- c.get[Execution]("execution")
     } yield ObsSummary(
       id,
       title,
@@ -189,7 +184,6 @@ object ObsSummary:
       posAngleConstraint,
       wavelength,
       groupId,
-      groupIndex,
-      execution
+      groupIndex
     )
   )

--- a/model/shared/src/main/scala/explore/model/ProgramDetails.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramDetails.scala
@@ -14,28 +14,22 @@ import monocle.Focus
 import monocle.Lens
 
 case class ProgramDetails(
-  proposal:                 Option[Proposal],
-  proposalStatus:           ProposalStatus,
-  pi:                       Option[ProgramUser],
-  users:                    List[ProgramUserWithRole],
-  programTimeEstimateRange: Option[ProgramTimeRange],
-  programTimeCharge:        ProgramTime
+  proposal:       Option[Proposal],
+  proposalStatus: ProposalStatus,
+  pi:             Option[ProgramUser],
+  users:          List[ProgramUserWithRole]
 ) derives Eq:
   val allUsers = pi.fold(users)(p => ProgramUserWithRole(p, None) :: users)
 
 object ProgramDetails:
-  val proposal: Lens[ProgramDetails, Option[Proposal]]                         = Focus[ProgramDetails](_.proposal)
-  val proposalStatus: Lens[ProgramDetails, ProposalStatus]                     = Focus[ProgramDetails](_.proposalStatus)
-  val programTimeEstimateRange: Lens[ProgramDetails, Option[ProgramTimeRange]] =
-    Focus[ProgramDetails](_.programTimeEstimateRange)
+  val proposal: Lens[ProgramDetails, Option[Proposal]]     = Focus[ProgramDetails](_.proposal)
+  val proposalStatus: Lens[ProgramDetails, ProposalStatus] = Focus[ProgramDetails](_.proposalStatus)
 
   given Decoder[ProgramDetails] = Decoder.instance(c =>
     for {
-      p   <- c.get[Option[Proposal]]("proposal")
-      ps  <- c.get[ProposalStatus]("proposalStatus")
-      pi  <- c.get[Option[ProgramUser]]("pi")
-      us  <- c.get[List[ProgramUserWithRole]]("users")
-      est <- c.get[Option[ProgramTimeRange]]("timeEstimateRange")
-      chg <- c.get[ProgramTime]("timeCharge")
-    } yield ProgramDetails(p, ps, pi, us, est, chg)
+      p  <- c.get[Option[Proposal]]("proposal")
+      ps <- c.get[ProposalStatus]("proposalStatus")
+      pi <- c.get[Option[ProgramUser]]("pi")
+      us <- c.get[List[ProgramUserWithRole]]("users")
+    } yield ProgramDetails(p, ps, pi, us)
   )

--- a/model/shared/src/main/scala/explore/model/ProgramTimes.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramTimes.scala
@@ -1,0 +1,14 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import io.circe.Decoder
+
+final case class ProgramTimes(
+  timeEstimateRange: Option[ProgramTimeRange],
+  timeCharge:        ProgramTime
+) derives Eq,
+      Decoder

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -5,6 +5,7 @@ package explore.model
 
 import cats.Order.given
 import cats.syntax.all.*
+import crystal.Pot
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.RefinedTypeOps
 import eu.timepit.refined.numeric.Interval
@@ -20,8 +21,10 @@ import lucuma.core.model.SpectralDefinition
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.{ObsAttachment => ObsAtt}
+import lucuma.core.util.NewType
 import lucuma.refined.*
 
+import java.util.UUID
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 
@@ -58,3 +61,16 @@ type ObsAttachmentAssignmentMap = Map[ObsAtt.Id, SortedSet[Observation.Id]]
 type ProgramInfoList            = SortedMap[Program.Id, ProgramInfo]
 
 type GroupList = List[GroupElement]
+
+object ObservationExecutionMap extends NewType[Map[Observation.Id, (UUID, Pot[Execution])]]:
+  extension (t: Type)
+    def getPot(obsId: Observation.Id): Pot[Execution]                                            =
+      t.value.get(obsId).map(_._2).getOrElse(Pot.pending)
+    def getUUID(obsId: Observation.Id): Option[UUID]                                             =
+      t.value.get(obsId).map(_._1)
+    def updated(obsId: Observation.Id, uuid: UUID, pot: Pot[Execution]): ObservationExecutionMap =
+      ObservationExecutionMap(t.value.updated(obsId, (uuid, pot)))
+    def updatePending(obsId: Observation.Id, uuid: UUID): ObservationExecutionMap                =
+      updated(obsId, uuid, Pot.pending)
+
+type ObservationExecutionMap = ObservationExecutionMap.Type


### PR DESCRIPTION
Don't include any of the `digest` or `execution` times in the original cache initialization or in the subscriptions. These are queried separately and provided via `Pot`s to the rest of the application.