### PR TITLE
Replace lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,13 +241,9 @@ jobs:
           cat vars.css
 
       - name: Run linters in dark mode
-        uses: wearerequired/lint-action@v2
-        with:
-          stylelint: true
-          stylelint_extensions: css,sass,scss
-          stylelint_args: common/src/main/webapp/sass
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prettier: true
+        run: |
+          npx prettier --check .
+          npx stylelint --formatter github common/src/main/webapp/sass
 
       - name: Setup and expand vars light
         if: github.event_name != 'pull_request'
@@ -257,10 +253,6 @@ jobs:
 
       - name: Run linters in light mode
         if: github.event_name != 'pull_request'
-        uses: wearerequired/lint-action@v2
-        with:
-          stylelint: true
-          stylelint_extensions: css,sass,scss
-          stylelint_args: common/src/main/webapp/sass
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prettier: true
+        run: |
+          npx prettier --check .
+          npx stylelint --formatter github common/src/main/webapp/sass

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,5 @@ hasura/user-prefs/
 node_modules
 target
 heroku/static
+
+explore/src/clue/resources/*.graphql

--- a/build.sbt
+++ b/build.sbt
@@ -339,16 +339,12 @@ def setupVars(mode: String) = WorkflowStep.Run(
   cond = if (mode == "dark") None else Some("github.event_name != 'pull_request'")
 )
 
-def runLinters(mode: String) = WorkflowStep.Use(
-  UseRef.Public("wearerequired", "lint-action", "v2"),
-  name = Some(s"Run linters in $mode mode"),
-  params = Map(
-    "github_token"         -> "${{ secrets.GITHUB_TOKEN }}",
-    "prettier"             -> "true",
-    "stylelint"            -> "true",
-    "stylelint_args"       -> "common/src/main/webapp/sass",
-    "stylelint_extensions" -> "css,sass,scss"
+def runLinters(mode: String) = WorkflowStep.Run(
+  List(
+    "npx prettier --check .",
+    "npx stylelint --formatter github common/src/main/webapp/sass"
   ),
+  name = Some(s"Run linters in $mode mode"),
   cond = if (mode == "dark") None else Some("github.event_name != 'pull_request'")
 )
 


### PR DESCRIPTION
Annotations in github still work as that's built-in, but I'm not sure if that ever worked for prettier:

<img width="1001" alt="afbeelding" src="https://github.com/gemini-hlsw/explore/assets/10114577/9dd639cb-593c-400a-a2d0-720439bd51b6">
