### PR TITLE
Fix transparent sticky header issue.

### DIFF
--- a/common/src/main/webapp/less/style.less
+++ b/common/src/main/webapp/less/style.less
@@ -434,7 +434,6 @@ tbody tr td.sticky-column {
 
 thead tr th.sticky-column {
   position: sticky;
-  background: inherit;
 
   &.sticky-header {
     z-index: 15;


### PR DESCRIPTION
The deleted css was not actually being used since it was overridden by the default `th` background color from our theme. However, prime-react has moved the themes into a `primereact` css layer. This makes sense in that it is easier to override the theme in user css. However, it means that now some of our css is not being overridden. Hopefully, we don't run into too many more issues like this.