### PR TITLE
Fix chart resize

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -164,7 +164,6 @@ object ExploreStyles:
 
   val ElevationPlotTileBody: Css           = Css("elevation-plot-tile-body")
   val ElevationPlot: Css                   = Css("elevation-plot")
-  val ElevationPlotSection: Css            = Css("elevation-plot-section")
   val ElevationPlotControls: Css           = Css("elevation-plot-controls")
   val ElevationPlotDatePickerControls: Css = Css("elevation-plot-datepicker-controls")
   val ElevationPlotDateInput: Css          = Css("elevation-plot-date-input")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -2038,22 +2038,18 @@ $help-title-height: 40px;
 }
 
 .elevation-plot {
-  flex-shrink: 1;
-  flex-grow: 1;
-  height: 100%;
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--plot-background-color);
+  color: var(--plot-text-color);
 
   .highcharts-xaxis .highcharts-axis-title {
     fill: hsl(0deg 87% 66%);
   }
 
   > div {
-    height: 100%;
-    max-height: 100%;
-
-    div[data-highcharts-chart] {
-      height: 100%;
-      max-height: 100%;
-    }
+    flex: 1 1 0;
   }
 }
 
@@ -2061,18 +2057,6 @@ $help-title-height: 40px;
   .p-button {
     border-color: var(--site-border-color);
   }
-}
-
-.elevation-plot-section {
-  min-width: 1px; // Needed to help highcharts recompute width on the fly.
-  width: 100%;
-  height: 100%;
-  max-height: 100%;
-  position: relative;
-  background-color: var(--plot-background-color);
-  color: var(--plot-text-color);
-  display: flex;
-  flex-direction: column;
 }
 
 .elevation-plot-controls {

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
@@ -142,9 +142,9 @@ object ElevationPlotSection:
                 .map(BoundedInterval.fromInterval)
                 .flattenOption
 
-        <.div(ExploreStyles.ElevationPlotSection)(
+        React.Fragment(
           HelpIcon("target/main/elevation-plot.md".refined, ExploreStyles.HelpIconFloating),
-          <.div(ExploreStyles.ElevationPlot) {
+          <.span(ExploreStyles.ElevationPlot)(
             opt.range match
               case PlotRange.Night    =>
                 ElevationPlotNight(
@@ -159,8 +159,8 @@ object ElevationPlotSection:
                   options.get,
                   props.coords,
                   windowsNetExcludeIntervals
-                )
-          },
+                ),
+          ),
           <.div(
             ExploreStyles.ElevationPlotControls,
             SelectButtonEnumView(

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
@@ -144,7 +144,7 @@ object ElevationPlotSection:
 
         React.Fragment(
           HelpIcon("target/main/elevation-plot.md".refined, ExploreStyles.HelpIconFloating),
-          <.span(ExploreStyles.ElevationPlot)(
+          <.div(ExploreStyles.ElevationPlot)(
             opt.range match
               case PlotRange.Night    =>
                 ElevationPlotNight(


### PR DESCRIPTION
Sizes as `100%` don't seem to play well together with flexboxes. The recommended way to do "`100%`" in flex seems to be `flex: 1 1 0;`.

This seems to fix at least the resizing issue with charts, where controls were sometimes lost when shrinking. Also, I removed a nesting level.