### PR TITLE
Fix broken band label

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotNight.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotNight.scala
@@ -356,16 +356,16 @@ object ElevationPlotNight:
                             .setTextAlign(AlignValue.center)
                             .setVerticalAlign(VerticalAlignValue.middle)
                         ),
-                      XAxisPlotBandsOptions() // Empty band, just to draw the label
+                      XAxisPlotBandsOptions() // Empty bands don't work on highcharts 11.4.8. Instead we create the same band in revese and no fill
                         .setFrom(tbNauticalNight.end.toEpochMilli.toDouble)
-                        .setTo(tbNauticalNight.end.toEpochMilli.toDouble)
+                        .setTo(tbNauticalNight.start.toEpochMilli.toDouble)
                         .setClassName("plot-band-twilight-nautical-end")
                         .setZIndex(1)
                         .setLabel(
                           XAxisPlotBandsLabelOptions()
                             .setText(s"  Morning 12° - Twilight: $dawn")
                             .setRotation(270)
-                            .setAlign(AlignValue.left)
+                            .setAlign(AlignValue.right)
                             .setTextAlign(AlignValue.center)
                             .setVerticalAlign(VerticalAlignValue.middle)
                         )


### PR DESCRIPTION
The right hand side label of the elevation plot looks incorrectly starting on 11.4.8.
After some debugging it was noted that the width of the label was set to 1 as the band is empty. this leads to the label being broken into words.

The fix is to make the band match the width or the whole range though perhaps a more appropriate solution would be to use a plot line, however the styling doesn't match