### PR TITLE
Plots use their set date/semester instead of obs time

### DIFF
--- a/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
+++ b/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
@@ -12,7 +12,7 @@ import explore.targeteditor.ElevationPlotSection
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.Site
-import lucuma.core.model.CoordinatesAtVizTime
+import lucuma.core.model.ObjectTracking
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.User
@@ -24,36 +24,35 @@ import java.time.Instant
 object ElevationPlotTile:
 
   def elevationPlotTile(
-    uid:               Option[User.Id],
-    tid:               Option[Target.Id],
+    userId:            Option[User.Id],
+    targetId:          Option[Target.Id],
+    tracking:          Option[ObjectTracking],
     site:              Option[Site],
-    coordinates:       Option[CoordinatesAtVizTime],
     vizTime:           Option[Instant],
     pendingTime:       Option[Duration],
     timingWindows:     List[TimingWindow] = List.empty,
     globalPreferences: GlobalPreferences
-  ) =
+  ): Tile[Unit] =
     Tile(
       ObsTabTilesIds.PlotId.id,
       "Elevation Plot",
       bodyClass = ExploreStyles.ElevationPlotTileBody
     ) { _ =>
-      (uid, tid, coordinates)
-        .mapN { (uid, targetId, coordinates) =>
-          ElevationPlotSection(uid,
-                               targetId,
-                               site,
-                               vizTime,
-                               pendingTime,
-                               coordinates,
-                               timingWindows,
-                               globalPreferences
+      (userId, targetId, tracking)
+        .mapN: (uid, tid, track) =>
+          ElevationPlotSection(
+            uid,
+            tid,
+            track,
+            site,
+            vizTime,
+            pendingTime,
+            timingWindows,
+            globalPreferences
           ): VdomNode
-        }
-        .getOrElse {
+        .getOrElse:
           <.div(
             ExploreStyles.FullHeightWidth |+| ExploreStyles.HVCenter |+| ExploreStyles.EmptyTreeContent,
             <.div("Select a target")
           )
-        }
     }

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -50,6 +50,7 @@ import lucuma.core.math.Offset
 import lucuma.core.math.skycalc.averageParallacticAngle
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.CoordinatesAtVizTime
+import lucuma.core.model.ObjectTracking
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
 import lucuma.core.model.Target
@@ -102,6 +103,13 @@ case class ObsTabTiles(
   val allTargets: TargetList                                        = programSummaries.targets
   val obsAttachmentAssignments: ObsAttachmentAssignmentMap          =
     programSummaries.obsAttachmentAssignments
+  val asterismTracking: Option[ObjectTracking]                      =
+    NonEmptyList
+      .fromList:
+        observation.get.scienceTargetIds.toList
+          .map(id => allTargets.get(id))
+          .flattenOption
+      .map(ObjectTracking.fromAsterism(_))
 
 object ObsTabTiles:
   private type Props = ObsTabTiles
@@ -369,8 +377,8 @@ object ObsTabTiles:
               ElevationPlotTile.elevationPlotTile(
                 props.vault.userId,
                 props.focusedTarget.orElse(props.observation.get.scienceTargetIds.headOption),
+                props.asterismTracking,
                 props.observation.get.observingMode.map(_.siteFor),
-                targetCoords,
                 vizTimeView.get,
                 obsDuration.map(_.toDuration),
                 timingWindows.get,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -42,8 +42,7 @@ import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.core.math.Coordinates
-import lucuma.core.model.CoordinatesAtVizTime
+import lucuma.core.model.ObjectTracking
 import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.Target.Nonsidereal
@@ -340,7 +339,7 @@ object TargetTabContents extends TwoPanels:
            * Render the asterism editor
            *
            * @param idsToEdit
-           *   The observations to include in the edit. This needs to be asubset of the ids in
+           *   The observations to include in the edit. This needs to be a subset of the ids in
            *   asterismGroup
            * @param asterismGroup
            *   The AsterismGroup that is the basis for editing. All or part of it may be included in
@@ -544,25 +543,19 @@ object TargetTabContents extends TwoPanels:
                 backButton = backButton.some
               )
 
-            // coordinates for the elevation plot, if no obs time default to base
-            val skyPlotCoordinates: Option[Coordinates] =
-              props.focused.target.flatMap: id =>
-                props.targets.get
-                  .get(id)
-                  .flatMap:
-                    case t @ Target.Sidereal(_, _, _, _) =>
-                      obsTimeView.get
-                        .flatMap(ot => Target.Sidereal.tracking.get(t).at(ot))
-                        // If no obs time default to base coords
-                        .orElse(t.tracking.baseCoordinates.some)
-                    case _                               => none
+            val tracking: Option[ObjectTracking] =
+              props.focused.target
+                .flatMap: targetId =>
+                  props.targets.get.get(targetId)
+                .map:
+                  ObjectTracking.fromTarget(_)
 
             val skyPlotTile =
               ElevationPlotTile.elevationPlotTile(
                 props.userId,
                 props.focused.target,
+                tracking,
                 configuration.map(_.siteFor),
-                skyPlotCoordinates.map(CoordinatesAtVizTime(_)),
                 obsTimeView.get,
                 none,
                 Nil,
@@ -610,8 +603,8 @@ object TargetTabContents extends TwoPanels:
                     ElevationPlotTile.elevationPlotTile(
                       props.userId,
                       targetId.some,
+                      ObjectTracking.fromTarget(target.get).some,
                       none,
-                      CoordinatesAtVizTime(Target.Sidereal.baseCoordinates.get(target.get)).some,
                       none,
                       none,
                       Nil,

--- a/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/ElevationPlotSection.scala
@@ -25,7 +25,10 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.Site
 import lucuma.core.enums.TimingWindowInclusion
 import lucuma.core.math.BoundedInterval
+import lucuma.core.math.Coordinates
 import lucuma.core.model.CoordinatesAtVizTime
+import lucuma.core.model.ObjectTracking
+import lucuma.core.model.Semester
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.User
@@ -48,12 +51,12 @@ import spire.math.extras.interval.IntervalSeq
 import java.time.*
 
 case class ElevationPlotSection(
-  uid:               User.Id,
-  tid:               Target.Id,
+  userId:            User.Id,
+  targetId:          Target.Id,
+  tracking:          ObjectTracking,
   site:              Option[Site],
   visualizationTime: Option[Instant],
   pendingTime:       Option[Duration],
-  coords:            CoordinatesAtVizTime,
   timingWindows:     List[TimingWindow],
   globalPreferences: GlobalPreferences
 ) extends ReactFnProps(ElevationPlotSection.component)
@@ -68,7 +71,7 @@ object ElevationPlotSection:
       // Plot options, will be read from the user preferences
       .useStateViewBy((props, _) =>
         ElevationPlotOptions
-          .default(props.site, props.visualizationTime, props.coords)
+          .default(props.site, props.visualizationTime, props.tracking)
           .copy(
             range = props.globalPreferences.elevationPlotRange,
             timeDisplay = props.globalPreferences.elevationPlotTime,
@@ -96,7 +99,7 @@ object ElevationPlotSection:
         val options = elevationPlotOptions.withOnMod(opts =>
           ElevationPlotPreference
             .updatePlotPreferences[IO](
-              props.uid,
+              props.userId,
               opts.range,
               opts.timeDisplay,
               opts.showScheduling.value,
@@ -108,15 +111,15 @@ object ElevationPlotSection:
             .runAsync
         )
 
-        val siteView           = options.zoom(ElevationPlotOptions.site)
-        val rangeView          = options.zoom(ElevationPlotOptions.range)
-        val dateView           = options.zoom(ElevationPlotOptions.date)
-        val semesterView       = options.zoom(ElevationPlotOptions.semester)
-        val timeDisplayView    = options.zoom(ElevationPlotOptions.timeDisplay)
-        val showSchedulingView =
+        val siteView: View[Site]                              = options.zoom(ElevationPlotOptions.site)
+        val rangeView: View[PlotRange]                        = options.zoom(ElevationPlotOptions.range)
+        val dateView: View[LocalDate]                         = options.zoom(ElevationPlotOptions.date)
+        val semesterView: View[Semester]                      = options.zoom(ElevationPlotOptions.semester)
+        val timeDisplayView: View[TimeDisplay]                = options.zoom(ElevationPlotOptions.timeDisplay)
+        val showSchedulingView: View[ElevationPlotScheduling] =
           options.zoom(ElevationPlotOptions.showScheduling)
 
-        val opt = options.get
+        val opt: ElevationPlotOptions = options.get
 
         def windowsToIntervals(windows: List[TimingWindow]): IntervalSeq[Instant] =
           windows
@@ -147,22 +150,31 @@ object ElevationPlotSection:
           <.div(ExploreStyles.ElevationPlot)(
             opt.range match
               case PlotRange.Night    =>
+                val coords: CoordinatesAtVizTime =
+                  props.tracking
+                    .at(dateView.get.atStartOfDay.toInstant(ZoneOffset.UTC))
+                    .getOrElse(CoordinatesAtVizTime(props.tracking.baseCoordinates))
+
                 ElevationPlotNight(
-                  props.coords,
+                  coords,
                   props.visualizationTime,
                   windowsNetExcludeIntervals,
                   props.pendingTime,
                   options
                 )
               case PlotRange.Semester =>
+                val coords: CoordinatesAtVizTime =
+                  props.tracking
+                    .at(semesterView.get.start.atSite(siteView.get).toInstant)
+                    .getOrElse(CoordinatesAtVizTime(props.tracking.baseCoordinates))
+
                 ElevationPlotSemester(
                   options.get,
-                  props.coords,
+                  coords,
                   windowsNetExcludeIntervals
                 ),
           ),
-          <.div(
-            ExploreStyles.ElevationPlotControls,
+          <.div(ExploreStyles.ElevationPlotControls)(
             SelectButtonEnumView(
               "elevation-plot-site".refined,
               siteView,

--- a/model/shared/src/main/scala/explore/model/ElevationPlotOptions.scala
+++ b/model/shared/src/main/scala/explore/model/ElevationPlotOptions.scala
@@ -12,7 +12,9 @@ import explore.model.enums.Visible
 import lucuma.core.enums.Site
 import lucuma.core.enums.TwilightType
 import lucuma.core.math.BoundedInterval
+import lucuma.core.math.Coordinates
 import lucuma.core.model.CoordinatesAtVizTime
+import lucuma.core.model.ObjectTracking
 import lucuma.core.model.ObservingNight
 import lucuma.core.model.Semester
 import monocle.Focus
@@ -91,12 +93,14 @@ object ElevationPlotOptions:
   def default(
     predefinedSite:  Option[Site],
     observationTime: Option[Instant],
-    coords:          CoordinatesAtVizTime
+    tracking:        ObjectTracking
   ) =
-    val site: Site       = predefinedSite.getOrElse(
-      if (coords.value.dec.toAngle.toSignedDoubleDegrees > -5) Site.GN else Site.GS
+    val coords: Coordinates =
+      observationTime.flatMap(tracking.at(_).map(_.value)).getOrElse(tracking.baseCoordinates)
+    val site: Site          = predefinedSite.getOrElse(
+      if (coords.dec.toAngle.toSignedDoubleDegrees > -5) Site.GN else Site.GS
     )
-    val (date, semester) = dateAndSemesterOf(observationTime, site)
+    val (date, semester)    = dateAndSemesterOf(observationTime, site)
 
     ElevationPlotOptions(
       site,


### PR DESCRIPTION
Coordinates were always corrected for the observation time (or not corrected if they were shown outside of an observation).

This PR always corrects them for the date selected in the plot tile, or the start of the semester.

When plotting an observation, it now uses the center of the asterism instead of the first target.