### PR TITLE
Group rework

### DIFF
--- a/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -32,8 +32,6 @@ object GroupQueriesGQL:
         id
         name
         minimumRequired
-        parentId
-        parentIndex
         ordered
         system
         minimumInterval $TimeSpanSubquery
@@ -57,7 +55,7 @@ object GroupQueriesGQL:
 
   @GraphQL
   trait CreateGroupMutation extends GraphQLOperation[ObservationDB]:
-    override val document = s"""#graphql
+    override val document = s"""
       mutation($$input: CreateGroupInput!) {
         createGroup(input: $$input) {
           group $GroupSubQuery

--- a/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -19,10 +19,8 @@ object GroupQueriesGQL:
     override val subquery: String = s"""
       {
         parentGroupId
-        observation {
-          id
-          groupIndex
-        }
+        parentIndex
+        observation { id }
         group $GroupSubQuery
       }
     """
@@ -41,12 +39,8 @@ object GroupQueriesGQL:
         minimumInterval $TimeSpanSubquery
         maximumInterval $TimeSpanSubquery
         elements {
-          observation {
-            id
-          }
-          group {
-            id
-          }
+          observation { id }
+          group { id }
         }
       }
     """
@@ -56,9 +50,7 @@ object GroupQueriesGQL:
     override val document = """
       mutation($input: UpdateGroupsInput!) {
         updateGroups(input: $input) {
-          groups {
-            id
-          }
+          groups { id }
         }
       }
     """

--- a/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -6,11 +6,13 @@ package queries.common
 import clue.GraphQLOperation
 import clue.GraphQLSubquery
 import clue.annotation.GraphQL
+import explore.model.Group
 import explore.model.GroupElement
 import explore.model.GroupWithChildren
 import explore.model.GroupWithChildren.given
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.odb.TimeSpanSubquery
+// gql: import io.circe.refined.given
 
 object GroupQueriesGQL:
 
@@ -28,7 +30,7 @@ object GroupQueriesGQL:
       }
     """
 
-  object GroupSubQuery extends GraphQLSubquery.Typed[ObservationDB, GroupWithChildren]("Group"):
+  object GroupSubQuery extends GraphQLSubquery.Typed[ObservationDB, Group]("Group"):
     override val subquery: String = s"""
       {
         id
@@ -72,5 +74,6 @@ object GroupQueriesGQL:
       mutation($$input: CreateGroupInput!) {
         createGroup(input: $$input) {
           group $GroupSubQuery
+          meta:group { parentIndex }
         }
       }"""

--- a/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -7,13 +7,13 @@ import clue.GraphQLOperation
 import clue.GraphQLSubquery
 import clue.annotation.GraphQL
 import explore.model.GroupElement
-import explore.model.Grouping
+import explore.model.GroupWithChildren
+import explore.model.GroupWithChildren.given
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.odb.TimeSpanSubquery
 
 object GroupQueriesGQL:
 
-  @GraphQL
   object GroupElementsSubQuery
       extends GraphQLSubquery.Typed[ObservationDB, GroupElement]("GroupElement"):
     override val subquery: String = s"""
@@ -22,11 +22,13 @@ object GroupQueriesGQL:
         parentIndex   # Only used if element is in root group
         observation { id }
         group $GroupSubQuery
+        groupChildren:group {
+          elements $GroupElementSubQuery
+        }
       }
     """
 
-  @GraphQL
-  object GroupSubQuery extends GraphQLSubquery.Typed[ObservationDB, Grouping]("Group"):
+  object GroupSubQuery extends GraphQLSubquery.Typed[ObservationDB, GroupWithChildren]("Group"):
     override val subquery: String = s"""
       {
         id
@@ -36,15 +38,20 @@ object GroupQueriesGQL:
         system
         minimumInterval $TimeSpanSubquery
         maximumInterval $TimeSpanSubquery
-        elements {
-          observation { 
-            id
-            groupIndex
-          }
-          group {
-            id
-            parentIndex
-          }
+      }
+    """
+
+  object GroupElementSubQuery
+      extends GraphQLSubquery.Typed[ObservationDB, GroupWithChildren.Child]("Group"):
+    override val subquery: String = s"""
+      {
+        observation { 
+          id
+          groupIndex
+        }
+        group {
+          id
+          parentIndex
         }
       }
     """

--- a/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/GroupQueriesGQL.scala
@@ -18,8 +18,8 @@ object GroupQueriesGQL:
       extends GraphQLSubquery.Typed[ObservationDB, GroupElement]("GroupElement"):
     override val subquery: String = s"""
       {
-        parentGroupId
-        parentIndex
+        parentGroupId # Only used for identifying root group
+        parentIndex   # Only used if element is in root group
         observation { id }
         group $GroupSubQuery
       }
@@ -37,8 +37,14 @@ object GroupQueriesGQL:
         minimumInterval $TimeSpanSubquery
         maximumInterval $TimeSpanSubquery
         elements {
-          observation { id }
-          group { id }
+          observation { 
+            id
+            groupIndex
+          }
+          group {
+            id
+            parentIndex
+          }
         }
       }
     """

--- a/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -17,6 +17,9 @@ object ObsQueriesGQL:
       mutation($$createObservation: CreateObservationInput!) {
         createObservation(input: $$createObservation) {
           observation $ObservationSubquery
+          meta:observation {
+            groupIndex
+          }
         }
       }
     """

--- a/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -8,6 +8,8 @@ import clue.annotation.GraphQL
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.odb.*
 
+// gql: import io.circe.refined.given
+
 object ObsQueriesGQL:
   @GraphQL
   trait ProgramCreateObservation extends GraphQLOperation[ObservationDB]:
@@ -173,6 +175,8 @@ object ObsQueriesGQL:
           observationId
           value $ObservationSubquery
           meta:value {
+            groupId
+            groupIndex
             existence
           }
           editType

--- a/explore/src/clue/scala/queries/common/ObservationSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ObservationSubquery.scala
@@ -46,8 +46,6 @@ object ObservationSubquery extends GraphQLSubquery.Typed[ObservationDB, Observat
             }
           }
           observingMode $ObservingModeSubquery
-          groupId
-          groupIndex
           validations {
             code
             messages

--- a/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -5,6 +5,7 @@ package queries.common
 
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
+import explore.model.GroupUpdate
 import lucuma.schemas.ObservationDB
 
 import GroupQueriesGQL.*
@@ -54,13 +55,19 @@ object ProgramQueriesGQL:
       }
     """
 
-  @GraphQL
-  trait GroupEditSubscription extends GraphQLOperation[ObservationDB]:
+  trait GroupEditSubscription
+      extends GraphQLOperation.Typed[
+        ObservationDB,
+        ObservationDB.Types.ProgramEditInput,
+        GroupUpdate
+      ]:
     val document: String = s"""
       subscription($$input: ProgramEditInput!) {
         groupEdit(input: $$input) {
           value $GroupSubQuery
-          meta:value {
+          meta:value { 
+            parentId
+            parentIndex
             existence
           }
           editType

--- a/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -46,7 +46,7 @@ object ProgramQueriesGQL:
 
   @GraphQL
   trait ProgramGroupsQuery extends GraphQLOperation[ObservationDB]:
-    val document: String = s"""#graphql
+    val document: String = s"""
       query ($$programId: ProgramId!) {
         program(programId: $$programId) {
           allGroupElements $GroupElementsSubQuery

--- a/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -5,8 +5,8 @@ package queries.common
 
 import clue.GraphQLOperation
 import clue.annotation.GraphQL
-import explore.model.GroupUpdate
 import lucuma.schemas.ObservationDB
+import explore.model.GroupUpdate
 
 import GroupQueriesGQL.*
 
@@ -55,12 +55,8 @@ object ProgramQueriesGQL:
       }
     """
 
-  trait GroupEditSubscription
-      extends GraphQLOperation.Typed[
-        ObservationDB,
-        ObservationDB.Types.ProgramEditInput,
-        GroupUpdate
-      ]:
+  @GraphQL
+  trait GroupEditSubscription extends GraphQLOperation[ObservationDB]:
     val document: String = s"""
       subscription($$input: ProgramEditInput!) {
         groupEdit(input: $$input) {
@@ -74,6 +70,9 @@ object ProgramQueriesGQL:
         }
       }
     """
+
+    object Data:
+      type GroupEdit = GroupUpdate
 
   @GraphQL
   trait ProgramEditAttachmentSubscription extends GraphQLOperation[ObservationDB]:

--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -3,6 +3,9 @@
 
 package explore.cache
 
+import cats.Endo
+import cats.Monoid
+import cats.MonoidK
 import cats.Order.given
 import cats.syntax.all.*
 import crystal.Pot
@@ -23,9 +26,6 @@ import queries.common.ObsQueriesGQL.ProgramObservationsDelta.Data.ObservationEdi
 import queries.common.ProgramQueriesGQL.ProgramEditAttachmentSubscription.Data.ProgramEdit as AttachmentProgramEdit
 import queries.common.ProgramQueriesGQL.ProgramInfoDelta.Data.ProgramEdit
 import queries.common.TargetQueriesGQL.ProgramTargetsDelta.Data.TargetEdit
-import cats.Monoid
-import cats.MonoidK
-import cats.Endo
 
 /**
  * Functions to modify cache through subscription updates

--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -56,9 +56,12 @@ trait CacheModifierUpdaters {
                 )
               else observations.removed(obsId)
 
-        // TODO: this won't be needed anymore when groups are also updated through events of observation updates
+        // TODO: this won't be needed anymore when groups are also updated through events of observation updates.
+        // We only need this for the root group, other groups are updated through the groupEdit subscription.
         val groupsUpdate: ProgramSummaries => ProgramSummaries =
-          updateGroupsMappingForObsEdit(observationEdit)
+          if (observationEdit.meta.exists(_.groupId.isEmpty))
+            updateGroupsMappingForObsEdit(observationEdit)
+          else identity
 
         val programTimesReset: ProgramSummaries => ProgramSummaries =
           ProgramSummaries.programTimesPot.replace(Pot.pending)

--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -180,14 +180,9 @@ trait CacheModifierUpdaters {
         val findIndexFn: GroupTree.Node => Boolean =
           _.value.parentIndex >= meta.groupIndex
 
-        println(s"modifying! ${obsId} ${meta}")
-
         val editGroup: ProgramSummaries => ProgramSummaries =
           ProgramSummaries.groups
             .modify: groupTree =>
-              // println(pprint(groupTree))
-              println("EDIT GROUP!!")
-
               groupTree.updated(
                 obsId.asLeft,
                 ServerIndexed(obsId.asLeft, meta.groupIndex),
@@ -195,6 +190,7 @@ trait CacheModifierUpdaters {
                 findIndexFn
               )
 
+        // I'm almost sure we don't need this anymore.
         // val parentTimeRangePotsReset: ProgramSummaries => ProgramSummaries =
         //   programSummaries =>
         //     programSummaries.groups

--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -168,16 +168,13 @@ trait CacheModifierUpdaters {
     (observationEdit.value, observationEdit.meta)
       .mapN: (newObservation, meta) =>
 
-        // TODO STRANGE THINGS ARE HAPPENING WHEN WE REARRANGE THINGS IN ROOT GROUP!
-        // (moved object jumps to top)
-
         val findIndexFn: GroupTree.Node => Boolean =
           _.value.parentIndex >= meta.groupIndex
 
         val editGroup: ProgramSummaries => ProgramSummaries =
           ProgramSummaries.groups
-            .modify: groupTree =>
-              groupTree.updated(
+            .modify:
+              _.updated(
                 obsId.asLeft,
                 ServerIndexed(obsId.asLeft, meta.groupIndex),
                 meta.groupId.map(_.asRight),

--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -123,7 +123,7 @@ trait CacheModifierUpdaters {
                     val findIndexFn: GroupTree.Node => Boolean =
                       _.value.parentIndex >= payload.value.parentIndex
 
-                    _.updated(
+                    _.upserted(
                       groupId.asRight,
                       payload.value.map(_.group.asRight),
                       newChildren,
@@ -174,7 +174,7 @@ trait CacheModifierUpdaters {
         val editGroup: ProgramSummaries => ProgramSummaries =
           ProgramSummaries.groups
             .modify:
-              _.updated(
+              _.upserted(
                 obsId.asLeft,
                 ServerIndexed(obsId.asLeft, meta.groupIndex),
                 meta.groupId.map(_.asRight),

--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -21,6 +21,7 @@ import queries.common.ProgramQueriesGQL.ProgramEditAttachmentSubscription.Data.P
 import queries.common.ProgramQueriesGQL.ProgramInfoDelta.Data.ProgramEdit
 import queries.common.TargetQueriesGQL.ProgramTargetsDelta.Data.TargetEdit
 import eu.timepit.refined.auto.autoUnwrap
+import explore.model.RootModelViews.programSummaries
 
 /**
  * Functions to modify cache through subscription updates
@@ -73,9 +74,9 @@ trait CacheModifierUpdaters {
   protected def modifyGroups(groupEdit: GroupEdit): ProgramSummaries => ProgramSummaries =
     (groupEdit.value, groupEdit.meta).tupled
       .map: (newGrouping, meta) =>
-        val groupId   = newGrouping.id
-        val editType  = groupEdit.editType
-        val existence = meta.existence
+        val groupId: Group.Id    = newGrouping.group.id
+        val editType: EditType   = groupEdit.editType
+        val existence: Existence = meta.existence
 
         val groupUpdate: ProgramSummaries => ProgramSummaries =
           ProgramSummaries.groups.modify:
@@ -86,11 +87,12 @@ trait CacheModifierUpdaters {
                 case DeletedCal       =>
                   _.removed(groupId.asRight)
                 case Created          =>
-                  _.inserted(
-                    groupId.asRight,
-                    Node(newGrouping.toGroupTreeGroup.asRight),
-                    newGrouping.toIndex
-                  )
+                  identity
+                // _.inserted(
+                //   groupId.asRight,
+                //   Node(newGrouping.toGroupTreeGroup.asRight),
+                //   newGrouping.toIndex
+                // )
                 case EditType.Updated =>
                   _.updated(
                     groupId.asRight,
@@ -98,14 +100,14 @@ trait CacheModifierUpdaters {
                     newGrouping.toIndex
                   )
 
-        val groupTimeRangePotsReset: ProgramSummaries => ProgramSummaries =
-          ProgramSummaries.groupTimeRangePots
-            .modify:
-              if existence === Existence.Present then _.withUpdatePending(groupId)
-              else _.removed(groupId)
-            .andThen(parentGroupTimeRangeReset(groupId.asRight))
+        // val groupTimeRangePotsReset: ProgramSummaries => ProgramSummaries =
+        //   ProgramSummaries.groupTimeRangePots
+        //     .modify:
+        //       if existence === Existence.Present then _.withUpdatePending(groupId)
+        //       else _.removed(groupId)
+        //     .andThen(parentGroupTimeRangeReset(groupId.asRight))
 
-        groupUpdate >>> groupTimeRangePotsReset
+        groupUpdate // >>> groupTimeRangePotsReset
       .getOrElse(identity)
 
   protected def modifyAttachments(
@@ -132,53 +134,58 @@ trait CacheModifierUpdaters {
     val obsId = observationEdit.observationId
     observationEdit.value
       .map { newObservation =>
-        val groupEdit: ProgramSummaries => ProgramSummaries =
-          programSummaries =>
-            ProgramSummaries.groups
-              .modify { groupElements =>
-                // TODO groupIndex IS NOT OUR INDEX!!!!
+        // val groupEdit: ProgramSummaries => ProgramSummaries =
+        //   programSummaries =>
+        //     ProgramSummaries.groups
+        //       .modify { groupElements =>
+        //         // TODO groupIndex IS NOT OUR INDEX!!!!
 
-                val groupId: Option[Group.Id]            = value.groupId
-                val newGroupObs: GroupTree.Obs           = GroupTree.Obs(obsId)
-                val newParent: Option[groupElements.Key] = groupId.map(_.asRight[Observation.Id])
-                // val newIndex: Index[Either[Observation.Id, Group.Id]] =
-                //   Index(groupId.map(_.asRight[Observation.Id]), value.groupIndex)
+        //         val groupId: Option[Group.Id]            = newObservation.groupId
+        //         val newGroupObs: GroupTree.Obs           = GroupTree.Obs(obsId)
+        //         val newParent: Option[groupElements.Key] = groupId.map(_.asRight[Observation.Id])
+        //         // val newIndex: Index[Either[Observation.Id, Group.Id]] =
+        //         //   Index(groupId.map(_.asRight[Observation.Id]), value.groupIndex)
 
-                val findIndexFn: GroupTree.Node => Boolean =
-                  _.value match
-                    case Left(obs)    =>
-                      programSummaries.observations
-                        .getValue(obs.id)
-                        .forall(_.groupIndex >= value.groupIndex)
-                    case Right(group) => true // Groups always go first.
+        //         val findIndexFn: GroupTree.Node => Boolean =
+        //           _.value match
+        //             case Left(obs)    =>
+        //               programSummaries.observations
+        //                 .getValue(obs.id)
+        //                 .forall(_.groupIndex >= value.groupIndex)
+        //             case Right(group) => true // Groups always go first.
 
-                // if (observationEdit.editType === EditType.Created)
-                //   groupElements.updated(
-                //     obsId.asLeft,
-                //     newGroupObs.asLeft,
-                //     newParent,
-                //     findIndexFn
-                //   )
-                // else
-                if (observationEdit.meta.forall(_.existence === Existence.Deleted))
-                  groupElements.removed(obsId.asLeft)
-                // else if (observationEdit.editType === EditType.Updated)
-                else // Created or Updated
-                  groupElements.updated(
-                    obsId.asLeft,
-                    newGroupObs.asLeft,
-                    newParent,
-                    findIndexFn
-                  )
-                // else groupElements
-              }(programSummaries)
+        //         // if (observationEdit.editType === EditType.Created)
+        //         //   groupElements.updated(
+        //         //     obsId.asLeft,
+        //         //     newGroupObs.asLeft,
+        //         //     newParent,
+        //         //     findIndexFn
+        //         //   )
+        //         // else
+        //         if (observationEdit.meta.forall(_.existence === Existence.Deleted))
+        //           groupElements.removed(obsId.asLeft)
+        //         // else if (observationEdit.editType === EditType.Updated)
+        //         else // Created or Updated
+        //           groupElements.updated(
+        //             obsId.asLeft,
+        //             newGroupObs.asLeft,
+        //             newParent,
+        //             findIndexFn
+        //           )
+        //         // else groupElements
+        //       }(programSummaries)
 
-        val parentTimeRangePotsReset: ProgramSummaries => ProgramSummaries =
-          value.groupId
-            .map(gid => parentGroupTimeRangeReset(gid.asRight))
-            .getOrElse(identity)
+        // val parentTimeRangePotsReset: ProgramSummaries => ProgramSummaries =
+        //   programSummaries =>
+        //     programSummaries.groups
+        //       .getNodeAndIndexByKey(obsId.asLeft)
+        //       // I think this may be wrong, the parent could be empty if it's the root node
+        //       .flatMap(_._2.parentKey)
+        //       .map(gid => parentGroupTimeRangeReset(gid))
+        //       .getOrElse(identity)(programSummaries)
 
-        groupEdit >>> parentTimeRangePotsReset
+        // groupEdit >>> parentTimeRangePotsReset
+        identity[ProgramSummaries]
       }
       .getOrElse:
         ProgramSummaries.groups

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -30,6 +30,7 @@ import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.react.common.ReactFnProps
 import lucuma.schemas.ObservationDB
+import lucuma.schemas.ObservationDB.Enums.Existence
 import lucuma.schemas.model.TargetWithId
 import lucuma.schemas.odb.input.*
 import queries.common.ObsQueriesGQL
@@ -38,7 +39,6 @@ import queries.common.ProgramSummaryQueriesGQL
 import queries.common.TargetQueriesGQL
 
 import scala.concurrent.duration.*
-import lucuma.schemas.ObservationDB.Enums.Existence
 
 case class ProgramCacheController(
   programId:           Program.Id,

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -235,10 +235,11 @@ object ProgramCacheController
             ProgramQueriesGQL.GroupEditSubscription.Data,
             ProgramSummaries => ProgramSummaries
           ] = keyedSwitchEvalMap(
-            _.groupEdit.value.elem.group.id,
-            data =>
-              updateGroupTimeRange(data.groupEdit.value.elem.group.id)
-                <* queryProgramTimes
+            _.groupEdit.payload.map(_.value.elem.group.id),
+            _.groupEdit.payload
+              .map: payload =>
+                updateGroupTimeRange(payload.value.elem.group.id) <* queryProgramTimes
+              .getOrElse(IO(identity))
           )
 
           val updateObservations: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -44,7 +44,8 @@ case class ProgramCacheController(
   programId:           Program.Id,
   modProgramSummaries: (Option[ProgramSummaries] => Option[ProgramSummaries]) => IO[Unit]
 )(using client: StreamingClient[IO, ObservationDB])
-    extends ReactFnProps(ProgramCacheController.component)
+// Do not remove the explicit type parameter below, it confuses the compiler.
+    extends ReactFnProps[ProgramCacheController](ProgramCacheController.component)
     with CacheControllerComponent.Props[ProgramSummaries]:
   val modState                             = modProgramSummaries
   given StreamingClient[IO, ObservationDB] = client

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -235,13 +235,10 @@ object ProgramCacheController
             ProgramQueriesGQL.GroupEditSubscription.Data,
             ProgramSummaries => ProgramSummaries
           ] = keyedSwitchEvalMap(
-            _.groupEdit.value.map(_.group.id),
+            _.groupEdit.value.elem.group.id,
             data =>
-              data.groupEdit.value
-                .map(_.group.id)
-                .fold(identity[ProgramSummaries].pure[IO])(
-                  updateGroupTimeRange
-                ) <* queryProgramTimes
+              updateGroupTimeRange(data.groupEdit.value.elem.group.id)
+                <* queryProgramTimes
           )
 
           val updateObservations: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -251,10 +251,10 @@ object ProgramCacheController
             ProgramQueriesGQL.GroupEditSubscription.Data,
             ProgramSummaries => ProgramSummaries
           ] = keyedSwitchEvalMap(
-            _.groupEdit.payload.map(_.value.elem.group.id),
+            _.groupEdit.payload.map(_.value.elem.id),
             _.groupEdit.payload
               .map: payload =>
-                updateGroupTimeRange(payload.value.elem.group.id) <* queryProgramTimes
+                updateGroupTimeRange(payload.value.elem.id) <* queryProgramTimes
               .getOrElse(IO(identity))
           )
 

--- a/explore/src/main/scala/explore/common/GroupQueries.scala
+++ b/explore/src/main/scala/explore/common/GroupQueries.scala
@@ -9,7 +9,7 @@ import clue.FetchClient
 import clue.data.syntax.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import explore.DefaultErrorPolicy
-import explore.model.Grouping
+import explore.model.GroupWithChildren
 import lucuma.core.model.Group
 import lucuma.core.model.Program
 import lucuma.schemas.ObservationDB
@@ -60,7 +60,7 @@ object GroupQueries:
 
   def createGroup[F[_]: Async](programId: Program.Id, parentId: Option[Group.Id])(using
     FetchClient[F, ObservationDB]
-  ): F[Grouping] =
+  ): F[GroupWithChildren] =
     CreateGroupMutation[F]
       .execute:
         CreateGroupInput(

--- a/explore/src/main/scala/explore/common/GroupQueries.scala
+++ b/explore/src/main/scala/explore/common/GroupQueries.scala
@@ -9,8 +9,7 @@ import clue.FetchClient
 import clue.data.syntax.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import explore.DefaultErrorPolicy
-import explore.model.GroupWithChildren
-import lucuma.core.model.Group
+import explore.model.Group
 import lucuma.core.model.Program
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Enums.Existence
@@ -60,14 +59,15 @@ object GroupQueries:
 
   def createGroup[F[_]: Async](programId: Program.Id, parentId: Option[Group.Id])(using
     FetchClient[F, ObservationDB]
-  ): F[GroupWithChildren] =
+  ): F[(Group, NonNegShort)] =
     CreateGroupMutation[F]
       .execute:
         CreateGroupInput(
           programId = programId.assign,
           SET = parentId.map(gId => GroupPropertiesInput(parentGroup = gId.assign)).orIgnore
         )
-      .map(_.createGroup.group)
+      .map: result =>
+        (result.createGroup.group, result.createGroup.meta.parentIndex)
 
   def deleteGroup[F[_]: Async](groupId: Group.Id)(using FetchClient[F, ObservationDB]): F[Unit] =
     updateGroup(groupId, GroupPropertiesInput(existence = Existence.Deleted.assign))

--- a/explore/src/main/scala/explore/observationtree/GroupBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/GroupBadge.scala
@@ -8,7 +8,7 @@ import eu.timepit.refined.types.string.NonEmptyString
 import explore.Icons
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
-import explore.model.GroupTree.Group
+import explore.model.Group
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.TagOf
 import japgolly.scalajs.react.vdom.html_<^.*

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -114,7 +114,7 @@ object ObsList:
   private def groupTreeNodeIsoBuilder(
     allObservations: ObservationList
   ): Iso[GroupTree, List[Node[GroupTree.Value]]] =
-    Iso[GroupTree, List[Node[GroupTree.Value]]](groups =>
+    Iso[GroupTree, List[Node[GroupTree.Value]]](groupTree =>
       def createNode(node: GroupTree.Node): Node[GroupTree.Value] =
         val isSystemGroup: Boolean    = node.value.toOption.exists(_.system)
         val isCalibrationObs: Boolean = node.value.left.toOption
@@ -132,7 +132,7 @@ object ObsList:
           children = node.children.map(createNode)
         )
 
-      groups.toTree.children.map(createNode)
+      groupTree.toTree.children.map(createNode)
     )(nodes =>
       def nodeToTree(node: Node[GroupTree.Value]): GroupTree.Node =
         ExploreNode(node.data, children = node.children.map(nodeToTree).toList)

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -228,24 +228,6 @@ object ObsList:
             val dropIndex: NonNegShort =
               NonNegShort.from(e.dropIndex.toShort).getOrElse(NonNegShort.unsafeFrom(0))
 
-            // Group updates are done through the `treeNodes.set`, but obs updates have to be done separately
-            // val obsEdit: Callback = dragNode.elem.left.toOption
-            //   .map: obsId =>
-            //     props.observations.model
-            //       .mod:
-            //         _.updatedValueWith(
-            //           obsId,
-            //           ???
-            //           // Observation.groupId
-            //           //   .replace(dropNodeId)
-            //           //   .andThen: // TODO groupIndex IS NOT OUR INDEX!!!!
-            //           //     Observation.groupIndex.replace(dropIndex)
-            //         )
-            //   .getOrEmpty
-
-            // println(e.dropNode)
-            // println(e.dropIndex)
-
             val newParentGroupIndex: NonNegShort =
               if dropIndex.value == 0 then dropIndex
               else
@@ -272,7 +254,6 @@ object ObsList:
               )
               .runAsync >>
               treeNodes.value.set(e.value.toList) >>
-              // obsEdit *>
               // Open the group we moved to
               dropNodeId.map(id => props.expandedGroups.mod(_ + id)).getOrEmpty
           }

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -27,9 +27,9 @@ import explore.model.GroupTree.syntax.*
 import explore.model.ObsIdSet
 import explore.model.Observation
 import explore.model.ObservationExecutionMap
+import explore.model.ServerIndexed
 import explore.model.enums.AppTab
 import explore.model.reusability.given
-import explore.model.syntax.all.*
 import explore.tabs.DeckShown
 import explore.undo.UndoSetter
 import explore.undo.Undoer
@@ -59,7 +59,6 @@ import queries.schemas.odb.ObsQueries
 import scala.scalajs.js
 
 import ObsQueries.*
-import explore.model.ServerIndexed
 
 case class ObsList(
   observations:         UndoSetter[ObservationList],

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -249,17 +249,20 @@ object ObsList:
             val newParentGroupIndex: NonNegShort =
               if dropIndex.value == 0 then dropIndex
               else
-                dropNodeId
+                val groupTree: GroupTree = props.groups.get
+
+                val newSiblings: List[GroupTree.Node] = dropNodeId
                   .flatMap: groupId =>
-                    props.groups.get.getNodeAndIndexByKey(groupId.asRight)
+                    groupTree.getNodeAndIndexByKey(groupId.asRight)
                   .map(_._1.children)
-                  .filter(_.nonEmpty)
-                  .flatMap(_.get(dropIndex.value.toInt - 1))
+                  .getOrElse(groupTree.rootChildren)
+
+                // Get the parentIndex of the previous node and add one.
+                newSiblings
+                  .get(dropIndex.value.toInt - 1)
                   .map: previousNode =>
                     NonNegShort.unsafeFrom((previousNode.value.parentIndex.value + 1).toShort)
                   .getOrElse(NonNegShort.unsafeFrom(0))
-
-            println(newParentGroupIndex)
 
             dragNode.id
               .fold(

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -378,6 +378,7 @@ object ObsList:
                           props.focusedGroup,
                           props.observations.get.length,
                           props.observations,
+                          props.groups.model,
                           adding,
                           ctx
                         ).runAsync *> expandFocusedGroup

--- a/explore/src/main/scala/explore/observationtree/ObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsList.scala
@@ -228,19 +228,22 @@ object ObsList:
             val obsEdit: Callback = dragNode.left.toOption
               .map: obs =>
                 props.observations.model
-                  .mod(
+                  .mod:
                     _.updatedValueWith(
                       obs.id,
-                      Observation.groupId
-                        .replace(dropNodeId)
-                        .andThen(Observation.groupIndex.replace(dropIndex))
+                      ???
+                      // Observation.groupId
+                      //   .replace(dropNodeId)
+                      //   .andThen: // TODO groupIndex IS NOT OUR INDEX!!!!
+                      //     Observation.groupIndex.replace(dropIndex)
                     )
-                  )
               .getOrEmpty
 
             dragNode.id
               .fold(
+                // TODO groupIndex IS NOT OUR INDEX!!!!
                 obsId => ObsQueries.moveObservation[IO](obsId, dropNodeId, dropIndex.some),
+                // TODO groupIndex IS NOT OUR INDEX!!!!
                 groupId => GroupQueries.moveGroup[IO](groupId, dropNodeId, dropIndex.some)
               )
               .runAsync *>
@@ -309,7 +312,8 @@ object ObsList:
                       cloneCB = cloneObs(
                         props.programId,
                         id,
-                        obs.groupId, // Clone to the same group
+                        ???,
+                        // obs.groupId, // Clone to the same group
                         props.observations,
                         ctx,
                         adding.async.set(AddingObservation(true)),

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -20,6 +20,7 @@ import explore.model.AppContext
 import explore.model.Asterism
 import explore.model.Execution
 import explore.model.Focused
+import explore.model.GroupTree
 import explore.model.Observation
 import explore.model.ObservationExecutionMap
 import explore.model.TargetList
@@ -64,6 +65,7 @@ final case class ObsSummaryTable(
   userId:        Option[User.Id],
   programId:     Program.Id,
   observations:  UndoSetter[ObservationList],
+  groups:        View[GroupTree],
   obsExecutions: ObservationExecutionMap,
   allTargets:    TargetList,
   tileState:     View[ColumnSelectorState[Expandable[ObsSummaryTable.ObsSummaryRow], Nothing]]
@@ -361,6 +363,7 @@ object ObsSummaryTable:
               none,
               0.refined,
               props.observations,
+              props.groups,
               adding,
               ctx
             ).runAsyncAndForget

--- a/explore/src/main/scala/explore/observationtree/package.scala
+++ b/explore/src/main/scala/explore/observationtree/package.scala
@@ -66,10 +66,7 @@ def cloneObs(
 ): IO[Unit] =
   import ctx.given
 
-  // import eu.timepit.refined.auto.autoUnwrap
-
-  IO.println(s"cloneObs $obsId $newGroupId") >>
-    before >>
+  before >>
     cloneObservation[IO](obsId, newGroupId)
       .flatMap: newObs =>
         obsExistence(newObs.id, o => setObs(programId, o.some, ctx))
@@ -211,7 +208,7 @@ def groupExistence(
         case None              => groupList.removed(groupId.asRight)
         case Some((node, idx)) =>
           val group = node.value
-          groupList.updated(groupId.asRight, group, idx)
+          groupList.upserted(groupId.asRight, group, idx)
 )(
   onSet = (_, node) =>
     node.fold {

--- a/explore/src/main/scala/explore/observationtree/package.scala
+++ b/explore/src/main/scala/explore/observationtree/package.scala
@@ -73,7 +73,7 @@ def cloneObs(
       .flatMap: newObs =>
         obsExistence(newObs.id, o => setObs(programId, o.some, ctx))
           .mod(observations): // TODO groupIndex IS NOT OUR INDEX!!!!
-            obsListMod.upsert(newObs, newObs.groupIndex.toNonNegInt)
+            obsListMod.upsert(newObs, ???) // newObs.groupIndex.toNonNegInt)
           .toAsync
       .guarantee(after)
 
@@ -233,11 +233,11 @@ def insertGroup(
   import ctx.given
   GroupQueries
     .createGroup[IO](programId, parentId)
-    .flatMap(group =>
-      groupExistence(group.id, g => setGroup(programId, g.some, ctx))
-        .set(groups)(
-          (Node(group.toGroupTreeGroup.asRight), group.toIndex).some
-        )
-        .toAsync
-    )
+    // .flatMap: grouping =>
+    //   groupExistence(grouping.group.id, g => setGroup(programId, g.some, ctx))
+    //     .set(groups)(
+    //       (Node(grouping.toGroupTreeGroup.asRight), grouping.group.toIndex).some
+    //     )
+    //     .toAsync
+    .void
     .switching(adding.zoom(AddingObservation.value.asLens).async)

--- a/explore/src/main/scala/explore/observationtree/package.scala
+++ b/explore/src/main/scala/explore/observationtree/package.scala
@@ -36,6 +36,7 @@ import lucuma.schemas.odb.input.*
 import monocle.Focus
 import queries.common.ObsQueriesGQL.*
 import queries.schemas.odb.ObsQueries.*
+import explore.model.syntax.all.toNonNegInt
 
 val obsListMod = KIListMod[Observation, Observation.Id](Observation.id)
 
@@ -71,8 +72,8 @@ def cloneObs(
     cloneObservation[IO](obsId, newGroupId)
       .flatMap: newObs =>
         obsExistence(newObs.id, o => setObs(programId, o.some, ctx))
-          .mod(observations): // Convert NonNegShort => NonNegInt
-            obsListMod.upsert(newObs, NonNegInt.unsafeFrom(newObs.groupIndex.value))
+          .mod(observations): // TODO groupIndex IS NOT OUR INDEX!!!!
+            obsListMod.upsert(newObs, newObs.groupIndex.toNonNegInt)
           .toAsync
       .guarantee(after)
 

--- a/explore/src/main/scala/explore/observationtree/package.scala
+++ b/explore/src/main/scala/explore/observationtree/package.scala
@@ -66,12 +66,16 @@ def cloneObs(
 ): IO[Unit] =
   import ctx.given
 
-  before >>
+  // import eu.timepit.refined.auto.autoUnwrap
+
+  IO.println(s"cloneObs $obsId $newGroupId") >>
+    before >>
     cloneObservation[IO](obsId, newGroupId)
       .flatMap: newObs =>
         obsExistence(newObs.id, o => setObs(programId, o.some, ctx))
-          .mod(observations): // TODO groupIndex IS NOT OUR INDEX!!!!
-            obsListMod.upsert(newObs, ???) // newObs.groupIndex.toNonNegInt)
+          .mod(observations):
+            // Just place the new obs at the end of the group, which is where the server clones it.
+            obsListMod.upsert(newObs, NonNegInt.MaxValue)
           .toAsync
       .guarantee(after)
 

--- a/explore/src/main/scala/explore/observationtree/package.scala
+++ b/explore/src/main/scala/explore/observationtree/package.scala
@@ -12,7 +12,6 @@ import eu.timepit.refined.types.numeric.NonNegInt
 import explore.DefaultErrorPolicy
 import explore.common.GroupQueries
 import explore.data.KeyedIndexedList
-import explore.data.tree.Node
 import explore.model.AppContext
 import explore.model.Focused
 import explore.model.GroupTree
@@ -36,7 +35,6 @@ import lucuma.schemas.odb.input.*
 import monocle.Focus
 import queries.common.ObsQueriesGQL.*
 import queries.schemas.odb.ObsQueries.*
-import explore.model.syntax.all.toNonNegInt
 
 val obsListMod = KIListMod[Observation, Observation.Id](Observation.id)
 

--- a/explore/src/main/scala/explore/tabs/GroupEditBody.scala
+++ b/explore/src/main/scala/explore/tabs/GroupEditBody.scala
@@ -18,7 +18,6 @@ import explore.Icons
 import explore.common.GroupQueries
 import explore.components.ui.ExploreStyles
 import explore.model.AppContext
-import explore.model.GroupTree
 import explore.model.ProgramTimeRange
 import explore.syntax.ui.*
 import explore.undo.UndoSetter
@@ -40,11 +39,12 @@ import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given
 import monocle.Iso
 import monocle.Lens
+import explore.model.Group
 
 import scala.scalajs.js
 
 case class GroupEditBody(
-  group:             UndoSetter[GroupTree.Group],
+  group:             UndoSetter[Group],
   elementsLength:    Int,
   timeEstimateRange: Pot[Option[ProgramTimeRange]],
   readonly:          Boolean
@@ -66,13 +66,10 @@ object GroupEditBody:
   val component = ScalaFnComponent
     .withHooks[Props]
     .useContext(AppContext.ctx)
-    // editType
-    .useStateViewBy: (props, _) =>
+    .useStateViewBy: (props, _) => // editType
       if props.group.get.isAnd then GroupEditType.And else GroupEditType.Or
-    // isLoading
-    .useStateView(false)
-    // nameDisplay
-    .useStateBy((props, _, _, _) => props.group.get.name)
+    .useStateView(false) // isLoading
+    .useStateBy((props, _, _, _) => props.group.get.name) // nameDisplay
     .render: (props, ctx, editType, isLoading, nameDisplay) =>
       import ctx.given
 
@@ -81,7 +78,7 @@ object GroupEditBody:
 
       val isDisabled: Boolean = props.readonly || isLoading.get
 
-      def groupModView[A](lens: Lens[GroupTree.Group, A], prop: A => GroupPropertiesInput) =
+      def groupModView[A](lens: Lens[Group, A], prop: A => GroupPropertiesInput) =
         props.group
           .undoableView(lens)
           .withOnMod(a =>
@@ -89,27 +86,27 @@ object GroupEditBody:
           )
 
       val minRequiredV = groupModView(
-        GroupTree.Group.minimumRequired,
+        Group.minimumRequired,
         m => GroupPropertiesInput(minimumRequired = m.orUnassign)
       )
       val nameV        = groupModView(
-        GroupTree.Group.name,
+        Group.name,
         n => GroupPropertiesInput(name = n.orUnassign)
       )
       val orderedV     =
-        groupModView(GroupTree.Group.ordered, o => GroupPropertiesInput(ordered = o.assign))
+        groupModView(Group.ordered, o => GroupPropertiesInput(ordered = o.assign))
 
       val timeSpanOrEmptyLens =
         Iso[Option[TimeSpan], TimeSpan](_.orEmpty)(_.some.filterNot(_.isZero))
       val minIntervalV        = groupModView(
-        GroupTree.Group.minimumInterval.andThen(timeSpanOrEmptyLens),
+        Group.minimumInterval.andThen(timeSpanOrEmptyLens),
         ts =>
           GroupPropertiesInput(minimumInterval =
             TimeSpanInput(microseconds = ts.toMicroseconds.assign).assign
           )
       )
       val maxIntervalV        = groupModView(
-        GroupTree.Group.maximumInterval.andThen(timeSpanOrEmptyLens),
+        Group.maximumInterval.andThen(timeSpanOrEmptyLens),
         ts =>
           GroupPropertiesInput(maximumInterval =
             TimeSpanInput(microseconds = ts.toMicroseconds.assign).assign
@@ -238,7 +235,7 @@ object GroupEditBody:
       )
 
 case class GroupEditTitle(
-  group:             UndoSetter[GroupTree.Group],
+  group:             UndoSetter[Group],
   elementsLength:    Int,
   timeEstimateRange: Pot[Option[ProgramTimeRange]]
 ) extends ReactFnProps(GroupEditTitle.component)
@@ -247,7 +244,7 @@ object GroupEditTitle:
   private type Props = GroupEditTitle
 
   private def makeTitle(
-    group:             GroupTree.Group,
+    group:             Group,
     timeEstimateRange: Pot[Option[ProgramTimeRange]],
     elementsLength:    Int
   ) =

--- a/explore/src/main/scala/explore/tabs/GroupEditBody.scala
+++ b/explore/src/main/scala/explore/tabs/GroupEditBody.scala
@@ -18,6 +18,7 @@ import explore.Icons
 import explore.common.GroupQueries
 import explore.components.ui.ExploreStyles
 import explore.model.AppContext
+import explore.model.Group
 import explore.model.ProgramTimeRange
 import explore.syntax.ui.*
 import explore.undo.UndoSetter
@@ -39,7 +40,6 @@ import lucuma.ui.primereact.*
 import lucuma.ui.primereact.given
 import monocle.Iso
 import monocle.Lens
-import explore.model.Group
 
 import scala.scalajs.js
 

--- a/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
@@ -10,6 +10,7 @@ import explore.components.TileController
 import explore.components.ui.ExploreStyles
 import explore.model.GroupEditIds
 import explore.model.GroupTree
+import explore.model.Group
 import explore.model.ProgramTimeRange
 import explore.model.enums.GridLayoutSection
 import explore.model.layout.LayoutsMap
@@ -61,9 +62,12 @@ object ObsGroupTiles:
             )
 
           // Then zoom to the Grouping itself
-          val group =
-            node.zoom(_._1.value.toOption.get,
-                      modF => _.leftMap(node => node.copy(value = node.value.map(modF)))
+          val group: UndoSetter[Group] =
+            node.zoom(
+              _._1.value.elem.toOption.get,
+              modF =>
+                _.leftMap: node =>
+                  node.copy(value = node.value.copy(elem = node.value.elem.map(modF)))
             )
 
           val editTile = Tile(

--- a/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
@@ -8,9 +8,9 @@ import crystal.Pot
 import explore.components.Tile
 import explore.components.TileController
 import explore.components.ui.ExploreStyles
+import explore.model.Group
 import explore.model.GroupEditIds
 import explore.model.GroupTree
-import explore.model.Group
 import explore.model.ProgramTimeRange
 import explore.model.enums.GridLayoutSection
 import explore.model.layout.LayoutsMap

--- a/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
@@ -56,7 +56,7 @@ object ObsGroupTiles:
                     .getNodeAndIndexByKey(groupTreeKey)
                     .map(modF)
                     .map((newValue, newIndex) =>
-                      groups.updated(groupTreeKey, newValue.value, newIndex)
+                      groups.upserted(groupTreeKey, newValue.value, newIndex)
                     )
                     .getOrElse(groups)
             )

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -55,6 +55,7 @@ import lucuma.ui.reusability.given
 import lucuma.ui.sso.UserVault
 import lucuma.ui.syntax.all.given
 import monocle.Iso
+import explore.model.GroupTree.syntax.*
 
 object DeckShown extends NewType[Boolean]:
   inline def Shown: DeckShown  = DeckShown(true)
@@ -81,11 +82,11 @@ case class ObsTabContents(
   private val focusedGroup: Option[Group.Id]                               = focused.group
   private val observations: UndoSetter[ObservationList]                    =
     programSummaries.zoom(ProgramSummaries.observations)
+  private val groups: UndoSetter[GroupTree]                                = programSummaries.zoom(ProgramSummaries.groups)
   private val activeGroup: Option[Group.Id]                                = focusedGroup.orElse:
-    focusedObs.flatMap(obsId => observations.get.getValue(obsId).flatMap(_.groupId))
+    focusedObs.flatMap(groups.get.obsGroupId)
   private val obsExecutions: ObservationExecutionMap                       = programSummaries.get.obsExecutionPots
   private val groupTimeRanges: GroupTimeRangeMap                           = programSummaries.get.groupTimeRangePots
-  private val groups: UndoSetter[GroupTree]                                = programSummaries.zoom(ProgramSummaries.groups)
   private val targets: UndoSetter[TargetList]                              = programSummaries.zoom(ProgramSummaries.targets)
   private val observationIdsWithIndices: List[(Observation.Id, NonNegInt)] =
     observations.get.toIndexedList.map((o, idx) => (o.id, idx))

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -87,9 +87,8 @@ case class ObsTabContents(
   private val groupTimeRanges: GroupTimeRangeMap                           = programSummaries.get.groupTimeRangePots
   private val groups: UndoSetter[GroupTree]                                = programSummaries.zoom(ProgramSummaries.groups)
   private val targets: UndoSetter[TargetList]                              = programSummaries.zoom(ProgramSummaries.targets)
-  private val observationIds: List[Observation.Id]                         = observations.get.values.map(_.id).toList
   private val observationIdsWithIndices: List[(Observation.Id, NonNegInt)] =
-    observationIds.zipWithIndex.map((id, idx) => id -> NonNegInt.unsafeFrom(idx))
+    observations.get.toIndexedList.map((o, idx) => (o.id, idx))
   val readonly: Boolean                                                    = programSummaries.get.proposalIsSubmitted
 
 object ObsTabContents extends TwoPanels:
@@ -102,13 +101,11 @@ object ObsTabContents extends TwoPanels:
       .useStateView[SelectedPanel](SelectedPanel.Uninitialized)
       .useEffectWithDepsBy((props, _, _) => props.focusedObs): (_, _, selected) =>
         focusedObs =>
-          (focusedObs, selected.get) match {
+          (focusedObs, selected.get) match
             case (Some(_), _)                 => selected.set(SelectedPanel.Editor)
             case (None, SelectedPanel.Editor) => selected.set(SelectedPanel.Summary)
             case _                            => Callback.empty
-          }
-      // Measure its size
-      .useResizeDetector()
+      .useResizeDetector() // Measure its size
       .useState(none[ObsIdSet]) // shadowClipboardObs (a copy as state only if it has observations)
       .useEffectOnMountBy: (_, ctx, _, _, shadowClipboardObs) => // initialize shadowClipboard
         import ctx.given

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -19,6 +19,7 @@ import explore.components.ui.ExploreStyles
 import explore.data.KeyedIndexedList
 import explore.model.*
 import explore.model.AppContext
+import explore.model.GroupTree.syntax.*
 import explore.model.Observation
 import explore.model.ObservationExecutionMap
 import explore.model.ProgramSummaries
@@ -55,7 +56,6 @@ import lucuma.ui.reusability.given
 import lucuma.ui.sso.UserVault
 import lucuma.ui.syntax.all.given
 import monocle.Iso
-import explore.model.GroupTree.syntax.*
 
 object DeckShown extends NewType[Boolean]:
   inline def Shown: DeckShown  = DeckShown(true)

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -266,6 +266,7 @@ object ObsTabContents extends TwoPanels:
                 props.vault.userId,
                 props.programId,
                 props.observations,
+                props.groups.model,
                 props.obsExecutions,
                 props.targets.get,
                 _

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -401,7 +401,7 @@ object TargetTabContents extends TwoPanels:
 
             val obsConf = idsToEdit.single match {
               case Some(id) =>
-                props.programSummaries.get.observations.values
+                props.programSummaries.get.observations.toList
                   .collect:
                     case o @ Observation(
                           obsId,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -420,8 +420,6 @@ object TargetTabContents extends TwoPanels:
                           _,
                           posAngle,
                           Some(wavelength),
-                          // _,
-                          // _,
                           _,
                           _,
                           _

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -420,8 +420,8 @@ object TargetTabContents extends TwoPanels:
                           _,
                           posAngle,
                           Some(wavelength),
-                          _,
-                          _,
+                          // _,
+                          // _,
                           _,
                           _,
                           _

--- a/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -154,7 +154,7 @@ object ObsQueries:
   def createObservation[F[_]: Async](
     programId: Program.Id,
     parentId:  Option[Group.Id]
-  )(using FetchClient[F, ObservationDB]): F[Observation] =
+  )(using FetchClient[F, ObservationDB]): F[(Observation, NonNegShort)] =
     ProgramCreateObservation[F]
       .execute(
         CreateObservationInput(
@@ -164,7 +164,8 @@ object ObsQueries:
             .orIgnore
         )
       )
-      .map(_.createObservation.observation)
+      .map: result =>
+        (result.createObservation.observation, result.createObservation.meta.groupIndex)
 
   def createObservationWithTargets[F[_]: Async](
     programId: Program.Id,

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
@@ -4,9 +4,7 @@
 package explore.model.arb
 
 import cats.Order.given
-import eu.timepit.refined.scalacheck.numeric.given
 import eu.timepit.refined.scalacheck.string.given
-import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.Observation
 import explore.model.ScienceRequirements
@@ -16,7 +14,6 @@ import lucuma.core.enums.ObsStatus
 import lucuma.core.math.Wavelength
 import lucuma.core.math.arb.ArbWavelength.given
 import lucuma.core.model.ConstraintSet
-import lucuma.core.model.Group
 import lucuma.core.model.ObsAttachment
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.PosAngleConstraint
@@ -64,8 +61,8 @@ trait ArbObservation:
         vizDuration         <- arbitrary[Option[TimeSpan]]
         posAngleConstraint  <- arbitrary[PosAngleConstraint]
         wavelength          <- arbitrary[Option[Wavelength]]
-        groupId             <- arbitrary[Option[Group.Id]]
-        groupIndex          <- arbitrary[NonNegShort]
+        // groupId             <- arbitrary[Option[Group.Id]]
+        // groupIndex          <- arbitrary[NonNegShort]
         validations         <- arbitrary[List[ObservationValidation]]
         observerNotes       <- arbitrary[Option[NonEmptyString]]
         calibrationRole     <- arbitrary[Option[CalibrationRole]]
@@ -86,8 +83,8 @@ trait ArbObservation:
         vizDuration,
         posAngleConstraint,
         wavelength,
-        groupId,
-        groupIndex,
+        // groupId,
+        // groupIndex,
         validations,
         observerNotes,
         calibrationRole
@@ -111,8 +108,8 @@ trait ArbObservation:
        Option[TimeSpan],
        PosAngleConstraint,
        Option[Wavelength],
-       Option[Group.Id],
-       Short,
+       //  Option[Group.Id],
+       //  Short,
        List[ObservationValidation],
        Option[String],
        Option[CalibrationRole]
@@ -134,8 +131,8 @@ trait ArbObservation:
          o.observationDuration,
          o.posAngleConstraint,
          o.wavelength,
-         o.groupId,
-         o.groupIndex.value,
+         //  o.groupId,
+         //  o.groupIndex.value,
          o.validations,
          o.observerNotes.map(_.value),
          o.calibrationRole

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
@@ -61,8 +61,6 @@ trait ArbObservation:
         vizDuration         <- arbitrary[Option[TimeSpan]]
         posAngleConstraint  <- arbitrary[PosAngleConstraint]
         wavelength          <- arbitrary[Option[Wavelength]]
-        // groupId             <- arbitrary[Option[Group.Id]]
-        // groupIndex          <- arbitrary[NonNegShort]
         validations         <- arbitrary[List[ObservationValidation]]
         observerNotes       <- arbitrary[Option[NonEmptyString]]
         calibrationRole     <- arbitrary[Option[CalibrationRole]]
@@ -83,8 +81,6 @@ trait ArbObservation:
         vizDuration,
         posAngleConstraint,
         wavelength,
-        // groupId,
-        // groupIndex,
         validations,
         observerNotes,
         calibrationRole
@@ -108,8 +104,6 @@ trait ArbObservation:
        Option[TimeSpan],
        PosAngleConstraint,
        Option[Wavelength],
-       //  Option[Group.Id],
-       //  Short,
        List[ObservationValidation],
        Option[String],
        Option[CalibrationRole]
@@ -131,8 +125,6 @@ trait ArbObservation:
          o.observationDuration,
          o.posAngleConstraint,
          o.wavelength,
-         //  o.groupId,
-         //  o.groupIndex.value,
          o.validations,
          o.observerNotes.map(_.value),
          o.calibrationRole

--- a/model-tests/shared/src/test/scala/explore/data/KeyedIndexedTreeSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/data/KeyedIndexedTreeSuite.scala
@@ -3,10 +3,10 @@
 
 package explore.data
 
-import cats.syntax.option.*
 import cats.data.NonEmptyList
 import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline.arbitrary.*
+import cats.syntax.option.*
 import explore.data.tree.KeyedIndexedTree
 import explore.data.tree.Node
 import explore.data.tree.Tree

--- a/model-tests/shared/src/test/scala/explore/data/KeyedIndexedTreeSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/data/KeyedIndexedTreeSuite.scala
@@ -3,6 +3,7 @@
 
 package explore.data
 
+import cats.syntax.option.*
 import cats.data.NonEmptyList
 import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline.arbitrary.*
@@ -32,6 +33,40 @@ class KeyedIndexedTreeSuite extends DisciplineSuite {
 
       assertEquals(tree.parentKeys(distinctNodes.head), distinctNodes.tail.reverse)
       assertEquals(tree.parentKeys(distinctNodes.last), Nil)
+    }
+  }
+
+  property("upsert with function") {
+    forAll { (tree: Tree[Int]) =>
+      val emptyTree = KeyedIndexedTree.empty[Int, Int]
+
+      def processNodeChildren(
+        acc:      KeyedIndexedTree[Int, Int],
+        children: List[Node[Int]],
+        parent:   Option[Int]
+      ): KeyedIndexedTree[Int, Int] =
+        children.foldLeft(acc): (tree, node) =>
+          tree.upserted(node.value, node.value, parent, _.value > node.value)
+
+      // Add children values, then go deeper into the tree.
+      def processNode(
+        acc:      KeyedIndexedTree[Int, Int],
+        children: List[Node[Int]],
+        parent:   Option[Int]
+      ): KeyedIndexedTree[Int, Int] =
+        val withChildren = processNodeChildren(acc, children, parent)
+        children.foldLeft(withChildren): (tree, node) =>
+          processNode(tree, node.children, node.value.some)
+
+      val sortedTree = processNode(emptyTree(identity), tree.children, none)
+
+      // Check that the built tree is actually sorted
+      def assertNode(children: List[Node[Int]]): Unit =
+        assertEquals(children.map(_.value), children.map(_.value).sorted)
+        children.foreach: node =>
+          assertNode(node.children)
+
+      assertNode(sortedTree.toTree.children)
     }
   }
 }

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -105,7 +105,7 @@ case class KeyedIndexedTree[K: Eq, A] private (
     val newTree: Tree[IndexedElem[K, A]]   = Tree(insertInChildren(cleanTree.children))
     KeyedIndexedTree(buildKeyMap(newTree, getKey), newTree)(getKey)
   }
-  def updated( // TODO TEST!!!
+  def upserted(
     key:         K,
     newValue:    A,
     newChildren: List[Node[A]],
@@ -113,11 +113,11 @@ case class KeyedIndexedTree[K: Eq, A] private (
   ): KeyedIndexedTree[K, A] =
     removed(key).inserted(key, Node(newValue, newChildren), newIndex)
 
-  def updated(key: K, newValue: A, newIndex: Index[K]): KeyedIndexedTree[K, A] =
+  def upserted(key: K, newValue: A, newIndex: Index[K]): KeyedIndexedTree[K, A] =
     val existingChildren: List[Node[A]] = getNodeAndIndexByKey(key).map(_._1.children).orEmpty
-    updated(key, newValue, existingChildren, newIndex)
+    upserted(key, newValue, existingChildren, newIndex)
 
-  def updated( // TODO TEST!!! call it upserted?
+  def upserted(
     key:             K,
     newValue:        A,
     newChildren:     List[Node[A]],
@@ -140,14 +140,14 @@ case class KeyedIndexedTree[K: Eq, A] private (
         Index(parentKey, NonNegInt.unsafeFrom(newIndex))
       )
 
-  def updated( // TODO TEST!!!
+  def upserted(
     key:             K,
     newValue:        A,
     parentKey:       Option[K],
     beforeNodeWhere: Node[A] => Boolean
   ): KeyedIndexedTree[K, A] =
     val existingChildren: List[Node[A]] = getNodeAndIndexByKey(key).map(_._1.children).orEmpty
-    updated(key, newValue, existingChildren, parentKey, beforeNodeWhere)
+    upserted(key, newValue, existingChildren, parentKey, beforeNodeWhere)
 
   def collect[B](pf: PartialFunction[(K, Node[A], Index[K]), B]): List[B] =
     byKey
@@ -233,6 +233,9 @@ object KeyedIndexedTree {
     val indexedTree: Tree[IndexedElem[K, A]] = Tree(indexedUniqueKeyChildren(tree.children, getKey))
     KeyedIndexedTree(buildKeyMap(indexedTree, getKey), indexedTree)(getKey)
   }
+
+  def empty[K: Eq, A](getKey: A => K): KeyedIndexedTree[K, A] =
+    KeyedIndexedTree.fromTree(Tree.empty, getKey)
 
   implicit def eqKeyedIndexedTree[K, A: Eq]: Eq[KeyedIndexedTree[K, A]] =
     Eq.by(_.toTree)

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -105,6 +105,8 @@ case class KeyedIndexedTree[K: Eq, A] private (
     val newTree: Tree[IndexedElem[K, A]]   = Tree(insertInChildren(cleanTree.children))
     KeyedIndexedTree(buildKeyMap(newTree, getKey), newTree)(getKey)
   }
+
+  /** SCALADOC TODO!!!! */
   def upserted(
     key:         K,
     newValue:    A,

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -103,13 +103,13 @@ case class KeyedIndexedTree[K: Eq, A] private (
     KeyedIndexedTree(buildKeyMap(newTree, getKey), newTree)(getKey)
   }
 
-  def updated(key: K, newNode: A, newIndex: Index[K]): KeyedIndexedTree[K, A] =
+  def updated(key: K, newValue: A, newIndex: Index[K]): KeyedIndexedTree[K, A] =
     val existingChildren: List[Node[A]] = getNodeAndIndexByKey(key).map(_._1.children).orEmpty
-    removed(key).inserted(key, Node(newNode, existingChildren), newIndex)
+    removed(key).inserted(key, Node(newValue, existingChildren), newIndex)
 
   def updated( // TODO TEST!!!
     key:             K,
-    newNode:         A,
+    newValue:        A,
     parentKey:       Option[K],
     beforeNodeWhere: Node[A] => Boolean
   ): KeyedIndexedTree[K, A] =
@@ -126,7 +126,7 @@ case class KeyedIndexedTree[K: Eq, A] private (
       val withRemovedNode: KeyedIndexedTree[K, A] = removed(key)
       withRemovedNode.inserted(
         key,
-        Node(newNode, existingChildren),
+        Node(newValue, existingChildren),
         Index(parentKey, NonNegInt.unsafeFrom(newIndex))
       )
 

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -117,23 +117,23 @@ case class KeyedIndexedTree[K: Eq, A] private (
     val existingChildren: List[Node[A]] = getNodeAndIndexByKey(key).map(_._1.children).orEmpty
     updated(key, newValue, existingChildren, newIndex)
 
-  def updated( // TODO TEST!!!
+  def updated( // TODO TEST!!! call it upserted?
     key:             K,
     newValue:        A,
     newChildren:     List[Node[A]],
     parentKey:       Option[K],
     beforeNodeWhere: Node[A] => Boolean
   ): KeyedIndexedTree[K, A] =
-    val newSiblings: Option[List[Node[A]]] =
+    val withRemovedNode: KeyedIndexedTree[K, A] = removed(key)
+    val newSiblings: Option[List[Node[A]]]      =
       parentKey match
-        case None       => tree.children.map(_.map(_.elem)).some
-        case Some(pkey) => getNodeAndIndexByKey(pkey).map(_._1.children)
+        case None       => withRemovedNode.tree.children.map(_.map(_.elem)).some
+        case Some(pkey) => withRemovedNode.getNodeAndIndexByKey(pkey).map(_._1.children)
     // If newSiblings is None, then parentKey doesn't exist. We don't alter the tree.
     newSiblings.fold(this): siblings =>
-      val newIndex: Int                           = Option(siblings.indexWhere(beforeNodeWhere))
+      val newIndex: Int = Option(siblings.indexWhere(beforeNodeWhere))
         .filter(_ =!= -1)
         .getOrElse(siblings.length)
-      val withRemovedNode: KeyedIndexedTree[K, A] = removed(key)
       withRemovedNode.inserted(
         key,
         Node(newValue, newChildren),

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -29,6 +29,9 @@ case class KeyedIndexedTree[K: Eq, A] private (
   def toKeyedTree: Tree[(K, A)] =
     tree.map(value => (getKey(value.elem), value.elem))
 
+  def rootChildren: List[Node[A]] =
+    tree.children.map(_.map(_.elem))
+
   def getNodeAndIndexByKey(key: K): Option[(Node[A], Index[K])] =
     byKey
       .get(key)

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -106,7 +106,13 @@ case class KeyedIndexedTree[K: Eq, A] private (
     KeyedIndexedTree(buildKeyMap(newTree, getKey), newTree)(getKey)
   }
 
-  /** SCALADOC TODO!!!! */
+  /**
+   * Insert or update a node in the tree at a given index.
+   *
+   * If the key is already present in the tree, the node is updated with the new value and children
+   * and possibly relocated to the given index. If the key is not present in the tree, the node is
+   * inserted at the given index.
+   */
   def upserted(
     key:         K,
     newValue:    A,
@@ -115,10 +121,25 @@ case class KeyedIndexedTree[K: Eq, A] private (
   ): KeyedIndexedTree[K, A] =
     removed(key).inserted(key, Node(newValue, newChildren), newIndex)
 
+  /**
+   * Insert or update a node in the tree at a given index, keeping its current children.
+   *
+   * If the key is already present in the tree, the node is updated with the new value and possibly
+   * relocated to the given index. If the key is not present in the tree, the node is inserted at
+   * the given index.
+   */
   def upserted(key: K, newValue: A, newIndex: Index[K]): KeyedIndexedTree[K, A] =
     val existingChildren: List[Node[A]] = getNodeAndIndexByKey(key).map(_._1.children).orEmpty
     upserted(key, newValue, existingChildren, newIndex)
 
+  /**
+   * Insert or update a node in the tree under a given parent and right before a node that satisfies
+   * a given predicate.
+   *
+   * If the key is already present in the tree, the node is updated with the new value and children
+   * and possibly relocated under the given parent. If the key is not present in the tree, the node
+   * is inserted under the given parent.
+   */
   def upserted(
     key:             K,
     newValue:        A,
@@ -142,6 +163,14 @@ case class KeyedIndexedTree[K: Eq, A] private (
         Index(parentKey, NonNegInt.unsafeFrom(newIndex))
       )
 
+  /**
+   * Insert or update a node in the tree, keeping its existing children, under a given parent and
+   * right before a node that satisfies a given predicate.
+   *
+   * If the key is already present in the tree, the node is updated with the new value and possibly
+   * relocated under the given parent. If the key is not present in the tree, the node is inserted
+   * under the given parent.
+   */
   def upserted(
     key:             K,
     newValue:        A,

--- a/model/shared/src/main/scala/explore/model/Group.scala
+++ b/model/shared/src/main/scala/explore/model/Group.scala
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.Order.*
+import cats.derived.*
+import cats.syntax.all.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.numeric.NonNegShort
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.model.syntax.all.*
+import lucuma.core.util.TimeSpan
+import monocle.Focus
+import monocle.Lens
+import io.circe.Decoder
+import io.circe.refined.given
+import lucuma.odb.json.time.decoder.given
+
+case class Group(
+  id:              Group.Id,
+  name:            Option[NonEmptyString],
+  minimumRequired: Option[NonNegShort],
+  minimumInterval: Option[TimeSpan],
+  maximumInterval: Option[TimeSpan],
+  ordered:         Boolean,
+  system:          Boolean
+) derives Eq,
+      Decoder:
+  def isAnd: Boolean = minimumRequired.isEmpty
+
+object Group:
+  type Id = lucuma.core.model.Group.Id
+
+  val id: Lens[Group, Group.Id]                         = Focus[Group](_.id)
+  val name: Lens[Group, Option[NonEmptyString]]         = Focus[Group](_.name)
+  val minimumInterval: Lens[Group, Option[TimeSpan]]    = Focus[Group](_.minimumInterval)
+  val maximumInterval: Lens[Group, Option[TimeSpan]]    = Focus[Group](_.maximumInterval)
+  val minimumRequired: Lens[Group, Option[NonNegShort]] = Focus[Group](_.minimumRequired)
+  val ordered: Lens[Group, Boolean]                     = Focus[Group](_.ordered)
+  val system: Lens[Group, Boolean]                      = Focus[Group](_.system)

--- a/model/shared/src/main/scala/explore/model/Group.scala
+++ b/model/shared/src/main/scala/explore/model/Group.scala
@@ -4,9 +4,7 @@
 package explore.model
 
 import cats.Eq
-import cats.Order.*
 import cats.derived.*
-import cats.syntax.all.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
@@ -32,6 +30,7 @@ case class Group(
 
 object Group:
   type Id = lucuma.core.model.Group.Id
+  val Id = lucuma.core.model.Group.Id
 
   val id: Lens[Group, Group.Id]                         = Focus[Group](_.id)
   val name: Lens[Group, Option[NonEmptyString]]         = Focus[Group](_.name)

--- a/model/shared/src/main/scala/explore/model/Group.scala
+++ b/model/shared/src/main/scala/explore/model/Group.scala
@@ -9,12 +9,12 @@ import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.syntax.all.*
-import lucuma.core.util.TimeSpan
-import monocle.Focus
-import monocle.Lens
 import io.circe.Decoder
 import io.circe.refined.given
+import lucuma.core.util.TimeSpan
 import lucuma.odb.json.time.decoder.given
+import monocle.Focus
+import monocle.Lens
 
 case class Group(
   id:              Group.Id,

--- a/model/shared/src/main/scala/explore/model/GroupElement.scala
+++ b/model/shared/src/main/scala/explore/model/GroupElement.scala
@@ -6,14 +6,15 @@ package explore.model
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
+import eu.timepit.refined.cats.given
 import eu.timepit.refined.types.numeric.NonNegShort
 import io.circe.Decoder
 import io.circe.refined.given
 import lucuma.core.model.Group
-import lucuma.schemas.ObservationDB.Enums.Existence
 import lucuma.schemas.ObservationDB.Enums.EditType
+import lucuma.schemas.ObservationDB.Enums.Existence
+
 import scala.annotation.targetName
-import eu.timepit.refined.cats.given
 
 // These case classes are only used for decoding the graphql response.
 case class Grouping(

--- a/model/shared/src/main/scala/explore/model/GroupElement.scala
+++ b/model/shared/src/main/scala/explore/model/GroupElement.scala
@@ -91,7 +91,7 @@ object GroupUpdate:
                     .flatMap:
                       _.map: grouping =>
                         for
-                          parentGroupId <- c.downField("meta").get[Option[Group.Id]]("parentGroupId")
+                          parentGroupId <- c.downField("meta").get[Option[Group.Id]]("parentId")
                           parentIndex   <- c.downField("meta").get[NonNegShort]("parentIndex")
                           existence     <- c.downField("meta").get[Existence]("existence")
                         yield GroupUpdatePayload(

--- a/model/shared/src/main/scala/explore/model/GroupElement.scala
+++ b/model/shared/src/main/scala/explore/model/GroupElement.scala
@@ -6,22 +6,32 @@ package explore.model
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
-import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.NonNegShort
-import eu.timepit.refined.types.string.NonEmptyString
-import explore.data.tree.KeyedIndexedTree.Index
 import io.circe.Decoder
 import io.circe.refined.given
 import lucuma.core.model.Group
-import lucuma.core.util.TimeSpan
-import lucuma.odb.json.time.decoder.given
-
-import io.circe.JsonObject
-import lucuma.typed.react.reactStrings.group
-
-// type GroupElement = ServerIndexed[Either[Observation.Id, Grouping]]
+import lucuma.schemas.ObservationDB.Enums.Existence
+import lucuma.schemas.ObservationDB.Enums.EditType
 
 // These case classes are only used for decoding the graphql response.
+case class Grouping(
+  group:    Group,
+  elements: List[Either[Observation.Id, Group.Id]]
+) derives Eq
+
+object Grouping:
+  private given Decoder[Either[Observation.Id, Group.Id]] =
+    Decoder
+      .instance(_.downField("group").get[Group.Id]("id").map(_.asRight))
+      .orElse:
+        Decoder.instance(_.downField("observation").get[Observation.Id]("id").map(_.asLeft))
+
+  given Decoder[Grouping] = Decoder.instance: c =>
+    for
+      group    <- c.as[Group]
+      elements <- c.get[List[Either[Observation.Id, Group.Id]]]("elements")
+    yield Grouping(group, elements)
+
 case class GroupElement(
   value:         ServerIndexed[Either[Observation.Id, Grouping]],
   parentGroupId: Option[Group.Id]
@@ -41,22 +51,19 @@ object GroupElement:
       parentGroupId <- c.get[Option[Group.Id]]("parentGroupId")
     yield GroupElement(ServerIndexed(value, parentIndex), parentGroupId)
 
-    // for
-    //   value       <- c.get[Grouping]("group")
-    //                    .map(_.asRight)
-    //                    .orElse(c.downField("observation").get[Observation.Id]("id").map(_.asLeft))
-    //   parentIndex <- c.get[NonNegShort]("parentIndex")
-    // yield GroupElement(value, parentIndex)
+case class GroupUpdate(
+  value:         ServerIndexed[Grouping],
+  parentGroupId: Option[Group.Id],
+  existence:     Existence,
+  editType:      EditType
+) derives Eq
 
-case class Grouping(
-  group:    Group,
-  elements: List[Either[Observation.Id, Group.Id]]
-) derives Eq,
-      Decoder
-
-object Grouping:
-  private given Decoder[Either[Observation.Id, Group.Id]] =
-    Decoder
-      .instance(_.downField("group").get[Group.Id]("id").map(_.asRight))
-      .orElse:
-        Decoder.instance(_.downField("observation").get[Observation.Id]("id").map(_.asLeft))
+object GroupUpdate:
+  given Decoder[GroupUpdate] = Decoder.instance: c =>
+    for
+      value         <- c.get[Grouping]("value")
+      parentGroupId <- c.downField("meta").get[Option[Group.Id]]("parentGroupId")
+      parentIndex   <- c.downField("meta").get[NonNegShort]("parentIndex")
+      existence     <- c.downField("meta").get[Existence]("existence")
+      editType      <- c.get[EditType]("editType")
+    yield GroupUpdate(ServerIndexed(value, parentIndex), parentGroupId, existence, editType)

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -22,7 +22,6 @@ import monocle.Lens
 type GroupTree = KeyedIndexedTree[GroupTree.Key, GroupTree.Value]
 
 object GroupTree:
-
   type Key   = Either[Observation.Id, GroupId]
   type Index = KeyedIndexedTree.Index[Key]
   type Value = Either[Obs, Group]

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -46,19 +46,19 @@ object GroupTree:
 
   def fromList(groups: List[GroupElement]): GroupTree = {
     // For faster lookup when creating the tree
-    val groupMap: Map[Group.Id, Grouping] =
+    val groupMap: Map[Group.Id, GroupWithChildren] =
       groups.mapFilter(_.value.toOption.map(g => g.group.id -> g)).toMap
 
     def createObsNode(obsId: Observation.Id, parentIndex: NonNegShort): Node =
       TreeNode(ServerIndexed(obsId.asLeft, parentIndex), Nil)
 
     def createGroupNode(groupId: Group.Id, parentIndex: NonNegShort): Node =
-      val grouping: Grouping   = groupMap(groupId)
-      val children: List[Node] =
-        grouping.elements
+      val groupWithChildren: GroupWithChildren = groupMap(groupId)
+      val children: List[Node]                 =
+        groupWithChildren.children
           .map(child => toChild(child.elem, child.parentIndex))
           .sortBy(_.value.parentIndex)
-      TreeNode(ServerIndexed(grouping.group.asRight, parentIndex), children)
+      TreeNode(ServerIndexed(groupWithChildren.group.asRight, parentIndex), children)
 
     def toChild(elem: Either[Observation.Id, Group.Id], parentIndex: NonNegShort): Node =
       elem.fold(createObsNode(_, parentIndex), createGroupNode(_, parentIndex))

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -63,14 +63,15 @@ object GroupTree:
     def toChild(elem: Either[Observation.Id, Group.Id], parentIndex: NonNegShort): Node =
       elem.fold(createObsNode(_, parentIndex), createGroupNode(_, parentIndex))
 
-    val rootElems: List[Node] =
+    val (rootSystemElems, rootElems): (List[Node], List[Node]) =
       groups
         .mapFilter: child =>
           child.indexInRootGroup
             .map(idx => toChild(child.value.map(_.group.id), idx))
         .sortBy(_.value.parentIndex)
+        .partition(_.value.elem.exists(_.system)) // Move system groups to the end.
 
-    KeyedIndexedTree.fromTree(Tree(rootElems), _.id)
+    KeyedIndexedTree.fromTree(Tree(rootElems ++ rootSystemElems), _.id)
   }
 
 // parentIndices may skip values, since they also index deleted elements, so we have to keep track of them.

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -63,15 +63,14 @@ object GroupTree:
     def toChild(elem: Either[Observation.Id, Group.Id], parentIndex: NonNegShort): Node =
       elem.fold(createObsNode(_, parentIndex), createGroupNode(_, parentIndex))
 
-    val (rootSystemElems, rootElems): (List[Node], List[Node]) =
+    val rootElems: List[Node] =
       groups
         .mapFilter: child =>
           child.indexInRootGroup
             .map(idx => toChild(child.value.map(_.group.id), idx))
         .sortBy(_.value.parentIndex)
-        .partition(_.value.elem.exists(_.system)) // Move system groups to the end.
 
-    KeyedIndexedTree.fromTree(Tree(rootElems ++ rootSystemElems), _.id)
+    KeyedIndexedTree.fromTree(Tree(rootElems), _.id)
   }
 
 // parentIndices may skip values, since they also index deleted elements, so we have to keep track of them.

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -3,6 +3,7 @@
 
 package explore.model
 
+import cats.Eq
 import cats.Order.*
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
@@ -11,7 +12,6 @@ import explore.data.tree.KeyedIndexedTree
 import explore.data.tree.Node as TreeNode
 import explore.data.tree.Tree
 import explore.model.syntax.all.*
-import cats.Eq
 import monocle.Lens
 
 type GroupTree = KeyedIndexedTree[GroupTree.Key, GroupTree.Value]

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -28,7 +28,7 @@ object GroupTree:
 
     extension (self: GroupTree)
       def obsGroupId(obsId: Observation.Id): Option[Group.Id] =
-        self.getNodeAndIndexByKey(Left(obsId)).flatMap(_._1.value.elem.toOption.map(_.id))
+        self.getNodeAndIndexByKey(Left(obsId)).flatMap(_._2.parentKey.flatMap(_.toOption))
 
   import syntax.*
 

--- a/model/shared/src/main/scala/explore/model/GroupTree.scala
+++ b/model/shared/src/main/scala/explore/model/GroupTree.scala
@@ -14,7 +14,6 @@ import explore.data.tree.KeyedIndexedTree
 import explore.data.tree.Node as TreeNode
 import explore.data.tree.Tree
 import explore.model.syntax.all.*
-import lucuma.core.model.Group.Id as GroupId
 import lucuma.core.util.TimeSpan
 import monocle.Focus
 import monocle.Lens
@@ -22,73 +21,55 @@ import monocle.Lens
 type GroupTree = KeyedIndexedTree[GroupTree.Key, GroupTree.Value]
 
 object GroupTree:
-  type Key   = Either[Observation.Id, GroupId]
+  type Key   = Either[Observation.Id, Group.Id]
   type Index = KeyedIndexedTree.Index[Key]
-  type Value = Either[Obs, Group]
+  type Value = ServerIndexed[Either[Observation.Id, Group]]
   type Node  = TreeNode[Value]
 
-  def key: Lens[Value, Key] = Lens[Value, Key](_.bimap(_.id, _.id))(newId =>
-    case Left(obs)    =>
-      newId match
-        case Left(id) => Obs.id.replace(id)(obs).asLeft
-        case _        => obs.asLeft
-    case Right(group) =>
-      newId match
-        case Right(id) => Group.id.replace(id)(group).asRight
-        case _         => group.asRight
-  )
+  // def key: Lens[Value, Key] = Lens[Value, Key](_.bimap(_.id, _.id))(newId =>
+  //   case Left(obs)    =>
+  //     newId match
+  //       case Left(id) => Obs.id.replace(id)(obs).asLeft
+  //       case _        => obs.asLeft
+  //   case Right(group) =>
+  //     newId match
+  //       case Right(id) => Group.id.replace(id)(group).asRight
+  //       case _         => group.asRight
+  // )
 
   def fromList(groups: List[GroupElement]): GroupTree = {
     // For faster lookup when creating the tree
-    val (obsList, groupList) = groups.partitionMap(_.value)
-    val obsMap               = obsList.map(obs => (obs.id, obs)).toMap
-    val groupMap             = groupList.map(group => (group.id, group)).toMap
+    val (obsList, groupList): (List[(Observation.Id, ServerIndexed[Observation.Id])],
+                               List[(Group.Id, ServerIndexed[Grouping])]
+    ) =
+      groups.partitionMap:
+        _.value match
+          case ServerIndexed(Left(obsId), parentIndex)     =>
+            Left(obsId -> ServerIndexed(obsId, parentIndex))
+          case ServerIndexed(Right(grouping), parentIndex) =>
+            Right(grouping.group.id -> ServerIndexed(grouping, parentIndex))
 
-    def createObsNode(obs: GroupObs): Node = TreeNode(Obs(obs.id).asLeft[Group], Nil)
+    val obsMap: Map[Observation.Id, ServerIndexed[Observation.Id]] = obsList.toMap
+    val groupMap: Map[Group.Id, ServerIndexed[Grouping]]           = groupList.toMap
 
-    def createGroupNode(group: Grouping): Node =
-      val children = group.elements
-        .flatMap(
-          _.fold(
-            obs => obsMap.get(obs.id).map(_.asLeft),
-            group => groupMap.get(group.id).map(_.asRight)
-          )
-        )
-        .sortBy(_.groupIndex)
-        .map(_.fold(createObsNode(_), createGroupNode))
-      TreeNode(group.toGroupTreeGroup.asRight, children)
+    def createObsNode(obsId: Observation.Id): Node =
+      TreeNode(obsMap(obsId).map(_.asLeft), Nil)
 
-    val rootGroups =
+    def createGroupNode(groupId: Group.Id): Node =
+      val grouping: ServerIndexed[Grouping] = groupMap(groupId)
+      val children: List[Node]              = toChildren(grouping.elem.elements)
+      TreeNode(grouping.map(_.group.asRight), children)
+
+    def toChildren(elems: List[Either[Observation.Id, Group.Id]]): List[Node] =
+      elems.map(_.fold(createObsNode, createGroupNode)).sortBy(_.value.parentIndex)
+
+    val rootElems: List[Either[Observation.Id, Group.Id]] =
       groups
-        .mapFilter(g => if g.parentGroupId.isEmpty then g.value.some else none)
-        .sortBy(_.groupIndex)
+        .mapFilter(g => Option.when(g.parentGroupId.isEmpty)(g.value.elem.map(_.group.id)))
 
-    val nodes = rootGroups.map(_.fold(createObsNode, createGroupNode))
-
-    KeyedIndexedTree.fromTree(Tree(nodes), _.id)
+    KeyedIndexedTree.fromTree(Tree(toChildren(rootElems)), _.elem.map(_.id))
   }
 
-  case class Group(
-    id:              GroupId,
-    name:            Option[NonEmptyString],
-    minimumRequired: Option[NonNegShort],
-    minimumInterval: Option[TimeSpan],
-    maximumInterval: Option[TimeSpan],
-    ordered:         Boolean,
-    system:          Boolean
-  ) derives Eq:
-    def isAnd: Boolean = minimumRequired.isEmpty
-
-  object Group:
-    val id: Lens[Group, GroupId]                          = Focus[Group](_.id)
-    val name: Lens[Group, Option[NonEmptyString]]         = Focus[Group](_.name)
-    val minimumInterval: Lens[Group, Option[TimeSpan]]    = Focus[Group](_.minimumInterval)
-    val maximumInterval: Lens[Group, Option[TimeSpan]]    = Focus[Group](_.maximumInterval)
-    val minimumRequired: Lens[Group, Option[NonNegShort]] = Focus[Group](_.minimumRequired)
-    val ordered: Lens[Group, Boolean]                     = Focus[Group](_.ordered)
-    val system: Lens[Group, Boolean]                      = Focus[Group](_.system)
-
-  case class Obs(id: Observation.Id) derives Eq
-
-  object Obs:
-    val id: Lens[Obs, Observation.Id] = Focus[Obs](_.id)
+// parentIndices may skip values, since they also index deleted elements, so we have to keep track of them.
+case class ServerIndexed[A](elem: A, parentIndex: NonNegShort):
+  def map[B](f: A => B): ServerIndexed[B] = ServerIndexed(f(elem), parentIndex)

--- a/model/shared/src/main/scala/explore/model/Observation.scala
+++ b/model/shared/src/main/scala/explore/model/Observation.scala
@@ -62,8 +62,6 @@ case class Observation(
   observationDuration: Option[TimeSpan],
   posAngleConstraint:  PosAngleConstraint,
   wavelength:          Option[Wavelength],
-  // groupId:             Option[Group.Id],
-  // groupIndex:          NonNegShort,
   validations:         List[ObservationValidation],
   observerNotes:       Option[NonEmptyString],
   calibrationRole:     Option[CalibrationRole]
@@ -201,8 +199,6 @@ object Observation:
   val observationDuration = Focus[Observation](_.observationDuration)
   val posAngleConstraint  = Focus[Observation](_.posAngleConstraint)
   val wavelength          = Focus[Observation](_.wavelength)
-  // val groupId             = Focus[Observation](_.groupId)
-  // val groupIndex          = Focus[Observation](_.groupIndex)
   val validations         = Focus[Observation](_.validations)
   val observerNotes       = Focus[Observation](_.observerNotes)
   val calibrationRole     = Focus[Observation](_.calibrationRole)
@@ -238,8 +234,6 @@ object Observation:
       wavelength          <- c.downField("scienceRequirements")
                                .downField("spectroscopy")
                                .get[Option[Wavelength]]("wavelength")
-      // groupId             <- c.get[Option[Group.Id]]("groupId")
-      // groupIndex          <- c.get[NonNegShort]("groupIndex")
       validations         <- c.get[List[ObservationValidation]]("validations")
       observerNotes       <- c.get[Option[NonEmptyString]]("observerNotes")
       calibrationRole     <- c.get[Option[CalibrationRole]]("calibrationRole")
@@ -260,8 +254,6 @@ object Observation:
       observationDur,
       posAngleConstraint,
       wavelength,
-      // groupId,
-      // groupIndex,
       validations,
       observerNotes,
       calibrationRole

--- a/model/shared/src/main/scala/explore/model/Observation.scala
+++ b/model/shared/src/main/scala/explore/model/Observation.scala
@@ -9,7 +9,6 @@ import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
-// import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.syntax.all.*
 import explore.modes.GmosSpectroscopyOverrides
@@ -25,7 +24,6 @@ import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
-// import lucuma.core.model.Group
 import lucuma.core.model.ObsAttachment
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.PosAngleConstraint

--- a/model/shared/src/main/scala/explore/model/Observation.scala
+++ b/model/shared/src/main/scala/explore/model/Observation.scala
@@ -9,7 +9,7 @@ import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
-import eu.timepit.refined.types.numeric.NonNegShort
+// import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.syntax.all.*
 import explore.modes.GmosSpectroscopyOverrides
@@ -25,7 +25,7 @@ import lucuma.core.enums.ObsActiveStatus
 import lucuma.core.enums.ObsStatus
 import lucuma.core.math.Wavelength
 import lucuma.core.model.ConstraintSet
-import lucuma.core.model.Group
+// import lucuma.core.model.Group
 import lucuma.core.model.ObsAttachment
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.PosAngleConstraint
@@ -64,8 +64,8 @@ case class Observation(
   observationDuration: Option[TimeSpan],
   posAngleConstraint:  PosAngleConstraint,
   wavelength:          Option[Wavelength],
-  groupId:             Option[Group.Id],
-  groupIndex:          NonNegShort,
+  // groupId:             Option[Group.Id],
+  // groupIndex:          NonNegShort,
   validations:         List[ObservationValidation],
   observerNotes:       Option[NonEmptyString],
   calibrationRole:     Option[CalibrationRole]
@@ -203,8 +203,8 @@ object Observation:
   val observationDuration = Focus[Observation](_.observationDuration)
   val posAngleConstraint  = Focus[Observation](_.posAngleConstraint)
   val wavelength          = Focus[Observation](_.wavelength)
-  val groupId             = Focus[Observation](_.groupId)
-  val groupIndex          = Focus[Observation](_.groupIndex)
+  // val groupId             = Focus[Observation](_.groupId)
+  // val groupIndex          = Focus[Observation](_.groupIndex)
   val validations         = Focus[Observation](_.validations)
   val observerNotes       = Focus[Observation](_.observerNotes)
   val calibrationRole     = Focus[Observation](_.calibrationRole)
@@ -240,8 +240,8 @@ object Observation:
       wavelength          <- c.downField("scienceRequirements")
                                .downField("spectroscopy")
                                .get[Option[Wavelength]]("wavelength")
-      groupId             <- c.get[Option[Group.Id]]("groupId")
-      groupIndex          <- c.get[NonNegShort]("groupIndex")
+      // groupId             <- c.get[Option[Group.Id]]("groupId")
+      // groupIndex          <- c.get[NonNegShort]("groupIndex")
       validations         <- c.get[List[ObservationValidation]]("validations")
       observerNotes       <- c.get[Option[NonEmptyString]]("observerNotes")
       calibrationRole     <- c.get[Option[CalibrationRole]]("calibrationRole")
@@ -262,8 +262,8 @@ object Observation:
       observationDur,
       posAngleConstraint,
       wavelength,
-      groupId,
-      groupIndex,
+      // groupId,
+      // groupIndex,
       validations,
       observerNotes,
       calibrationRole

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -46,18 +46,16 @@ case class ProgramSummaries(
     optProgramDetails.flatMap(_.proposal.flatMap(_.reference))
 
   lazy val asterismGroups: AsterismGroupList =
-    SortedMap.from(
-      observations.values
+    SortedMap.from:
+      observations.toList
         .map(obs => obs.id -> obs.scienceTargetIds)
         .groupMap(_._2)(_._1)
-        .map((targets, observations) =>
+        .map: (targets, observations) =>
           ObsIdSet(NonEmptySet.of(observations.head, observations.tail.toList*)) -> SortedSet
             .from(targets)
-        )
-    )
 
   lazy val targetObservations: Map[Target.Id, SortedSet[Observation.Id]] =
-    observations.values
+    observations.toList
       .flatMap(obs => obs.scienceTargetIds.map(targetId => targetId -> obs.id))
       .groupMap(_._1)(_._2)
       .view
@@ -65,7 +63,7 @@ case class ProgramSummaries(
       .toMap
 
   lazy val obsAttachmentAssignments: ObsAttachmentAssignmentMap =
-    observations.values
+    observations.toList
       .flatMap(obs => obs.attachmentIds.map(_ -> obs.id))
       .groupMap(_._1)(_._2)
       .view
@@ -79,15 +77,14 @@ case class ProgramSummaries(
     )
 
   lazy val constraintGroups: ConstraintGroupList =
-    SortedMap.from(
-      observations.values
+    SortedMap.from:
+      observations.toList
         .groupMap(_.constraints)(_.id)
         .map((c, obsIds) => ObsIdSet.of(obsIds.head, obsIds.tail.toList*) -> c)
-    )
 
   lazy val schedulingGroups: SchedulingGroupList =
     SortedMap.from(
-      observations.values
+      observations.toList
         .groupMap(_.timingWindows.sorted)(_.id)
         .map((tws, obsIds) => ObsIdSet.of(obsIds.head, obsIds.tail.toList*) -> tws.sorted)
     )

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -24,7 +24,6 @@ import java.time.ZoneOffset
 import scala.annotation.targetName
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
-// import explore.model.GroupTree.Group
 
 object all:
 
@@ -119,12 +118,6 @@ object all:
       s"${Constants.GppDateFormatter.format(i)} @ ${Constants.GppTimeTZFormatterWithZone.format(i)}"
 
   extension (t: IO.type) def now(): IO[Instant] = IO(Instant.now)
-
-  // extension (e: Either[Group.Obs, Grouping])
-  //   // @targetName("groupIndexGrouping")
-  //   def parentIndex: NonNegShort = e.fold(_.parentIndex, _.parentIndex)
-
-  // extension (e: GroupTree.Value) def id: GroupTree.Key = e.bimap(_.id, _.id)
 
   extension (e: NonNegShort) def toNonNegInt: NonNegInt = NonNegInt.unsafeFrom(e.value)
 

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -24,6 +24,7 @@ import java.time.ZoneOffset
 import scala.annotation.targetName
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
+// import explore.model.GroupTree.Group
 
 object all:
 
@@ -119,11 +120,11 @@ object all:
 
   extension (t: IO.type) def now(): IO[Instant] = IO(Instant.now)
 
-  extension (e: Either[GroupObs, Grouping])
-    @targetName("groupIndexGrouping")
-    def groupIndex: NonNegShort = e.fold(_.groupIndex, _.parentIndex)
+  // extension (e: Either[Group.Obs, Grouping])
+  //   // @targetName("groupIndexGrouping")
+  //   def parentIndex: NonNegShort = e.fold(_.parentIndex, _.parentIndex)
 
-  extension (e: GroupTree.Value) def id: GroupTree.Key = e.bimap(_.id, _.id)
+  // extension (e: GroupTree.Value) def id: GroupTree.Key = e.bimap(_.id, _.id)
 
   extension (e: NonNegShort) def toNonNegInt: NonNegInt = NonNegInt.unsafeFrom(e.value)
 

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -68,7 +68,7 @@ object all:
         list.updatedValueWith(obsId, Observation.scienceTargetIds.modify(_ - targetId))
       )
     def allWithTarget(targetId: Target.Id): Set[Observation.Id]                              =
-      observations.values
+      observations.toList
         .filter(_.scienceTargetIds.contains(targetId))
         .map(_.id)
         .toSet


### PR DESCRIPTION
This PR started as an attempt to fix https://app.shortcut.com/lucuma/story/3444/changing-observation-status-should-not-reorder-observations, where observations jumped to the end of the current group when edited.

This happened because we were interpreting the `index` provided by the server as an index in the group. However, the server contemplates deleted groups and observations, and therefore can contain gaps when querying only present elements, as we do in explore.

I changed the logic so that elements are sorted by their index, but it is not interpreted as a position in the list. When repositioning elements, we take the index of the previous element and add one.

Along the way, I found that we were not taking into account the index of groups. I therefore reworked things so that we can take them into account in a unified way. In particular, I removed the tree positioning of groups and observations from the model (ie: from `Group` and `Observation`).

Finally, I realized that when things are rearranged in a group (or the root) we get edit messages for all deleted objects in the group, which was triggering time requests. I now filter these cases, which should result in an eased load.