### PR TITLE
Fix ITC chart display on resize

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -172,6 +172,7 @@ object ExploreStyles:
   val ItcPlotSelector: Css        = Css("itc-plot-selector")
   val ItcPlotSection: Css         = Css("itc-plot-section")
   val ItcPlotDetailsHidden: Css   = Css("itc-plot-details-hidden")
+  val ItcPlotHelpIcon: Css        = Css("itc-plot-help-icon")
   val ItcPlotLoading: Css         = Css("itc-plot-loading")
   val ItcPlotChart: Css           = Css("itc-plot-chart")
   val ItcPlotWvPlotLine: Css      = Css("itc-plot-wavelength-line")

--- a/common/src/main/webapp/sass/charts.scss
+++ b/common/src/main/webapp/sass/charts.scss
@@ -170,17 +170,24 @@ See https://github.com/highcharts/highcharts/issues/13320 */
     background-color: var(--plot-background-color);
     color: var(--plot-text-color);
     display: grid;
-    width: 100%;
-    overflow: hidden;
-    min-height: 0;
-    grid-template: 'description plot' minmax(0, 1fr) // minmax is required to properly shrink
-      'description plot-controls' / minmax(max-content, 2fr) minmax(0, 5fr);
+    flex: 0 0 100%;
+    grid-template-areas: 'description plot' 'description plot-controls';
+    grid-template-rows: 1fr max-content;
+    grid-template-columns: max-content 1fr;
+
+    &.itc-plot-details-hidden {
+      grid-template-columns: 0 1fr;
+    }
   }
 
-  .itc-plot-body {
-    position: relative;
+  .tile-xs-width {
+    .itc-plot-section.itc-plot-description {
+      grid-template-columns: 0 1fr;
+    }
+  }
+
+  .itc-plot-body {  
     grid-area: plot;
-    width: 100%;
     background-color: var(--plot-background-color);
   }
 
@@ -193,6 +200,11 @@ See https://github.com/highcharts/highcharts/issues/13320 */
     padding-right: 1em;
     padding-left: 1em;
     justify-content: space-between;
+
+    .itc-plot-help-icon {
+      top: exploreCommon.$tile-title-height + 8px;
+      margin-left: -10px;
+    }
   }
 
   $description-column-count: 2;
@@ -228,20 +240,6 @@ See https://github.com/highcharts/highcharts/issues/13320 */
 
     span {
       font-weight: lighter;
-    }
-  }
-
-  .itc-plot-details-hidden {
-    grid-template-columns: 0 3fr;
-
-    .itc-plot-description {
-      display: none;
-    }
-  }
-
-  .tile-xs-width {
-    .itc-plot-description {
-      display: none;
     }
   }
 

--- a/common/src/main/webapp/sass/charts.scss
+++ b/common/src/main/webapp/sass/charts.scss
@@ -186,7 +186,7 @@ See https://github.com/highcharts/highcharts/issues/13320 */
     }
   }
 
-  .itc-plot-body {  
+  .itc-plot-body {
     grid-area: plot;
     background-color: var(--plot-background-color);
   }

--- a/common/src/main/webapp/sass/charts.scss
+++ b/common/src/main/webapp/sass/charts.scss
@@ -171,9 +171,11 @@ See https://github.com/highcharts/highcharts/issues/13320 */
     color: var(--plot-text-color);
     display: grid;
     flex: 0 0 100%;
+    /* stylelint-disable declaration-block-no-redundant-longhand-properties */
     grid-template-areas: 'description plot' 'description plot-controls';
     grid-template-rows: 1fr max-content;
     grid-template-columns: max-content 1fr;
+    /* stylelint-enable declaration-block-no-redundant-longhand-properties */
 
     &.itc-plot-details-hidden {
       grid-template-columns: 0 1fr;

--- a/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
+++ b/explore/src/main/scala/explore/itc/ItcGraphPanel.scala
@@ -39,7 +39,7 @@ object ItcGraphPanel:
     ScalaFnComponent
       .withHooks[Props]
       .useContext(AppContext.ctx)
-      .render { (props, ctx) =>
+      .render: (props, ctx) =>
         import ctx.given
 
         val globalPreferences = props.globalPreferences.withOnMod(prefs =>
@@ -79,7 +79,8 @@ object ItcGraphPanel:
 
         <.div(
           ExploreStyles.ItcPlotSection,
-          ExploreStyles.ItcPlotDetailsHidden.unless(detailsView.get.value),
+          ExploreStyles.ItcPlotDetailsHidden.unless(detailsView.get.value)
+        )(
           ItcSpectroscopyPlotDescription(
             selectedTarget.flatMap(props.itcProps.targetBrightness),
             selectedResult.map(_.itcExposureTime),
@@ -99,5 +100,3 @@ object ItcGraphPanel:
           ),
           ItcPlotControl(chartTypeView, detailsView)
         )
-
-      }

--- a/explore/src/main/scala/explore/itc/ItcPlotControl.scala
+++ b/explore/src/main/scala/explore/itc/ItcPlotControl.scala
@@ -5,6 +5,7 @@ package explore.itc
 
 import cats.syntax.all.*
 import crystal.react.View
+import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
 import explore.model.itc.PlotDetails
 import japgolly.scalajs.react.*
@@ -51,8 +52,11 @@ object ItcPlotControl:
     val descText     = if (props.showDetails.get.value) "Hide details" else "Show details"
     val allowedChart = props.chartType.zoom(typePrism).asView
 
-    <.div(
-      ExploreStyles.ItcPlotControls,
+    <.div(ExploreStyles.ItcPlotControls)(
+      HelpIcon(
+        "target/main/itc-spectroscopy-plot.md".refined,
+        ExploreStyles.HelpIconFloating |+| ExploreStyles.ItcPlotHelpIcon
+      ),
       Button(
         onClick = props.showDetails.mod {
           case PlotDetails.Shown  => PlotDetails.Hidden


### PR DESCRIPTION
It seems that when we have a chart in a `flex` or `grid`, the `div` containing the chart should be a direct child of the `flex`/`grid` `div`. Otherwise, strange things seem to happen when HighCharts attempts to resize itself.

This PR rearranges things in the ITC tile to achieve this. The help icon is moved so that it's rendered together with the controls instead of the chart.

Also, the grid definition was simplified. Hiding of the details panel is now done by setting its size to `0` or `max-content` in `grid-template-columns`.