### PR TITLE
Invoke ITC chart only once when Image Quality changes

### DIFF
--- a/explore/src/main/scala/explore/itc/ItcProps.scala
+++ b/explore/src/main/scala/explore/itc/ItcProps.scala
@@ -152,14 +152,13 @@ case class ItcProps(
     action.getOrElse(orElse)
 
 object ItcProps:
-  given Reusability[ItcProps] = Reusability.by(p =>
-    (p.observation.scienceTargetIds.toList,
-     p.observation.constraints,
-     p.observation.scienceRequirements,
-     p.observation.observingMode,
-     p.observation.wavelength,
-     p.selectedConfig,
-     p.at,
-     p.modeOverrides
-    )
-  )
+  given Reusability[ItcProps] =
+    Reusability.by: p =>
+      (p.observation.scienceTargetIds.toList.sorted,
+       p.observation.constraints,
+       p.observation.scienceRequirements,
+       p.observation.wavelength,
+       p.selectedConfig,
+       p.at,
+       p.modeOverrides
+      )

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -75,7 +75,6 @@ case class GmosNorthSpectroscopyRow(
   val instrument = Instrument.GmosNorth
   val site       = Site.GN
   val hasFilter  = filter.isDefined
-
 }
 
 case class GmosSouthSpectroscopyRow(

--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -43,7 +43,7 @@ object ITCGraphRequests:
   )(using Monoid[F[Unit]], ItcClient[F]): F[Unit] =
 
     val itcRowsParams = mode match // Only handle known modes
-      case m: GmosNorthSpectroscopyRow =>
+      case m @ GmosNorthSpectroscopyRow(_, _, _, _) =>
         ItcGraphRequestParams(
           wavelength,
           signalToNoise,
@@ -52,7 +52,7 @@ object ITCGraphRequests:
           targets,
           m
         ).some
-      case m: GmosSouthSpectroscopyRow =>
+      case m @ GmosSouthSpectroscopyRow(_, _, _, _) =>
         ItcGraphRequestParams(
           wavelength,
           signalToNoise,
@@ -61,7 +61,7 @@ object ITCGraphRequests:
           targets,
           m
         ).some
-      case _                           =>
+      case _                                        =>
         none
 
     def doRequest(request: ItcGraphRequestParams): F[GraphResponse] =


### PR DESCRIPTION
Changing the Image Quality can change the CCD binning. We have logic to compute the new binning but it was being ignored, in favor of getting the value from the server.

This caused the ITC chart to be invoked twice when the IQ changed: once with the old binning, and again with the fixed new binning once the server roundtrip completed.

This PR does 2 things:
- Invoke ITC with the new, computed in the client, binning.
- Change reusability so that the server binning doesn't take part in it (otherwise the chart was still being invoked twice, albeit both times with the right values).