### PR TITLE
Don't allow targets for executed observations to be edited

### DIFF
--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -48,6 +48,7 @@ object reusability:
     Reusability.by(_.toList)
 
   given Reusability[ObsIdSet]                = Reusability.byEq
+  given Reusability[TargetEditObsInfo]       = Reusability.byEq
   given Reusability[TargetIdSet]             = Reusability.byEq
   given Reusability[TargetWithId]            = Reusability.byEq
   given Reusability[TargetWithIdAndObs]      = Reusability.byEq

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -16,6 +16,7 @@ import explore.model.GlobalPreferences
 import explore.model.ObsConfiguration
 import explore.model.ObsIdSet
 import explore.model.ObsTabTilesIds
+import explore.model.TargetEditObsInfo
 import explore.model.TargetList
 import explore.model.enums.TileSizeState
 import explore.targeteditor.AsterismEditor
@@ -28,6 +29,7 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.model.BasicConfiguration
+import lucuma.schemas.model.TargetWithId
 import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
 import queries.schemas.odb.ObsQueries
@@ -47,7 +49,8 @@ object AsterismEditorTile:
     obsConf:           ObsConfiguration,
     currentTarget:     Option[Target.Id],
     setTarget:         (Option[Target.Id], SetRouteVia) => Callback,
-    otherObsCount:     Target.Id => Int,
+    onCloneTarget:     (Target.Id, TargetWithId, ObsIdSet) => Callback,
+    obsInfo:           Target.Id => TargetEditObsInfo,
     searching:         View[Set[Target.Id]],
     title:             String,
     globalPreferences: View[GlobalPreferences],
@@ -81,7 +84,8 @@ object AsterismEditorTile:
           obsConf,
           currentTarget,
           setTarget,
-          otherObsCount,
+          onCloneTarget,
+          obsInfo,
           searching,
           renderInTitle,
           globalPreferences,

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -72,19 +72,15 @@ case class ObsTabContents(
   expandedGroups:   View[Set[Group.Id]],
   readonly:         Boolean
 ) extends ReactFnProps(ObsTabContents.component):
-  val focusedObs: Option[Observation.Id]                   = focused.obsSet.map(_.head)
-  val focusedTarget: Option[Target.Id]                     = focused.target
-  val focusedGroup: Option[Group.Id]                       = focused.group
-  val obsAttachments: View[ObsAttachmentList]              =
-    programSummaries.model.zoom(ProgramSummaries.obsAttachments)
-  val obsAttachmentAssignments: ObsAttachmentAssignmentMap =
-    programSummaries.get.obsAttachmentAssignments
-  val observations: UndoSetter[ObservationList]            =
+  val focusedObs: Option[Observation.Id]        = focused.obsSet.map(_.head)
+  val focusedTarget: Option[Target.Id]          = focused.target
+  val focusedGroup: Option[Group.Id]            = focused.group
+  val observations: UndoSetter[ObservationList] =
     programSummaries.zoom(ProgramSummaries.observations)
-  val obsExecutions: ObservationExecutionMap               = programSummaries.get.obsExecutionPots
-  val groupTimeRanges: GroupTimeRangeMap                   = programSummaries.get.groupTimeRangePots
-  val groups: UndoSetter[GroupTree]                        = programSummaries.zoom(ProgramSummaries.groups)
-  val targets: UndoSetter[TargetList]                      = programSummaries.zoom(ProgramSummaries.targets)
+  val obsExecutions: ObservationExecutionMap    = programSummaries.get.obsExecutionPots
+  val groupTimeRanges: GroupTimeRangeMap        = programSummaries.get.groupTimeRangePots
+  val groups: UndoSetter[GroupTree]             = programSummaries.zoom(ProgramSummaries.groups)
+  val targets: UndoSetter[TargetList]           = programSummaries.zoom(ProgramSummaries.targets)
 
 object ObsTabContents extends TwoPanels:
   private type Props = ObsTabContents
@@ -159,18 +155,12 @@ object ObsTabContents extends TwoPanels:
             // FIXME Find a better mechanism for this.
             // Something like .mapValue but for UndoContext
             props.observations.zoom(indexValue.getOption.andThen(_.get), indexValue.modify),
-            props.obsExecutions.getPot(obsView.get.id),
-            props.targets,
-            // maybe we want constraintGroups, so we can get saner ids?
-            props.programSummaries.get.constraintGroups.map(_._2).toSet,
-            props.programSummaries.get.targetObservations,
+            props.programSummaries,
             props.focusedTarget,
             props.searching,
             ExploreGridLayouts.sectionLayout(GridLayoutSection.ObservationsLayout),
             props.userPreferences.get.observationsTabLayout,
             resize,
