### PR TITLE
Tighten up brightness table to avoid horizontal scrolling

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -90,7 +90,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                 _._1,
                 "Band",
                 _.value.shortName,
-                size = 70.toPx
+                size = 67.toPx
               ).sortable,
               ColDef(
                 ValueColumnId,
@@ -105,7 +105,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                       ChangeAuditor.bigDecimal(2.refined, 3.refined).allowExp(2.refined),
                     disabled = disabled
                   ),
-                size = 100.toPx
+                size = 77.toPx
               ).sortableBy(_.get),
               ColDef(
                 UnitsColumnId,
@@ -118,7 +118,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                     disabled = disabled,
                     clazz = ExploreStyles.BrightnessesTableUnitsDropdown
                   ),
-                size = 183.toPx
+                size = 145.toPx
               ).sortableBy(_.get),
               ColDef(
                 DeleteColumnId,


### PR DESCRIPTION
I narrowed the minimum width of the columns so it will go to this point before requiring scroll bars:
![image](https://github.com/gemini-hlsw/explore/assets/6035943/e269e4dd-e83f-4edc-8294-4d76b7a92b73)
Any more and we will not be able to see all the information or be able to distinguish the units or have the sortable header (Band).

If we want to be able to go narrow, we could do some additional work to allow stackable tables in ReactTable, but I'm not sure that's a great option because of the vertical space it would require.