### PR TITLE
Show calibrations at the bottom of observation tree

### DIFF
--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -105,8 +105,14 @@ trait CacheModifierUpdaters {
             if isPresentInServer || isPresentLocally then mod(programSummaries)
             else programSummaries
 
+        val groupMod: Endo[GroupTree] => Endo[ProgramSummaries] =
+          if (groupUpdate.payload.exists(_.value.elem.system))
+            ProgramSummaries.systemGroups.modify
+          else
+            ProgramSummaries.groups.modify
+
         val updateGroup: ProgramSummaries => ProgramSummaries =
-          ProgramSummaries.groups.modify: groupTree =>
+          groupMod: groupTree =>
             val mod: GroupTree => GroupTree =
               if (!isPresentInServer)
                 _.removed(groupId.asRight)

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -83,6 +83,7 @@ case class ObsTabContents(
   private val observations: UndoSetter[ObservationList]                    =
     programSummaries.zoom(ProgramSummaries.observations)
   private val groups: UndoSetter[GroupTree]                                = programSummaries.zoom(ProgramSummaries.groups)
+  private val systemGroups: GroupTree                                      = programSummaries.get.systemGroups
   private val activeGroup: Option[Group.Id]                                = focusedGroup.orElse:
     focusedObs.flatMap(groups.get.obsGroupId)
   private val obsExecutions: ObservationExecutionMap                       = programSummaries.get.obsExecutionPots
@@ -229,6 +230,7 @@ object ObsTabContents extends TwoPanels:
                 props.focusedGroup,
                 twoPanelState.set(SelectedPanel.Summary),
                 props.groups,
+                props.systemGroups,
                 props.expandedGroups,
                 deckShown,
                 copyCallback,

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -32,6 +32,7 @@ case class ProgramSummaries(
   targets:             TargetList,
   observations:        ObservationList,
   groups:              GroupTree,
+  systemGroups:        GroupTree,
   obsAttachments:      ObsAttachmentList,
   proposalAttachments: List[ProposalAttachment],
   programs:            ProgramInfoList,
@@ -160,6 +161,7 @@ object ProgramSummaries:
   val observations: Lens[ProgramSummaries, ObservationList]                 =
     Focus[ProgramSummaries](_.observations)
   val groups: Lens[ProgramSummaries, GroupTree]                             = Focus[ProgramSummaries](_.groups)
+  val systemGroups: Lens[ProgramSummaries, GroupTree]                       = Focus[ProgramSummaries](_.systemGroups)
   val obsAttachments: Lens[ProgramSummaries, ObsAttachmentList]             =
     Focus[ProgramSummaries](_.obsAttachments)
   val proposalAttachments: Lens[ProgramSummaries, List[ProposalAttachment]] =
@@ -188,6 +190,7 @@ object ProgramSummaries:
     targetList:          List[TargetWithId],
     obsList:             List[Observation],
     groups:              GroupTree,
+    systemGroups:        GroupTree,
     obsAttachments:      List[ObsAttachment],
     proposalAttachments: List[ProposalAttachment],
     programs:            List[ProgramInfo],
@@ -200,6 +203,7 @@ object ProgramSummaries:
       targetList.toSortedMap(_.id, _.target),
       KeyedIndexedList.fromList(obsList, Observation.id.get),
       groups,
+      systemGroups,
       obsAttachments.toSortedMap(_.id),
       proposalAttachments,
       programs.toSortedMap(_.id),


### PR DESCRIPTION
This is achieved by keeping the calibration tree separate in the model and rendering 2 trees.