### PR TITLE
Avoid captures and provide stable undo modders

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -5,3 +5,4 @@ GraphQLGen.scalaJSReactReuse=false
 GraphQLGen.catsShow=false
 
 OrganizeImports.removeUnused = false
+OrganizeImports.targetDialect = Scala3

--- a/common/src/main/scala/explore/common/AlignerF.scala
+++ b/common/src/main/scala/explore/common/AlignerF.scala
@@ -41,7 +41,7 @@ trait AlignerF[F[_], B, S]:
   protected val _remoteMod: (S => S) => _T => _T // Delta structure drill-down modifier function
 
   /** Get the value of the model. */
-  def get: B = _modelGet(_undoCtx.model.get)
+  def get: B = _modelGet(_undoCtx.get)
 
   /**
    * Build an undoable `View` at the current level, specifying a function that modifies the delta
@@ -78,12 +78,13 @@ trait AlignerF[F[_], B, S]:
     modelMod:  (C => C) => B => B,
     remoteMod: (U => U) => S => S
   ): AlignerF[F, C, U] =
-    AlignerF(_undoCtx,
-             _remoteBaseInput,
-             _onMod,
-             _modelGet.andThen(modelGet),
-             _modelMod.compose(modelMod),
-             _remoteMod.compose(remoteMod)
+    AlignerF(
+      _undoCtx,
+      _remoteBaseInput,
+      _onMod,
+      _modelGet.andThen(modelGet),
+      _modelMod.compose(modelMod),
+      _remoteMod.compose(remoteMod)
     )
 
   /** Drill-down specifying model `Lens` and delta structure modification function. */

--- a/common/src/main/scala/explore/utils/CloneListView.scala
+++ b/common/src/main/scala/explore/utils/CloneListView.scala
@@ -12,5 +12,7 @@ import crystal.ViewListF
 final class CloneListView[F[_]: Monad, A](val underlying: ViewListF[F, A])
     extends ViewF[F, A](
       get = underlying.get.head,
-      modCB = (mod, cb) => underlying.modCB(mod, l => cb(l.head))
+      modCB = (mod, cb) =>
+        val previous = underlying.get.head
+        underlying.modCB(mod, l => cb(previous, l.head))
     )

--- a/common/src/test/scala/explore/syntax/ui/SwitchingSpec.scala
+++ b/common/src/test/scala/explore/syntax/ui/SwitchingSpec.scala
@@ -47,5 +47,17 @@ class SwitchingSpec extends munit.CatsEffectSuite {
    */
   private def mkView = Ref[IO]
     .of(false)
-    .map(ref => (ref, ViewF.apply[IO, Boolean](false, (f, cb) => ref.updateAndGet(f).flatMap(cb))))
+    .map(ref =>
+      (ref,
+       ViewF.apply[IO, Boolean](
+         false,
+         (f, cb) =>
+           ref
+             .modify: previous =>
+               val current = f(previous)
+               (current, (previous, current))
+             .flatMap((previous, current) => cb(previous, current))
+       )
+      )
+    )
 }

--- a/common/src/test/scala/explore/undo/TestUndoable.scala
+++ b/common/src/test/scala/explore/undo/TestUndoable.scala
@@ -34,8 +34,8 @@ class TestUndoable[M](
 
   private def varRefModCB[A](
     ref: VarRef[DefaultS, A]
-  ): (A => A, A => DefaultS[Unit]) => DefaultS[Unit] =
-    (f, cb) => ref.update(f) >>= cb
+  ): (A => A, (A, A) => DefaultS[Unit]) => DefaultS[Unit] =
+    (f, cb) => ref.update(f) >>= ((p, c) => cb(p, c))
 
   private def varRefView[A](ref: VarRef[DefaultS, A]): DefaultS[View[A]] =
     ref.get.map(a => View(a, varRefModCB(ref)))

--- a/common/src/test/scala/explore/undo/package.scala
+++ b/common/src/test/scala/explore/undo/package.scala
@@ -4,6 +4,7 @@
 package explore
 
 import cats.Applicative
