### PR TITLE
Revert "Bump primereact from 10.5.1 to 10.6.5"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "highcharts": "11.4.0",
         "loglevel": "1.9.1",
         "primeicons": "^7.0.0",
-        "primereact": "~10.6.5",
+        "primereact": "~10.5.1",
         "prop-types": "15.8.1",
         "react": "18.2.0",
         "react-beautiful-dnd": "13.1.1",
@@ -7008,9 +7008,9 @@
       "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw=="
     },
     "node_modules/primereact": {
-      "version": "10.6.5",
-      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.6.5.tgz",
-      "integrity": "sha512-YbdvyIRIGSfZVhtIbltizUISBuXVXBn2S4/491xdDJLrxohjjf0uIogu+/sSKRBVVT17b6zFEwARTvc9yUA7tQ==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.5.1.tgz",
+      "integrity": "sha512-v+JpIisXmqUHWwYDojWibB4Kx8n6KOliBYhmRUQ2nzQAz14i53paU6YfSXe8zOSX3uNnbJAZF76hCKlXsUDlbQ==",
       "dependencies": {
         "@types/react-transition-group": "^4.4.1",
         "react-transition-group": "^4.4.1"
@@ -14542,9 +14542,9 @@
       "integrity": "sha512-jK3Et9UzwzTsd6tzl2RmwrVY/b8raJ3QZLzoDACj+oTJ0oX7L9Hy+XnVwgo4QVKlKpnP/Ur13SXV/pVh4LzaDw=="
     },
     "primereact": {
-      "version": "10.6.5",
-      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.6.5.tgz",
-      "integrity": "sha512-YbdvyIRIGSfZVhtIbltizUISBuXVXBn2S4/491xdDJLrxohjjf0uIogu+/sSKRBVVT17b6zFEwARTvc9yUA7tQ==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.5.1.tgz",
+      "integrity": "sha512-v+JpIisXmqUHWwYDojWibB4Kx8n6KOliBYhmRUQ2nzQAz14i53paU6YfSXe8zOSX3uNnbJAZF76hCKlXsUDlbQ==",
       "requires": {
         "@types/react-transition-group": "^4.4.1",
         "react-transition-group": "^4.4.1"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "highcharts": "11.4.0",
     "loglevel": "1.9.1",
     "primeicons": "^7.0.0",
-    "primereact": "~10.6.5",
+    "primereact": "~10.5.1",
     "prop-types": "15.8.1",
     "react": "18.2.0",
     "react-beautiful-dnd": "13.1.1",


### PR DESCRIPTION
Reverts gemini-hlsw/explore#3825

<img width="384" alt="image" src="https://github.com/gemini-hlsw/explore/assets/10114577/1cc4af49-4946-47da-8300-e107531f8bc4">
