### PR TITLE
Final (hopefully) fix for minimized tile bug on target tab

### DIFF
--- a/common/src/main/scala/explore/model/layout.scala
+++ b/common/src/main/scala/explore/model/layout.scala
@@ -89,15 +89,6 @@ object layout {
       }(l)
     }
 
-  extension (li: LayoutItem)
-    def isValid: Boolean =
-      li.w > 0 && li.minW.forall(_ <= li.w) && li.maxW.forall(_ >= li.w) &&
-        li.h > 0 && li.minH.forall(_ <= li.h) && li.maxH.forall(_ >= li.h) &&
-        li.i.nonEmpty
-
-  extension (ls: Layouts)
-    def areValid: Boolean = ls.layouts.flatMap(_.layout.asList).forall(_.isValid)
-
   val layoutItem: Lens[Layout, List[LayoutItem]] =
     Lens[Layout, List[LayoutItem]](_.asList)(list => _ => Layout(list))
   val layoutItems: Traversal[Layout, LayoutItem] = layoutItem.each

--- a/explore/src/main/scala/explore/components/TileController.scala
+++ b/explore/src/main/scala/explore/components/TileController.scala
@@ -155,17 +155,10 @@ object TileController:
                 .setState(bk),
           onLayoutChange = (m: Layout, newLayouts: Layouts) =>
             // Store the current layout in the state for debugging
-            // But only update local or user preferences state if the layouts are valid, otherwise
-            // an issue with all the tiles being shrunk to nothing can happen. The error about
-            // `minWidth larger than item width/maxWidth` will still occur in the console, and
-            // the tiles will sometimes shrink, but it will usually return to normal from the saved
-            // state and the problem will not be persisted to user preferences.
-            if (newLayouts.areValid)
-              currentLayout
-                .mod(breakpointLayout(breakpoint.value).replace(m)) *>
-                storeLayouts(p.userId, p.section, newLayouts)
-                  .when_(p.storeLayout)
-            else Callback.empty,
+            currentLayout
+              .mod(breakpointLayout(breakpoint.value).replace(m)) *>
+              storeLayouts(p.userId, p.section, newLayouts)
+                .when_(p.storeLayout),
           layouts = currentLayout.get,
           className = p.clazz.map(_.htmlClass).orUndefined
         )(


### PR DESCRIPTION
This should address the `minWidth larger than item width/maxWidth` error on the targets tab. I had more extensive changes, but it turns out that this is all that is needed. 

This reverts the changes from #3843 as they are no longer necessary.