### PR TITLE
Remove matrix from 'full' GH action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.5.0]
         java: [temurin@17]
     runs-on: ${{ matrix.os }}
     steps:
@@ -168,7 +167,7 @@ jobs:
         run: npm clean-install --verbose
 
       - name: Stage
-        run: sbt -v -J-Xmx6g '++ ${{ matrix.scala }}' stage
+        run: sbt -v -J-Xmx6g stage
 
       - name: Build application
         env:

--- a/build.sbt
+++ b/build.sbt
@@ -367,7 +367,9 @@ ThisBuild / githubWorkflowAddedJobs +=
       // firebaseDeployReview ::
       firebaseDeployDev ::
       Nil,
-    scalas = List(scalaVersion.value),
+    // Only 1 scalaVersion, so no need for matrix
+    sbtStepPreamble = Nil,
+    scalas = Nil,
     javas = githubWorkflowJavaVersions.value.toList.take(1),
     cond = Some(allConds(anyConds(masterCond, prCond), geminiRepoCond))
   )


### PR DESCRIPTION
The 'required' workflow includes the scala version in the name, which makes upgrading scala versions more annoying because you have to disable the required action, merge, and enable the new workflow with the new scala version in the name
