### PR TITLE
Add editing of observation duration

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -161,6 +161,7 @@ object ExploreStyles:
   val TargetTileController: Css      = Css("target-tile-controller")
   val TargetTileBody: Css            = Css("target-tile-body")
   val TargetTileEditor: Css          = Css("target-tile-editor")
+  val TargetTileObsDuration: Css     = Css("target-tile-obs-duration")
   val AddTargetButton: Css           = Css("add-target-button")
   val TargetSourceProfileEditor: Css = Css("target-source-profile-editor")
   val WithGaussian: Css              = Css("with-gaussian")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -841,12 +841,17 @@ thead tr th.sticky-header {
       font-size: small;
     }
   }
+
+  .target-tile-obs-duration {
+    display: none;
+  }
 }
 
 @container tile (min-width: #{exploreCommon.$tile-small-cutoff}) {
   .explore-obs-instant-tile-title {
     label:first-child {
       max-width: unset;
+      display: unset;
     }
 
     label[data-abbrv]::after {
@@ -863,10 +868,11 @@ thead tr th.sticky-header {
   }
 }
 
-@container tile (min-width: #{exploreCommon.$tile-small-cutoff}) {
+@container tile (min-width: #{exploreCommon.$tile-medium-cutoff}) {
   .explore-obs-instant-tile-title {
-    label:first-child {
-      display: unset;
+    .target-tile-obs-duration {
+      display: flex;
+      gap: 0.5em;
     }
   }
 }
@@ -1034,6 +1040,14 @@ thead tr th.sticky-header {
   // In the observation tile, the target tile controller's z-index must be greater than
   // the z-index of the other tiles' controllers for the obs time picker to be visible over them.
   z-index: 20;
+
+  .explore-tile-title-control-area {
+    min-width: 60%;
+
+    .explore-tile-control {
+      justify-content: space-between;
+    }
+  }
 }
 
 .target-tile-body {

--- a/explore/src/clue/scala/queries/common/ObservationSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ObservationSubquery.scala
@@ -20,6 +20,7 @@ object ObservationSubquery extends GraphQLSubquery.Typed[ObservationDB, Observat
           status
           activeStatus
           observationTime
+          observationDuration $TimeSpanSubquery
           posAngleConstraint $PosAngleConstraintSubquery
           targetEnvironment {
             asterism {

--- a/explore/src/main/scala/explore/config/ObsTimeEditor.scala
+++ b/explore/src/main/scala/explore/config/ObsTimeEditor.scala
@@ -3,26 +3,36 @@
 
 package explore.config
 
+import cats.data.NonEmptyList
 import cats.syntax.all.*
 import crystal.react.View
+import explore.Icons
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.util.TimeSpan
 import lucuma.react.common.ReactFnProps
 import lucuma.react.datepicker.*
 import lucuma.react.primereact.Button
 import lucuma.refined.*
 import lucuma.typed.reactDatepicker.mod.ReactDatePicker
+import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
+import lucuma.ui.reusability.given
 import lucuma.ui.syntax.all.given
 
 import java.time.Instant
+import java.util.concurrent.TimeUnit
 
 import scalajs.js
 
-case class ObsTimeEditor(vizTimeView: View[Option[Instant]])
-    extends ReactFnProps(ObsTimeEditor.component)
+case class ObsTimeEditor(
+  vizTimeView:     View[Option[Instant]],
+  vizDurationView: View[Option[TimeSpan]],
+  pendingTime:     Option[TimeSpan]
+) extends ReactFnProps(ObsTimeEditor.component)
 
 object ObsTimeEditor {
   private type Props = ObsTimeEditor
@@ -31,7 +41,9 @@ object ObsTimeEditor {
     ScalaFnComponent
       .withHooks[Props]
       .useRef[Option[ReactDatePicker[Any, Any]]](none)
-      .render: (props, ref) =>
+      .useMemoBy((props, _) => props.pendingTime)((_, _) => _.getOrElse(TimeSpan.fromHours(1).get))
+      .render: (props, ref, defaultDuration) =>
+        println(s"Pending: ${props.pendingTime}")
         <.div(ExploreStyles.ObsInstantTileTitle)(
           React.Fragment(
             <.label(
@@ -54,7 +66,35 @@ object ObsTimeEditor {
                 )("Now")
               )
               .withRef(r => ref.set(r.some).runNow()),
-            <.label("UTC")
+            <.label("UTC"),
+            <.span(
+              ExploreStyles.TargetTileObsDuration,
+              props.vizDurationView
+                .mapValue((v: View[TimeSpan]) =>
+                  <.span(
+                    ExploreStyles.TargetTileObsDuration,
+                    FormTimeSpanInput(id = "obsDuration".refined,
+                                      value = v,
+                                      units = NonEmptyList.of(TimeUnit.HOURS, TimeUnit.MINUTES)
+                    ),
+                    Button(
+                      text = true,
+                      clazz = ExploreStyles.DeleteButton,
+                      icon = Icons.Eraser,
+                      tooltip = "Clear explicit duration and use full remaining sequence",
+                      onClick = props.vizDurationView.set(none)
+                    ).tiny.compact
+                  )
+                )
+                .getOrElse(
+                  Button(
+                    label = "Set duration",
+                    onClick = props.vizDurationView.set(defaultDuration.value.some),
+                    tooltip = "Set an explicit duration instead of using the remaining sequence",
+                    clazz = ExploreStyles.TargetTileObsDuration
+                  ).tiny.compact
+                )
+            )
           )
         )
 }

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -29,6 +29,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
+import lucuma.core.util.TimeSpan
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.model.BasicConfiguration
 import lucuma.ui.syntax.all.given
@@ -46,7 +47,9 @@ object AsterismEditorTile:
     obsAndTargets:     UndoSetter[ObservationsAndTargets],
     configuration:     Option[BasicConfiguration],
     vizTime:           View[Option[Instant]],
+    vizDuration:       View[Option[TimeSpan]],
     obsConf:           ObsConfiguration,
+    pendingTime:       Option[TimeSpan], // estimated remaining execution time.
     currentTarget:     Option[Target.Id],
     setTarget:         (Option[Target.Id], SetRouteVia) => Callback,
     onCloneTarget:     OnCloneParameters => Callback,
@@ -63,6 +66,11 @@ object AsterismEditorTile:
     // It's OK to save the viz time for executed observations, I think.
     val vizTimeView =
       vizTime.withOnMod(t => ObsQueries.updateVisualizationTime[IO](obsIds.toList, t).runAsync)
+
+    val vizDurationView =
+      vizDuration.withOnMod(t =>
+        ObsQueries.updateVisualizationDuration[IO](obsIds.toList, t).runAsync
+      )
 
     Tile(
       ObsTabTilesIds.TargetId.id,
@@ -100,6 +108,8 @@ object AsterismEditorTile:
                             onAsterismUpdate,
                             readonly,
                             vizTimeView,
+                            vizDurationView,
+                            pendingTime,
                             s
         )
     )

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorBody.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorBody.scala
@@ -31,6 +31,7 @@ import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.core.util.NewType
+import lucuma.core.util.TimeSpan
 import lucuma.react.common.ReactFnProps
 import lucuma.schemas.model.SiderealTargetWithId
 import lucuma.ui.reusability.given
@@ -63,7 +64,7 @@ case class AsterismEditorBody(
   userId:            User.Id,
   obsIds:            ObsIdSet,
   obsAndTargets:     UndoSetter[ObservationsAndTargets],
-  vizTime:           View[Option[Instant]],
+  obsTime:           View[Option[Instant]],
   configuration:     ObsConfiguration,
   focusedTargetId:   Option[Target.Id],
   setTarget:         (Option[Target.Id], SetRouteVia) => Callback,
@@ -106,7 +107,7 @@ object AsterismEditorBody extends AsterismModifier:
       .useStateView(AladinFullScreen.Normal)
       .render { (props, obsEditInfo, fullScreen) =>
 
-        val vizTime = props.vizTime.get
+        val vizTime = props.obsTime.get
 
         val selectedTargetView: View[Option[Target.Id]] =
           View(
@@ -191,7 +192,9 @@ case class AsterismEditorTitle(
   obsAndTargets:    UndoSetter[ObservationsAndTargets],
   onAsterismUpdate: OnAsterismUpdateParams => Callback,
   readonly:         Boolean,
-  vizTimeView:      View[Option[Instant]],
+  obsTimeView:      View[Option[Instant]],
+  obsDurationView:  View[Option[TimeSpan]],
+  pendingTime:      Option[TimeSpan],
   tileState:        View[AsterismTileState]
 ) extends ReactFnProps(AsterismEditorTitle.component)
 
@@ -223,7 +226,7 @@ object AsterismEditorTitle extends AsterismModifier:
               ExploreStyles.AddTargetButton
             )
           ),
-          ObsTimeEditor(props.vizTimeView),
+          ObsTimeEditor(props.obsTimeView, props.obsDurationView, props.pendingTime),
           ColumnSelectorInTitle(TargetTable.columnNames,
                                 props.tileState.zoom(AsterismTileState.table)
           )

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorBody.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorBody.scala
@@ -226,7 +226,11 @@ object AsterismEditorTitle extends AsterismModifier:
               ExploreStyles.AddTargetButton
             )
           ),
-          ObsTimeEditor(props.obsTimeView, props.obsDurationView, props.pendingTime),
+          ObsTimeEditor(props.obsTimeView,
+                        props.obsDurationView,
+                        props.pendingTime,
+                        props.obsIds.size > 1
+          ),
           ColumnSelectorInTitle(TargetTable.columnNames,
                                 props.tileState.zoom(AsterismTileState.table)
           )

--- a/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -21,6 +21,7 @@ import lucuma.core.model.Group
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
 import lucuma.core.model.Target
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Enums.*
@@ -81,6 +82,25 @@ object ObsQueries:
 
     val editInput = ObservationTimesInput(observationTime =
       observationTime.flatMap(Timestamp.fromInstantTruncated).orUnassign
+    )
+
+    UpdateObservationTimesMutation[F]
+      .execute(
+        UpdateObservationsTimesInput(
+          WHERE = obsIds.toWhereObservation.assign,
+          SET = editInput
+        )
+      )
+      .void
+  }
+
+  def updateVisualizationDuration[F[_]: Async](
+    obsIds:              List[Observation.Id],
+    observationDuration: Option[TimeSpan]
+  )(using FetchClient[F, ObservationDB]): F[Unit] = {
+
+    val editInput = ObservationTimesInput(
+      observationDuration = observationDuration.map(_.toInput).orUnassign
     )
 
     UpdateObservationTimesMutation[F]

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
@@ -26,8 +26,10 @@ import lucuma.core.model.arb.ArbConstraintSet.given
 import lucuma.core.model.arb.ArbObservationValidation.given
 import lucuma.core.model.arb.ArbPosAngleConstraint.given
 import lucuma.core.model.arb.ArbTimingWindow.given
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.arb.ArbEnumerated.given
 import lucuma.core.util.arb.ArbGid.given
+import lucuma.core.util.arb.ArbTimeSpan.given
 import lucuma.schemas.model.ObservingMode
 import lucuma.schemas.model.arb.ArbObservingMode
 import org.scalacheck.Arbitrary
@@ -58,6 +60,7 @@ trait ArbObservation:
         scienceRequirements <- arbitrary[ScienceRequirements]
         observingMode       <- arbitrary[Option[ObservingMode]]
         vizTime             <- arbitrary[Option[Instant]]
+        vizDuration         <- arbitrary[Option[TimeSpan]]
         posAngleConstraint  <- arbitrary[PosAngleConstraint]
         wavelength          <- arbitrary[Option[Wavelength]]
         groupId             <- arbitrary[Option[Group.Id]]
@@ -78,6 +81,7 @@ trait ArbObservation:
         scienceRequirements,
         observingMode,
         vizTime,
+        vizDuration,
         posAngleConstraint,
         wavelength,
         groupId,
@@ -101,6 +105,7 @@ trait ArbObservation:
        ScienceRequirements,
        Option[ObservingMode],
        Option[Instant],
+       Option[TimeSpan],
        PosAngleConstraint,
        Option[Wavelength],
        Option[Group.Id],
@@ -122,6 +127,7 @@ trait ArbObservation:
          o.scienceRequirements,
          o.observingMode,
          o.observationTime,
+         o.observationDuration,
          o.posAngleConstraint,
          o.wavelength,
          o.groupId,

--- a/model/shared/src/main/scala/explore/model/ObsIdSet.scala
+++ b/model/shared/src/main/scala/explore/model/ObsIdSet.scala
@@ -24,6 +24,7 @@ case class ObsIdSet(idSet: NonEmptySet[Observation.Id]):
   def -(other: Observation.Id): Option[ObsIdSet]       =
     NonEmptySet.fromSet(idSet - other).map(ObsIdSet(_))
   def head: Observation.Id                             = idSet.head
+  def size: Long                                       = idSet.size
 
 object ObsIdSet {
   given Order[ObsIdSet] = Order.by(_.idSet)

--- a/model/shared/src/main/scala/explore/model/Observation.scala
+++ b/model/shared/src/main/scala/explore/model/Observation.scala
@@ -32,7 +32,9 @@ import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.sequence.gmos.GmosCcdMode
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
+import lucuma.odb.json.time.decoder.given
 import lucuma.odb.json.wavelength.decoder.given
 import lucuma.schemas.decoders.given
 import lucuma.schemas.model.BasicConfiguration
@@ -56,6 +58,7 @@ case class Observation(
   scienceRequirements: ScienceRequirements,
   observingMode:       Option[ObservingMode],
   observationTime:     Option[Instant],
+  observationDuration: Option[TimeSpan],
   posAngleConstraint:  PosAngleConstraint,
   wavelength:          Option[Wavelength],
   groupId:             Option[Group.Id],
@@ -190,6 +193,7 @@ object Observation:
   val scienceRequirements = Focus[Observation](_.scienceRequirements)
   val observingMode       = Focus[Observation](_.observingMode)
   val observationTime     = Focus[Observation](_.observationTime)
+  val observationDuration = Focus[Observation](_.observationDuration)
   val posAngleConstraint  = Focus[Observation](_.posAngleConstraint)
   val wavelength          = Focus[Observation](_.wavelength)
   val groupId             = Focus[Observation](_.groupId)
@@ -220,6 +224,7 @@ object Observation:
       scienceRequirements <- c.get[ScienceRequirements]("scienceRequirements")
       observingMode       <- c.get[Option[ObservingMode]]("observingMode")
       observationTime     <- c.get[Option[Timestamp]]("observationTime")
+      observationDur      <- c.get[Option[TimeSpan]]("observationDuration")
       posAngleConstraint  <- c.get[PosAngleConstraint]("posAngleConstraint")
       wavelength          <- c.downField("scienceRequirements")
                                .downField("spectroscopy")
@@ -242,6 +247,7 @@ object Observation:
       scienceRequirements,
       observingMode,
       observationTime.map(_.toInstant),
+      observationDur,
       posAngleConstraint,
       wavelength,
       groupId,


### PR DESCRIPTION
This adds a duration editor alongside the observation time editor in the asterism editor tile. I tweaked the CSS a bit to give all the control in that title bar some space (Add Button, time and duration editor, column selector). 
When observation duration has a value:
![image](https://github.com/user-attachments/assets/2865b90a-b8a7-461e-97a8-5d768ecbc5e1)
When it is empty:
![image](https://github.com/user-attachments/assets/3bfd87e2-4410-437c-bb31-ad1a4b926016)

We may need to play with the UI a bit. Because of the amount of space it takes up, I had to hide the duration editor when the tile width got down to medium...