### PR TITLE
Copy observations into groups

### DIFF
--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -76,7 +76,8 @@ case class ObsList(
   clipboardObsContents: Option[ObsIdSet],
   readonly:             Boolean
 ) extends ReactFnProps(ObsList.component):
-  private val activeGroup: Option[Group.Id] = focusedGroup.orElse(focusedObs.flatMap(obsId => observations.get.getValue(obsId).flatMap(_.groupId)))
+  private val activeGroup: Option[Group.Id] = focusedGroup.orElse:
+    focusedObs.flatMap(obsId => observations.get.getValue(obsId).flatMap(_.groupId))
 
   private val copyDisabled: Boolean   = focusedObs.isEmpty
   private val pasteDisabled: Boolean  = clipboardObsContents.isEmpty
@@ -85,14 +86,15 @@ case class ObsList(
   private def observationText(obsId: Observation.Id): String = s"observation $obsId"
   private def groupText(groupId:     Group.Id): String       = s"group $groupId"
 
-  private val copyText: Option[String]   = focusedObs.map(observationText)
-  private val selectedText: Option[String]  =
+  private val copyText: Option[String]     = focusedObs.map(observationText)
+  private val selectedText: Option[String] =
     clipboardObsContents.map: obdIdSet =>
       obdIdSet.idSet.size match
         case 1    => s"observation ${obdIdSet.idSet.head}"
         case more => s"$more observations"
-  private val pasteText: Option[String]  = selectedText.map(_ + activeGroup.map(gid => s" into ${groupText(gid)}").orEmpty)
-  private val deleteText: Option[String] =
+  private val pasteText: Option[String]    =
+    selectedText.map(_ + activeGroup.map(gid => s" into ${groupText(gid)}").orEmpty)
+  private val deleteText: Option[String]   =
     focusedObs.map(observationText).orElse(focusedGroup.map(groupText))
 
 object ObsList:

--- a/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -183,12 +183,17 @@ object ObsQueries:
       .map(_.createObservation.observation)
 
   def cloneObservation[F[_]: Async](
-    obsId: Observation.Id
+    obsId:      Observation.Id,
+    newGroupId: Option[Group.Id]
   )(using
     FetchClient[F, ObservationDB]
   ): F[Observation] =
     CloneObservationMutation[F]
-      .execute(CloneObservationInput(observationId = obsId.assign))
+      .execute:
+        CloneObservationInput(
+          observationId = obsId.assign,
+          SET = ObservationPropertiesInput(groupId = newGroupId.orUnassign).assign
+        )
       .map(_.cloneObservation.newObservation)
 
   def applyObservation[F[_]: Async](


### PR DESCRIPTION
Previous functionality only allowed cloning observations within same group.