### PR TITLE
Explicit selection of target editor in summary table

### DIFF
--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -65,7 +65,7 @@ case class AsterismGroupObsList(
   undoCtx:               UndoContext[ProgramSummaries], // TODO Targets are not modified here
   selectedIdsOpt:        Option[Either[TargetIdSet, ObsIdSet]],
   clipboardContent:      LocalClipboard,
-  focusTarget:           Option[Target.Id] => Callback,
+  focusTargetId:         Option[Target.Id] => Callback,
   selectSummaryTargets:  List[Target.Id] => Callback,
   modTargets:            (TargetList => TargetList) => Callback,
   copyCallback:          Callback,
@@ -396,7 +396,7 @@ object AsterismGroupObsList:
                 .deleteTargets(
                   selectedTargetsIds,
                   props.programId,
-                  props.focusTarget(none).toAsync,
+                  props.focusTargetId(none).toAsync,
                   ToastCtx[IO].showToast(_)
                 )
                 .set(props.undoCtx)(selectedTargetsIds.map(_ => none))
@@ -544,7 +544,7 @@ object AsterismGroupObsList:
                   props.programId,
                   props.undoCtx,
                   addingTargetOrObs,
-                  props.focusTarget
+                  props.focusTargetId
                 ).runAsync
               ).compact.mini
             ),
@@ -572,7 +572,7 @@ object AsterismGroupObsList:
               severity = Button.Severity.Secondary,
               onClick =
                 ctx.pushPage(AppTab.Targets, props.programId, props.focused.withoutObsSet) *>
-                  props.focusTarget(None) *>
+                  props.focusTargetId(None) *>
                   props.selectSummaryTargets(props.focused.target.toList),
               clazz = ExploreStyles.ButtonSummary
             )(

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -65,7 +65,7 @@ case class AsterismGroupObsList(
   undoCtx:               UndoContext[ProgramSummaries], // TODO Targets are not modified here
   selectedIdsOpt:        Option[Either[TargetIdSet, ObsIdSet]],
   clipboardContent:      LocalClipboard,
-  selectTargetOrSummary: Option[Target.Id] => Callback,
+  focusTarget:           Option[Target.Id] => Callback,
   selectSummaryTargets:  List[Target.Id] => Callback,
   modTargets:            (TargetList => TargetList) => Callback,
   copyCallback:          Callback,
@@ -396,7 +396,7 @@ object AsterismGroupObsList:
                 .deleteTargets(
                   selectedTargetsIds,
                   props.programId,
-                  props.selectTargetOrSummary(none).toAsync,
+                  props.focusTarget(none).toAsync,
                   ToastCtx[IO].showToast(_)
                 )
                 .set(props.undoCtx)(selectedTargetsIds.map(_ => none))
@@ -544,7 +544,7 @@ object AsterismGroupObsList:
                   props.programId,
                   props.undoCtx,
                   addingTargetOrObs,
-                  props.selectTargetOrSummary
+                  props.focusTarget
                 ).runAsync
               ).compact.mini
             ),
@@ -572,7 +572,7 @@ object AsterismGroupObsList:
               severity = Button.Severity.Secondary,
               onClick =
                 ctx.pushPage(AppTab.Targets, props.programId, props.focused.withoutObsSet) *>
