### PR TITLE
Fix issue of broken Semester Plot

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
@@ -159,7 +159,7 @@ object ElevationPlotSection:
                   options.get,
                   props.coords,
                   windowsNetExcludeIntervals
-                )
+                ).withKey(s"${options.get}-${props.coords}")
           },
           <.div(
             ExploreStyles.ElevationPlotControls,


### PR DESCRIPTION
This fixes an issue where switching between GS and GN on a semester plot would break the semester plot and no elevation line would appear even when switching back to the original site. In the case of breakage, the console would show this error:
```
Uncaught TypeError: Cannot read properties of undefined (reading '0')
```
Even reloading would not fix the problem, and in addition to the above error you would also get:
```
scala.scalajs.js.JavaScriptException: TypeError: Cannot read properties of undefined (reading 'data')
```
The fact that reloading wouldn't fix the issue was surprising. The code involves one of the service workers, so maybe that has something to do with it?

However, minimizing the elevation plot tile or switching to `Night` and then back to `Semester` would "fix" it.