### PR TITLE
Break race condition when selecting newly created target and previous focus was on observation

### DIFF
--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -523,7 +523,7 @@ object TargetTabContents extends TwoPanels:
           case _                                              => Callback.empty
       }
       .useStateViewBy((props, _, _) => props.focused.target.toList)
-      .useEffectWithDepsBy((props, _, _, _) => props.focused.target)((_, _, _, selIds) =>
+      .useLayoutEffectWithDepsBy((props, _, _, _) => props.focused.target)((_, _, _, selIds) =>
         _.foldMap(focusedTarget => selIds.set(List(focusedTarget)))
       )
       .useGlobalHotkeysWithDepsBy((props, ctx, _, selIds) =>


### PR DESCRIPTION
Fixes https://app.shortcut.com/lucuma/story/3057/select-new-target