### PR TITLE
Initial observation validations

### DIFF
--- a/explore/src/clue/scala/queries/common/ObservationSummarySubquery.scala
+++ b/explore/src/clue/scala/queries/common/ObservationSummarySubquery.scala
@@ -47,5 +47,9 @@ object ObservationSummarySubquery
           observingMode $ObservingModeSubquery
           groupId
           groupIndex
+          validations {
+            code
+            messages
+          }
         }
       """

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -131,6 +131,13 @@ object ObsBadge:
         renderEnumProgress(obs.status)
       )
 
+      val validationTooltip = <.div(
+        obs.validations.toTagMod(ov =>
+          <.div(ov.code.name, <.ul(ov.messages.toList.toTagMod(<.li(_))))
+        )
+      )
+      val validationIcon    = Tooltip.Fragment(content = validationTooltip)(<.span(Icons.ErrorIcon))
+
       <.div(
         <.div(ExploreStyles.ObsBadge, ExploreStyles.ObsBadgeSelected.when(props.selected))(
           header,
@@ -189,7 +196,8 @@ object ObsBadge:
                 ^.onClick ==> { e => e.preventDefaultCB >> e.stopPropagationCB }
               )
             ),
-            props.executionTime.orSpinner(_.map(TimeSpanView(_)))
+            props.executionTime.orSpinner(_.map(TimeSpanView(_))),
+            validationIcon.unless(obs.validations.isEmpty)
           )
         )
       )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -253,6 +253,7 @@ object TargetTabContents extends TwoPanels:
                   posAngle,
                   Some(wavelength),
                   _,
+                  _,
                   _
                 ) if obsId === id =>
               (const, conf.toBasicConfiguration, posAngle, wavelength)

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObsSummary.scala
@@ -19,10 +19,12 @@ import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Group
 import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
+import lucuma.core.model.ObservationValidation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.arb.ArbConstraintSet.given
+import lucuma.core.model.arb.ArbObservationValidation.given
 import lucuma.core.model.arb.ArbPosAngleConstraint.given
 import lucuma.core.model.arb.ArbTimingWindow.given
 import lucuma.core.util.arb.ArbEnumerated.given
@@ -60,6 +62,7 @@ trait ArbObsSummary:
         wavelength          <- arbitrary[Option[Wavelength]]
         groupId             <- arbitrary[Option[Group.Id]]
         groupIndex          <- arbitrary[NonNegShort]
+        validations         <- arbitrary[List[ObservationValidation]]
       yield ObsSummary(
         id,
         title,
@@ -76,7 +79,8 @@ trait ArbObsSummary:
         posAngleConstraint,
         wavelength,
         groupId,
-        groupIndex
+        groupIndex,
+        validations
       )
     )
 
@@ -96,7 +100,8 @@ trait ArbObsSummary:
        PosAngleConstraint,
        Option[Wavelength],
        Option[Group.Id],
-       Short
+       Short,
+       List[ObservationValidation]
       )
     ]
       .contramap(o =>
@@ -114,7 +119,8 @@ trait ArbObsSummary:
          o.posAngleConstraint,
          o.wavelength,
          o.groupId,
-         o.groupIndex.value
+         o.groupIndex.value,
+         o.validations
         )
       )
 

--- a/model/shared/src/main/scala/explore/model/ObsSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObsSummary.scala
@@ -27,6 +27,7 @@ import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Group
 import lucuma.core.model.ObsAttachment
 import lucuma.core.model.Observation
+import lucuma.core.model.ObservationValidation
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
@@ -59,7 +60,8 @@ case class ObsSummary(
   posAngleConstraint:  PosAngleConstraint,
   wavelength:          Option[Wavelength],
   groupId:             Option[Group.Id],
-  groupIndex:          NonNegShort
+  groupIndex:          NonNegShort,
+  validations:         List[ObservationValidation]
 ) derives Eq:
   lazy val configurationSummary: Option[String] = observingMode.map(_.toBasicConfiguration) match
     case Some(BasicConfiguration.GmosNorthLongSlit(grating, _, fpu, _)) =>
@@ -139,6 +141,7 @@ object ObsSummary:
   val wavelength          = Focus[ObsSummary](_.wavelength)
   val groupId             = Focus[ObsSummary](_.groupId)
   val groupIndex          = Focus[ObsSummary](_.groupIndex)
+  val validations         = Focus[ObsSummary](_.validations)
 
   private case class TargetIdWrapper(id: Target.Id)
   private object TargetIdWrapper:
@@ -168,6 +171,7 @@ object ObsSummary:
                                .get[Option[Wavelength]]("wavelength")
       groupId             <- c.get[Option[Group.Id]]("groupId")
       groupIndex          <- c.get[NonNegShort]("groupIndex")
+      validations         <- c.get[List[ObservationValidation]]("validations")
     } yield ObsSummary(
       id,
       title,
@@ -184,6 +188,7 @@ object ObsSummary:
       posAngleConstraint,
       wavelength,
       groupId,
-      groupIndex
+      groupIndex,
+      validations
     )
   )


### PR DESCRIPTION
The first step in display observation validations in explore. Currently, if there are validation errors, it shows an error icon with a tooltip in the observation badges. 
![image](https://github.com/gemini-hlsw/explore/assets/6035943/6689477a-f0b1-4ba9-86bd-fa76c99ffb27)

The next step will be showing the full list in the `Warnings and Errors` tile.