### PR TITLE
Final obs summary table improvements

### DIFF
--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -116,28 +116,28 @@ object ExploreGridLayouts:
   end scheduling
 
   object targets:
-    private lazy val SummaryHeight: NonNegInt = 6.refined
+    private lazy val SummaryHeight: NonNegInt = 9.refined
     private lazy val TargetHeight: NonNegInt  = 18.refined
     private lazy val SkyPlotHeight: NonNegInt = 9.refined
 
     private lazy val layoutMedium: Layout = Layout(
       List(
         LayoutItem(
-          i = ObsTabTileIds.TargetSummaryId.id.value,
+          i = TargetTabTileIds.Summary.id,
           x = 0,
           y = 0,
           w = DefaultWidth.value,
           h = SummaryHeight.value
         ),
         LayoutItem(
-          i = ObsTabTileIds.TargetId.id.value,
+          i = TargetTabTileIds.AsterismEditor.id,
           x = 0,
           y = SummaryHeight.value,
           w = DefaultWidth.value,
           h = TargetHeight.value
         ),
         LayoutItem(
-          i = ObsTabTileIds.PlotId.id.value,
+          i = TargetTabTileIds.ElevationPlot.id,
           x = 0,
           y = SummaryHeight.value + TargetHeight.value,
           w = DefaultWidth.value,

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTable.scala
@@ -219,7 +219,6 @@ object ObsSummaryTable:
               }
             )(obsId.toString)
 
-          // TODO Groups are a dependency now, check that this updates is obs is moved around
           def groupLink(group: Group): VdomNode =
             <.a(
               ^.href := ctx.pageUrl(

--- a/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/AsterismEditorTile.scala
@@ -13,7 +13,6 @@ import explore.model.GlobalPreferences
 import explore.model.GuideStarSelection
 import explore.model.ObsConfiguration
 import explore.model.ObsIdSet
-import explore.model.ObsTabTileIds
 import explore.model.ObservationsAndTargets
 import explore.model.OnAsterismUpdateParams
 import explore.model.OnCloneParameters
@@ -42,6 +41,7 @@ object AsterismEditorTile:
 
   def asterismEditorTile(
     userId:             Option[User.Id],
+    tileId:             Tile.TileId,
     programId:          Program.Id,
     obsIds:             ObsIdSet,
     obsAndTargets:      UndoSetter[ObservationsAndTargets],
@@ -74,7 +74,7 @@ object AsterismEditorTile:
       )
 
     Tile(
-      ObsTabTileIds.TargetId.id,
+      tileId,
       title,
       AsterismTileState(),
       back = backButton,

--- a/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
+++ b/explore/src/main/scala/explore/tabs/ElevationPlotTile.scala
@@ -30,7 +30,8 @@ object ElevationPlotTile:
     vizTime:           Option[Instant],
     pendingTime:       Option[Duration],
     timingWindows:     List[TimingWindow] = List.empty,
-    globalPreferences: GlobalPreferences
+    globalPreferences: GlobalPreferences,
+    emptyMessage:      String
   ): Tile[Unit] =
     Tile(
       tileId,
@@ -46,7 +47,8 @@ object ElevationPlotTile:
             vizTime,
             pendingTime,
             timingWindows,
-            globalPreferences
+            globalPreferences,
+            emptyMessage
           ): VdomNode
         .getOrElse:
           <.div(

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -272,7 +272,7 @@ object ObsTabContents extends TwoPanels:
           val obsSummaryTableTile: Tile[?] =
             Tile(
               ObsSummaryTabTileIds.SummaryId.id,
-              s"Observations Summary (${props.observations.get.length})",
+              s"Observations Summary (${props.observations.get.toList.filterNot(_.isCalibration).length})",
               none[Table[Expandable[ObsSummaryTable.ObsSummaryRow], Nothing]],
               backButton.some,
               canMinimize = false,

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -320,7 +320,8 @@ object ObsTabContents extends TwoPanels:
               none,
               none,
               List.empty,
-              props.globalPreferences.get
+              props.globalPreferences.get,
+              "No observation selected"
             )
 
           val summaryTiles: VdomNode =

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -272,7 +272,7 @@ object ObsTabContents extends TwoPanels:
           val obsSummaryTableTile: Tile[?] =
             Tile(
               ObsSummaryTabTileIds.SummaryId.id,
-              s"Observations Summary (${props.observations.get.size})",
+              s"Observations Summary (${props.observations.get.length})",
               none[Table[Expandable[ObsSummaryTable.ObsSummaryRow], Nothing]],
               backButton.some,
               canMinimize = false,

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -272,7 +272,7 @@ object ObsTabContents extends TwoPanels:
           val obsSummaryTableTile: Tile[?] =
             Tile(
               ObsSummaryTabTileIds.SummaryId.id,
-              "Observations Summary",
+              s"Observations Summary (${props.observations.get.size})",
               none[Table[Expandable[ObsSummaryTable.ObsSummaryRow], Nothing]],
               backButton.some,
               canMinimize = false,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -411,7 +411,8 @@ object ObsTabTiles:
                   vizTimeView.get,
                   obsDuration.map(_.toDuration),
                   timingWindows.get,
-                  props.globalPreferences.get
+                  props.globalPreferences.get,
+                  "No target selected"
                 )
 
             def getObsInfo(obsId: Observation.Id)(targetId: Target.Id): TargetEditObsInfo =
@@ -444,6 +445,7 @@ object ObsTabTiles:
             val targetTile =
               AsterismEditorTile.asterismEditorTile(
                 props.vault.userId,
+                ObsTabTileIds.TargetId.id,
                 props.programId,
                 ObsIdSet.one(props.obsId),
                 props.obsAndTargets,

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -11,10 +11,10 @@ import explore.model.AladinFullScreen
 import explore.model.Asterism
 import explore.model.GlobalPreferences
 import explore.model.GuideStarSelection
-import explore.model.ObsTabTileIds
 import explore.model.ObservationsAndTargets
 import explore.model.OnCloneParameters
 import explore.model.TargetEditObsInfo
+import explore.model.TargetTabTileIds
 import explore.targeteditor.SiderealTargetEditor
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
@@ -44,7 +44,7 @@ object SiderealTargetEditorTile:
     backButton:         Option[VdomNode] = none
   ) =
     Tile(
-      ObsTabTileIds.TargetId.id,
+      TargetTabTileIds.AsterismEditor.id,
       title,
       back = backButton,
       bodyClass = ExploreStyles.TargetTileBody

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -501,8 +501,9 @@ object TargetTabContents extends TwoPanels:
                  } else {
                    // We'll open all of the original groups who had any observations affected by the cloning.
                    props.expandedIds.mod(_ ++ SortedSet.from(allOriginalGroups)) >>
-                     setCurrentTarget(idsToEdit.some)(params.originalId.some,
-                                                      SetRouteVia.HistoryReplace
+                     setCurrentTarget(idsToEdit.some)(
+                       params.originalId.some,
+                       SetRouteVia.HistoryReplace
                      )
                  })
 
@@ -544,6 +545,7 @@ object TargetTabContents extends TwoPanels:
             val asterismEditorTile =
               AsterismEditorTile.asterismEditorTile(
                 props.userId,
+                TargetTabTileIds.AsterismEditor.id,
                 props.programId,
                 idsToEdit,
                 props.obsAndTargets,
@@ -586,7 +588,8 @@ object TargetTabContents extends TwoPanels:
                 obsTimeView.get,
                 none,
                 Nil,
-                props.globalPreferences.get
+                props.globalPreferences.get,
+                "No target selected"
               )
 
             List(asterismEditorTile, skyPlotTile)
@@ -594,9 +597,9 @@ object TargetTabContents extends TwoPanels:
 
           // We still want to render these 2 tiles, even when not shown, so as not to mess up the stored layout.
           val dummyTargetTile: Tile[Unit]    =
-            Tile(ObsTabTileIds.TargetId.id, "", hidden = true)(_ => EmptyVdom)
+            Tile(TargetTabTileIds.AsterismEditor.id, "", hidden = true)(_ => EmptyVdom)
           val dummyElevationTile: Tile[Unit] =
-            Tile(ObsTabTileIds.PlotId.id, "", hidden = true)(_ => EmptyVdom)
+            Tile(TargetTabTileIds.ElevationPlot.id, "", hidden = true)(_ => EmptyVdom)
 
           /**
            * Renders a single sidereal target editor without an obs context
@@ -640,7 +643,8 @@ object TargetTabContents extends TwoPanels:
               none,
               none,
               Nil,
-              props.globalPreferences.get
+              props.globalPreferences.get,
+              "No target selected"
             )
 
           val rightSide = { (resize: UseResizeDetectorReturn) =>

--- a/explore/src/main/scala/explore/targeteditor/plots/NightPlot.scala
+++ b/explore/src/main/scala/explore/targeteditor/plots/NightPlot.scala
@@ -46,7 +46,8 @@ case class NightPlot(
   coordsTime:       Instant,
   excludeIntervals: List[BoundedInterval[Instant]],
   pendingTime:      Option[Duration],
-  options:          View[ObjectPlotOptions]
+  options:          View[ObjectPlotOptions],
+  emptyMessage:     String
 ) extends ReactFnProps(NightPlot.component)
 
 object NightPlot:
@@ -431,10 +432,10 @@ object NightPlot:
       .useRef(none[Chart_]) // chart handler (chartOpt)
       .useEffectWithDepsBy((props, _, _, _, _, chartOpt) =>
         (props.plotData.value.size, chartOpt.value.void)
-      ): (_, _, _, _, _, chartOpt) =>
+      ): (props, _, _, _, _, chartOpt) =>
         (size, _) =>
           Callback:
-            if size === 0 then chartOpt.value.foreach(_.showLoading("No target selected"))
+            if size === 0 then chartOpt.value.foreach(_.showLoading(props.emptyMessage))
             else chartOpt.value.foreach(_.hideLoading())
       .render: (props, _, _, chartAndMoonData, chartOptions, chartOpt) =>
         React.Fragment(

--- a/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotSection.scala
+++ b/explore/src/main/scala/explore/targeteditor/plots/ObjectPlotSection.scala
@@ -55,7 +55,8 @@ case class ObjectPlotSection(
   visualizationTime: Option[Instant],
   pendingTime:       Option[Duration],
   timingWindows:     List[TimingWindow],
-  globalPreferences: GlobalPreferences
+  globalPreferences: GlobalPreferences,
+  emptyMessage:      String
 ) extends ReactFnProps(ObjectPlotSection.component)
 
 object ObjectPlotSection:
@@ -161,7 +162,8 @@ object ObjectPlotSection:
                   dateView.get.atStartOfDay.toInstant(ZoneOffset.UTC),
                   windowsNetExcludeIntervals,
                   props.pendingTime,
-                  options
+                  options,
+                  props.emptyMessage
                 )
               case PlotRange.Semester =>
                 props.plotData.value.headOption.map { case (_, data) =>

--- a/hasura/user-prefs/migrations/default/1730138000453_insert_into_public_lucumaGridLayoutId/down.sql
+++ b/hasura/user-prefs/migrations/default/1730138000453_insert_into_public_lucumaGridLayoutId/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."lucumaGridLayoutId" WHERE "id" = 'observation_list';

--- a/hasura/user-prefs/migrations/default/1730138000453_insert_into_public_lucumaGridLayoutId/up.sql
+++ b/hasura/user-prefs/migrations/default/1730138000453_insert_into_public_lucumaGridLayoutId/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."lucumaGridLayoutId"("id") VALUES (E'observation_list');

--- a/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
+++ b/model/shared/src/main/scala/explore/data/tree/KeyedIndexedTree.scala
@@ -202,6 +202,13 @@ case class KeyedIndexedTree[K: Eq, A] private (
     go(Nil, key)
   }
 
+  def parentValue(key: K): Option[Node[A]] =
+    byKey
+      .get(key)
+      .flatMap: node =>
+        node.value.index.parentKey.flatMap: parentKey =>
+          byKey.get(parentKey).map(_.map(_.elem))
+
   def mapElement[B](f: A => B, getKey: B => K): KeyedIndexedTree[K, B] = {
     val newTree: Tree[IndexedElem[K, B]] = tree.map { case IndexedElem(a, idx) =>
       IndexedElem(f(a), idx)


### PR DESCRIPTION
- Include missing migration from previous PR.
- Show column with observation group. The name of the group is shown. If missing, then the id is shown. It's clickable and redirects to the group edit.
- Show the number of observations in the list header.

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/04bad442-8fe5-439c-b653-13719fb503ec">
