### PR TITLE
Fix crash when double clicking on the target table

### DIFF
--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -455,7 +455,7 @@ object TargetTabContents extends TwoPanels:
       .useContext(AppContext.ctx)
       // Two panel state
       .useStateView[SelectedPanel](SelectedPanel.Uninitialized)
-      .useEffectWithDepsBy((props, _, state) => props.focused) { (_, _, selected) => focused =>
+      .useEffectWithDepsBy((props, _, _) => props.focused) { (_, _, selected) => focused =>
         (focused, selected.get) match
           case (Focused(Some(_), _, _), _)                    => selected.set(SelectedPanel.Editor)
           case (Focused(None, Some(_), _), _)                 => selected.set(SelectedPanel.Editor)

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -8,7 +8,6 @@ import cats.syntax.all.*
 import crystal.*
 import crystal.react.*
 import crystal.react.hooks.*
-import crystal.react.reuse.*
 import explore.*
 import explore.components.FocusedStatus
 import explore.components.Tile
@@ -21,7 +20,6 @@ import explore.model.ObsSummary
 import explore.model.enums.AppTab
 import explore.model.enums.GridLayoutSection
 import explore.model.enums.SelectedPanel
-import explore.model.reusability.given
 import explore.model.syntax.all.*
 import explore.observationtree.AsterismGroupObsList
 import explore.shortcuts.*
@@ -457,14 +455,13 @@ object TargetTabContents extends TwoPanels:
       .useContext(AppContext.ctx)
       // Two panel state
       .useStateView[SelectedPanel](SelectedPanel.Uninitialized)
-      .useEffectWithDepsBy((props, _, state) => (props.focused, state.reuseByValue)) {
-        (_, _, selected) => (focused, _) =>
-          (focused, selected.get) match
-            case (Focused(Some(_), _, _), _)                    => selected.set(SelectedPanel.Editor)
-            case (Focused(None, Some(_), _), _)                 => selected.set(SelectedPanel.Editor)
-            case (Focused(None, None, _), SelectedPanel.Editor) =>
-              selected.set(SelectedPanel.Summary)
-            case _                                              => Callback.empty
+      .useEffectWithDepsBy((props, _, state) => props.focused) { (_, _, selected) => focused =>
+        (focused, selected.get) match
+          case (Focused(Some(_), _, _), _)                    => selected.set(SelectedPanel.Editor)
+          case (Focused(None, Some(_), _), _)                 => selected.set(SelectedPanel.Editor)
+          case (Focused(None, None, _), SelectedPanel.Editor) =>
+            selected.set(SelectedPanel.Summary)
+          case _                                              => Callback.empty
       }
       .useStateViewBy((props, _, _) => props.focused.target.toList)
       .useEffectWithDepsBy((props, _, _, _) => props.focused.target)((_, _, _, selIds) =>


### PR DESCRIPTION
There were actually (at least) 2 issues that caused the target table to crash when clicking.

Raúl fixed one by rewriting our highcharts facade. This is the one that was actually demonstrated in the video in the referenced Shortcut ticket.

However, a second issue was discovered. This PR seems to fix that one.