### PR TITLE
Action buttons for target tab

### DIFF
--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -275,6 +275,10 @@ object Icons {
   val faClone: FAIcon = js.native
 
   @js.native
+  @JSImport("@fortawesome/pro-light-svg-icons", "faClipboard")
+  val faClipboard: FAIcon = js.native
+
+  @js.native
   @JSImport("@fortawesome/pro-regular-svg-icons", "faXmark")
   val faSquareXMark: FAIcon = js.native
 
@@ -409,6 +413,7 @@ object Icons {
     faExpandDiagonal,
     faContractDiagonal,
     faClone,
+    faClipboard,
     faSquareXMark,
     faSquareXMarkLarge,
     faBug,
@@ -493,6 +498,7 @@ object Icons {
   val ExpandDiagonal       = FontAwesomeIcon(faExpandDiagonal)
   val ContractDiagonal     = FontAwesomeIcon(faContractDiagonal)
   val Clone                = FontAwesomeIcon(faClone)
+  val Clipboard            = FontAwesomeIcon(faClipboard)
   val CheckDouble          = FontAwesomeIcon(faListCheck)
   val SquareXMark          = FontAwesomeIcon(faSquareXMark)
   val SquareXMarkLarge     = FontAwesomeIcon(faSquareXMarkLarge)

--- a/common/src/main/scala/explore/components/ActionButtons.scala
+++ b/common/src/main/scala/explore/components/ActionButtons.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import cats.syntax.option.*
+import explore.Icons
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.Css
+import lucuma.react.common.ReactFnProps
+import lucuma.react.primereact.Button
+import lucuma.ui.primereact.*
+import lucuma.ui.syntax.all.given
+
+case class ActionButtons(
+  copyProps:   ActionButtons.ButtonProps,
+  pasteProps:  ActionButtons.ButtonProps,
+  deleteProps: ActionButtons.ButtonProps
+) extends ReactFnProps(ActionButtons.component)
+
+object ActionButtons:
+  private type Props = ActionButtons
+
+  case class ButtonProps(
+    callback:     Callback,
+    disabled:     Boolean = false,
+    tooltipExtra: Option[String] = none
+  ):
+    val tooltipExtraStr: String = tooltipExtra.map(" " + _).orEmpty
+
+  private val component =
+    ScalaFnComponent[Props]: props =>
+      <.span(Css("p-button-group"))(
+        Button(
+          icon = Icons.Clone.withFixedWidth(),
+          onClick = props.copyProps.callback,
+          tooltip = "Copy" + props.copyProps.tooltipExtraStr,
+          tooltipOptions = ToolbarTooltipOptions.Default,
+          disabled = props.copyProps.disabled,
+          severity = Button.Severity.Secondary
+        ).compact.mini,
+        Button(
+          icon = Icons.Clipboard.withFixedWidth(),
+          onClick = props.pasteProps.callback,
+          tooltip = "Paste" + props.pasteProps.tooltipExtraStr,
+          tooltipOptions = ToolbarTooltipOptions.Default,
+          disabled = props.pasteProps.disabled,
+          severity = Button.Severity.Secondary,
+          clazz = PlSize.Mini.cls
+        ).compact.mini,
+        Button(
+          icon = Icons.Trash.withFixedWidth(),
+          onClick = props.deleteProps.callback,
+          tooltip = "Delete" + props.deleteProps.tooltipExtraStr,
+          tooltipOptions = ToolbarTooltipOptions.Default,
+          disabled = props.deleteProps.disabled,
+          severity = Button.Severity.Secondary
+        ).compact.mini
+      )

--- a/common/src/main/scala/explore/components/package.scala
+++ b/common/src/main/scala/explore/components/package.scala
@@ -1,0 +1,15 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import lucuma.react.primereact.Tooltip
+import lucuma.react.primereact.TooltipOptions
+
+object ToolbarTooltipOptions:
+  val Default =
+    TooltipOptions(
+      showOnDisabled = true,
+      position = Tooltip.Position.Top,
+      showDelay = 200
+    )

--- a/common/src/main/scala/explore/components/undo/UndoButtons.scala
+++ b/common/src/main/scala/explore/components/undo/UndoButtons.scala
@@ -4,6 +4,7 @@
 package explore.components.undo
 
 import explore.Icons
+import explore.components.ToolbarTooltipOptions
 import explore.components.ui.ExploreStyles
 import explore.undo.Undoer
 import japgolly.scalajs.react.*
@@ -25,30 +26,28 @@ object UndoButtons:
 
   private val component =
     ScalaFnComponent[Props](props =>
-      <.div(
-        ExploreStyles.ButtonsUndo,
-        <.span(
-          Css("p-button-group"),
-          Button(
-            severity = Button.Severity.Secondary,
-            outlined = true,
-            onClick = props.undoer.undo,
-            disabled = props.undoer.isUndoEmpty || props.disabled || props.undoer.working,
-            loading = props.undoer.working,
-            clazz = props.size.cls,
-            icon = Icons.Undo,
-            label = "Undo"
-          ).compact,
-          Button(
-            severity = Button.Severity.Secondary,
-            outlined = true,
-            onClick = props.undoer.redo,
-            disabled = props.undoer.isRedoEmpty || props.disabled || props.undoer.working,
-            loading = props.undoer.working,
-            clazz = props.size.cls,
-            icon = Icons.Redo,
-            label = "Redo"
-          ).compact
-        )
+      <.span(ExploreStyles.ButtonsUndo, Css("p-button-group"))(
+        Button(
+          severity = Button.Severity.Secondary,
+          outlined = true,
+          onClick = props.undoer.undo,
+          disabled = props.undoer.isUndoEmpty || props.disabled || props.undoer.working,
+          loading = props.undoer.working,
+          clazz = props.size.cls,
+          icon = Icons.Undo,
+          tooltip = "Undo",
+          tooltipOptions = ToolbarTooltipOptions.Default
+        ).compact,
+        Button(
+          severity = Button.Severity.Secondary,
+          outlined = true,
+          onClick = props.undoer.redo,
+          disabled = props.undoer.isRedoEmpty || props.disabled || props.undoer.working,
+          loading = props.undoer.working,
+          clazz = props.size.cls,
+          icon = Icons.Redo,
+          tooltip = "Redo",
+          tooltipOptions = ToolbarTooltipOptions.Default
+        ).compact
       )
     )

--- a/common/src/main/scala/explore/model/LocalClipboard.scala
+++ b/common/src/main/scala/explore/model/LocalClipboard.scala
@@ -3,9 +3,7 @@
 
 package explore.model
 
-sealed trait LocalClipboard
-
-object LocalClipboard:
-  case object Empty                             extends LocalClipboard
-  case class CopiedObservations(oids: ObsIdSet) extends LocalClipboard
-  case class CopiedTargets(tids: TargetIdSet)   extends LocalClipboard
+enum LocalClipboard(val isEmpty: Boolean, val isObservations: Boolean, val isTargets: Boolean):
+  case Empty                              extends LocalClipboard(true, false, false)
+  case CopiedObservations(oids: ObsIdSet) extends LocalClipboard(false, true, false)
+  case CopiedTargets(tids: TargetIdSet)   extends LocalClipboard(false, false, true)

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -667,9 +667,7 @@ thead tr th.sticky-header {
 // Undo
 // -------
 .explore-buttons-undo {
-  margin-left: auto;
-
-  .p-button-group .p-component.p-button {
+  .p-component.p-button {
     color: var(--site-text-color);
   }
 }
@@ -3327,4 +3325,30 @@ a.explore-upgrade-link {
 
 .explore-hidden {
   visibility: hidden;
+}
+
+// Correctly set styles in input and button groups when they are wrapped in a tooltip-target-wrapper.
+.p-inputgroup, .p-button-group {
+  .p-tooltip-target-wrapper:first-child, .p-inputgroup-addon:first-child .p-tooltip-target-wrapper {
+    button, input {
+      border-top-left-radius: 4px;
+      border-bottom-left-radius: 4px;
+    }
+  }
+}
+
+.p-inputgroup, .p-button-group {
+  .p-tooltip-target-wrapper .p-component {
+    border-radius: 0;
+    margin: 0;
+  }
+}
+
+.p-inputgroup, .p-button-group {
+  .p-tooltip-target-wrapper:last-child, .p-inputgroup-addon:last-child .p-tooltip-target-wrapper {
+    button, input {
+      border-top-right-radius: 4px;
+      border-bottom-right-radius: 4px;
+    }
+  }
 }

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -3328,25 +3328,32 @@ a.explore-upgrade-link {
 }
 
 // Correctly set styles in input and button groups when they are wrapped in a tooltip-target-wrapper.
-.p-inputgroup, .p-button-group {
-  .p-tooltip-target-wrapper:first-child, .p-inputgroup-addon:first-child .p-tooltip-target-wrapper {
-    button, input {
+.p-inputgroup,
+.p-button-group {
+  .p-tooltip-target-wrapper:first-child,
+  .p-inputgroup-addon:first-child .p-tooltip-target-wrapper {
+    button,
+    input {
       border-top-left-radius: 4px;
       border-bottom-left-radius: 4px;
     }
   }
 }
 
-.p-inputgroup, .p-button-group {
+.p-inputgroup,
+.p-button-group {
   .p-tooltip-target-wrapper .p-component {
     border-radius: 0;
     margin: 0;
   }
 }
 
-.p-inputgroup, .p-button-group {
-  .p-tooltip-target-wrapper:last-child, .p-inputgroup-addon:last-child .p-tooltip-target-wrapper {
-    button, input {
+.p-inputgroup,
+.p-button-group {
+  .p-tooltip-target-wrapper:last-child,
+  .p-inputgroup-addon:last-child .p-tooltip-target-wrapper {
+    button,
+    input {
       border-top-right-radius: 4px;
       border-bottom-right-radius: 4px;
     }

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -3338,18 +3338,12 @@ a.explore-upgrade-link {
       border-bottom-left-radius: 4px;
     }
   }
-}
 
-.p-inputgroup,
-.p-button-group {
   .p-tooltip-target-wrapper .p-component {
     border-radius: 0;
     margin: 0;
   }
-}
 
-.p-inputgroup,
-.p-button-group {
   .p-tooltip-target-wrapper:last-child,
   .p-inputgroup-addon:last-child .p-tooltip-target-wrapper {
     button,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -85,437 +85,6 @@ case class TargetTabContents(
 object TargetTabContents extends TwoPanels:
   private type Props = TargetTabContents
 
-  private def renderFn(
-    props:             Props,
-    ctx:               AppContext[IO],
-    selectedView:      View[SelectedPanel],
-    selectedTargetIds: View[List[Target.Id]],
-    fullScreen:        View[AladinFullScreen],
-    resize:            UseResizeDetectorReturn
-  ): VdomNode = {
-    import ctx.given
-
-    def getObsInfo(editing: Option[ObsIdSet])(targetId: Target.Id): TargetEditObsInfo =
-      TargetEditObsInfo.fromProgramSummaries(targetId, editing, props.programSummaries.get)
-
-    def targetTree(programSummaries: UndoContext[ProgramSummaries]) =
-      AsterismGroupObsList(
-        props.programId,
-        props.focused,
-        props.expandedIds,
-        programSummaries,
-        selectTargetOrSummary,
-        selectedTargetIds,
-        props.readonly
-      )
-
-    def findAsterismGroup(obsIds: ObsIdSet, agl: AsterismGroupList): Option[AsterismGroup] =
-      agl.find((agObsIds, _) => obsIds.subsetOf(agObsIds)).map(AsterismGroup.fromTuple)
-
-    def setPage(focused: Focused): Callback =
-      ctx.pushPage(AppTab.Targets, props.programId, focused)
-
-    def selectObservationAndTarget(expandedIds: View[SortedSet[ObsIdSet]])(
-      obsId:    Observation.Id,
-      targetId: Target.Id
-    ): Callback = {
-      val obsIdSet = ObsIdSet.one(obsId)
-      findAsterismGroup(obsIdSet, props.programSummaries.get.asterismGroups)
-        .map(ag => expandedIds.mod(_ + ag.obsIds))
-        .orEmpty >>
-        setPage(Focused(obsIdSet.some, targetId.some))
-    }
-
-    def selectTargetOrSummary(oTargetId: Option[Target.Id]): Callback =
-      oTargetId.fold(
-        selectedView.set(SelectedPanel.Summary) *>
-          setPage(Focused.None)
-      )(targetId => setPage(Focused.target(targetId)))
-
-    val backButton: VdomNode =
-      makeBackButton(props.programId, AppTab.Targets, selectedView, ctx)
-
-    /**
-     * Render the summary table.
-     */
-    val renderSummary: Tile[TargetSummaryTileState] = Tile(
-      ObsTabTilesIds.TargetSummaryId.id,
-      "Target Summary",
-      TargetSummaryTileState(Nil, ColumnSelectorState(), DeletingTargets(false)),
-      backButton.some
-    )(
-      TargetSummaryBody(
-        props.userId,
-        props.programId,
-        props.targets.model,
-        props.programSummaries.get.targetObservations,
-        props.programSummaries.get.calibrationObservations,
-        selectObservationAndTarget(props.expandedIds),
-        selectTargetOrSummary,
-        selectedTargetIds,
-        props.programSummaries,
-        props.readonly,
-        _
-      ),
-      (s, _) =>
-        TargetSummaryTitle(props.programId,
-                           props.targets.model,
-                           selectTargetOrSummary,
-                           selectedTargetIds,
-                           props.programSummaries,
-                           props.readonly,
-                           s
-        )
-    )
-
-    /**
-     * Render the asterism editor
-     *
-     * @param idsToEdit
-     *   The observations to include in the edit. This needs to be asubset of the ids in
-     *   asterismGroup
-     * @param asterismGroup
-     *   The AsterismGroup that is the basis for editing. All or part of it may be included in the
-     *   edit.
-     */
-    def renderAsterismEditor(
-      resize:        UseResizeDetectorReturn,
-      idsToEdit:     ObsIdSet,
-      asterismGroup: AsterismGroup
-    ): List[Tile[?]] = {
-      val getObsTime: ProgramSummaries => Option[Instant] = a =>
-        for
-          id <- idsToEdit.single
-          o  <- a.observations.getValue(id)
-          t  <- o.observationTime
-        yield t
-
-      def modObsTime(
-        mod: Option[Instant] => Option[Instant]
-      ): ProgramSummaries => ProgramSummaries = ps =>
-        idsToEdit.single
-          .map(i =>
-            ProgramSummaries.observations
-              .filterIndex((id: Observation.Id) => id === i)
-              .andThen(KeyedIndexedList.value)
-              .andThen(Observation.observationTime)
-              .modify(mod)(ps)
-          )
-          .getOrElse(ps)
-
-      val obsTimeView: View[Option[Instant]] =
-        props.programSummaries.model.zoom(getObsTime)(modObsTime)
-
-      val getObsDuration: ProgramSummaries => Option[TimeSpan] = a =>
-        for
-          id <- idsToEdit.single
-          o  <- a.observations.getValue(id)
-          t  <- o.observationDuration
-        yield t
-
-      def modObsDuration(
-        mod: Option[TimeSpan] => Option[TimeSpan]
-      ): ProgramSummaries => ProgramSummaries = ps =>
-        idsToEdit.single
-          .map(i =>
-            ProgramSummaries.observations
-              .filterIndex((id: Observation.Id) => id === i)
-              .andThen(KeyedIndexedList.value)
-              .andThen(Observation.observationDuration)
-              .modify(mod)(ps)
-          )
-          .getOrElse(ps)
-
-      val obsDurationView: View[Option[TimeSpan]] =
-        props.programSummaries.model.zoom(getObsDuration)(modObsDuration)
-
-      val title = idsToEdit.single match {
-        case Some(id) => s"Observation $id"
-        case None     => s"Editing ${idsToEdit.size} Asterisms"
-      }
-
-      val obsConf = idsToEdit.single match {
-        case Some(id) =>
-          props.programSummaries.get.observations.values.collect {
-            case Observation(
-                  obsId,
-                  _,
-                  _,
-                  _,
-                  _,
-                  _,
-                  const,
-                  _,
-                  _,
-                  _,
-                  Some(conf),
-                  _,
-                  _,
-                  posAngle,
-                  Some(wavelength),
-                  _,
-                  _,
-                  _,
-                  _,
-                  _
-                ) if obsId === id =>
-              (const, conf.toBasicConfiguration, posAngle, wavelength)
-          }.headOption
-        case _        => None
-      }
-
-      val constraints                               = obsConf.map(_._1)
-      val configuration: Option[BasicConfiguration] = obsConf.map(_._2)
-      val wavelength                                = obsConf.map(_._4)
-
-      def setCurrentTarget(oids: Option[ObsIdSet])(
-        tid: Option[Target.Id],
-        via: SetRouteVia
-      ): Callback =
-        ctx.setPageVia(AppTab.Targets, props.programId, Focused(oids, tid), via)
-
-      def onCloneTarget4Asterism(params: OnCloneParameters): Callback =
-        // props.programSummaries.get will always contain the original groups. On creating,
-        val allOriginalGroups = props.programSummaries.get.asterismGroups
-          .filterForObsInSet(params.obsIds)
-          .map(_._1)
-          .toSet
-        selectedTargetIds.set(List(params.idToAdd)) >>
-          (if (params.areCreating) {
-             val obsIds4Url =
-               ObsIdSet.fromSortedSet(idsToEdit.idSet.intersect(params.obsIds.idSet))
-               // all of the original groups that have any of the cloned ids
-               // Deal with the expanded groups - we'll open all affected groups
-             allOriginalGroups.toList.traverse { ids =>
-               val intersect = ids.idSet.intersect(params.obsIds.idSet)
-               if (intersect === ids.idSet.toSortedSet)
-                 props.expandedIds.mod(_ + ids) // it is the whole group, so make sure it is open
-               else
-                 // otherwise, close the original and open the subsets
-                 ObsIdSet
-                   .fromSortedSet(intersect)
-                   .foldMap(i =>
-                     Callback.log(s"Setting expanded ids for $ids subset $i") >>
-                       props.expandedIds.mod(_ - ids + i + ids.removeUnsafe(i))
-                   )
-             }.void >>
-               setCurrentTarget(obsIds4Url)(params.cloneId.some, SetRouteVia.HistoryReplace)
-           } else {
-             // We'll open all of the original groups who had any observations affected by the cloning.
-             props.expandedIds.mod(_ ++ SortedSet.from(allOriginalGroups)) >>
-               setCurrentTarget(idsToEdit.some)(params.originalId.some, SetRouteVia.HistoryReplace)
-           })
-
-      def onAsterismUpdate(params: OnAsterismUpdateParams): Callback =
-        val originalGroups = props.programSummaries.get.asterismGroups
-        // props.programSummaries.get will always contain the original groups, so we should find the group
-        originalGroups
-          .findContainingObsIds(params.obsIds)
-          .foldMap(group =>
-            val newAsterism                      =
-              if (params.isAddAction) group.targetIds + params.targetId
-              else group.targetIds - params.targetId
-            val existingGroup                    = originalGroups.findWithTargetIds(newAsterism)
-            val mergedObs                        = existingGroup.map(_.obsIds ++ params.obsIds)
-            val obsIdsAfterAction                = mergedObs.getOrElse(params.obsIds)
-            val unmodified                       = group.obsIds -- params.obsIds
-            val setExpanded                      = unmodified.fold {
-              if (params.isUndo) props.expandedIds.mod(_ - obsIdsAfterAction + group.obsIds)
-              else props.expandedIds.mod(_ - group.obsIds + obsIdsAfterAction)
-            }(unmod =>
-              if (params.isUndo) props.expandedIds.mod(_ - obsIdsAfterAction - unmod + group.obsIds)
-              else props.expandedIds.mod(_ - group.obsIds + obsIdsAfterAction + unmod)
-            )
-            val targetForPage: Option[Target.Id] =
-              if (params.areAddingTarget) params.targetId.some
-              else none // if we're deleting, let UI focus the first one in the asterism
-            val setPage =
-              if (params.isUndo)
-                setCurrentTarget(idsToEdit.some)(targetForPage, SetRouteVia.HistoryReplace)
-              else setCurrentTarget(params.obsIds.some)(targetForPage, SetRouteVia.HistoryReplace)
-            setExpanded >> setPage
-          )
-
-      val asterismEditorTile =
-        AsterismEditorTile.asterismEditorTile(
-          props.userId,
-          props.programId,
-          idsToEdit,
-          props.obsAndTargets,
-          configuration,
-          obsTimeView,
-          obsDurationView,
-          ObsConfiguration(configuration, none, constraints, wavelength, none, none, none, none),
-          none,
-          props.focused.target,
-          setCurrentTarget(idsToEdit.some),
-          onCloneTarget4Asterism,
-          onAsterismUpdate,
-          getObsInfo(idsToEdit.some),
-          props.searching,
-          title,
-          props.globalPreferences,
-          props.readonly,
-          backButton = backButton.some
-        )
-
-      val selectedCoordinates: Option[Coordinates] =
-        props.focused.target.flatMap: id =>
-          props.targets.get
-            .get(id)
-            .flatMap:
-              case t @ Target.Sidereal(_, _, _, _) =>
-                obsTimeView.get.flatMap(ot => Target.Sidereal.tracking.get(t).at(ot))
-              case _                               => none
-
-      val skyPlotTile =
-        ElevationPlotTile.elevationPlotTile(
-          props.userId,
-          props.focused.target,
-          configuration.map(_.siteFor),
-          selectedCoordinates.map(CoordinatesAtVizTime(_)),
-          obsTimeView.get,
-          none,
-          Nil,
-          props.globalPreferences.get
-        )
-
-      List(asterismEditorTile, skyPlotTile)
-    }
-
-    /**
-     * Renders a single sidereal target editor without an obs context
-     */
-    def renderSiderealTargetEditor(
-      resize:   UseResizeDetectorReturn,
-      targetId: Target.Id
-    ): List[Tile[?]] = {
-
-      def onCloneTarget4Target(params: OnCloneParameters): Callback =
-        // It's not perfect, but we'll go to whatever url has the "new" id. This means
-        // that if the user went elsewhere before doing undo/redo, they will go back to the new target.
-        selectedTargetIds.set(List(params.idToAdd)) >>
-          ctx.replacePage(AppTab.Targets, props.programId, Focused.target(params.idToAdd))
-
-      val targetTiles: List[Tile[?]] =
-        props.targets
-          .zoom(Iso.id[TargetList].index(targetId).andThen(Target.sidereal))
-          .map { target =>
-            val targetTile = SiderealTargetEditorTile.noObsSiderealTargetEditorTile(
-              props.programId,
-              props.userId,
-              targetId,
-              target,
-              props.obsAndTargets,
-              props.searching,
-              s"Editing Target ${target.get.name.value} [$targetId]",
-              fullScreen,
-              props.globalPreferences,
-              props.readonly,
-              getObsInfo(none)(targetId),
-              onCloneTarget4Target
-            )
-
-            val skyPlotTile =
-              ElevationPlotTile.elevationPlotTile(
-                props.userId,
-                targetId.some,
-                none,
-                CoordinatesAtVizTime(Target.Sidereal.baseCoordinates.get(target.get)).some,
-                none,
-                none,
-                Nil,
-                props.globalPreferences.get
-              )
-
-            List(targetTile, skyPlotTile)
-          }
-          .orEmpty
-
-      renderSummary +: targetTiles
-    }
-
-    val optSelected: Option[Either[Target.Id, ObsIdSet]] = props.focused match
-      case Focused(Some(obsIdSet), _, _)    => obsIdSet.asRight.some
-      case Focused(None, Some(targetId), _) => targetId.asLeft.some
-      case _                                => none
-
-    // We still want to render these 2 tiles, even when not shown, so as not to mess up the stored layout.
-    val dummyTargetTile: Tile[Unit]    =
-      Tile(ObsTabTilesIds.TargetId.id, "", hidden = true)(_ => EmptyVdom)
-    val dummyElevationTile: Tile[Unit] =
-      Tile(ObsTabTilesIds.PlotId.id, "", hidden = true)(_ => EmptyVdom)
-
-    val renderNonSiderealTargetEditor: List[Tile[?]] =
-      List(
-        renderSummary,
-        Tile("nonSiderealTarget".refined, "Non-sidereal target")(_ =>
-          <.div("Editing of Non-Sidereal targets not supported")
-        ),
-        dummyElevationTile
-      )
-
-    val rightSide = { (resize: UseResizeDetectorReturn) =>
-      val tileListKeyOpt: Option[(List[Tile[?]], NonEmptyString)] =
-        optSelected
-          .flatMap:
-            _ match
-              case Left(targetId) =>
-                props.targets.get
-                  .get(targetId)
-                  .map:
-                    case Nonsidereal(_, _, _) =>
-                      (renderNonSiderealTargetEditor, TargetTabControllerIds.Summary.id)
-                    case Sidereal(_, _, _, _) =>
-                      (renderSiderealTargetEditor(resize, targetId),
-                       TargetTabControllerIds.Summary.id
-                      )
-              case Right(obsIds)  =>
-                findAsterismGroup(obsIds, props.programSummaries.get.asterismGroups)
-                  .map: asterismGroup =>
-                    (renderAsterismEditor(resize, obsIds, asterismGroup),
-                     TargetTabControllerIds.AsterismEditor.id
-                    )
-
-      val justSummaryTiles = List(
-        renderSummary,
-        dummyTargetTile,
-        dummyElevationTile
-      )
-
-      val (tiles, key) =
-        tileListKeyOpt.fold(
-          (justSummaryTiles, TargetTabControllerIds.Summary.id)
-        )((tiles, key) => (tiles, key))
-
-      TileController(
-        props.userId,
-        resize.width.getOrElse(1),
-        ExploreGridLayouts.targets.defaultTargetLayouts,
-        props.userPreferences.get.targetTabLayout,
-        tiles,
-        GridLayoutSection.TargetLayout,
-        backButton.some,
-        Option.when(tileListKeyOpt.isEmpty)(ExploreStyles.SingleTileMaximized),
-        storeLayout = tileListKeyOpt.nonEmpty
-      ).withKey(key.value): VdomNode
-      // withKey is required for the controller to clear it's state between the different
-      // layouts or it can get into an invalid state.
-    }
-
-    React.Fragment(
-      if (LinkingInfo.developmentMode) FocusedStatus(AppTab.Targets, props.programId, props.focused)
-      else EmptyVdom,
-      makeOneOrTwoPanels(
-        selectedView,
-        targetTree(props.programSummaries),
-        rightSide,
-        RightSideCardinality.Multi,
-        resize
-      )
-    )
-  }
-
   private def applyObs(
     obsIds:           List[(Observation.Id, List[Target.Id])],
     programSummaries: UndoSetter[ProgramSummaries],
@@ -558,98 +127,566 @@ object TargetTabContents extends TwoPanels:
           case _                                              => Callback.empty
       }
       .useStateViewBy((props, _, _) => props.focused.target.toList)
-      .useLayoutEffectWithDepsBy((props, _, _, _) => props.focused.target)((_, _, _, selIds) =>
-        _.foldMap(focusedTarget => selIds.set(List(focusedTarget)))
-      )
-      .useGlobalHotkeysWithDepsBy((props, ctx, _, selIds) =>
-        (props.focused, props.programSummaries.get.asterismGroups, props.readonly, selIds.get)
-      ) { (props, ctx, _, _) => (target, asterismGroups, readonly, selectedIds) =>
-        import ctx.given
-
-        def selectObsIds: ObsIdSet => IO[Unit] =
-          obsIds => ctx.pushPage(AppTab.Targets, props.programId, Focused.obsSet(obsIds)).toAsync
-
-        def callbacks: ShortcutCallbacks = {
-          case CopyAlt1 | CopyAlt2 =>
+      .useLayoutEffectWithDepsBy((props, _, _, _) => props.focused.target):
+        (_, _, _, selTargetIds) => _.foldMap(focusedTarget => selTargetIds.set(List(focusedTarget)))
+      .useMemoBy((props, _, _, selTargetIds) => (props.focused, selTargetIds.get)): // Selected observations (right) or targets (left)
+        (_, _, _, _) =>
+          (target, selTargetIds) =>
             target.obsSet
-              .map(ids =>
-                ExploreClipboard
-                  .set(LocalClipboard.CopiedObservations(ids))
-                  .withToast(s"Copied obs ${ids.idSet.toList.mkString(", ")}")
-              )
-              .orElse(
-                TargetIdSet
-                  .fromTargetIdList(selectedIds)
-                  .map(tids =>
-                    ExploreClipboard
-                      .set(LocalClipboard.CopiedTargets(tids))
-                      .withToast(s"Copied targets ${tids.toList.mkString(", ")}")
-                  )
-              )
-              .orUnit
-              .runAsync
+              .map(_.asRight)
+              .orElse:
+                TargetIdSet.fromTargetIdList(selTargetIds).map(_.asLeft)
+      .useState[LocalClipboard](LocalClipboard.Empty) // shadowClipboard (a copy as state)
+      .useEffectOnMountBy: (_, ctx, _, _, _, shadowClipboard) => // initialize shadowClipboard
+        import ctx.given
+        ExploreClipboard.get.flatMap(shadowClipboard.setStateAsync)
+      .useCallbackWithDepsBy((_, _, _, _, selIdsOpt, _) => selIdsOpt): // COPY Action Callback
+        (_, ctx, _, _, _, shadowClipboard) =>
+          selIdsOpt =>
+            import ctx.given
 
-          case PasteAlt1 | PasteAlt2 =>
-            ExploreClipboard.get
-              .flatMap {
-                case LocalClipboard.CopiedObservations(id) =>
-                  val obsAndTargets =
-                    props.focused.obsSet
-                      // This with some targets on the tree seelected
-                      .map(i => id.idSet.toList.map((_, asterismGroups.get(i).foldMap(_.toList))))
-                      // These are targets on the table
-                      .getOrElse {
-                        for {
-                          tid <- selectedIds
-                          oid <- id.idSet.toList
-                        } yield (oid, List(tid))
-                      }
-
-                  if (obsAndTargets.nonEmpty)
-                    // Apply the obs to selected targets on the tree
-                    applyObs(
-                      obsAndTargets,
-                      props.programSummaries,
-                      ctx,
-                      props.expandedIds
-                    ).withToast(s"Pasting obs ${id.idSet.toList.mkString(", ")}")
-                  else IO.unit
-
-                case LocalClipboard.CopiedTargets(tids) =>
-                  props.focused.obsSet
-                    .foldMap(obsIds =>
-                      // Only want to paste targets that aren't already in the target asterism or
-                      // undo is messed up.
-                      // If all the targets are already there, do nothing.
-                      val targetAsterism =
-                        props.programSummaries.get.asterismGroups.findContainingObsIds(obsIds)
-                      targetAsterism
-                        .flatMap(ag => tids.removeSet(ag.targetIds))
-                        .foldMap(uniqueTids =>
-                          TargetPasteAction
-                            .pasteTargets(
-                              obsIds,
-                              uniqueTids,
-                              selectObsIds,
-                              props.expandedIds
-                            )
-                            .set(props.programSummaries)(())
-                            .toAsync
-                        )
+            selIdsOpt.value
+              .map:
+                _.fold[(LocalClipboard, String)](
+                  tids =>
+                    (LocalClipboard.CopiedTargets(tids),
+                     s"Copied target(s) ${tids.toList.mkString(", ")}"
+                    ),
+                  oids =>
+                    (LocalClipboard.CopiedObservations(oids),
+                     s"Copied observation(s) ${oids.idSet.toList.mkString(", ")}"
                     )
-
-                case _ => IO.unit
-              }
+                )
+              .map: (newClipboard, toastText) =>
+                (ExploreClipboard.set(newClipboard) >>
+                  shadowClipboard.setStateAsync(newClipboard))
+                  .withToast(toastText)
+              .orEmpty
               .runAsync
-              .unless_(readonly)
+      .useCallbackWithDepsBy((props, _, _, selTargetIds, _, _, _) => // PASTE Action Callback
+        (props.programSummaries.get.asterismGroups, props.readonly, selTargetIds.get)
+      ): (props, ctx, _, _, _, _, _) =>
+        (asterismGroups, readonly, selTargetIds) =>
+          import ctx.given
 
-          case GoToSummary =>
-            ctx.pushPage(AppTab.Targets, props.programId, Focused.None)
-        }
+          val selectObsIds: ObsIdSet => IO[Unit] =
+            obsIds => ctx.pushPage(AppTab.Targets, props.programId, Focused.obsSet(obsIds)).toAsync
+
+          ExploreClipboard.get
+            .flatMap {
+              case LocalClipboard.CopiedObservations(id) =>
+                val obsAndTargets =
+                  props.focused.obsSet
+                    // This with some targets on the tree selected
+                    .map(i => id.idSet.toList.map((_, asterismGroups.get(i).foldMap(_.toList))))
+                    // These are targets on the table
+                    .getOrElse {
+                      for
+                        tid <- selTargetIds
+                        oid <- id.idSet.toList
+                      yield (oid, List(tid))
+                    }
+
+                if (obsAndTargets.nonEmpty)
+                  // Apply the obs to selected targets on the tree
+                  applyObs(
+                    obsAndTargets,
+                    props.programSummaries,
+                    ctx,
+                    props.expandedIds
+                  ).withToast(s"Pasting obs ${id.idSet.toList.mkString(", ")}")
+                else IO.unit
+
+              case LocalClipboard.CopiedTargets(tids) =>
+                props.focused.obsSet
+                  .foldMap(obsIds =>
+                    // Only want to paste targets that aren't already in the target asterism or
+                    // undo is messed up.
+                    // If all the targets are already there, do nothing.
+                    val targetAsterism =
+                      props.programSummaries.get.asterismGroups.findContainingObsIds(obsIds)
+                    targetAsterism
+                      .flatMap(ag => tids.removeSet(ag.targetIds))
+                      .foldMap(uniqueTids =>
+                        TargetPasteAction
+                          .pasteTargets(
+                            obsIds,
+                            uniqueTids,
+                            selectObsIds,
+                            props.expandedIds
+                          )
+                          .set(props.programSummaries)(())
+                          .toAsync
+                      )
+                  )
+
+              case _ => IO.unit
+            }
+            .runAsync
+            .unless_(readonly)
+      .useGlobalHotkeysWithDepsBy((_, _, _, _, _, _, copyCallback, pasteCallback) =>
+        (copyCallback, pasteCallback)
+      ) { (props, ctx, _, _, _, _, _, _) => (copyCallback, pasteCallback) =>
+        val callbacks: ShortcutCallbacks =
+          case CopyAlt1 | CopyAlt2   => copyCallback
+          case PasteAlt1 | PasteAlt2 => pasteCallback
+          case GoToSummary           => ctx.pushPage(AppTab.Targets, props.programId, Focused.None)
+
         UseHotkeysProps((GoToSummary :: (CopyKeys ::: PasteKeys)).toHotKeys, callbacks)
       }
-      // full screen aladin
-      .useStateView(AladinFullScreen.Normal)
-      // Measure its size
-      .useResizeDetector()
-      .render(renderFn)
+      .useStateView(AladinFullScreen.Normal) // full screen aladin
+      .useResizeDetector() // Measure its size
+      .render:
+        (
+          props,
+          ctx,
+          selectedView,
+          selectedTargetIds,
+          selectedIdsOpt,
+          shadowClipboard,
+          copyCallback,
+          pasteCallback,
+          fullScreen,
+          resize
+        ) =>
+          import ctx.given
+
+          def getObsInfo(editing: Option[ObsIdSet])(targetId: Target.Id): TargetEditObsInfo =
+            TargetEditObsInfo.fromProgramSummaries(targetId, editing, props.programSummaries.get)
+
+          def targetTree(programSummaries: UndoContext[ProgramSummaries]) =
+            AsterismGroupObsList(
+              props.programId,
+              props.focused,
+              props.expandedIds,
+              programSummaries,
+              selectedIdsOpt,
+              shadowClipboard.value,
+              selectTargetOrSummary,
+              selectedTargetIds.set,
+              copyCallback,
+              pasteCallback,
+              props.readonly
+            )
+
+          def findAsterismGroup(obsIds: ObsIdSet, agl: AsterismGroupList): Option[AsterismGroup] =
+            agl.find((agObsIds, _) => obsIds.subsetOf(agObsIds)).map(AsterismGroup.fromTuple)
+
+          def setPage(focused: Focused): Callback =
+            ctx.pushPage(AppTab.Targets, props.programId, focused)
+
+          def selectObservationAndTarget(expandedIds: View[SortedSet[ObsIdSet]])(
+            obsId:    Observation.Id,
+            targetId: Target.Id
+          ): Callback =
+            val obsIdSet = ObsIdSet.one(obsId)
+            findAsterismGroup(obsIdSet, props.programSummaries.get.asterismGroups)
+              .map(ag => expandedIds.mod(_ + ag.obsIds))
+              .orEmpty >>
+              setPage(Focused(obsIdSet.some, targetId.some))
+
+          def selectTargetOrSummary(oTargetId: Option[Target.Id]): Callback =
+            oTargetId.fold(
+              selectedView.set(SelectedPanel.Summary) *>
+                setPage(Focused.None)
+            ): targetId =>
+              setPage(Focused.target(targetId))
+
+          val backButton: VdomNode =
+            makeBackButton(props.programId, AppTab.Targets, selectedView, ctx)
+
+          /**
+           * Render the summary table.
+           */
+          val renderSummary: Tile[TargetSummaryTileState] = Tile(
+            ObsTabTilesIds.TargetSummaryId.id,
+            "Target Summary",
+            TargetSummaryTileState(Nil, ColumnSelectorState(), DeletingTargets(false)),
+            backButton.some
+          )(
+            TargetSummaryBody(
+              props.userId,
+              props.programId,
+              props.targets.model,
+              props.programSummaries.get.targetObservations,
+              props.programSummaries.get.calibrationObservations,
+              selectObservationAndTarget(props.expandedIds),
+              selectTargetOrSummary,
+              selectedTargetIds,
+              props.programSummaries,
+              props.readonly,
+              _
+            ),
+            (s, _) =>
+              TargetSummaryTitle(
+                props.programId,
+                props.targets.model,
+                selectTargetOrSummary,
+                selectedTargetIds,
+                props.programSummaries,
+                props.readonly,
+                s
+              )
+          )
+
+          /**
+           * Render the asterism editor
+           *
+           * @param idsToEdit
+           *   The observations to include in the edit. This needs to be asubset of the ids in
+           *   asterismGroup
+           * @param asterismGroup
+           *   The AsterismGroup that is the basis for editing. All or part of it may be included in
+           *   the edit.
+           */
+          def renderAsterismEditor(
+            resize:        UseResizeDetectorReturn,
+            idsToEdit:     ObsIdSet,
+            asterismGroup: AsterismGroup
+          ): List[Tile[?]] = {
+            val getObsTime: ProgramSummaries => Option[Instant] = a =>
+              for
+                id <- idsToEdit.single
+                o  <- a.observations.getValue(id)
+                t  <- o.observationTime
+              yield t
+
+            def modObsTime(
+              mod: Option[Instant] => Option[Instant]
+            ): ProgramSummaries => ProgramSummaries = ps =>
+              idsToEdit.single
+                .map: i =>
+                  ProgramSummaries.observations
+                    .filterIndex((id: Observation.Id) => id === i)
+                    .andThen(KeyedIndexedList.value)
+                    .andThen(Observation.observationTime)
+                    .modify(mod)(ps)
+                .getOrElse(ps)
+
+            val obsTimeView: View[Option[Instant]] =
+              props.programSummaries.model.zoom(getObsTime)(modObsTime)
+
+            val getObsDuration: ProgramSummaries => Option[TimeSpan] = a =>
+              for
+                id <- idsToEdit.single
+                o  <- a.observations.getValue(id)
+                t  <- o.observationDuration
+              yield t
+
+            def modObsDuration(
+              mod: Option[TimeSpan] => Option[TimeSpan]
+            ): ProgramSummaries => ProgramSummaries = ps =>
+              idsToEdit.single
+                .map: i =>
+                  ProgramSummaries.observations
+                    .filterIndex((id: Observation.Id) => id === i)
+                    .andThen(KeyedIndexedList.value)
+                    .andThen(Observation.observationDuration)
+                    .modify(mod)(ps)
+                .getOrElse(ps)
+
+            val obsDurationView: View[Option[TimeSpan]] =
+              props.programSummaries.model.zoom(getObsDuration)(modObsDuration)
+
+            val title = idsToEdit.single match {
+              case Some(id) => s"Observation $id"
+              case None     => s"Editing ${idsToEdit.size} Asterisms"
+            }
+
+            val obsConf = idsToEdit.single match {
+              case Some(id) =>
+                props.programSummaries.get.observations.values
+                  .collect:
+                    case Observation(
+                          obsId,
+                          _,
+                          _,
+                          _,
+                          _,
+                          _,
+                          const,
+                          _,
+                          _,
+                          _,
+                          Some(conf),
+                          _,
+                          _,
+                          posAngle,
+                          Some(wavelength),
+                          _,
+                          _,
+                          _,
+                          _,
+                          _
+                        ) if obsId === id =>
+                      (const, conf.toBasicConfiguration, posAngle, wavelength)
+                  .headOption
+              case _        => None
+            }
+
+            val constraints                               = obsConf.map(_._1)
+            val configuration: Option[BasicConfiguration] = obsConf.map(_._2)
+            val wavelength                                = obsConf.map(_._4)
+
+            def setCurrentTarget(oids: Option[ObsIdSet])(
+              tid: Option[Target.Id],
+              via: SetRouteVia
+            ): Callback =
+              ctx.setPageVia(AppTab.Targets, props.programId, Focused(oids, tid), via)
+
+            def onCloneTarget4Asterism(params: OnCloneParameters): Callback =
+              // props.programSummaries.get will always contain the original groups. On creating,
+              val allOriginalGroups = props.programSummaries.get.asterismGroups
+                .filterForObsInSet(params.obsIds)
+                .map(_._1)
+                .toSet
+              selectedTargetIds.set(List(params.idToAdd)) >>
+                (if (params.areCreating) {
+                   val obsIds4Url =
+                     ObsIdSet.fromSortedSet(idsToEdit.idSet.intersect(params.obsIds.idSet))
+                     // all of the original groups that have any of the cloned ids
+                     // Deal with the expanded groups - we'll open all affected groups
+                   allOriginalGroups.toList.traverse { ids =>
+                     val intersect = ids.idSet.intersect(params.obsIds.idSet)
+                     if (intersect === ids.idSet.toSortedSet)
+                       props.expandedIds.mod(
+                         _ + ids
+                       ) // it is the whole group, so make sure it is open
+                     else
+                       // otherwise, close the original and open the subsets
+                       ObsIdSet
+                         .fromSortedSet(intersect)
+                         .foldMap(i =>
+                           Callback.log(s"Setting expanded ids for $ids subset $i") >>
+                             props.expandedIds.mod(_ - ids + i + ids.removeUnsafe(i))
+                         )
+                   }.void >>
+                     setCurrentTarget(obsIds4Url)(params.cloneId.some, SetRouteVia.HistoryReplace)
+                 } else {
+                   // We'll open all of the original groups who had any observations affected by the cloning.
+                   props.expandedIds.mod(_ ++ SortedSet.from(allOriginalGroups)) >>
+                     setCurrentTarget(idsToEdit.some)(params.originalId.some,
+                                                      SetRouteVia.HistoryReplace
+                     )
+                 })
+
+            def onAsterismUpdate(params: OnAsterismUpdateParams): Callback =
+              val originalGroups = props.programSummaries.get.asterismGroups
+              // props.programSummaries.get will always contain the original groups, so we should find the group
+              originalGroups
+                .findContainingObsIds(params.obsIds)
+                .foldMap(group =>
+                  val newAsterism                      =
+                    if (params.isAddAction) group.targetIds + params.targetId
+                    else group.targetIds - params.targetId
+                  val existingGroup                    = originalGroups.findWithTargetIds(newAsterism)
+                  val mergedObs                        = existingGroup.map(_.obsIds ++ params.obsIds)
+                  val obsIdsAfterAction                = mergedObs.getOrElse(params.obsIds)
+                  val unmodified                       = group.obsIds -- params.obsIds
+                  val setExpanded                      = unmodified.fold {
+                    if (params.isUndo) props.expandedIds.mod(_ - obsIdsAfterAction + group.obsIds)
+                    else props.expandedIds.mod(_ - group.obsIds + obsIdsAfterAction)
+                  }(unmod =>
+                    if (params.isUndo)
+                      props.expandedIds.mod(_ - obsIdsAfterAction - unmod + group.obsIds)
+                    else props.expandedIds.mod(_ - group.obsIds + obsIdsAfterAction + unmod)
+                  )
+                  val targetForPage: Option[Target.Id] =
+                    if (params.areAddingTarget) params.targetId.some
+                    else none // if we're deleting, let UI focus the first one in the asterism
+                  val setPage =
+                    if (params.isUndo)
+                      setCurrentTarget(idsToEdit.some)(targetForPage, SetRouteVia.HistoryReplace)
+                    else
+                      setCurrentTarget(params.obsIds.some)(targetForPage,
+                                                           SetRouteVia.HistoryReplace
+                      )
+                  setExpanded >> setPage
+                )
+
+            val asterismEditorTile =
+              AsterismEditorTile.asterismEditorTile(
+                props.userId,
+                props.programId,
+                idsToEdit,
+                props.obsAndTargets,
+                configuration,
+                obsTimeView,
+                obsDurationView,
+                ObsConfiguration(
+                  configuration,
+                  none,
+                  constraints,
+                  wavelength,
+                  none,
+                  none,
+                  none,
+                  none
+                ),
+                none,
+                props.focused.target,
+                setCurrentTarget(idsToEdit.some),
+                onCloneTarget4Asterism,
+                onAsterismUpdate,
+                getObsInfo(idsToEdit.some),
+                props.searching,
+                title,
+                props.globalPreferences,
+                props.readonly,
+                backButton = backButton.some
+              )
+
+            val selectedCoordinates: Option[Coordinates] =
+              props.focused.target.flatMap: id =>
+                props.targets.get
+                  .get(id)
+                  .flatMap:
+                    case t @ Target.Sidereal(_, _, _, _) =>
+                      obsTimeView.get.flatMap(ot => Target.Sidereal.tracking.get(t).at(ot))
+                    case _                               => none
+
+            val skyPlotTile =
+              ElevationPlotTile.elevationPlotTile(
+                props.userId,
+                props.focused.target,
+                configuration.map(_.siteFor),
+                selectedCoordinates.map(CoordinatesAtVizTime(_)),
+                obsTimeView.get,
+                none,
+                Nil,
+                props.globalPreferences.get
+              )
+
+            List(asterismEditorTile, skyPlotTile)
+          }
+
+          /**
+           * Renders a single sidereal target editor without an obs context
+           */
+          def renderSiderealTargetEditor(
+            resize:   UseResizeDetectorReturn,
+            targetId: Target.Id
+          ): List[Tile[?]] = {
+            def onCloneTarget4Target(params: OnCloneParameters): Callback =
+              // It's not perfect, but we'll go to whatever url has the "new" id. This means
+              // that if the user went elsewhere before doing undo/redo, they will go back to the new target.
+              selectedTargetIds.set(List(params.idToAdd)) >>
+                ctx.replacePage(AppTab.Targets, props.programId, Focused.target(params.idToAdd))
+
+            val targetTiles: List[Tile[?]] =
+              props.targets
+                .zoom(Iso.id[TargetList].index(targetId).andThen(Target.sidereal))
+                .map { target =>
+                  val targetTile = SiderealTargetEditorTile.noObsSiderealTargetEditorTile(
+                    props.programId,
+                    props.userId,
+                    targetId,
+                    target,
+                    props.obsAndTargets,
+                    props.searching,
+                    s"Editing Target ${target.get.name.value} [$targetId]",
+                    fullScreen,
+                    props.globalPreferences,
+                    props.readonly,
+                    getObsInfo(none)(targetId),
+                    onCloneTarget4Target
+                  )
+
+                  val skyPlotTile =
+                    ElevationPlotTile.elevationPlotTile(
+                      props.userId,
+                      targetId.some,
+                      none,
+                      CoordinatesAtVizTime(Target.Sidereal.baseCoordinates.get(target.get)).some,
+                      none,
+                      none,
+                      Nil,
+                      props.globalPreferences.get
+                    )
+
+                  List(targetTile, skyPlotTile)
+                }
+                .orEmpty
+
+            renderSummary +: targetTiles
+          }
+
+          val optSelected: Option[Either[Target.Id, ObsIdSet]] = props.focused match
+            case Focused(Some(obsIdSet), _, _)    => obsIdSet.asRight.some
+            case Focused(None, Some(targetId), _) => targetId.asLeft.some
+            case _                                => none
+
+          // We still want to render these 2 tiles, even when not shown, so as not to mess up the stored layout.
+          val dummyTargetTile: Tile[Unit]    =
+            Tile(ObsTabTilesIds.TargetId.id, "", hidden = true)(_ => EmptyVdom)
+          val dummyElevationTile: Tile[Unit] =
+            Tile(ObsTabTilesIds.PlotId.id, "", hidden = true)(_ => EmptyVdom)
+
+          val renderNonSiderealTargetEditor: List[Tile[?]] =
+            List(
+              renderSummary,
+              Tile("nonSiderealTarget".refined, "Non-sidereal target")(_ =>
+                <.div("Editing of Non-Sidereal targets not supported")
+              ),
+              dummyElevationTile
+            )
+
+          val rightSide = { (resize: UseResizeDetectorReturn) =>
+            val tileListKeyOpt: Option[(List[Tile[?]], NonEmptyString)] =
+              optSelected
+                .flatMap:
+                  _ match
+                    case Left(targetId) =>
+                      props.targets.get
+                        .get(targetId)
+                        .map:
+                          case Nonsidereal(_, _, _) =>
+                            (renderNonSiderealTargetEditor, TargetTabControllerIds.Summary.id)
+                          case Sidereal(_, _, _, _) =>
+                            (renderSiderealTargetEditor(resize, targetId),
+                             TargetTabControllerIds.Summary.id
+                            )
+                    case Right(obsIds)  =>
+                      findAsterismGroup(obsIds, props.programSummaries.get.asterismGroups)
+                        .map: asterismGroup =>
+                          (renderAsterismEditor(resize, obsIds, asterismGroup),
+                           TargetTabControllerIds.AsterismEditor.id
+                          )
+
+            val justSummaryTiles = List(
+              renderSummary,
+              dummyTargetTile,
+              dummyElevationTile
+            )
+
+            val (tiles, key) =
+              tileListKeyOpt.fold((justSummaryTiles, TargetTabControllerIds.Summary.id)):
+                (tiles, key) => (tiles, key)
+
+            TileController(
+              props.userId,
+              resize.width.getOrElse(1),
+              ExploreGridLayouts.targets.defaultTargetLayouts,
+              props.userPreferences.get.targetTabLayout,
+              tiles,
+              GridLayoutSection.TargetLayout,
+              backButton.some,
+              Option.when(tileListKeyOpt.isEmpty)(ExploreStyles.SingleTileMaximized),
+              storeLayout = tileListKeyOpt.nonEmpty
+            ).withKey(key.value): VdomNode
+            // withKey is required for the controller to clear it's state between the different
+            // layouts or it can get into an invalid state.
+          }
+
+          React.Fragment(
+            if (LinkingInfo.developmentMode)
+              FocusedStatus(AppTab.Targets, props.programId, props.focused)
+            else EmptyVdom,
+            makeOneOrTwoPanels(
+              selectedView,
+              targetTree(props.programSummaries),
+              rightSide,
+              RightSideCardinality.Multi,
+              resize
+            )
+          )


### PR DESCRIPTION
Addresses https://app.shortcut.com/lucuma/story/1708/action-buttons only for the Target Tab. I'm sending separate PRs to keep them more manageable.

- Copy copies from either the tree or the target summary table.
- Paste pastes either in the tree or the summary table.
- Delete only deletes from the tree, and only if a single observation is selected.
  - Supporting multiple obs delete seems complicated, mainly due to undo.
  - Unifying with deletion in the summary table is an option, probably desired, to keep the UI consistent. I took a cursory look and it's not completely straightforward since the delete action interacts with the table (which is not available when the delete button in the tree is rendered).

![Kapture 2024-09-11 at 17 24 26](https://github.com/user-attachments/assets/e6183979-1bb6-4ef7-81aa-bcdb7f4483f4)
