### PR TITLE
Avoid remount on observation time change

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -162,6 +162,7 @@ object ExploreStyles:
 
   val DraggingOver: Css = Css("dragging-over")
 
+  val TargetTileController: Css      = Css("target-tile-controller")
   val TargetTileBody: Css            = Css("target-tile-body")
   val TargetTileEditor: Css          = Css("target-tile-editor")
   val AddTargetButton: Css           = Css("add-target-button")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1010,6 +1010,13 @@ thead tr th.sticky-header {
   }
 }
 
+.target-tile-controller {
+  // Container size queries provoke new stacking contexts at the tile controller level.
+  // In the observation tile, the target tile controller's z-index must be greater than 
+  // the z-index of the other tiles' controllers for the obs time picker to be visible over them.
+  z-index: 20;
+}
+
 .target-tile-body {
   display: flex;
   flex-direction: column;

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1012,7 +1012,7 @@ thead tr th.sticky-header {
 
 .target-tile-controller {
   // Container size queries provoke new stacking contexts at the tile controller level.
-  // In the observation tile, the target tile controller's z-index must be greater than 
+  // In the observation tile, the target tile controller's z-index must be greater than
   // the z-index of the other tiles' controllers for the obs time picker to be visible over them.
   z-index: 20;
 }

--- a/explore/src/main/scala/explore/RootComponent.scala
+++ b/explore/src/main/scala/explore/RootComponent.scala
@@ -27,10 +27,7 @@ object RootComponent:
     ScalaFnComponent
       .withHooks[Props]
       .useStateViewBy(_.initialModel)
-      .render((props, rootModel) =>
-        AppContext.ctx.provide(props.ctx)(
-          HelpContext.Provider(
+      .render: (props, rootModel) =>
+        AppContext.ctx.provide(props.ctx):
+          HelpContext.Provider:
             props.router(rootModel)
-          )
-        )
-      )

--- a/explore/src/main/scala/explore/components/TileController.scala
+++ b/explore/src/main/scala/explore/components/TileController.scala
@@ -122,7 +122,7 @@ object TileController:
               case l                     => l
             }
 
-        def addBackButton: List[Tile] = {
+        val tilesWithBackButton: List[Tile] = {
           val topTile =
             currentLayout.get.get(breakpoint.value).flatMap(_._3.asList.sortBy(_.y).headOption)
           (topTile, p.backButton)
@@ -162,15 +162,15 @@ object TileController:
           layouts = currentLayout.get,
           className = p.clazz.map(_.htmlClass).orUndefined
         )(
-          addBackButton.map { t =>
+          tilesWithBackButton.map { tile =>
             <.div(
-              ^.key := t.id.value,
+              ^.key := tile.id.value,
               // Show tile properties on the title if enabled
               currentLayout.get
                 .get(breakpoint.value)
                 .flatMap { case (p, c, l) =>
                   l.asList
-                    .find(_.i === t.id.value)
+                    .find(_.i === tile.id.value)
                     .flatMap { i =>
                       TagMod
                         .devOnly(
@@ -188,8 +188,8 @@ object TileController:
                     }
                 }
                 .getOrElse(EmptyVdom),
-              t.controllerClass,
-              t.withState(unsafeSizeToState(currentLayout.get, t.id), sizeState(t.id))
+              tile.controllerClass,
+              tile.withState(unsafeSizeToState(currentLayout.get, tile.id), sizeState(tile.id))
             )
           }.toVdomArray
         )

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -71,7 +71,8 @@ object AsterismEditorTile:
       back = backButton,
       canMinimize = true,
       control = s => control.some.filter(_ => s === TileSizeState.Minimized),
-      bodyClass = ExploreStyles.TargetTileBody
+      bodyClass = ExploreStyles.TargetTileBody,
+      controllerClass = ExploreStyles.TargetTileController
     )((renderInTitle: Tile.RenderInTitle) =>
       userId.map(uid =>
         AsterismEditor(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   val circeGolden            = "0.3.0"
   val coulomb                = "0.8.0"
   val clue                   = "0.40.0"
-  val crystal                = "0.41.1"
+  val crystal                = "0.42.0"
   val discipline             = "1.7.0"
   val disciplineMUnit        = "2.0.0"
   val fs2                    = "3.10.2"


### PR DESCRIPTION
Also, fix observation time picker display over other tiles when target tile is collapsed.