-                  props.selectTargetOrSummary(None) *>
+                  props.focusTarget(None) *>
                   props.selectSummaryTargets(props.focused.target.toList),
               clazz = ExploreStyles.ButtonSummary
             )(

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -4,7 +4,6 @@
 package explore.tabs
 
 import cats.data.NonEmptyList
-import cats.data.NonEmptyMap
 import cats.effect.IO
 import cats.syntax.all.*
 import clue.FetchClient
@@ -382,13 +381,13 @@ object ObsTabTiles:
             val plotData: Option[PlotData] =
               props.asterismTracking.map: tracking =>
                 PlotData:
-                  NonEmptyMap.one(
-                    ObjectPlotData.Id(props.obsId.asLeft),
-                    ObjectPlotData(
-                      NonEmptyString.from(props.obsId.toString).getOrElse("Observation".refined),
-                      tracking,
-                      Enumerated[Site].all // In obs elevation plot, we want all solid lines
-                    )
+                  Map(
+                    ObjectPlotData.Id(props.obsId.asLeft) ->
+                      ObjectPlotData(
+                        NonEmptyString.from(props.obsId.toString).getOrElse("Observation".refined),
+                        tracking,
+                        Enumerated[Site].all // In obs elevation plot, we want all solid lines
+                      )
                   )
 
             val skyPlotTile =

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -346,20 +346,6 @@ object TargetTabContents extends TwoPanels:
             (s, _) => TargetSummaryTitle(props.programId, props.readonly, s)
           )
 
-          val plotData: PlotData =
-            PlotData:
-              selectedTargetIds.get
-                .flatMap: targetId =>
-                  props.targets.get
-                    .get(targetId)
-                    .map: target =>
-                      ObjectPlotData.Id(targetId.asRight) -> ObjectPlotData(
-                        target.name,
-                        ObjectTracking.fromTarget(target),
-                        props.sitesForTarget(targetId)
-                      )
-                .toMap
-
           /**
            * Render the asterism editor
            *
@@ -569,7 +555,21 @@ object TargetTabContents extends TwoPanels:
                 backButton = backButton.some
               )
 
-            val skyPlotTile =
+            val plotData: PlotData =
+              PlotData:
+                focusedTargetId
+                  .flatMap: targetId =>
+                    props.targets.get
+                      .get(targetId)
+                      .map: target =>
+                        ObjectPlotData.Id(targetId.asRight) -> ObjectPlotData(
+                          target.name,
+                          ObjectTracking.fromTarget(target),
+                          props.sitesForTarget(targetId)
+                        )
+                  .toMap
+
+            val skyPlotTile: Tile[?] =
               ElevationPlotTile.elevationPlotTile(
                 props.userId,
                 plotData,
@@ -621,6 +621,20 @@ object TargetTabContents extends TwoPanels:
                   onCloneTarget4Target
                 )
           }
+
+          val plotData: PlotData =
+            PlotData:
+              selectedTargetIds.get
+                .flatMap: targetId =>
+                  props.targets.get
+                    .get(targetId)
+                    .map: target =>
+                      ObjectPlotData.Id(targetId.asRight) -> ObjectPlotData(
+                        target.name,
+                        ObjectTracking.fromTarget(target),
+                        props.sitesForTarget(targetId)
+                      )
+                .toMap
 
           val skyPlotTile: Tile[?] =
             ElevationPlotTile.elevationPlotTile(

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -131,7 +131,7 @@ object TargetTabContents extends TwoPanels:
     ScalaFnComponent
       .withHooks[Props]
       .useContext(AppContext.ctx)
-      .useStateView[SelectedPanel](SelectedPanel.Uninitialized)     // Two panel state
+      .useStateView[SelectedPanel](SelectedPanel.Uninitialized) // Two panel state
       .useEffectWithDepsBy((props, _, _) => props.focused): (_, _, selected) =>
         focused =>
           (focused, selected.get) match
@@ -140,9 +140,10 @@ object TargetTabContents extends TwoPanels:
             case (Focused(None, None, _), SelectedPanel.Editor) =>
               selected.set(SelectedPanel.Summary)
             case _                                              => Callback.empty
-      .useStateViewBy((props, _, _) => props.focused.target.toList) // Selected targets on table
+      .useStateViewBy((props, _, _) => List.empty[Target.Id])   // Selected targets on table
       .useLayoutEffectWithDepsBy((props, _, _, _) => props.focused.target):
-        (_, _, _, selTargetIds) => _.foldMap(focusedTarget => selTargetIds.set(List(focusedTarget)))
+        // If a target enters edit mode, unselect the rows.
+        (_, _, _, selTargetIds) => _.foldMap(_ => selTargetIds.set(List.empty))
       .useMemoBy((props, _, _, selTargetIds) => (props.focused, selTargetIds.get)): // Selected observations (right) or targets (left)
         (_, _, _, _) =>
           (target, selTargetIds) =>
@@ -328,22 +329,10 @@ object TargetTabContents extends TwoPanels:
               props.programSummaries.get.targetObservations,
               props.programSummaries.get.calibrationObservations,
               selectObservationAndTarget(props.expandedIds),
-              selectTargetOrSummary,
               selectedTargetIds,
-              props.programSummaries,
-              props.readonly,
               _
             ),
-            (s, _) =>
-              TargetSummaryTitle(
-                props.programId,
-                props.targets.model,
-                selectTargetOrSummary,
-                selectedTargetIds,
-                props.programSummaries,
-                props.readonly,
-                s
-              )
+            (s, _) => TargetSummaryTitle(props.programId, props.readonly, s)
           )
 
           val plotData: PlotData =

--- a/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotData.scala
+++ b/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotData.scala
@@ -5,7 +5,6 @@ package explore.targeteditor.plots
 
 import cats.Eq
 import cats.Order
-import cats.data.NonEmptyMap
 import cats.derived.*
 import eu.timepit.refined.cats.given
 import eu.timepit.refined.types.string.NonEmptyString
@@ -126,9 +125,7 @@ object ObjectPlotData:
       val moonIllum                      = midOfNightResult.lunarIlluminatedFraction.toDouble
       MoonData(moonPhase, moonIllum)
 
-object PlotData extends NewType[NonEmptyMap[ObjectPlotData.Id, ObjectPlotData]]:
+object PlotData extends NewType[Map[ObjectPlotData.Id, ObjectPlotData]]:
   given Reusability[PlotData] =
-    Reusability.by[Type, Map[ObjectPlotData.Id, ObjectPlotData]](
-      _.value.toSortedMap.unsorted
-    )(using Reusability.map)
+    Reusability.by[Type, Map[ObjectPlotData.Id, ObjectPlotData]](_.value)(using Reusability.map)
 type PlotData = PlotData.Type

--- a/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotSection.scala
@@ -71,7 +71,7 @@ object ObjectPlotSection:
           .default(
             props.site,
             props.visualizationTime,
-            props.plotData.value.head._2.tracking
+            props.plotData.value.headOption.map(_._2.tracking)
           )
           .copy(
             range = props.globalPreferences.elevationPlotRange,
@@ -168,17 +168,19 @@ object ObjectPlotSection:
                   options
                 )
               case PlotRange.Semester =>
-                val coords: CoordinatesAtVizTime =
-                  props.plotData.value.head._2.tracking
-                    .at(semesterView.get.start.atSite(siteView.get).toInstant)
-                    .getOrElse:
-                      CoordinatesAtVizTime(props.plotData.value.head._2.tracking.baseCoordinates)
+                props.plotData.value.headOption.map { case (_, data) =>
+                  val coords: CoordinatesAtVizTime =
+                    data.tracking
+                      .at(semesterView.get.start.atSite(siteView.get).toInstant)
+                      .getOrElse:
+                        CoordinatesAtVizTime(data.tracking.baseCoordinates)
 
-                SemesterPlot(
-                  options.get,
-                  coords,
-                  windowsNetExcludeIntervals
-                )
+                  SemesterPlot(
+                    options.get,
+                    coords,
+                    windowsNetExcludeIntervals
+                  )
+                }
           ),
           <.div(ExploreStyles.ElevationPlotControls)(
             SelectButtonEnumView(

--- a/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotSection.scala
@@ -66,7 +66,7 @@ object ObjectPlotSection:
       .withHooks[Props]
       .useContext(AppContext.ctx)
       // Plot options, will be read from the user preferences
-      .useStateViewBy((props, _) =>
+      .useStateViewBy: (props, _) =>
         ObjectPlotOptions
           .default(
             props.site,
@@ -92,19 +92,16 @@ object ObjectPlotSection:
               )(SeriesType.LunarElevation)
             ).flattenOption
           )
-      )
       // If predefined site changes, switch to it.
-      .useEffectWithDepsBy((props, _, _) => props.site)((props, _, options) =>
+      .useEffectWithDepsBy((props, _, _) => props.site): (props, _, options) =>
         _.map(options.zoom(ObjectPlotOptions.site).set).orEmpty
-      )
       // If visualization time changes, switch to it.
-      .useEffectWithDepsBy((props, _, _) => props.visualizationTime)((props, _, options) =>
+      .useEffectWithDepsBy((props, _, _) => props.visualizationTime): (props, _, options) =>
         _.map(vt => options.mod(_.withDateAndSemesterOf(vt))).orEmpty
-      )
       .render: (props, ctx, elevationPlotOptions) =>
         import ctx.given
 
-        val options = elevationPlotOptions.withOnMod(opts =>
+        val options: View[ObjectPlotOptions] = elevationPlotOptions.withOnMod: opts =>
           ElevationPlotPreference
             .updatePlotPreferences[IO](
               props.userId,
@@ -117,7 +114,8 @@ object ObjectPlotSection:
               Visible(opts.visiblePlots.contains_(SeriesType.LunarElevation))
             )
             .runAsync
-        )
+
+        val opt: ObjectPlotOptions = options.get
 
         val siteView: View[Site]                              = options.zoom(ObjectPlotOptions.site)
         val rangeView: View[PlotRange]                        = options.zoom(ObjectPlotOptions.range)
@@ -128,8 +126,6 @@ object ObjectPlotSection:
           options.zoom(ObjectPlotOptions.visiblePlots)
         val showSchedulingView: View[ElevationPlotScheduling] =
           options.zoom(ObjectPlotOptions.showScheduling)
-
-        val opt: ObjectPlotOptions = options.get
 
         def windowsToIntervals(windows: List[TimingWindow]): IntervalSeq[Instant] =
           windows

--- a/explore/src/main/scala/explore/targets/TargetSummaryBody.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryBody.scala
@@ -16,11 +16,9 @@ import explore.components.ui.ExploreStyles
 import explore.model.AppContext
 import explore.model.Focused
 import explore.model.Observation
-import explore.model.ProgramSummaries
 import explore.model.TargetList
 import explore.model.enums.AppTab
 import explore.model.enums.TableId
-import explore.undo.UndoContext
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
@@ -63,10 +61,7 @@ case class TargetSummaryBody(
   targetObservations:      Map[Target.Id, SortedSet[Observation.Id]],
   calibrationObservations: Set[Observation.Id],
   selectObservation:       (Observation.Id, Target.Id) => Callback,
-  selectTargetOrSummary:   Option[Target.Id] => Callback,
   selectedTargetIds:       View[List[Target.Id]],
-  undoCtx:                 UndoContext[ProgramSummaries],
-  readonly:                Boolean,
   tileState:               View[TargetSummaryTileState]
 ) extends ReactFnProps(TargetSummaryBody.component):
   val filesToImport = tileState.zoom(TargetSummaryTileState.filesToImport)
@@ -306,13 +301,9 @@ object TargetSummaryBody:
         ).withKey(s"summary-table-${props.filesToImport.get.size}")
 
 case class TargetSummaryTitle(
-  programId:             Program.Id,
-  targets:               View[TargetList],
-  selectTargetOrSummary: Option[Target.Id] => Callback,
-  selectedTargetIds:     View[List[Target.Id]],
-  undoCtx:               UndoContext[ProgramSummaries],
-  readonly:              Boolean,
-  tileState:             View[TargetSummaryTileState]
+  programId: Program.Id,
+  readonly:  Boolean,
+  tileState: View[TargetSummaryTileState]
 ) extends ReactFnProps(TargetSummaryTitle.component):
   val filesToImport = tileState.zoom(TargetSummaryTileState.filesToImport)
   val table         = tileState.zoom(TargetSummaryTileState.table)

--- a/explore/src/main/scala/explore/targets/TargetSummaryBody.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryBody.scala
@@ -175,7 +175,7 @@ object TargetSummaryBody:
           targets.toList
             .filterNot((id, _) => isCalibrationTarget(id))
             .map((id, target) => TargetWithId(id, target))
-      .useReactTableWithStateStoreBy: (props, ctx, cols, rows) =>
+      .useReactTableWithStateStoreBy((props, ctx, cols, rows) =>
         import ctx.given
 
         def targetIds2RowSelection: List[Target.Id] => RowSelection = targetIds =>
@@ -216,6 +216,7 @@ object TargetSummaryBody:
           ),
           TableStore(props.userId, TableId.TargetsSummary, cols)
         )
+      )
       .useEffectOnMountBy((p, _, _, _, table) => p.table.set(ColumnSelectorState(table.some)))
       .useRef(none[HTMLTableVirtualizer])
       .useResizeDetector()

--- a/explore/src/main/scala/explore/targets/TargetSummaryBody.scala
+++ b/explore/src/main/scala/explore/targets/TargetSummaryBody.scala
@@ -203,13 +203,14 @@ object TargetSummaryBody:
             state = PartialTableState(
               rowSelection = targetIds2RowSelection(props.selectedTargetIds.get)
             ),
-            onRowSelectionChange = _ match
-              case Updater.Set(selection) =>
-                props.selectedTargetIds.set(rowSelection2TargetIds(selection))
-              case Updater.Mod(f)         =>
-                props.selectedTargetIds.mod: targetIds =>
-                  rowSelection2TargetIds(f(targetIds2RowSelection(targetIds)))
-              >> props.focusTargetId(none), // Unselect edited target if rows are selected.
+            onRowSelectionChange = (u: Updater[RowSelection]) =>
+              (u match
+                case Updater.Set(selection) =>
+                  props.selectedTargetIds.set(rowSelection2TargetIds(selection))
+                case Updater.Mod(f)         =>
+                  props.selectedTargetIds.mod: targetIds =>
+                    rowSelection2TargetIds(f(targetIds2RowSelection(targetIds)))
+              ) >> props.focusTargetId(none), // Unselect edited target if rows are selected.
             initialState = TableState(
               columnVisibility = TargetColumns.DefaultVisibility
             )


### PR DESCRIPTION
With this PR, the target editor is only shown below the target summary table if the user clicks on the target id. Also in that case, the plot is hidden.

The plot is restored if any row is selected by clicking anywhere else except the target id.

Also, the plot is always show even if no rows are selected (unless the target editor is shown).