### PR TITLE
Deglitch

### DIFF
--- a/common/src/main/scala/explore/model/RootModelViews.scala
+++ b/common/src/main/scala/explore/model/RootModelViews.scala
@@ -13,7 +13,6 @@ case class RootModelViews(
   rootModel:        View[RootModel],
   programSummaries: ThrottlingView[Option[ProgramSummaries]]
 ):
-  // export rootModel.*
   lazy val programSummariesValue: Option[ProgramSummaries] = programSummaries.throttlerView.get
 
 object RootModelViews:

--- a/common/src/main/scala/explore/model/RootModelViews.scala
+++ b/common/src/main/scala/explore/model/RootModelViews.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.syntax.all.*
+import crystal.react.ThrottlingView
+import crystal.react.View
+import monocle.Focus
+import monocle.Lens
+
+case class RootModelViews(
+  rootModel:        View[RootModel],
+  programSummaries: ThrottlingView[Option[ProgramSummaries]]
+):
+  // export rootModel.*
+  lazy val programSummariesValue: Option[ProgramSummaries] = programSummaries.throttlerView.get
+
+object RootModelViews:
+  val rootModel: Lens[RootModelViews, View[RootModel]]                                 =
+    Focus[RootModelViews](_.rootModel)
+  val programSummaries: Lens[RootModelViews, ThrottlingView[Option[ProgramSummaries]]] =
+    Focus[RootModelViews](_.programSummaries)

--- a/explore/src/main/scala/explore/Explore.scala
+++ b/explore/src/main/scala/explore/Explore.scala
@@ -65,7 +65,7 @@ object ExploreMain {
       .withCache(dom.RequestCache.`no-store`)
       .create
 
-  def initialModel(vault: Option[UserVault], pref: ExploreLocalPreferences) =
+  def initialModel(vault: Option[UserVault], pref: ExploreLocalPreferences): RootModel =
     RootModel(vault = vault, localPreferences = pref)
 
   def setupDOM[F[_]: Sync]: F[Element] = Sync[F].delay(

--- a/explore/src/main/scala/explore/config/ObsTimeEditor.scala
+++ b/explore/src/main/scala/explore/config/ObsTimeEditor.scala
@@ -44,7 +44,6 @@ object ObsTimeEditor {
       .useRef[Option[ReactDatePicker[Any, Any]]](none)
       .useMemoBy((props, _) => props.pendingTime)((_, _) => _.getOrElse(TimeSpan.fromHours(1).get))
       .render: (props, ref, defaultDuration) =>
-        println(s"Pending: ${props.pendingTime}")
         <.div(ExploreStyles.ObsInstantTileTitle)(
           React.Fragment(
             <.label(

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   val circeGolden            = "0.3.0"
   val coulomb                = "0.8.0"
   val clue                   = "0.40.0"
-  val crystal                = "0.42.1"
+  val crystal                = "0.43.0"
   val discipline             = "1.7.0"
   val disciplineMUnit        = "2.0.0"
   val fs2                    = "3.11.0"


### PR DESCRIPTION
`ProgramSummaries` has been removed from `RootModel` into another `View` which is wrapped in a `ThrottlingView`. Both are now in a new class `RootModelViews` which is the new root state of the app (instead of `View[RootModel]`).

Then the `throttledView` of the `ProgramSummaries` is passed to the `CacheController`, while the `throttlerView` is passed to the rest of the app.