### PR TITLE
Elevation plot improvements

### DIFF
--- a/common/src/main/webapp/sass/charts.scss
+++ b/common/src/main/webapp/sass/charts.scss
@@ -55,6 +55,12 @@ See https://github.com/highcharts/highcharts/issues/13320 */
     fill-opacity: 0.75;
   }
 
+  .plot-elevation-minimum {
+    fill: hsl(0deg 87% 66%);
+    stroke: hsl(0deg 87% 66%);
+    opacity: 0.5;
+  }
+
   .plot-sky-brightness-percentile {
     stroke-dasharray: 3, 5;
   }
@@ -112,7 +118,7 @@ See https://github.com/highcharts/highcharts/issues/13320 */
 
   .highcharts-plot-band-label {
     // Twilight labels
-    fill: hsl(0deg 0% 40%);
+    fill: hsl(0deg 0% 60%);
   }
 
   .highcharts-xaxis-grid .highcharts-grid-line {

--- a/explore/src/main/scala/explore/targeteditor/plots/NightPlot.scala
+++ b/explore/src/main/scala/explore/targeteditor/plots/NightPlot.scala
@@ -424,6 +424,9 @@ object NightPlot:
                       .setVisible(series.visible)
                       .setFillOpacity(0)
                       .setZoneAxis("x")
+                      .setThreshold: // Ensure that the zones are always painted towards the bottom
+                        if (series.seriesType === SeriesType.SkyBrightness) Double.PositiveInfinity
+                        else Double.NegativeInfinity
 
                   zones
                     .fold(baseSeries)(z => baseSeries.setZones(z))

--- a/explore/src/main/scala/explore/targeteditor/plots/NightPlot.scala
+++ b/explore/src/main/scala/explore/targeteditor/plots/NightPlot.scala
@@ -62,8 +62,14 @@ object NightPlot:
     val seconds = "%02d".format(dms.arcseconds)
     s"$degrees°$minutes′$seconds″"
 
-  private val SkyBrightnessPercentileLines =
-    def plotLine(id: String, value: Double) =
+  private val ElevationMinimumLine =
+    YAxisPlotLinesOptions()
+      .setValue(30)
+      .setClassName("plot-elevation-minimum")
+      .setZIndex(1)
+
+  private val SkyBrightnessPercentileLines: List[YAxisPlotLinesOptions] =
+    def plotLine(id: String, value: Double): YAxisPlotLinesOptions =
       YAxisPlotLinesOptions()
         .setId(s"sky-brightness-$id")
         .setValue(value)
@@ -78,7 +84,7 @@ object NightPlot:
     )
 
   private val SkyBrightnessPercentileBands: List[YAxisPlotBandsOptions] =
-    def plotBand(id: String, label: String, from: Double, to: Double) =
+    def plotBand(id: String, label: String, from: Double, to: Double): YAxisPlotBandsOptions =
       YAxisPlotBandsOptions()
         .setId(s"sky-brightness-$id")
         .setLabel(
@@ -340,7 +346,8 @@ object NightPlot:
                     .setTickInterval(10)
                     .setMinorTickInterval(5)
                     .setShowEmpty(false)
-                    .setLabels(YAxisLabelsOptions().setFormat("{value}°")),
+                    .setLabels(YAxisLabelsOptions().setFormat("{value}°"))
+                    .setPlotLines(js.Array(ElevationMinimumLine)),
                   YAxisOptions()
                     .setOpposite(true)
                     .setTitle(YAxisTitleOptions().setText("Parallactic angle"))


### PR DESCRIPTION
- Make sure areas are painted below lines
- Draw faint line with minimum elevation at 30 degrees (only if plotting elevations).
- Make twilight texts a bit lighter.