### PR TITLE
Disable submission/retraction when program has a CfP that is due

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,11 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: sbt
 
-      - name: sbt update
-        if: matrix.java == 'temurin@17' && steps.setup-java-temurin-17.outputs.cache-hit == 'false'
-        run: sbt -v -J-Xmx6g +update
+      - name: Setup SBT
+        uses: sbt/setup-sbt@v1
+        with:
+          sbt-runner-version: 1.10.2
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/build.sbt
+++ b/build.sbt
@@ -253,6 +253,12 @@ def anyConds(conds: String*) = conds.mkString("(", " || ", ")")
 
 val faNpmAuthToken = "FONTAWESOME_NPM_AUTH_TOKEN" -> "${{ secrets.FONTAWESOME_NPM_AUTH_TOKEN }}"
 
+lazy val setupSbt = WorkflowStep.Use(
+  UseRef.Public("sbt", "setup-sbt", "v1"),
+  name = Some("Setup SBT"),
+  params = Map("sbt-runner-version" -> "1.10.2")
+)
+
 // https://github.com/actions/setup-node/issues/835#issuecomment-1753052021
 lazy val setupNodeNpmInstall =
   List(
@@ -358,7 +364,11 @@ ThisBuild / githubWorkflowAddedJobs +=
     "full",
     "full",
     WorkflowStep.Checkout ::
-      WorkflowStep.SetupJava(githubWorkflowJavaVersions.value.toList.take(1)) :::
+      WorkflowStep.SetupJava(
+        githubWorkflowJavaVersions.value.toList.take(1),
+        enableCaching = false
+      ) :::
+      setupSbt ::
       setupNodeNpmInstall :::
       sbtStage ::
       npmBuild ::

--- a/explore/src/main/scala/explore/SubmittedProposalMessage.scala
+++ b/explore/src/main/scala/explore/SubmittedProposalMessage.scala
@@ -43,7 +43,7 @@ object SubmittedProposalMessage:
               Timestamp.ofEpochMilli(finiteDuration.toMillis)
       .render: (props, nowPot) =>
         val retractStr: String = nowPot.toOption.flatten
-          .filter(now => props.deadline.forall(_ > now))
+          .filter(now => props.deadline.exists(_ > now))
           .as(s" and may be retracted${props.deadlineStr}")
           .orEmpty
 

--- a/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
@@ -102,7 +102,7 @@ object ProposalSubmissionBar:
           )
 
         nowPot.toOption.flatten.map: now =>
-          val isDueDeadline: Boolean = props.deadline.exists(_ < now)
+          val isDueDeadline: Boolean = props.deadline.forall(_ < now)
 
           Toolbar(left =
             <.div(ExploreStyles.ProposalSubmissionBar)(

--- a/model/shared/src/main/scala/explore/Proposal.scala
+++ b/model/shared/src/main/scala/explore/Proposal.scala
@@ -31,7 +31,7 @@ case class Proposal(
   reference:    Option[ProposalReference]
 ) derives Eq:
   def deadline(cfps: List[CallForProposal], piPartner: Option[PartnerLink]): Option[Timestamp] =
-    cfps.find(u => callId.exists(_ === u.id)).flatMap(_.deadline(piPartner))
+    cfps.find(cfp => callId.exists(_ === cfp.id)).flatMap(_.deadline(piPartner))
 
 object Proposal:
   val callId: Lens[Proposal, Option[CallForProposals.Id]]  =


### PR DESCRIPTION
If the user set a CfP for a program before the deadline, they could still submit it after the deadline.

The CfP still apprared set, but the deadline was None, which was interpreted as the CfP having no deadline.

We are now disallowing submission/retraction if there's no deadline.