### PR TITLE
Add margin to last item in the obs lists to provide room for url preview

### DIFF
--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -2458,6 +2458,12 @@ input[type='file'].explore-fileupload {
     right: 0.2em;
     left: 0.2em;
   }
+
+  // margin at the bottom to allow space for the browser link preview
+  // SC-3885
+  & > div:last-child {
+    margin-bottom: 30px;
+  }
 }
 
 .obs-tree-wrapper {
@@ -2498,6 +2504,12 @@ input[type='file'].explore-fileupload {
     padding: 0;
     border: none;
     overflow-y: auto;
+
+    // margin at the bottom to allow space for the browser link preview
+    // SC-3885
+    &:last-child {
+      margin-bottom: 30px;
+    }
   }
 
   .obs-tree-group-leaf {


### PR DESCRIPTION
As suggested in the shortcut story, this adds a margin to the last item in the trees/lists in the left panel of explore so that the user can scroll them up above the url preview in the browser.