+import cats.syntax.all.*
 
 package undo {
   class VarRef[F[_]: Applicative, A](init: A) {
@@ -11,9 +12,10 @@ package undo {
 
     def get: F[A] = Applicative[F].pure(a)
 
-    def update(f: A => A): F[A] = {
+    def update(f: A => A): F[(A, A)] = {
+      val previous = a
       a = f(a)
-      get
+      get.map((previous, _))
     }
   }
 

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -164,8 +164,10 @@ object ExploreLayout:
             View(
               routingInfo,
               (mod, cb) =>
+                val oldRoute = routingInfo
                 val newRoute = mod(routingInfo)
-                ctx.pushPage(newRoute.appTab, newRoute.programId, newRoute.focused) >> cb(newRoute)
+                ctx.pushPage(newRoute.appTab, newRoute.programId, newRoute.focused) >>
+                  cb(oldRoute, newRoute)
             )
 
           val helpView = helpCtx.displayedHelp

--- a/explore/src/main/scala/explore/config/ConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationPanel.scala
@@ -203,7 +203,7 @@ object ConfigurationPanel:
                 )
             else
               ScienceRequirements.spectroscopy
-                .getOption(props.requirements.model.get)
+                .getOption(props.requirements.get)
                 .map(spectroscopyRequirements =>
                   React.Fragment(
                     // Gmos North Long Slit

--- a/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsPanel.scala
@@ -41,7 +41,7 @@ case class ConstraintsPanel(
   undoCtx:  UndoSetter[ConstraintSet],
   readonly: Boolean
 ) extends ReactFnProps(ConstraintsPanel.component):
-  val constraintSet: ConstraintSet = undoCtx.model.get
+  val constraintSet: ConstraintSet = undoCtx.get
 
 object ConstraintsPanel:
   private type Props = ConstraintsPanel
@@ -118,16 +118,15 @@ object ConstraintsPanel:
           View[ElevationRangeType](
             elevationRangeOptions.value.rangeType,
             (mod, cb) =>
+              val previous = elevationRangeOptions.value.rangeType
               erView
                 .setCB(
-                  mod(elevationRangeOptions.value.rangeType) match {
+                  mod(elevationRangeOptions.value.rangeType) match
                     case AirMass   => elevationRangeOptions.value.airMass
-                    case HourAngle => elevationRangeOptions.value.hourAngle
-                  },
-                  _ match {
-                    case ElevationRange.AirMass(_, _)   => cb(AirMass)
-                    case ElevationRange.HourAngle(_, _) => cb(HourAngle)
-                  }
+                    case HourAngle => elevationRangeOptions.value.hourAngle,
+                  _ match
+                    case ElevationRange.AirMass(_, _)   => cb(previous, AirMass)
+                    case ElevationRange.HourAngle(_, _) => cb(previous, HourAngle)
                 )
           )
 
@@ -137,7 +136,10 @@ object ConstraintsPanel:
             (mod, cb) =>
               erView
                 .zoom(ElevationRange.airMass)
-                .modCB(mod, _.map(cb).orEmpty)
+                .modCB(
+                  mod,
+                  (previous, current) => (previous, current).tupled.map((p, c) => cb(p, c)).orEmpty
+                )
           )
 
         val hourAngleView: View[ElevationRange.HourAngle] =
@@ -146,7 +148,10 @@ object ConstraintsPanel:
             (mod, cb) =>
               erView
                 .zoom(ElevationRange.hourAngle)
-                .modCB(mod, _.map(cb).orEmpty)
+                .modCB(
+                  mod,
+                  (previous, current) => (previous, current).tupled.map((p, c) => cb(p, c)).orEmpty
+                )
           )
 
         React.Fragment(

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -181,10 +181,10 @@ object ObsBadge:
                   id = NonEmptyString.unsafeFrom(s"obs-status-${obs.id}-2"),
                   value = View[ObsStatus](
                     obs.status,
-                    { (f, cb) =>
+                    (f, cb) =>
+                      val oldValue = obs.status
                       val newValue = f(obs.status)
-                      setStatus(newValue) >> cb(newValue)
-                    }
+                      setStatus(newValue) >> cb(oldValue, newValue)
                   ),
                   size = PlSize.Mini,
                   clazz = ExploreStyles.ObsStatusSelect,

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -57,6 +57,7 @@ import ObsQueries.*
 
 case class ObsList(
   observations:      UndoSetter[ObservationList],
+  // observations:      UndoContext[ObservationList],
   obsExecutionTimes: ObservationExecutionMap,
   undoer:            Undoer,
   programId:         Program.Id,
@@ -65,6 +66,7 @@ case class ObsList(
   focusedGroup:      Option[Group.Id],
   setSummaryPanel:   Callback,
   groups:            UndoSetter[GroupTree],
+  // groups:            UndoContext[GroupTree],
   expandedGroups:    View[Set[Group.Id]],
   deckShown:         View[DeckShown],
   readonly:          Boolean

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -102,10 +102,10 @@ object AsterismEditor extends AsterismModifier:
         val targetView: View[Option[Target.Id]] =
           View[Option[Target.Id]](
             props.focusedTargetId,
-            { (f, cb) =>
+            (f, cb) =>
+              val oldValue = props.focusedTargetId
               val newValue = f(props.focusedTargetId)
-              props.setTarget(newValue, SetRouteVia.HistoryPush) >> cb(newValue)
-            }
+              props.setTarget(newValue, SetRouteVia.HistoryPush) >> cb(oldValue, newValue)
           )
 
         // Save the time here. this works for the obs and target tabs
@@ -121,8 +121,9 @@ object AsterismEditor extends AsterismModifier:
           View(
             props.focusedTargetId,
             (mod, cb) =>
+              val oldValue = props.focusedTargetId
               val newValue = mod(props.focusedTargetId)
-              props.setTarget(newValue, SetRouteVia.HistoryPush) >> cb(newValue)
+              props.setTarget(newValue, SetRouteVia.HistoryPush) >> cb(oldValue, newValue)
           )
 
         <.div(

--- a/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/BrightnessesEditor.scala
@@ -66,11 +66,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
 
   private type RowValue = (Band, View[BrightnessMeasure[T]])
 
-  protected[targeteditor] case class TableMeta(
-    // needs to be in the table meta because it is needed by the `delete` column.
-    brightnesses: View[SortedMap[Band, BrightnessMeasure[T]]],
-    disabled:     Boolean
-  )
+  protected[targeteditor] case class TableMeta(disabled: Boolean)
 
   private val ColDef = ColumnDef.WithTableMeta[RowValue, TableMeta]
 
@@ -134,7 +130,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
                     clazz = ExploreStyles.DeleteButton,
                     text = true,
                     disabled = cell.table.options.meta.exists(_.disabled),
-                    onClick = cell.table.options.meta.foldMap(_.brightnesses.mod(_ - cell.value))
+                    onClick = props.brightnesses.mod(_ - cell.value)
                   ).small
                 ),
               size = 20.toPx,
@@ -152,7 +148,7 @@ sealed abstract class BrightnessesEditorBuilder[T, Props <: BrightnessesEditor[T
           enableColumnResizing = true,
           columnResizeMode = ColumnResizeMode.OnChange,
           initialState = TableState(sorting = Sorting(ColumnId("band") -> SortDirection.Ascending)),
-          meta = TableMeta(brightnesses = props.brightnesses, disabled = props.disabled)
+          meta = TableMeta(disabled = props.disabled)
         )
       .render: (props, state, _, _, table) =>
         val footer =

--- a/explore/src/main/scala/explore/targeteditor/TargetTable.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetTable.scala
@@ -62,12 +62,7 @@ case class TargetTable(
 object TargetTable extends AsterismModifier:
   private type Props = TargetTable
 
-  private case class TableMeta(
-    obsIds:    ObsIdSet,
-    targetIds: View[AsterismIds]
-  )
-
-  private val ColDef = ColumnDef.WithTableMeta[SiderealTargetWithId, TableMeta]
+  private val ColDef = ColumnDef[SiderealTargetWithId]
 
   private val DeleteColumnId: ColumnId = ColumnId("delete")
 
@@ -110,10 +105,8 @@ object TargetTable extends AsterismModifier:
                     onClickE = (e: ReactMouseEvent) =>
                       e.preventDefaultCB >>
                         e.stopPropagationCB >>
-                        cell.table.options.meta.foldMap(m =>
-                          m.targetIds.mod(_ - cell.value) >>
-                            deleteSiderealTarget(m.obsIds, cell.value).runAsync
-                        )
+                        props.targetIds.mod(_ - cell.value) >>
+                        deleteSiderealTarget(props.obsIds, cell.value).runAsync
                   ).tiny.compact,
                 size = 35.toPx,
                 enableSorting = false
@@ -147,8 +140,7 @@ object TargetTable extends AsterismModifier:
             enableSorting = true,
             enableColumnResizing = true,
             columnResizeMode = ColumnResizeMode.OnChange,
-            initialState = TableState(columnVisibility = TargetColumns.DefaultVisibility),
-            meta = TableMeta(props.obsIds, props.targetIds)
+            initialState = TableState(columnVisibility = TargetColumns.DefaultVisibility)
           ),
           TableStore(props.userId, TableId.AsterismTargets, cols)
         )

--- a/explore/src/main/scala/explore/targets/TargetColumns.scala
+++ b/explore/src/main/scala/explore/targets/TargetColumns.scala
@@ -100,11 +100,11 @@ object TargetColumns:
     )
 
   object Builder:
-    trait Common[D, TM](colDef: ColumnDef.Applied[D, TM], getTarget: D => Option[Target]):
+    trait Common[D](colDef: ColumnDef.Applied.NoMeta[D], getTarget: D => Option[Target]):
       def baseColumn[V](
         id:       ColumnId,
         accessor: Target => V
-      ): ColumnDef.Single.WithTableMeta[D, Option[V], TM] =
+      ): ColumnDef.Single.NoMeta[D, Option[V]] =
         colDef(id, getTarget.andThen(_.map(accessor)), BaseColNames(id))
 
       val NameColumn =
@@ -141,20 +141,20 @@ object TargetColumns:
             .sortableBy(_.flatten.map(_.toString))
         )
 
