### PR TITLE
Vite warmup of files that take long to process.

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -218,6 +218,13 @@ export default defineConfig(async ({ mode }) => {
           },
         ],
       },
+      warmup: {
+        clientFiles: [
+          path.resolve(sjs, '*.js'),
+          path.resolve(webappCommon, 'sass/*.scss'),
+          path.resolve(lucumaCss, '*.scss')
+        ]
+      }
     },
     build: {
       emptyOutDir: true,


### PR DESCRIPTION
Warms up files that take a long time for Vite to transform.

Performance improvement is minimal, but at least explore always seems to load correctly on the first try now.

Reference:
https://vitejs.dev/guide/performance#warm-up-frequently-used-files
https://vitejs.dev/config/server-options#server-warmup