### PR TITLE
Remember configuration choice after revert

### DIFF
--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -67,7 +67,6 @@ import lucuma.ui.utils.*
 import java.text.DecimalFormat
 import scala.collection.decorators.*
 import scala.concurrent.duration.*
-import scala.math.Ordering.OptionOrdering
 
 import scalajs.js
 import scalajs.js.JSConverters.*
@@ -171,12 +170,6 @@ private object SpectroscopyModesTable:
   private given Ordering[InstrumentRow#Grating] = Ordering.by(_.toString)
   private given Ordering[InstrumentRow#Filter]  = Ordering.by(_.toString)
   private given Ordering[TimeSpan | Unit]       = Ordering.by(_.toOption)
-
-  // This one is not lawful, so we're not making in implicit
-  private val ordConf: Ordering[BasicConfigAndItc]                   =
-    Ordering.by(_.configuration.configurationSummary)
-  private val orderingOptConfig: Ordering[Option[BasicConfigAndItc]] =
-    new OptionOrdering[BasicConfigAndItc] { val optionOrdering = ordConf }
 
   private def formatInstrument(r: (Instrument, NonEmptyString)): String = r match
     case (i @ Instrument.Gnirs, m) => s"${i.longName} $m"
@@ -301,7 +294,10 @@ private object SpectroscopyModesTable:
       column(AvailablityColumnId, row => row.rowToConf(cw))
         .setCell(_.value.fold("No")(_ => "Yes"))
         .setColumnSize(FixedSize(66.toPx))
-        .sortable(using orderingOptConfig)
+        .sortableBy(
+          // None are first, just like in Ordering[Option[?]]
+          _.fold("")(_.configuration.configurationSummary)
+        )
     ).filter { case c => (c.id.toString) != FPUColumnId.value || fpu.isEmpty }
 
   extension (row: SpectroscopyModeRowWithResult)

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -465,7 +465,15 @@ private object SpectroscopyModesTable:
         table.getSortedRowModel().rows.map(_.original).toList
       }
       // selectedRow
-      .useState(none[SpectroscopyModeRow])
+      .useStateBy((props, _, _, rows, _, _, _, _, _, _, _) =>
+        props.selectedConfig.get
+          .flatMap(c =>
+            rows.value.find(
+              _.equalsConf(c.configuration, props.spectroscopyRequirements.wavelength)
+            )
+          )
+          .map(_.entry)
+      )
       // selectedIndex
       // The selected index needs to be the index into the sorted data, because that is what
       // the virtualizer uses for scrollTo.

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -294,10 +294,7 @@ private object SpectroscopyModesTable:
       column(AvailablityColumnId, row => row.rowToConf(cw))
         .setCell(_.value.fold("No")(_ => "Yes"))
         .setColumnSize(FixedSize(66.toPx))
-        .sortableBy(
-          // None are first, just like in Ordering[Option[?]]
-          _.fold("")(_.configuration.configurationSummary)
-        )
+        .sortableBy(_.map(_.configuration.configurationSummary))
     ).filter { case c => (c.id.toString) != FPUColumnId.value || fpu.isEmpty }
 
   extension (row: SpectroscopyModeRowWithResult)


### PR DESCRIPTION
This seems to fix the issue. It is a complex section, so hopefully it doesn't cause additional problems...

The second commit fixes a problem where a local, unlawful Order instance was being used for an === comparison. The result was that a view was not getting updated and the `Accept Configuration` button was not getting enabled sometimes when reverting a configuration.