-    trait CommonSidereal[D, TM](
-      colDef:            ColumnDef.Applied[D, TM],
+    trait CommonSidereal[D](
+      colDef:            ColumnDef.Applied.NoMeta[D],
       getSiderealTarget: D => Option[Target.Sidereal]
     ):
       def siderealColumnOpt[V](
         id:       ColumnId,
         accessor: Target.Sidereal => Option[V]
-      ): ColumnDef.Single.WithTableMeta[D, Option[V], TM] =
+      ): ColumnDef.Single.NoMeta[D, Option[V]] =
         colDef(id, getSiderealTarget.andThen(_.flatMap(accessor)), SiderealColNames(id))
 
       def siderealColumn[V](
         id:       ColumnId,
         accessor: Target.Sidereal => V
-      ): ColumnDef.Single.WithTableMeta[D, Option[V], TM] =
+      ): ColumnDef.Single.NoMeta[D, Option[V]] =
         siderealColumnOpt(id, accessor.andThen(_.some))
 
       /** Display measure without the uncertainty */
@@ -223,8 +223,8 @@ object TargetColumns:
               .sortable
           )
 
-    case class ForProgram[D, TM](
-      colDef:    ColumnDef.Applied[D, TM],
+    case class ForProgram[D](
+      colDef:    ColumnDef.Applied.NoMeta[D],
       getTarget: D => Option[Target]
     ) extends Common(colDef, getTarget)
         with CommonSidereal(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   val circeGolden            = "0.3.0"
   val coulomb                = "0.8.0"
   val clue                   = "0.37.0"
-  val crystal                = "0.39.3"
+  val crystal                = "0.41.0"
   val discipline             = "1.7.0"
   val disciplineMUnit        = "2.0.0"
   val fs2                    = "3.10.2"


### PR DESCRIPTION
It's desirable that state/view modification functions are stable, but this was not the case when undoer was involved, since it relied on capturing the old values.

This PR reworks the undo so that no capture is performed, relying on the new `View` functionality which now reports the previous value when it is modified.

We were also capturing values in a couple of other places, which are now fixed.

This PR also reverts #3969 and #3970, which implemented workarounds to propagate updated modder functions.

Review hints:
- Start with `UndoContext` and then `UndoSetter`.
- The changes in `TargetTable`, `TargetColumns` and `BrightnessEditor` are just reversals of the workarounds.
- The changes in `TargetTabContents` avoid capture of the target in the target editor shown below the target summary table.
- Other changes are adjustments for the new `View` API (basically reporting the previous value on mod).