### PR TITLE
Fix observations not appearing in groups on first render

### DIFF
--- a/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -43,11 +43,9 @@ object GroupQueriesGQL:
         elements {
           observation {
             id
-            groupIndex
           }
           group {
             id
-            parentIndex
           }
         }
       }

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -97,9 +97,6 @@ object all:
 
   extension (t: IO.type) def now(): IO[Instant] = IO(Instant.now)
 
-  extension (e: Either[GroupObs, GroupingElement])
-    def groupIndex: NonNegShort = e.fold(_.groupIndex, _.parentIndex)
-
   extension (e: Either[GroupObs, Grouping])
     @targetName("groupIndexGrouping")
     def groupIndex: NonNegShort = e.fold(_.groupIndex, _.parentIndex)


### PR DESCRIPTION
Because the `existence` was an `Option` in two different query elements, the `GroupObs` existence was not being checked correctly on group children, as it would always be `None` on those.
With this change the `elements` of groups now only query the `id`, and existence is checked on the 'root' elements of the group tree.
