### PR TITLE
Add word break on long target names

### DIFF
--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -946,6 +946,7 @@ svg.fa-triangle-exclamation.explore-error-icon {
       /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
       font-size: var(--pl-large-font-size);
       font-weight: 400;
+      word-break: break-all;
     }
 
     .p-component.p-button.obs-clone-button,
@@ -962,6 +963,7 @@ svg.fa-triangle-exclamation.explore-error-icon {
     font-weight: normal;
     font-size: small;
     opacity: 0.5;
+    word-break: normal;
   }
 
   .obs-badge-description {


### PR DESCRIPTION
Before:

<img width="330" alt="afbeelding" src="https://github.com/gemini-hlsw/explore/assets/10114577/30618c9a-0176-4fc1-9978-c2541fd277dd">

Scrolled to the right:

<img width="310" alt="afbeelding" src="https://github.com/gemini-hlsw/explore/assets/10114577/b55d5fe1-b0a0-4fc6-ab57-4e84e58a91e1">

After:

<img width="336" alt="afbeelding" src="https://github.com/gemini-hlsw/explore/assets/10114577/83259143-dc82-4458-addc-ac9debff0351">
