### PR TITLE
Keep minimized target tiles from persisting.

### DIFF
--- a/common/src/main/scala/explore/model/layout.scala
+++ b/common/src/main/scala/explore/model/layout.scala
@@ -89,6 +89,15 @@ object layout {
       }(l)
     }
 
+  extension (li: LayoutItem)
+    def isValid: Boolean =
+      li.w > 0 && li.minW.forall(_ <= li.w) && li.maxW.forall(_ >= li.w) &&
+        li.h > 0 && li.minH.forall(_ <= li.h) && li.maxH.forall(_ >= li.h) &&
+        li.i.nonEmpty
+
+  extension (ls: Layouts)
+    def areValid: Boolean = ls.layouts.flatMap(_.layout.asList).forall(_.isValid)
+
   val layoutItem: Lens[Layout, List[LayoutItem]] =
     Lens[Layout, List[LayoutItem]](_.asList)(list => _ => Layout(list))
   val layoutItems: Traversal[Layout, LayoutItem] = layoutItem.each

--- a/explore/src/main/scala/explore/components/TileController.scala
+++ b/explore/src/main/scala/explore/components/TileController.scala
@@ -155,10 +155,17 @@ object TileController:
                 .setState(bk),
           onLayoutChange = (m: Layout, newLayouts: Layouts) =>
             // Store the current layout in the state for debugging
-            currentLayout
-              .mod(breakpointLayout(breakpoint.value).replace(m)) *>
-              storeLayouts(p.userId, p.section, newLayouts)
-                .when_(p.storeLayout),
+            // But only update local or user preferences state if the layouts are valid, otherwise
+            // an issue with all the tiles being shrunk to nothing can happen. The error about
+            // `minWidth larger than item width/maxWidth` will still occur in the console, and
+            // the tiles will sometimes shrink, but it will usually return to normal from the saved
+            // state and the problem will not be persisted to user preferences.
+            if (newLayouts.areValid)
+              currentLayout
+                .mod(breakpointLayout(breakpoint.value).replace(m)) *>
+                storeLayouts(p.userId, p.section, newLayouts)
+                  .when_(p.storeLayout)
+            else Callback.empty,
           layouts = currentLayout.get,
           className = p.clazz.map(_.htmlClass).orUndefined
         )(


### PR DESCRIPTION
As mentioned in the code comment, the `minWidth larger than item width/maxWidth` still happens on occasion on the targets tab when doing things like double clicking on the target summary table. The tiles minimize but it is transient and they restore to normal, probably from the local saved state. And, it is never persisted to User Preferences.

It would be nice to get rid of the error and transient minimization, but it seems to be happening within the ResponsiveReactGridLayout.