### PR TITLE
Undo/Redo for target cloning

### DIFF
--- a/common/src/main/scala/explore/model/Focused.scala
+++ b/common/src/main/scala/explore/model/Focused.scala
@@ -4,6 +4,7 @@
 package explore.model
 
 import cats.Eq
+import cats.derived.*
 import cats.syntax.all.*
 import japgolly.scalajs.react.ReactCats.*
 import japgolly.scalajs.react.Reusability
@@ -19,7 +20,7 @@ case class Focused(
   obsSet: Option[ObsIdSet] = none,
   target: Option[Target.Id] = none,
   group:  Option[Group.Id] = none
-) {
+) derives Eq {
   def withObsSetOpt(obsSet: Option[ObsIdSet]): Focused = Focused.obsSet.replace(obsSet)(this)
 
   def withObsSet(obsSet: ObsIdSet): Focused = withObsSetOpt(obsSet.some)
@@ -59,8 +60,6 @@ object Focused {
     Focused(ObsIdSet.one(obsId).some, targetId, none)
 
   def group(group: Group.Id): Focused = Focused(none, none, group.some)
-
-  given Eq[Focused] = Eq.by(x => (x.obsSet, x.target, x.group))
 
   given Reusability[Focused] = Reusability.byEq
 

--- a/common/src/main/scala/explore/undo/Action.scala
+++ b/common/src/main/scala/explore/undo/Action.scala
@@ -18,11 +18,11 @@ case class Action[M, A](
   onSet:     (M, A) => DefaultA[Unit],
   onRestore: (M, A) => DefaultA[Unit]
 ) {
-  def set(undoCtx: UndoSetter[M])(v: A): DefaultS[Unit] =
-    undoCtx.set(getter, setter, onSet, onRestore)(v)
+  def set(undoSetter: UndoSetter[M])(v: A): DefaultS[Unit] =
+    undoSetter.set(getter, setter, onSet, onRestore)(v)
 
-  def mod(undoCtx: UndoSetter[M])(f: A => A): DefaultS[Unit] =
-    undoCtx.mod(getter, setter, onSet, onRestore)(f)
+  def mod(undoSetter: UndoSetter[M])(f: A => A): DefaultS[Unit] =
+    undoSetter.mod(getter, setter, onSet, onRestore)(f)
 }
 
 object Action {

--- a/explore/src/clue/scala/queries/common/TargetQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/TargetQueriesGQL.scala
@@ -6,7 +6,6 @@ package queries.common
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import lucuma.schemas.ObservationDB
-import lucuma.schemas.model as schemasModel
 import lucuma.schemas.odb.*
 // gql: import lucuma.schemas.decoders.given
 
@@ -53,30 +52,11 @@ object TargetQueriesGQL {
   }
 
   @GraphQL
-  trait UpdateTargetsMutationWithResult extends GraphQLOperation[ObservationDB] {
-    val document = s"""
-      mutation($$input: UpdateTargetsInput!) {
-        updateTargets(input: $$input) {
-          targets $TargetWithIdSubquery
-        }
-      }
-    """
-
-    object Data {
-      object UpdateTargets {
-        type Targets = schemasModel.TargetWithId
-      }
-    }
-  }
-
-  @GraphQL
   trait CloneTargetMutation extends GraphQLOperation[ObservationDB] {
-    val document = """
-      mutation($input: CloneTargetInput!) {
-        cloneTarget(input: $input) {
-          newTarget {
-            id
-          }
+    val document = s"""
+      mutation($$input: CloneTargetInput!) {
+        cloneTarget(input: $$input) {
+          newTarget $TargetWithIdSubquery
         }
       }
     """

--- a/explore/src/main/scala/explore/common/AsterismQueries.scala
+++ b/explore/src/main/scala/explore/common/AsterismQueries.scala
@@ -49,3 +49,14 @@ object AsterismQueries:
       SET = EditAsterismsPatchInput(DELETE = targetIds.assign)
     )
     UpdateAsterismsMutation[F].execute(input).void
+
+  def addAndRemoveTargetsFromAsterisms[F[_]: Async](
+    obsIds:   List[Observation.Id],
+    toAdd:    List[Target.Id],
+    toRemove: List[Target.Id]
+  )(using FetchClient[F, ObservationDB]) =
+    val input = UpdateAsterismsInput(
+      WHERE = obsIds.toWhereObservation.assign,
+      SET = EditAsterismsPatchInput(ADD = toAdd.assign, DELETE = toRemove.assign)
+    )
+    UpdateAsterismsMutation[F].execute(input).void

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -16,10 +16,13 @@ import explore.model.GlobalPreferences
 import explore.model.ObsConfiguration
 import explore.model.ObsIdSet
 import explore.model.ObsTabTilesIds
+import explore.model.OnCloneParameters
+import explore.model.ProgramSummaries
 import explore.model.TargetEditObsInfo
 import explore.model.TargetList
 import explore.model.enums.TileSizeState
 import explore.targeteditor.AsterismEditor
+import explore.undo.UndoContext
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.extra.router.SetRouteVia
@@ -29,7 +32,6 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.model.BasicConfiguration
-import lucuma.schemas.model.TargetWithId
 import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
 import queries.schemas.odb.ObsQueries
@@ -44,12 +46,13 @@ object AsterismEditorTile:
     obsIds:            ObsIdSet,
     asterismIds:       View[AsterismIds],
     allTargets:        UndoSetter[TargetList],
+    programSummaries:  UndoContext[ProgramSummaries],
     configuration:     Option[BasicConfiguration],
     vizTime:           View[Option[Instant]],
     obsConf:           ObsConfiguration,
     currentTarget:     Option[Target.Id],
     setTarget:         (Option[Target.Id], SetRouteVia) => Callback,
-    onCloneTarget:     (Target.Id, TargetWithId, ObsIdSet) => Callback,
+    onCloneTarget:     OnCloneParameters => Callback,
     obsInfo:           Target.Id => TargetEditObsInfo,
     searching:         View[Set[Target.Id]],
     title:             String,
@@ -80,6 +83,7 @@ object AsterismEditorTile:
           obsIds,
           asterismIds,
           allTargets,
+          programSummaries,
           vizTime,
           obsConf,
           currentTarget,

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -16,13 +16,11 @@ import explore.model.GlobalPreferences
 import explore.model.ObsConfiguration
 import explore.model.ObsIdSet
 import explore.model.ObsTabTilesIds
+import explore.model.ObservationsAndTargets
 import explore.model.OnCloneParameters
-import explore.model.ProgramSummaries
 import explore.model.TargetEditObsInfo
-import explore.model.TargetList
 import explore.model.enums.TileSizeState
 import explore.targeteditor.AsterismEditor
-import explore.undo.UndoContext
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.extra.router.SetRouteVia
@@ -45,8 +43,7 @@ object AsterismEditorTile:
     programId:         Program.Id,
     obsIds:            ObsIdSet,
     asterismIds:       View[AsterismIds],
-    allTargets:        UndoSetter[TargetList],
-    programSummaries:  UndoContext[ProgramSummaries],
+    obsAndTargets:     UndoSetter[ObservationsAndTargets],
     configuration:     Option[BasicConfiguration],
     vizTime:           View[Option[Instant]],
     obsConf:           ObsConfiguration,
@@ -82,8 +79,7 @@ object AsterismEditorTile:
           programId,
           obsIds,
           asterismIds,
-          allTargets,
-          programSummaries,
+          obsAndTargets,
           vizTime,
           obsConf,
           currentTarget,

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -44,6 +44,7 @@ import lucuma.react.primereact.Button
 import lucuma.react.resizeDetector.*
 import lucuma.react.resizeDetector.hooks.*
 import lucuma.refined.*
+import lucuma.ui.optics.*
 import lucuma.ui.primereact.*
 import lucuma.ui.reusability.given
 import lucuma.ui.sso.UserVault
@@ -155,7 +156,10 @@ object ObsTabContents extends TwoPanels:
             // FIXME Find a better mechanism for this.
             // Something like .mapValue but for UndoContext
             props.observations.zoom(indexValue.getOption.andThen(_.get), indexValue.modify),
-            props.programSummaries,
+            props.programSummaries
+              .zoom((ProgramSummaries.observations, ProgramSummaries.targets).disjointZip),
+            props.programSummaries.model.zoom(ProgramSummaries.obsAttachments),
+            props.programSummaries.get,
             props.focusedTarget,
             props.searching,
             ExploreGridLayouts.sectionLayout(GridLayoutSection.ObservationsLayout),

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -26,6 +26,7 @@ import explore.model.*
 import explore.model.AppContext
 import explore.model.LoadingState
 import explore.model.ObsSummary.observingMode
+import explore.model.OnCloneParameters
 import explore.model.ProgramSummaries
 import explore.model.TargetEditObsInfo
 import explore.model.display.given
@@ -483,11 +484,8 @@ object ObsTabTiles:
                 via
               )
 
-            def onCloneTarget(oldTid: Target.Id, newTarget: TargetWithId, obsIds: ObsIdSet)
-              : Callback =
-              props.programSummaries.model.mod(
-                _.cloneTargetForObservations(oldTid, newTarget, obsIds)
-              ) *> setCurrentTarget(newTarget.id.some, SetRouteVia.HistoryReplace)
+            def onCloneTarget(params: OnCloneParameters): Callback =
+              setCurrentTarget(params.idToAdd.some, SetRouteVia.HistoryReplace)
 
             val targetTile: Tile =
               AsterismEditorTile.asterismEditorTile(
@@ -496,6 +494,7 @@ object ObsTabTiles:
                 ObsIdSet.one(props.obsId),
                 asterismIds,
                 props.allTargets,
+                props.programSummaries,
                 basicConfiguration,
                 vizTimeView,
                 obsConf,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -26,6 +26,7 @@ import explore.model.*
 import explore.model.AppContext
 import explore.model.LoadingState
 import explore.model.ObsSummary.observingMode
+import explore.model.ObservationsAndTargets
 import explore.model.OnCloneParameters
 import explore.model.ProgramSummaries
 import explore.model.TargetEditObsInfo
@@ -42,7 +43,6 @@ import explore.modes.SpectroscopyModesMatrix
 import explore.observationtree.obsEditAttachments
 import explore.syntax.ui.*
 import explore.timingwindows.TimingWindowsPanel
-import explore.undo.UndoContext
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
@@ -87,7 +87,9 @@ case class ObsTabTiles(
   modes:             SpectroscopyModesMatrix,
   backButton:        VdomNode,
   observation:       UndoSetter[ObsSummary],
-  programSummaries:  UndoContext[ProgramSummaries],
+  obsAndTargets:     UndoSetter[ObservationsAndTargets],
+  obsAttachments:    View[ObsAttachmentList],
+  programSummaries:  ProgramSummaries,
   focusedTarget:     Option[Target.Id],
   searching:         View[Set[Target.Id]],
   defaultLayouts:    LayoutsMap,
@@ -97,15 +99,13 @@ case class ObsTabTiles(
   readonly:          Boolean
 ) extends ReactFnProps(ObsTabTiles.component):
   val obsId: Observation.Id                                         = observation.get.id
-  val allConstraintSets: Set[ConstraintSet]                         = programSummaries.get.constraintGroups.map(_._2).toSet
+  val allConstraintSets: Set[ConstraintSet]                         = programSummaries.constraintGroups.map(_._2).toSet
   val targetObservations: Map[Target.Id, SortedSet[Observation.Id]] =
-    programSummaries.get.targetObservations
-  val obsExecution: Pot[Execution]                                  = programSummaries.get.obsExecutionPots.getPot(obsId)
-  val allTargets: UndoSetter[TargetList]                            = programSummaries.zoom(ProgramSummaries.targets)
-  val obsAttachments: View[ObsAttachmentList]                       =
-    programSummaries.model.zoom(ProgramSummaries.obsAttachments)
+    programSummaries.targetObservations
+  val obsExecution: Pot[Execution]                                  = programSummaries.obsExecutionPots.getPot(obsId)
+  val allTargets: TargetList                                        = programSummaries.targets
   val obsAttachmentAssignments: ObsAttachmentAssignmentMap          =
-    programSummaries.get.obsAttachmentAssignments
+    programSummaries.obsAttachmentAssignments
 
 object ObsTabTiles:
   private type Props = ObsTabTiles
@@ -225,7 +225,7 @@ object ObsTabTiles:
           props.observation.get,
           time,
           selectedConfig.get,
-          props.allTargets.get
+          props.allTargets
         )
       )
       // Chart results
@@ -239,7 +239,7 @@ object ObsTabTiles:
           props.observation.get,
           time,
           selectedConfig.get,
-          props.allTargets.get
+          props.allTargets
         )
       } { (props, ctx, _, _, _, _, _, oldItcProps, charts, loading) => itcProps =>
         import ctx.given
@@ -332,7 +332,7 @@ object ObsTabTiles:
             val asterismAsNel: Option[NonEmptyList[TargetWithId]] =
               NonEmptyList.fromList(
                 props.observation.get.scienceTargetIds.toList
-                  .map(id => props.allTargets.get.get(id).map(t => TargetWithId(id, t)))
+                  .map(id => props.allTargets.get(id).map(t => TargetWithId(id, t)))
                   .flattenOption
               )
 
@@ -416,7 +416,7 @@ object ObsTabTiles:
                 props.userId,
                 props.obsId,
                 selectedItcTarget,
-                props.allTargets.get,
+                props.allTargets,
                 itcProps.value,
                 itcChartResults.value,
                 itcLoading.value,
@@ -469,7 +469,7 @@ object ObsTabTiles:
               TargetEditObsInfo.fromProgramSummaries(
                 targetId,
                 ObsIdSet.one(obsId).some,
-                props.programSummaries.get
+                props.programSummaries
               )
 
             def setCurrentTarget(
@@ -493,8 +493,7 @@ object ObsTabTiles:
                 props.programId,
                 ObsIdSet.one(props.obsId),
                 asterismIds,
-                props.allTargets,
-                props.programSummaries,
+                props.obsAndTargets,
                 basicConfiguration,
                 vizTimeView,
                 obsConf,
@@ -545,7 +544,7 @@ object ObsTabTiles:
                 obsConf,
                 selectedConfig,
                 props.modes,
-                props.allTargets.get,
+                props.allTargets,
                 sequenceChanged.mod {
                   case Ready(x) => Pot.pending
                   case x        => x

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -11,11 +11,10 @@ import explore.model.AladinFullScreen
 import explore.model.Asterism
 import explore.model.GlobalPreferences
 import explore.model.ObsTabTilesIds
+import explore.model.ObservationsAndTargets
 import explore.model.OnCloneParameters
-import explore.model.ProgramSummaries
 import explore.model.TargetEditObsInfo
 import explore.targeteditor.SiderealTargetEditor
-import explore.undo.UndoContext
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -32,7 +31,7 @@ object SiderealTargetEditorTile {
     userId:            Option[User.Id],
     targetId:          Target.Id,
     target:            UndoSetter[Target.Sidereal],
-    programSummaries:  UndoContext[ProgramSummaries],
+    obsAndTargets:     UndoSetter[ObservationsAndTargets],
     searching:         View[Set[Target.Id]],
     title:             String,
     fullScreen:        View[AladinFullScreen],
@@ -58,7 +57,7 @@ object SiderealTargetEditorTile {
               programId,
               uid,
               target,
-              programSummaries,
+              obsAndTargets,
               Asterism.one(TargetWithId(targetId, target.get)),
               vizTime = none,
               obsConf = none,

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -10,13 +10,16 @@ import explore.components.ui.ExploreStyles
 import explore.model.AladinFullScreen
 import explore.model.Asterism
 import explore.model.GlobalPreferences
-import explore.model.ObsIdSet
 import explore.model.ObsTabTilesIds
+import explore.model.OnCloneParameters
+import explore.model.ProgramSummaries
 import explore.model.TargetEditObsInfo
 import explore.targeteditor.SiderealTargetEditor
+import explore.undo.UndoContext
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.schemas.model.TargetWithId
@@ -25,16 +28,18 @@ import lucuma.ui.syntax.all.given
 object SiderealTargetEditorTile {
 
   def noObsSiderealTargetEditorTile(
+    programId:         Program.Id,
     userId:            Option[User.Id],
     targetId:          Target.Id,
     target:            UndoSetter[Target.Sidereal],
+    programSummaries:  UndoContext[ProgramSummaries],
     searching:         View[Set[Target.Id]],
     title:             String,
     fullScreen:        View[AladinFullScreen],
     globalPreferences: View[GlobalPreferences],
     readonly:          Boolean,
     obsInfo:           TargetEditObsInfo,
-    onClone:           (Target.Id, TargetWithId, ObsIdSet) => Callback,
+    onClone:           OnCloneParameters => Callback,
     backButton:        Option[VdomNode] = none
   ) =
     Tile(
@@ -50,8 +55,10 @@ object SiderealTargetEditorTile {
           ExploreStyles.TargetTileEditor,
           userId.map(uid =>
             SiderealTargetEditor(
+              programId,
               uid,
               target,
+              programSummaries,
               Asterism.one(TargetWithId(targetId, target.get)),
               vizTime = none,
               obsConf = none,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -50,6 +50,7 @@ import lucuma.react.resizeDetector.*
 import lucuma.react.resizeDetector.hooks.*
 import lucuma.refined.*
 import lucuma.schemas.model.*
+import lucuma.ui.optics.*
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.given
 import monocle.Iso
@@ -70,7 +71,9 @@ case class TargetTabContents(
   expandedIds:      View[SortedSet[ObsIdSet]],
   readonly:         Boolean
 ) extends ReactFnProps(TargetTabContents.component):
-  val targets: UndoSetter[TargetList] = programSummaries.zoom(ProgramSummaries.targets)
+  val targets: UndoSetter[TargetList]                   = programSummaries.zoom(ProgramSummaries.targets)
+  val obsAndTargets: UndoSetter[ObservationsAndTargets] =
+    programSummaries.zoom((ProgramSummaries.observations, ProgramSummaries.targets).disjointZip)
 
   val globalPreferences: View[GlobalPreferences] =
     userPreferences.zoom(UserPreferences.globalPreferences)
@@ -308,8 +311,7 @@ object TargetTabContents extends TwoPanels:
           props.programId,
           idsToEdit,
           asterismView,
-          props.targets,
-          props.programSummaries,
+          props.obsAndTargets,
           configuration,
           vizTimeView,
           ObsConfiguration(configuration, none, constraints, wavelength, none, none, none),
@@ -368,7 +370,7 @@ object TargetTabContents extends TwoPanels:
               props.userId,
               targetId,
               target,
-              props.programSummaries,
+              props.obsAndTargets,
               props.searching,
               s"Editing Target ${target.get.name.value} [$targetId]",
               fullScreen,

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditor.scala
@@ -17,11 +17,10 @@ import explore.model.AsterismIds
 import explore.model.GlobalPreferences
 import explore.model.ObsConfiguration
 import explore.model.ObsIdSet
+import explore.model.ObservationsAndTargets
 import explore.model.OnCloneParameters
-import explore.model.ProgramSummaries
 import explore.model.TargetEditObsInfo
 import explore.model.TargetList
-import explore.undo.UndoContext
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
@@ -43,8 +42,7 @@ case class AsterismEditor(
   programId:         Program.Id,
   obsIds:            ObsIdSet,
   asterismIds:       View[AsterismIds],
-  allTargets:        UndoSetter[TargetList],
-  programSummaries:  UndoContext[ProgramSummaries],
+  obsAndTargets:     UndoSetter[ObservationsAndTargets],
   vizTime:           View[Option[Instant]],
   configuration:     ObsConfiguration,
   focusedTargetId:   Option[Target.Id],
@@ -56,7 +54,8 @@ case class AsterismEditor(
   globalPreferences: View[GlobalPreferences],
   readonly:          Boolean,
   sequenceChanged:   Callback
-) extends ReactFnProps(AsterismEditor.component)
+) extends ReactFnProps(AsterismEditor.component):
+  val allTargets: UndoSetter[TargetList] = obsAndTargets.zoom(ObservationsAndTargets.targets)
 
 object AreAdding extends NewType[Boolean]
 type AreAdding = AreAdding.Type
@@ -147,7 +146,7 @@ object AsterismEditor extends AsterismModifier:
                     props.programId,
                     props.userId,
                     siderealTarget,
-                    props.programSummaries,
+                    props.obsAndTargets,
                     asterism.focusOn(focusedTargetId),
                     vizTime,
                     props.configuration.some,

--- a/explore/src/main/scala/explore/targeteditor/TargetCloneAction.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetCloneAction.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.targeteditor
+
+import cats.effect.IO
+import clue.FetchClient
+import clue.data.syntax.*
+import crystal.react.syntax.all.*
+import explore.DefaultErrorPolicy
+import explore.common.AsterismQueries
+import explore.model.ObsIdSet
+import explore.model.OnCloneParameters
+import explore.model.ProgramSummaries
+import explore.undo.*
+import japgolly.scalajs.react.*
+import lucuma.core.model.Program
+import lucuma.core.model.Target
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.ObservationDB.Enums.Existence
+import lucuma.schemas.ObservationDB.Types.*
+import lucuma.schemas.model.TargetWithId
+import lucuma.schemas.odb.input.*
+import queries.common.TargetQueriesGQL
+
+object TargetCloneAction {
+  private def getter(cloneId: Target.Id): ProgramSummaries => Option[Target] =
+    _.targets.get(cloneId)
+
+  def setter(originalId: Target.Id, clone: TargetWithId, obsIds: ObsIdSet)(
+    optClone: Option[Target]
+  ): ProgramSummaries => ProgramSummaries = ps =>
+    // if the clone is in programs summaries, we're undoing.
+    ps.targets
+      .get(clone.id)
+      .fold(
+        ps.cloneTargetForObservations(originalId, clone, obsIds)
+      )(_ => ps.unCloneTargetForObservations(originalId, clone.id, obsIds))
+
+  def updateRemote(
+    programId:    Program.Id,
+    onCloneParms: OnCloneParameters
+  )(using
+    FetchClient[IO, ObservationDB]
+  ): IO[Unit] =
+    val existence = if (onCloneParms.areCreating) Existence.Present else Existence.Deleted
+    TargetQueriesGQL
+      .UpdateTargetsMutation[IO]
+      .execute(
+        UpdateTargetsInput(
+          WHERE = onCloneParms.cloneId.toWhereTarget
+            .copy(program = programId.toWhereProgram.assign)
+            .assign,
+          SET = TargetPropertiesInput(existence = existence.assign),
+          includeDeleted = true.assign
+        )
+      ) >>
+      AsterismQueries.addAndRemoveTargetsFromAsterisms(onCloneParms.obsIds.toList,
+                                                       toAdd = List(onCloneParms.idToAdd),
+                                                       toRemove = List(onCloneParms.idToRemove)
+      )
+
+  def cloneTarget(
+    programId:  Program.Id,
+    originalId: Target.Id,
+    clone:      TargetWithId,
+    obsIds:     ObsIdSet,
+    onClone:    OnCloneParameters => Callback
+  )(using
+    FetchClient[IO, ObservationDB]
+  ): Action[ProgramSummaries, Option[Target]] =
+    Action[ProgramSummaries, Option[Target]](getter(clone.id), setter(originalId, clone, obsIds))(
+      onSet = (_, _) => IO.unit, // clone is created and first `onClone` called outside of Action
+      onRestore = (ps, optClone) =>
+        val params = OnCloneParameters(originalId, clone.id, obsIds, optClone.isDefined)
+        onClone(params).toAsync >>
+          updateRemote(programId, params)
+    )
+}

--- a/model/shared/src/main/scala/explore/model/OnCloneParameters.scala
+++ b/model/shared/src/main/scala/explore/model/OnCloneParameters.scala
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import lucuma.core.model.Target
+
+/**
+ * Parameters for the onClone parameter to the target edit.
+ *
+ * onClone is called when the target is cloned, and also during undo/redo.
+ *
+ * @param originalId
+ *   The id of the target that was cloned
+ * @param cloneId
+ *   The id of the clone
+ * @param obsIds
+ *   The observation ids for which the target was cloned
+ * @param areCreating
+ *   True if this is set or redo, false for undo
+ */
+case class OnCloneParameters(
+  originalId:  Target.Id,
+  cloneId:     Target.Id,
+  obsIds:      ObsIdSet,
+  areCreating: Boolean
+) derives Eq:
+  val idToAdd    = if (areCreating) cloneId else originalId
+  val idToRemove = if (areCreating) originalId else cloneId

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -105,14 +105,25 @@ case class ProgramSummaries(
     ProgramSummaries.observations.modify(_.removed(obsId))(this)
 
   def cloneTargetForObservations(
-    oldTid:    Target.Id,
-    newTarget: TargetWithId,
-    obsIds:    ObsIdSet
+    originalId: Target.Id,
+    clone:      TargetWithId,
+    obsIds:     ObsIdSet
   ): ProgramSummaries =
     val obs = obsIds.idSet.foldLeft(observations)((list, obsId) =>
-      list.updatedValueWith(obsId, ObsSummary.scienceTargetIds.modify(_ - oldTid + newTarget.id))
+      list.updatedValueWith(obsId, ObsSummary.scienceTargetIds.modify(_ - originalId + clone.id))
     )
-    val ts  = targets + (newTarget.id -> newTarget.target)
+    val ts  = targets + (clone.id -> clone.target)
+    copy(observations = obs, targets = ts)
+
+  def unCloneTargetForObservations(
+    originalId: Target.Id,
+    cloneId:    Target.Id,
+    obsIds:     ObsIdSet
+  ): ProgramSummaries =
+    val obs = obsIds.idSet.foldLeft(observations)((list, obsId) =>
+      list.updatedValueWith(obsId, ObsSummary.scienceTargetIds.modify(_ + originalId - cloneId))
+    )
+    val ts  = targets - cloneId
     copy(observations = obs, targets = ts)
 
 object ProgramSummaries:

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -24,6 +24,8 @@ import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.util.NewType
 import lucuma.refined.*
+import monocle.Focus
+import monocle.Lens
 
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
@@ -59,6 +61,13 @@ type SchedulingGroupList        = SortedMap[ObsIdSet, List[TimingWindow]]
 type ObsAttachmentList          = SortedMap[ObsAtt.Id, ObsAttachment]
 type ObsAttachmentAssignmentMap = Map[ObsAtt.Id, SortedSet[Observation.Id]]
 type ProgramInfoList            = SortedMap[Program.Id, ProgramInfo]
+
+type ObservationsAndTargets = (ObservationList, TargetList)
+
+object ObservationsAndTargets:
+  val observations: Lens[ObservationsAndTargets, ObservationList] =
+    Focus[ObservationsAndTargets](_._1)
+  val targets: Lens[ObservationsAndTargets, TargetList]           = Focus[ObservationsAndTargets](_._2)
 
 object ObservationExecutionMap extends PotMap[Observation.Id, Execution]
 type ObservationExecutionMap = ObservationExecutionMap.Type

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -42,8 +42,13 @@ object all:
       case PosAngleConstraint.Unbounded              => PosAngleOptions.Unconstrained
 
   extension (self: AsterismGroupList)
+    // find the first group which contains the entirety of obsIds
     def findContainingObsIds(obsIds: ObsIdSet): Option[AsterismGroup] =
       self.find { case (ids, _) => obsIds.subsetOf(ids) }.map(AsterismGroup.fromTuple)
+
+    // find all the groups that contain any of the obsIds
+    def filterForObsInSet(obsIds: ObsIdSet): AsterismGroupList =
+      self.filterNot(_._1.idSet.intersect(obsIds.idSet).isEmpty)
 
     def findWithTargetIds(targetIds: SortedSet[Target.Id]): Option[AsterismGroup] =
       self.find { case (_, grpIds) => grpIds === targetIds }.map(AsterismGroup.fromTuple)


### PR DESCRIPTION
The following things need to happen in all cases when a clone is created

1. Create the clone via the API, assign it to the specified observations, and make whatever changes to the target triggered the cloning. This is all done via a single call to `cloneTarget` mutation with the appropriate `Input`.
2. Add the target target to the local list of targets and swap the original target id for the cloned target id in the local list of ObsSummaries.

Depending on where the cloning was initiated from (target tab with one or more observations selected, target tab with a row in the summary table selected, or an observation selected on the observation tab) various other things need to be done. This always includes setting the URL, but can also include expanding groups in the AsterismGroupList. This is done via the `onCloneTarget` function passed to the SIderealTargetEditor. On creation this is called directly so that it happens in the same cycle as the cloning. If I waited to call this in the `onSet` of the action, when editing a asterism from the target tab, the URL would usually be incorrect. This is because the page would be set to the summary table in the meantime, and it would force the URL back to it.

For `undo`, everything is handled in the `TargetCloneAction`:

1. Remotely, the target needs to be deleted (I avoid that if someone in another session has assigned the new target to a different observation) and the asterism of all the affected observations need to have the clone removed and the original target added. 
2. Locally the clone is deleted and the asterisms are updated according. This is via the `onCloneTarget` method mentioned above.

`redo` is similar to undo, but in the reverse.

The core of the changes are in the cloning in `SiderealTargetEditor` and the `TargetCloneAction` that is used there. The `Fix problem of updating undostacks multiple times` commit also changes how the `Aligner` is created so that the `UndoSetter[Target.Sidereal]` that is passed in the props does not get updated when a clone will be performed. Before this change, the undo stacks got modified both by the change to the target AND by the cloning.

Next are the `onCloneTarget*` functions in `TargetTabContents` and `ObsTabTiles` that are passed to `SidereralTargetEditor` and on to `TargetCloneAction`.

For the initial clone and redoing, the URL seems to work correctly, however when undoing something about the cycle of events and the async nature of the undo often results in the TargetSummaryTable being displayed instead of the original target editor. I have decided that this is enough of a `best effort`.