### PR TITLE
A fix and a preemptive fix

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -8,7 +8,6 @@ import cats.syntax.all.*
 import crystal.*
 import crystal.react.*
 import crystal.react.hooks.*
-import crystal.react.reuse.*
 import eu.timepit.refined.types.numeric.NonNegInt
 import explore.*
 import explore.Icons
@@ -22,7 +21,6 @@ import explore.model.ProgramSummaries
 import explore.model.enums.AppTab
 import explore.model.enums.GridLayoutSection
 import explore.model.enums.SelectedPanel
-import explore.model.reusability.given
 import explore.modes.SpectroscopyModesMatrix
 import explore.observationtree.*
 import explore.shortcuts.*
@@ -31,7 +29,6 @@ import explore.undo.UndoContext
 import explore.undo.UndoSetter
 import explore.utils.*
 import japgolly.scalajs.react.*
-import japgolly.scalajs.react.callback.CallbackCatsEffect.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Group
@@ -213,14 +210,12 @@ object ObsTabContents extends TwoPanels:
       .withHooks[Props]
       .useContext(AppContext.ctx)
       .useStateView[SelectedPanel](SelectedPanel.Uninitialized)
-      .useEffectWithDepsBy((props, _, panels) => (props.focusedObs, panels.reuseByValue)) {
-        (_, _, _) => params =>
-          val (focusedObs, selected) = params
-          (focusedObs, selected.get) match {
-            case (Some(_), _)                 => selected.set(SelectedPanel.Editor)
-            case (None, SelectedPanel.Editor) => selected.set(SelectedPanel.Summary)
-            case _                            => Callback.empty
-          }
+      .useEffectWithDepsBy((props, _, _) => props.focusedObs) { (_, _, selected) => focusedObs =>
+        (focusedObs, selected.get) match {
+          case (Some(_), _)                 => selected.set(SelectedPanel.Editor)
+          case (None, SelectedPanel.Editor) => selected.set(SelectedPanel.Summary)
+          case _                            => Callback.empty
+        }
       }
       // Measure its size
       .useResizeDetector()

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -286,7 +286,8 @@ object TargetTabContents extends TwoPanels:
           props.searching,
           title,
           props.globalPreferences,
-          props.readonly
+          props.readonly,
+          backButton = backButton.some
         )
 
       val selectedCoordinates: Option[Coordinates] =


### PR DESCRIPTION
Similar to #3841, this removes the dependency of `useEffectsWithDepsBy` on the same thing that it is setting. I can't see any problem this was causing at the moment, but since removing it does not seem to affect the behavior, I thought it best to not wait and see what it could break in the future.

It also adds the backbutton on the asterism editor in narrow windows. There was no way to get back to the obs list after clicking on an asterism.