### PR TITLE
Enable trace logging

### DIFF
--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -287,6 +287,10 @@ object Icons {
   val faBug: FAIcon = js.native
 
   @js.native
+  @JSImport("@fortawesome/pro-regular-svg-icons", "faPencil")
+  val faPencil: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-light-svg-icons", "faArrowsFromLine")
   val faArrowsFromLine: FAIcon = js.native
 
@@ -408,6 +412,7 @@ object Icons {
     faSquareXMark,
     faSquareXMarkLarge,
     faBug,
+    faPencil,
     faArrowsFromLine,
     faWrench,
     faArrowRotateLeft,
@@ -492,6 +497,7 @@ object Icons {
   val SquareXMark          = FontAwesomeIcon(faSquareXMark)
   val SquareXMarkLarge     = FontAwesomeIcon(faSquareXMarkLarge)
   val Bug                  = FontAwesomeIcon(faBug)
+  val Pencil               = FontAwesomeIcon(faPencil)
   val ArrowsFromLine       = FontAwesomeIcon(faArrowsFromLine)
   val Wrench               = FontAwesomeIcon(faWrench)
   val ArrowRotateLeft      = FontAwesomeIcon(faArrowRotateLeft)

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -146,6 +146,12 @@ object TopBar:
                   command = setLogLevel(LogLevelDesc.DEBUG),
                   disabled = level === LogLevelDesc.DEBUG,
                   icon = Icons.Bug
+                ),
+                MenuItem.Item(
+                  label = "Trace",
+                  command = setLogLevel(LogLevelDesc.TRACE),
+                  disabled = level === LogLevelDesc.TRACE,
+                  icon = Icons.Pencil
                 )
               )
               .some,


### PR DESCRIPTION
Adds the option in the menu to switch to trace logging. Useful in particular for debugging issues with clue.