### PR TITLE
Change SASS deprecated color function

### DIFF
--- a/common/src/main/webapp/sass/datepicker/datepicker.scss
+++ b/common/src/main/webapp/sass/datepicker/datepicker.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 @import 'variables.scss';
 @import 'mixins.scss';
 
@@ -454,7 +456,7 @@ h2.react-datepicker__current-month {
     }
 
     &:hover {
-      background-color: darken($datepicker__holidays-color, 10%);
+      background-color: color.adjust($datepicker__holidays-color, $lightness: -10%);
     }
 
     &:hover .overlay {


### PR DESCRIPTION
We were getting a deprecation error for this in CI.

There is also another SASS related deprecation error (repeated many times)

> DEPRECATION WARNING: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.
More info: https://sass-lang.com/d/legacy-js-api

Vite defaults to the legacy API, but provides a config setting to use the `modern` API. However, this setting is only available in vite 5, which is still very slow to load explore during development. 