### PR TITLE
Temporary fix until the CfP changes in the API can be integrated.

### DIFF
--- a/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
@@ -14,7 +14,6 @@ object ProgramDetailsSubquery
   override val subquery: String = s"""
     {
       type
-      proposal $ProposalSubquery
       proposalStatus
       pi $ProgramUserSubquery
       users $ProgramUserWithRoleSubquery
@@ -22,3 +21,15 @@ object ProgramDetailsSubquery
       userInvitations $ProgramInvitationsSubquery
     }
   """
+  // Restore when integrating API CfP changes
+  // override val subquery: String = s"""
+  //   {
+  //     type
+  //     proposal $ProposalSubquery
+  //     proposalStatus
+  //     pi $ProgramUserSubquery
+  //     users $ProgramUserWithRoleSubquery
+  //     reference $ProgramReferenceSubquery
+  //     userInvitations $ProgramInvitationsSubquery
+  //   }
+  // """


### PR DESCRIPTION
This makes explore usable with the new API changes for Calls for Proposals. The exception is Proposals. Trying to do anything with proposals in the UI will be a source of pain and suffering. 
 