### PR TITLE
Rerender ITC graph when basic config is overriden

### DIFF
--- a/explore/src/main/scala/explore/itc/ItcProps.scala
+++ b/explore/src/main/scala/explore/itc/ItcProps.scala
@@ -96,13 +96,13 @@ case class ItcProps(
       .map:
         case BasicConfiguration.GmosNorthLongSlit(grating, filter, fpu, _) =>
           val gmosOverride: Option[GmosSpectroscopyOverrides] = modeOverrides match
-            case Some(o: GmosSpectroscopyOverrides) => o.some
-            case _                                  => none
+            case Some(o @ GmosSpectroscopyOverrides(_, _, _)) => o.some
+            case _                                            => none
           GmosNorthSpectroscopyRow(grating, fpu, filter, gmosOverride)
         case BasicConfiguration.GmosSouthLongSlit(grating, filter, fpu, _) =>
           val gmosOverride: Option[GmosSpectroscopyOverrides] = modeOverrides match
-            case Some(o: GmosSpectroscopyOverrides) => o.some
-            case _                                  => none
+            case Some(o @ GmosSpectroscopyOverrides(_, _, _)) => o.some
+            case _                                            => none
           GmosSouthSpectroscopyRow(grating, fpu, filter, gmosOverride)
 
   val itcTargets: Option[NonEmptyList[ItcTarget]] =
@@ -164,6 +164,7 @@ object ItcProps:
        p.observation.constraints,
        p.observation.scienceRequirements,
        p.observation.wavelength,
+       p.observation.basicConfiguration,
        p.selectedConfig,
        p.at,
        p.modeOverrides

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -223,10 +223,9 @@ object ObsTabTiles:
       // Store guide star selection in a view for fast local updates
       // This is not the ideal place for this but we need to share the selected guide star
       // across the configuration and target tile
-      .useStateViewBy((props, _, _, _, _, _, _, _, _, _, _) =>
+      .useStateViewBy: (props, _, _, _, _, _, _, _, _, _, _) =>
         props.selectedGSName.get.fold(GuideStarSelection.Default)(RemoteGSSelection.apply)
-      )
-      .localValBy((props, ctx, _, _, _, _, _, _, _, _, _, guideStarSelection) =>
+      .localValBy: (props, ctx, _, _, _, _, _, _, _, _, _, guideStarSelection) =>
         import ctx.given
 
         // We tell the backend and the local cache of changes to the selected guidestar
@@ -256,7 +255,6 @@ object ObsTabTiles:
               Callback.empty
           }
         }
-      )
       .render:
         (
           props,

--- a/model/shared/src/main/scala/queries/schemas/itc/syntax.scala
+++ b/model/shared/src/main/scala/queries/schemas/itc/syntax.scala
@@ -4,7 +4,6 @@
 package queries.schemas.itc
 
 import cats.Hash
-import cats.data.NonEmptyList
 import cats.syntax.all.*
 import explore.model.AsterismIds
 import explore.model.TargetList
@@ -14,7 +13,6 @@ import explore.modes.GmosSouthSpectroscopyRow
 import explore.modes.InstrumentRow
 import explore.optics.all.*
 import lucuma.core.enums.GmosRoi
-import lucuma.core.enums.ImageQuality
 import lucuma.core.math.RadialVelocity
 import lucuma.core.model.*
 import lucuma.core.model.sequence.gmos.GmosCcdMode
@@ -26,7 +24,7 @@ import lucuma.itc.client.TargetInput
 trait syntax:
 
   extension (row: InstrumentRow)
-    def toItcClientMode(ps: NonEmptyList[SourceProfile], iq: ImageQuality): Option[InstrumentMode] =
+    def toItcClientMode: Option[InstrumentMode] =
       row match
         case GmosNorthSpectroscopyRow(grating, fpu, filter, modeOverrides) =>
           val roi: Option[GmosRoi]     = modeOverrides.flatMap(_.roi).orElse(DefaultRoi.some)

--- a/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCGraphRequests.scala
@@ -65,8 +65,7 @@ object ITCGraphRequests:
         none
 
     def doRequest(request: ItcGraphRequestParams): F[GraphResponse] =
-      request.mode
-        .toItcClientMode(request.asterism.map(_.sourceProfile), request.constraints.imageQuality)
+      request.mode.toItcClientMode
         .map: mode =>
           ItcClient[F]
             .spectroscopyIntegrationTimeAndGraphs(

--- a/workers/src/main/scala/workers/itc/ITCRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCRequests.scala
@@ -76,11 +76,7 @@ object ITCRequests:
         .debug(
           s"ITC: Request for mode: ${params.mode}, centralWavelength: ${params.wavelength} and target count: ${params.asterism.length}"
         ) *>
-        params.mode
-          .toItcClientMode(
-            params.asterism.map(_.sourceProfile),
-            params.constraints.imageQuality
-          )
+        params.mode.toItcClientMode
           .traverse: mode =>
             ItcClient[F]
               .spectroscopy(


### PR DESCRIPTION
The actual fix is adding the basicConfiguration to the Reusability of ItcProps.

The other changes are things I found while debugging, notably that the parameters to `toItcClientMode` were not being used since the last ITC refactor.