### PR TITLE
Unify delete buttons in target tab

### DIFF
--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -31,7 +31,6 @@ import explore.model.syntax.all.*
 import explore.observationtree.AsterismGroupObsList
 import explore.shortcuts.*
 import explore.shortcuts.given
-import explore.targets.DeletingTargets
 import explore.targets.TargetPasteAction
 import explore.targets.TargetSummaryBody
 import explore.targets.TargetSummaryTileState
@@ -289,6 +288,7 @@ object TargetTabContents extends TwoPanels:
               shadowClipboard.value,
               selectTargetOrSummary,
               selectedTargetIds.set,
+              props.programSummaries.undoableView(ProgramSummaries.targets).mod,
               copyCallback,
               pasteCallback,
               props.readonly
@@ -303,7 +303,7 @@ object TargetTabContents extends TwoPanels:
           val renderSummary: Tile[TargetSummaryTileState] = Tile(
             ObsTabTilesIds.TargetSummaryId.id,
             "Target Summary",
-            TargetSummaryTileState(Nil, ColumnSelectorState(), DeletingTargets(false)),
+            TargetSummaryTileState(Nil, ColumnSelectorState()),
             backButton.some
           )(
             TargetSummaryBody(


### PR DESCRIPTION
Now targets can be deleted via the action button above the tree. This results in a more consistent experience with respect to the copy/paste buttons behavior.