### PR TITLE
Remove program times update on `programEdit`

### DIFF
--- a/explore/src/main/scala/explore/cache/ProgramCache.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCache.scala
@@ -227,7 +227,7 @@ object ProgramCache
               _.map: data => // Replace program and reset times.
                 ProgramSummaries.optProgramDetails.replace(data.programEdit.value.some) >>>
                   ProgramSummaries.programTimesPot.replace(Pot.pending)
-            .evalTap(_ => queryProgramTimes)
+              .evalTap(_ => queryProgramTimes)
 
         val updateTargets: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
           TargetQueriesGQL.ProgramTargetsDelta

--- a/explore/src/main/scala/explore/cache/ProgramCache.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCache.scala
@@ -224,10 +224,8 @@ object ProgramCache
           ProgramQueriesGQL.ProgramEditDetailsSubscription
             .subscribe[IO](props.programId.toProgramEditInput)
             .map:
-              _.map: data => // Replace program and reset times.
-                ProgramSummaries.optProgramDetails.replace(data.programEdit.value.some) >>>
-                  ProgramSummaries.programTimesPot.replace(Pot.pending)
-              .evalTap(_ => queryProgramTimes)
+              _.map: data => // Replace program.
+                ProgramSummaries.optProgramDetails.replace(data.programEdit.value.some)
 
         val updateTargets: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
           TargetQueriesGQL.ProgramTargetsDelta


### PR DESCRIPTION
After editing a program, the program times would be invalidated but the request for new times wouldn't fire, so we ended up with perpetual spinners.

However, I'm wondering if any change we would receive a `programEdit` subscription message for would actually change the program times... Maybe we could just remove the update on `programEdit`? 