### PR TITLE
Remove times from ProgramDetailsSubquery

### DIFF
--- a/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
@@ -18,8 +18,6 @@ object ProgramDetailsSubquery
       proposalStatus
       pi $ProgramUserSubquery
       users $ProgramUserWithRoleSubquery
-      timeEstimateRange $ProgramTimeRangeSubquery
-      timeCharge $ProgramTimeSubquery
       userInvitations $ProgramInvitationsSubquery
     }
   """


### PR DESCRIPTION
The program times were removed from `ProgramDetails`, but remained in the query. This sort of defeated the purpose of removing them from ProgramDetails...