-            props.obsAttachments,
-            props.obsAttachmentAssignments,
             props.userPreferences.zoom(UserPreferences.globalPreferences),
             props.readonly
           ).withKey(s"${obsId.show}")

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -10,7 +10,9 @@ import explore.components.ui.ExploreStyles
 import explore.model.AladinFullScreen
 import explore.model.Asterism
 import explore.model.GlobalPreferences
+import explore.model.ObsIdSet
 import explore.model.ObsTabTilesIds
+import explore.model.TargetEditObsInfo
 import explore.targeteditor.SiderealTargetEditor
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
@@ -19,8 +21,6 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.schemas.model.TargetWithId
 import lucuma.ui.syntax.all.given
-
-import java.time.Instant
 
 object SiderealTargetEditorTile {
 
@@ -33,6 +33,8 @@ object SiderealTargetEditorTile {
     fullScreen:        View[AladinFullScreen],
     globalPreferences: View[GlobalPreferences],
     readonly:          Boolean,
+    obsInfo:           TargetEditObsInfo,
+    onClone:           (Target.Id, TargetWithId, ObsIdSet) => Callback,
     backButton:        Option[VdomNode] = none
   ) =
     Tile(
@@ -51,9 +53,11 @@ object SiderealTargetEditorTile {
               uid,
               target,
               Asterism.one(TargetWithId(targetId, target.get)),
-              none,
-              none,
-              searching,
+              vizTime = none,
+              obsConf = none,
+              searching = searching,
+              obsInfo = obsInfo,
+              onClone = onClone,
               renderInTitle = renderInTitle.some,
               fullScreen = fullScreen,
               globalPreferences = globalPreferences,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -282,15 +282,13 @@ object TargetTabContents extends TwoPanels:
           .toList
           .distinct
         // update the programSummaries
-        props.programSummaries.model.mod { ps =>
-          val newPs = ps.cloneTargetForObservations(oldTid, newTarget, obsIdsToClone)
-          newPs
+        props.programSummaries.model.mod {
+          _.cloneTargetForObservations(oldTid, newTarget, obsIdsToClone)
         } *>
           setCurrentTarget(obsIds4Url)(newTarget.id.some, SetRouteVia.HistoryReplace) *>
           // Deal with the expanded groups - we'll open all affected groups
           allGroups.traverse { ids =>
             val intersect = ids.idSet.intersect(obsIdsToClone.idSet)
-            println(s"Group Ids: $ids intersection: $intersect")
             if (intersect === ids.idSet.toSortedSet)
               props.expandedIds.mod(_ + ids) // it is the whole group, so make sure it is open
             else

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -17,6 +17,7 @@ import explore.data.KeyedIndexedList
 import explore.model.*
 import explore.model.AppContext
 import explore.model.ObsSummary
+import explore.model.TargetEditObsInfo
 import explore.model.enums.AppTab
 import explore.model.enums.GridLayoutSection
 import explore.model.enums.SelectedPanel
@@ -85,14 +86,8 @@ object TargetTabContents extends TwoPanels:
   ): VdomNode = {
     import ctx.given
 
-    def otherObsCount(obsIds: ObsIdSet)(targetId: Target.Id): Int =
-      props.targets.get
-        .get(targetId)
-        .fold(0)(tg =>
-          (props.programSummaries.get.targetObservations
-            .get(targetId)
-            .orEmpty -- obsIds.toSortedSet).size
-        )
+    def getObsInfo(editing: Option[ObsIdSet])(targetId: Target.Id): TargetEditObsInfo =
+      TargetEditObsInfo.fromProgramSummaries(targetId, editing, props.programSummaries.get)
 
     def targetTree(programSummaries: UndoContext[ProgramSummaries]) =
       AsterismGroupObsList(
@@ -265,11 +260,45 @@ object TargetTabContents extends TwoPanels:
       val configuration: Option[BasicConfiguration] = obsConf.map(_._2)
       val wavelength                                = obsConf.map(_._4)
 
-      def setCurrentTarget(programId: Program.Id, oids: ObsIdSet)(
+      def setCurrentTarget(oids: Option[ObsIdSet])(
         tid: Option[Target.Id],
         via: SetRouteVia
       ): Callback =
-        ctx.setPageVia(AppTab.Targets, programId, Focused(oids.some, tid), via)
+        ctx.setPageVia(AppTab.Targets, props.programId, Focused(oids, tid), via)
+
+      def onCloneTarget4Asterism(
+        oldTid:        Target.Id,
+        newTarget:     TargetWithId,
+        obsIdsToClone: ObsIdSet
+      ): Callback =
+        // the new observation ids in the url will be the intersection of what were editing and
+        // what was cloned. This should always have something because otherwise the target editor
+        // would have been readonly.
+        val obsIds4Url = ObsIdSet.fromSortedSet(idsToEdit.idSet.intersect(obsIdsToClone.idSet))
+        // all of the current groups that contain any of the obsIdsToClone
+        val allGroups  = props.programSummaries.model.get.asterismGroups
+          .filterNot(_._1.idSet.intersect(obsIdsToClone.idSet).isEmpty)
+          .map(_._1)
+          .toList
+          .distinct
+        // update the programSummaries
+        props.programSummaries.model.mod { ps =>
+          val newPs = ps.cloneTargetForObservations(oldTid, newTarget, obsIdsToClone)
+          newPs
+        } *>
+          setCurrentTarget(obsIds4Url)(newTarget.id.some, SetRouteVia.HistoryReplace) *>
+          // Deal with the expanded groups - we'll open all affected groups
+          allGroups.traverse { ids =>
+            val intersect = ids.idSet.intersect(obsIdsToClone.idSet)
+            println(s"Group Ids: $ids intersection: $intersect")
+            if (intersect === ids.idSet.toSortedSet)
+              props.expandedIds.mod(_ + ids) // it is the whole group, so make sure it is open
+            else
+              // otherwise, close the original and open the subsets
+              ObsIdSet
+                .fromSortedSet(intersect)
+                .foldMap(i => props.expandedIds.mod(_ - ids + i + ids.removeUnsafe(i)))
+          }.void
 
       val asterismEditorTile =
         AsterismEditorTile.asterismEditorTile(
@@ -282,8 +311,9 @@ object TargetTabContents extends TwoPanels:
           vizTimeView,
           ObsConfiguration(configuration, none, constraints, wavelength, none, none, none),
           props.focused.target,
-          setCurrentTarget(props.programId, idsToEdit),
-          otherObsCount(idsToEdit),
+          setCurrentTarget(idsToEdit.some),
+          onCloneTarget4Asterism,
+          getObsInfo(idsToEdit.some),
           props.searching,
           title,
           props.globalPreferences,
@@ -322,6 +352,15 @@ object TargetTabContents extends TwoPanels:
       resize:   UseResizeDetectorReturn,
       targetId: Target.Id
     ): List[Tile] = {
+
+      def onCloneTarget4Target(
+        oldTid:    Target.Id,
+        newTarget: TargetWithId,
+        obsIds:    ObsIdSet
+      ): Callback =
+        props.programSummaries.model.mod(_.cloneTargetForObservations(oldTid, newTarget, obsIds))
+          *> ctx.replacePage(AppTab.Targets, props.programId, Focused(none, newTarget.id.some))
+
       val targetTiles: List[Tile] =
         props.targets
           .zoom(Iso.id[TargetList].index(targetId).andThen(Target.sidereal))
@@ -335,7 +374,9 @@ object TargetTabContents extends TwoPanels:
               s"Editing Target ${target.get.name.value} [$targetId]",
               fullScreen,
               props.globalPreferences,
-              props.readonly
+              props.readonly,
+              getObsInfo(none)(targetId),
+              onCloneTarget4Target
             )
 
             val skyPlotTile: Tile =

--- a/explore/src/main/scala/explore/targeteditor/TargetCloneSelector.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetCloneSelector.scala
@@ -1,0 +1,69 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targeteditor
+
+import cats.Eq
+import cats.syntax.all.*
+import crystal.react.View
+import crystal.react.hooks.*
+import explore.components.ui.ExploreStyles
+import explore.model.ObsIdSet
+import explore.model.TargetEditCloneInfo
+import explore.model.TargetEditObsInfo
+import explore.model.reusability.given
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.util.NewType
+import lucuma.react.common.ReactFnProps
+import lucuma.refined.*
+import lucuma.ui.primereact.BooleanRadioButtons
+import lucuma.ui.primereact.given
+
+final case class TargetCloneSelector(
+  obsInfo:    TargetEditObsInfo,
+  toCloneFor: View[Option[ObsIdSet]]
+) extends ReactFnProps(TargetCloneSelector.component)
+
+object TargetCloneSelector:
+  private type Props = TargetCloneSelector
+
+  private object EditScope extends NewType[Boolean]:
+    inline def AllInstances: EditScope = EditScope(true)
+    inline def CurrentOnly: EditScope  = EditScope(false)
+
+  private type EditScope = EditScope.Type
+
+  private given Reusability[EditScope] = Reusability.byEq
+
+  extension (cloneInfo: TargetEditCloneInfo)
+    private def cloneForScope(scope: EditScope): Option[ObsIdSet] =
+      if (scope === EditScope.CurrentOnly) cloneInfo.cloneForCurrent else cloneInfo.cloneForAll
+
+  private val component =
+    ScalaFnComponent
+      .withHooks[Props]
+      .useMemoBy(props => props.obsInfo)(_ => TargetEditCloneInfo.fromObsInfo)
+      .useStateView(EditScope.CurrentOnly)
+      .useEffectWithDepsBy((_, info, scope) => (info, scope.get)) {
+        (props, _, _) => (info, scope) =>
+          props.toCloneFor.set(info.cloneForScope(scope))
+      }
+      .render: (props, info, editScope) =>
+        if (info.noMessages) <.div()
+        else
+          <.div(
+            ExploreStyles.SharedEditWarning,
+            info.message.map(_.value),
+            info.choice
+              .map((currentText, allText) =>
+                BooleanRadioButtons(
+                  view = editScope.as(EditScope.value),
+                  idBase = "editscope".refined,
+                  name = "editscope".refined,
+                  trueLabel = allText,
+                  falseLabel = currentText
+                ).toFalseTrueFragment
+              )
+              .getOrElse(TagMod.empty)
+          )

--- a/model-tests/shared/src/test/scala/explore/model/TargetEditCloneInfoSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/TargetEditCloneInfoSuite.scala
@@ -1,0 +1,307 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.syntax.all.*
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.model.Observation
+import munit.FunSuite
+import munit.Location
+
+trait MyAssertions extends munit.Assertions {
+  private def fullMsg(ci: TargetEditCloneInfo, fieldMsg: String) =
+    s"$fieldMsg\nTargetEditCloneInfo was $ci"
+
+  private def assertStrEq(
+    ci:       TargetEditCloneInfo,
+    current:  Option[NonEmptyString],
+    expected: Option[NonEmptyString],
+    field:    String
+  )(using loc: Location): Unit =
+    assertEquals(current, expected, fullMsg(ci, s"$field should be '$expected'"))
+
+  private def assertMessage(ci: TargetEditCloneInfo, expected: Option[NonEmptyString])(using
+    loc: Location
+  ): Unit =
+    assertStrEq(ci, ci.message, expected, "message")
+
+  private def assertCurrent(ci: TargetEditCloneInfo, expected: Option[ObsIdSet])(using
+    loc: Location
+  ) =
+    assertEquals(ci.cloneForCurrent,
+                 expected,
+                 fullMsg(ci, s"cloneForCurrent should be '$expected'")
+    )
+
+  private def assertForAll(ci: TargetEditCloneInfo, expected: Option[ObsIdSet])(using
+    loc: Location
+  ) =
+    assertEquals(ci.cloneForAll, expected, fullMsg(ci, s"cloneForAll should be '$expected'"))
+
+  private def assertCurrentText(ci: TargetEditCloneInfo, expected: Option[NonEmptyString])(using
+    loc: Location
+  ): Unit =
+    assertStrEq(ci, ci.cloneForCurrentText, expected, "cloneForCurrentText")
+
+  private def assertForAllText(ci: TargetEditCloneInfo, expected: Option[NonEmptyString])(using
+    loc: Location
+  ): Unit =
+    assertStrEq(ci, ci.cloneForAllText, expected, "cloneForAllText")
+
+  private def assertIsReadonly(ci: TargetEditCloneInfo)(using loc: Location) =
+    assert(ci.readonly, fullMsg(ci, "Should be readonly"))
+
+  private def assertIsNotReadonly(ci: TargetEditCloneInfo)(using loc: Location) =
+    assert(!ci.readonly, fullMsg(ci, "Should not be readonly"))
+
+  def assertChoice(
+    ci:          TargetEditCloneInfo,
+    message:     NonEmptyString,
+    current:     ObsIdSet,
+    currentText: NonEmptyString,
+    all:         Option[ObsIdSet],
+    allText:     NonEmptyString
+  )(using loc: Location): Unit =
+    assertIsNotReadonly(ci)
+    assertMessage(ci, message.some)
+    assertCurrent(ci, current.some)
+    assertCurrentText(ci, currentText.some)
+    assertForAll(ci, all)
+    assertForAllText(ci, allText.some)
+
+  def assertSimple(
+    ci:         TargetEditCloneInfo,
+    message:    NonEmptyString,
+    toCloneFor: Option[ObsIdSet]
+  )(using loc: Location): Unit =
+    assertIsNotReadonly(ci)
+    assertMessage(ci, message.some)
+    assertCurrent(ci, toCloneFor)
+    assertCurrentText(ci, none)
+    assertForAll(ci, none)
+    assertForAllText(ci, none)
+
+  def assertNoMessage(ci: TargetEditCloneInfo)(using loc: Location): Unit =
+    assertIsNotReadonly(ci)
+    assertMessage(ci, none)
+    assertCurrent(ci, none)
+    assertCurrentText(ci, none)
+    assertForAll(ci, none)
+    assertForAllText(ci, none)
+
+  def assertReadonly(ci: TargetEditCloneInfo, message: NonEmptyString)(using loc: Location): Unit =
+    assertIsReadonly(ci)
+    assertMessage(ci, message.some)
+    assertCurrent(ci, none)
+    assertCurrentText(ci, none)
+    assertForAll(ci, none)
+    assertForAllText(ci, none)
+
+}
+
+class TargetEditCloneInfoSuite extends FunSuite with MyAssertions {
+  val o1          = Observation.Id.fromLong(1L).get
+  val o2          = Observation.Id.fromLong(2L).get
+  val o3          = Observation.Id.fromLong(3L).get
+  val o4          = Observation.Id.fromLong(4L).get
+  val one         = ObsIdSet.one(o1)
+  val two         = ObsIdSet.one(o2)
+  val three       = ObsIdSet.one(o3)
+  val four        = ObsIdSet.one(o4)
+  val oneTwo      = ObsIdSet.of(o1, o2)
+  val oneThree    = ObsIdSet.of(o1, o3)
+  val oneTwoThree = ObsIdSet.of(o1, o2, o3)
+  val twoThree    = ObsIdSet.of(o2, o3)
+  val twoFour     = ObsIdSet.of(o2, o4)
+  val oneTwoFour  = ObsIdSet.of(o1, o2, o4)
+  val threeFour   = ObsIdSet.of(o3, o4)
+  val allFour     = ObsIdSet.of(o1, o2, o3, o4)
+
+  test("at target level, no observations") {
+    val obsInfo   = TargetEditObsInfo(none, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("at target level, none are executed") {
+    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertNoMessage(cloneInfo)
+  }
+  test("at target level, none are executed 2") {
+    val obsInfo   = TargetEditObsInfo(none, two.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("at target level, some are executed") {
+    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, three.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, oneTwo.some)
+  }
+
+  test("at target level, some are executed 2") {
+    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, oneThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, two.some)
+  }
+
+  test("at target level, all are executed") {
+    val obsInfo   = TargetEditObsInfo(none, oneThree.some, oneThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allForTargetExecutedMsg)
+  }
+
+  test("at target level, all are executed 2") {
+    val obsInfo   = TargetEditObsInfo(none, three.some, three.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allForTargetExecutedMsg)
+  }
+
+  test("none are executed, all are being edited") {
+    val obsInfo   = TargetEditObsInfo(one.some, one.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("none are executed, all are being edited 2") {
+    val obsInfo   = TargetEditObsInfo(oneThree.some, oneThree.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("none are executed, not all are being edited") {
+    val obsInfo   = TargetEditObsInfo(one.some, oneTwo.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.otherMessage(1L, false),
+      one,
+      TargetEditCloneInfo.onlyThisMsg,
+      none,
+      TargetEditCloneInfo.allForTargetMsg(false)
+    )
+  }
+
+  test("none are executed, not all are being edited 2") {
+    val obsInfo   = TargetEditObsInfo(oneTwoThree.some, allFour.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.otherMessage(1L, false),
+      oneTwoThree,
+      TargetEditCloneInfo.onlyCurrentMsg,
+      none,
+      TargetEditCloneInfo.allForTargetMsg(false)
+    )
+  }
+
+  test("some are executed, all are being edited") {
+    val obsInfo   = TargetEditObsInfo(allFour.some, allFour.some, oneThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, twoFour.some)
+  }
+
+  test("some are executed, all are being edited 2") {
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, oneTwo.some, one.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, two.some)
+  }
+
+  test("some of other executed") {
+    val obsInfo   = TargetEditObsInfo(one.some, oneTwoThree.some, three.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.otherMessage(1L, true),
+      one,
+      TargetEditCloneInfo.onlyThisMsg,
+      oneTwo.some,
+      TargetEditCloneInfo.allForTargetMsg(true)
+    )
+  }
+
+  test("some of other executed 2") {
+    val obsInfo   = TargetEditObsInfo(one.some, allFour.some, four.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.otherMessage(2L, true),
+      one,
+      TargetEditCloneInfo.onlyThisMsg,
+      oneTwoThree.some,
+      TargetEditCloneInfo.allForTargetMsg(true)
+    )
+  }
+
+  test("some of other executed 3") {
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, four.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.otherMessage(1L, true),
+      oneTwo,
+      TargetEditCloneInfo.onlyCurrentMsg,
+      oneTwoThree.some,
+      TargetEditCloneInfo.allForTargetMsg(true)
+    )
+  }
+
+  test("some of current and other executed") {
+    val obsInfo   = TargetEditObsInfo(oneThree.some, allFour.some, three.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.someExecutedMsg,
+      one,
+      TargetEditCloneInfo.unexecutedOfCurrentMsg,
+      oneTwoFour.some,
+      TargetEditCloneInfo.allUnexectedMsg
+    )
+  }
+
+  test("some of current and other executed 2") {
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, oneThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.someExecutedMsg,
+      two,
+      TargetEditCloneInfo.unexecutedOfCurrentMsg,
+      twoFour.some,
+      TargetEditCloneInfo.allUnexectedMsg
+    )
+  }
+
+  test("all besides current are executed") {
+    val obsInfo   = TargetEditObsInfo(oneThree.some, allFour.some, twoFour.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("all besides current are executed 2") {
+    val obsInfo   = TargetEditObsInfo(three.some, allFour.some, oneTwoFour.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("all of current are executed") {
+    val obsInfo   = TargetEditObsInfo(two.some, oneTwo.some, two.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentExecutedMsg)
+  }
+
+  test("all of current are executed 2") {
+    val obsInfo   = TargetEditObsInfo(twoThree.some, allFour.some, oneTwoThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentExecutedMsg)
+  }
+
+  test("all of current are executed 3") {
+    val obsInfo   = TargetEditObsInfo(twoThree.some, allFour.some, allFour.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentExecutedMsg)
+  }
+
+}

--- a/model/shared/src/main/scala/explore/model/ObsIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/ObsIdSet.scala
@@ -36,8 +36,11 @@ object ObsIdSet {
   implicit def nonEmptySetWrapper(ids: ObsIdSet): NonEmptySetWrapper[ObsIdSet, Observation.Id] =
     NonEmptySetWrapper(ids, iso)
 
+  def fromSortedSet(obsIds: SortedSet[Observation.Id]): Option[ObsIdSet] =
+    NonEmptySet.fromSet(obsIds).map(ObsIdSet.apply)
+
   def fromList(obsIds: List[Observation.Id]): Option[ObsIdSet] =
-    NonEmptySet.fromSet(SortedSet.from(obsIds)).map(ObsIdSet.apply)
+    fromSortedSet(SortedSet.from(obsIds))
 
   val fromString: Prism[String, ObsIdSet] =
     Prism(parse)(ids =>

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -104,6 +104,17 @@ case class ProgramSummaries(
   def removeObs(obsId: Observation.Id): ProgramSummaries =
     ProgramSummaries.observations.modify(_.removed(obsId))(this)
 
+  def cloneTargetForObservations(
+    oldTid:    Target.Id,
+    newTarget: TargetWithId,
+    obsIds:    ObsIdSet
+  ): ProgramSummaries =
+    val obs = obsIds.idSet.foldLeft(observations)((list, obsId) =>
+      list.updatedValueWith(obsId, ObsSummary.scienceTargetIds.modify(_ - oldTid + newTarget.id))
+    )
+    val ts  = targets + (newTarget.id -> newTarget.target)
+    copy(observations = obs, targets = ts)
+
 object ProgramSummaries:
   val optProgramDetails: Lens[ProgramSummaries, Option[ProgramDetails]]     =
     Focus[ProgramSummaries](_.optProgramDetails)

--- a/model/shared/src/main/scala/explore/model/TargetEditCloneInfo.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEditCloneInfo.scala
@@ -1,0 +1,132 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.refined.*
+
+// Class used by TargetCloneSelector to determine what observations a target needs to
+// be cloned for and what messages to display.
+final case class TargetEditCloneInfo(
+  readonly:            Boolean,
+  message:             Option[NonEmptyString] = None,
+  cloneForCurrent:     Option[ObsIdSet] = None, // also used for the "simple" case
+  cloneForCurrentText: Option[NonEmptyString] = None,
+  cloneForAll:         Option[ObsIdSet] = None,
+  cloneForAllText:     Option[NonEmptyString] = None
+) derives Eq:
+  def choice: Option[(NonEmptyString, NonEmptyString)] =
+    (message, cloneForCurrentText, cloneForAllText) match
+      case (Some(_), Some(current), Some(all)) => (current, all).some
+      case _                                   => none
+  // if it is readonly, there should always be a message
+  def readonlyMsg: Option[NonEmptyString]              =
+    if (readonly) message else none
+  def noMessages: Boolean                              =
+    readonly === false && message.isEmpty
+
+object TargetEditCloneInfo:
+  // just a message, no choices
+  def simple(simpleMessage: NonEmptyString, cloneFor: Option[ObsIdSet]): TargetEditCloneInfo =
+    TargetEditCloneInfo(false, simpleMessage.some, cloneFor)
+  def readonly(message: NonEmptyString): TargetEditCloneInfo                                 =
+    TargetEditCloneInfo(true, message.some)
+  def choice(
+    message:         NonEmptyString,
+    cloneForOnly:    Option[ObsIdSet],
+    onlyCurrentMsg:  NonEmptyString,
+    cloneForAll:     Option[ObsIdSet],
+    cloneForAllText: NonEmptyString
+  ): TargetEditCloneInfo =
+    TargetEditCloneInfo(false,
+                        message.some,
+                        cloneForOnly,
+                        onlyCurrentMsg.some,
+                        cloneForAll,
+                        cloneForAllText.some
+    )
+  def noMessages: TargetEditCloneInfo                                                        = TargetEditCloneInfo(false)
+
+  val onlyThisMsg: NonEmptyString             = "only this observation".refined
+  val onlyCurrentMsg: NonEmptyString          = "only the current observations".refined
+  val allCurrentExecutedMsg: NonEmptyString   =
+    "All the current observations have been executed. Target is readonly.".refined
+  val allForTargetExecutedMsg: NonEmptyString =
+    "All associated observations have been executed. Target is readonly".refined
+  val onlyUnexecutedMsg: NonEmptyString       =
+    "Target will only be modified for the un-executed observations.".refined
+  val someExecutedMsg: NonEmptyString         =
+    "Some of the observations being edited have been executed.".refined
+  val unexecutedOfCurrentMsg: NonEmptyString  =
+    "unexecuted observations of the current asterism".refined
+  val allUnexectedMsg: NonEmptyString         = "all unexecuted observations".refined
+
+  extension (obsIds: ObsIdSet)
+    def onlyCurrentText: NonEmptyString =
+      if (obsIds.size === 1) onlyThisMsg
+      else onlyCurrentMsg
+
+  def otherMessage(otherCount: Long, hasExecuted: Boolean): NonEmptyString =
+    val plural = if (otherCount === 1) "" else "s"
+    val ex     = if (hasExecuted) "unexecuted " else ""
+    NonEmptyString.unsafeFrom(
+      s"Target is in $otherCount other ${ex}observation$plural. Edits here should apply to."
+    )
+
+  def allForTargetMsg(hasExecuted: Boolean): NonEmptyString =
+    val ex = if (hasExecuted) "unexecuted " else ""
+    NonEmptyString.unsafeFrom(s"all ${ex}observations of this target")
+
+  def fromObsInfo(obsInfo: TargetEditObsInfo): TargetEditCloneInfo =
+    obsInfo.current match
+      // We're editing at the target level (not for an asterism)
+      case None                                                   =>
+        if (obsInfo.allForTargetAreExecuted)
+          TargetEditCloneInfo.readonly(allForTargetExecutedMsg)
+        else if (obsInfo.allForTargetAreOK) TargetEditCloneInfo.noMessages
+        else
+          TargetEditCloneInfo.simple(
+            onlyUnexecutedMsg,
+            obsInfo.unexecutedForTarget
+          )
+      case Some(editing) if obsInfo.allCurrentAreExecuted         =>
+        TargetEditCloneInfo.readonly(allCurrentExecutedMsg)
+      // need to know if the other observations are executed or not
+      case Some(editing) if obsInfo.otherUnexecutedObsCount === 0 =>
+        if (obsInfo.allCurrentAreOK)
+          TargetEditCloneInfo.noMessages
+        else
+          TargetEditCloneInfo.simple(
+            onlyUnexecutedMsg,
+            obsInfo.unexecutedForTarget
+          )
+      case Some(editing)                                          =>
+        if (obsInfo.allForTargetAreOK)
+          TargetEditCloneInfo.choice(
+            otherMessage(obsInfo.otherObsCount, false),
+            editing.some,
+            editing.onlyCurrentText,
+            none,
+            allForTargetMsg(false)
+          )
+        else if (obsInfo.allCurrentAreOK) // some of the other observations have been executed.
+          TargetEditCloneInfo.choice(
+            otherMessage(obsInfo.otherUnexecutedObsCount, true),
+            editing.some,
+            editing.onlyCurrentText,
+            obsInfo.unexecutedForTarget,
+            allForTargetMsg(true)
+          )
+        else                              // some of observations being edited have been executed
+          TargetEditCloneInfo.choice(
+            someExecutedMsg,
+            obsInfo.unexecutedForCurrent,
+            unexecutedOfCurrentMsg,
+            obsInfo.unexecutedForTarget,
+            allUnexectedMsg
+          )

--- a/model/shared/src/main/scala/explore/model/TargetEditObsInfo.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEditObsInfo.scala
@@ -1,0 +1,66 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import cats.syntax.all.*
+import lucuma.core.enums.ObsStatus
+import lucuma.core.model.Target
+
+/**
+ * Information about the observations associated with a target that is being edited
+ *
+ * @param current
+ *   The observations for with the target is currently being edited.
+ * @param allForTarget
+ *   All of the observations associated with a given target.
+ * @param executedForTarget
+ *   The executed observations associated with the target.
+ */
+case class TargetEditObsInfo(
+  current:           Option[ObsIdSet],
+  allForTarget:      Option[ObsIdSet],
+  executedForTarget: Option[ObsIdSet]
+) derives Eq:
+  private def unexecuted(fullSet: Option[ObsIdSet]): Option[ObsIdSet] =
+    fullSet.flatMap(b => executedForTarget.fold(b.some)(b -- _))
+
+  lazy val isReadonly: Boolean                  = current.fold(allForTargetAreExecuted)(_ => allCurrentAreExecuted)
+  // the `other*` values only really have meaning if editing is not empty, and if we are editing, we should also have allForTarget
+  lazy val otherObs: Option[ObsIdSet]           = (current, allForTarget).flatMapN((e, a) => a -- e)
+  lazy val otherObsCount: Long                  = otherObs.fold(0L)(_.size)
+  lazy val otherUnexecutedObs: Option[ObsIdSet] = unexecuted(otherObs)
+  lazy val otherUnexecutedObsCount: Long        = otherUnexecutedObs.fold(0L)(_.size)
+
+  lazy val unexecutedForCurrent: Option[ObsIdSet] = unexecuted(current)
+  lazy val allCurrentAreExecuted: Boolean         = current.isDefined && unexecutedForCurrent.isEmpty
+  lazy val allCurrentAreOK: Boolean               =
+    current.fold(true)(ids =>
+      executedForTarget.fold(true)(ex => ids.idSet.intersect(ex.idSet).isEmpty)
+    )
+
+  lazy val unexecutedForTarget: Option[ObsIdSet] = unexecuted(allForTarget)
+  lazy val allForTargetAreExecuted: Boolean      = allForTarget.isDefined && unexecutedForTarget.isEmpty
+  lazy val allForTargetAreOK: Boolean            = executedForTarget.isEmpty
+
+object TargetEditObsInfo:
+  def fromProgramSummaries(
+    tid:       Target.Id,
+    current:   Option[ObsIdSet],
+    summaries: ProgramSummaries
+  ): TargetEditObsInfo =
+    val allObsIds = summaries.targetsWithObs.get(tid).map(_.obsIds)
+    // we should always find the ids in `observations`
+    val executed  =
+      allObsIds.map(
+        _.filter(id =>
+          summaries.observations.getValue(id).fold(false)(_.status >= ObsStatus.Ongoing)
+        )
+      )
+    TargetEditObsInfo(
+      current,
+      allObsIds.flatMap(ObsIdSet.fromSortedSet),
+      executed.flatMap(ObsIdSet.fromSortedSet)
+    )


### PR DESCRIPTION
This implements clone on demand for targets when some associated observations have been executed, or readonly if all have been. It uses the same space that was in the Asterism for the `current only` or `all instances of target` choice. But, now the messages are a bit different depending on what would need cloning.

To be addressed in following PRs:

1. Neither the old nor this new cloning implementation play well with undo/redo. I will try to make the cloning undoable/redoable. This will require treating target undo/redo with obs assignment undo/redo as a single step. 
2. Prevent deleting of targets from the target summary table if any of the observations have been executed.
3. Prevent editing of asterisms for observations that have been cloned. This may require additional cloning behavior.