### PR TITLE
Remove existence checks from allGroupElements query

### DIFF
--- a/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -22,7 +22,6 @@ object GroupQueriesGQL:
         observation {
           id
           groupIndex
-          existence
         }
         group $GroupSubQuery
       }

--- a/model/shared/src/main/scala/explore/model/GroupElement.scala
+++ b/model/shared/src/main/scala/explore/model/GroupElement.scala
@@ -16,7 +16,6 @@ import lucuma.core.model.Group
 import lucuma.core.model.Observation
 import lucuma.core.util.TimeSpan
 import lucuma.odb.json.time.decoder.given
-import lucuma.schemas.ObservationDB.Enums.Existence
 
 import GroupElement.given
 
@@ -45,9 +44,7 @@ object GroupElement:
         .orElse(c.get[ObsElement]("observation").map(_.asLeft))
     )
 
-case class GroupObs(id: Observation.Id, groupIndex: NonNegShort, existence: Existence)
-    derives Eq,
-      Decoder
+case class GroupObs(id: Observation.Id, groupIndex: NonNegShort) derives Eq, Decoder
 
 case class Grouping(
   id:              Group.Id,

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -53,6 +53,7 @@ object GroupTree:
     val rootGroups =
       groups
         .mapFilter(g => if g.parentGroupId.isEmpty then g.value.some else none)
+        .filter(_.left.forall(_.existence === Existence.Present))
         .sortBy(_.groupIndex)
 
     val nodes = rootGroups.map(_.fold(createObsNode, createGroupNode))

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -17,7 +17,6 @@ import explore.model.syntax.all.*
 import lucuma.core.model.Group.Id as GroupId
 import lucuma.core.model.Observation
 import lucuma.core.util.TimeSpan
-import lucuma.schemas.ObservationDB.Enums.Existence
 import monocle.Focus
 import monocle.Lens
 
@@ -42,7 +41,7 @@ object GroupTree:
       val children = group.elements
         .flatMap(
           _.fold(
-            obs => obsMap.get(obs.id).filter(_.existence === Existence.Present).map(_.asLeft),
+            obs => obsMap.get(obs.id).map(_.asLeft),
             group => groupMap.get(group.id).map(_.asRight)
           )
         )
@@ -53,7 +52,6 @@ object GroupTree:
     val rootGroups =
       groups
         .mapFilter(g => if g.parentGroupId.isEmpty then g.value.some else none)
-        .filter(_.left.forall(_.existence === Existence.Present))
         .sortBy(_.groupIndex)
 
     val nodes = rootGroups.map(_.fold(createObsNode, createGroupNode))


### PR DESCRIPTION
~~Alternative way to fix #3810~~

Removes the checks that are no longer needed since the backend filters out deleted groups/observations
