### PR TITLE
Avoid table remounts in ObsSummaryTable and ObsAttachmentsTable

### DIFF
--- a/explore/src/main/scala/explore/common/UserPreferencesQueries.scala
+++ b/explore/src/main/scala/explore/common/UserPreferencesQueries.scala
@@ -416,7 +416,7 @@ object UserPreferencesQueries:
   case class TableStore[F[_]: MonadThrow](
     userId:  Option[User.Id],
     tableId: TableId,
-    columns: List[ColumnDef.NoMeta[?, ?]]
+    columns: List[ColumnDef[?, ?, ?, ?]]
   )(using FetchClient[F, UserPreferencesDB], Logger[F])
       extends TableStateStore[F]:
     def load(): F[TableState => TableState] =


### PR DESCRIPTION
In ObsSumaryTable all data was moved to rows, in ObsAttachmentsTable we make use of `meta`.