### PR TITLE
Hide the proposal tab for non-Science program types

### DIFF
--- a/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
@@ -13,6 +13,7 @@ object ProgramDetailsSubquery
     extends GraphQLSubquery.Typed[ObservationDB, ProgramDetails]("Program"):
   override val subquery: String = s"""
     {
+      type
       proposal $ProposalSubquery
       proposalStatus
       pi $ProgramUserSubquery

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -26,6 +26,7 @@ import japgolly.scalajs.react.React
 import japgolly.scalajs.react.extra.router.ResolutionWithProps
 import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.enums.ProgramType
 import lucuma.core.util.Display
 import lucuma.react.common.*
 import lucuma.react.hotkeys.*
@@ -232,7 +233,12 @@ object ExploreLayout:
                 "side-tabs".refined,
                 routingInfoView.zoom(RoutingInfo.appTab),
                 ctx.pageUrl(_, routingInfo.programId, routingInfo.focused),
-                _.separatorAfter
+                _.separatorAfter,
+                tab =>
+                  props.view.get.programSummaries
+                    .flatMap(_.optProgramDetails)
+                    .map(_.programType === ProgramType.Science || tab =!= AppTab.Proposal)
+                    .getOrElse(true)
               ),
               if (showProgsPopup)
                 ProgramsPopup(

--- a/model/shared/src/main/scala/explore/model/ProgramDetails.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramDetails.scala
@@ -7,6 +7,7 @@ import cats.Eq
 import cats.derived.*
 import io.circe.Decoder
 import io.circe.generic.semiauto.*
+import lucuma.core.enums.ProgramType
 import lucuma.core.model.Proposal
 import lucuma.schemas.decoders.given
 import lucuma.schemas.enums.ProposalStatus
@@ -14,6 +15,7 @@ import monocle.Focus
 import monocle.Lens
 
 case class ProgramDetails(
+  programType:    ProgramType,
   proposal:       Option[Proposal],
   proposalStatus: ProposalStatus,
   pi:             Option[ProgramUser],
@@ -28,10 +30,11 @@ object ProgramDetails:
 
   given Decoder[ProgramDetails] = Decoder.instance(c =>
     for {
+      t  <- c.get[ProgramType]("type")
       p  <- c.get[Option[Proposal]]("proposal")
       ps <- c.get[ProposalStatus]("proposalStatus")
       pi <- c.get[Option[ProgramUser]]("pi")
       us <- c.get[List[ProgramUserWithRole]]("users")
       in <- c.get[List[CoIInvitation]]("userInvitations")
-    } yield ProgramDetails(p, ps, pi, us, in)
+    } yield ProgramDetails(t, p, ps, pi, us, in)
   )


### PR DESCRIPTION
The button in the side tabs is removed for non-science program types. However, since it is possible to directly go to the `proposals` url, I also display a message on the proposal tab in that case. Since it is very unlikely for someone to try to go directly to the proposal tab for a non-science program, this seemed simpler than trying to prevent it in the router.

Hint: Hiding whitespace changes will make this simpler to compare.