### PR TITLE
Exclude inactive and calibration obs from config request tables

### DIFF
--- a/explore/src/main/scala/explore/model/AppContext.scala
+++ b/explore/src/main/scala/explore/model/AppContext.scala
@@ -59,7 +59,7 @@ case class AppContext[F[_]](
     appTab:    AppTab,
     programId: Program.Id,
     focused:   Focused,
-    text:      String,
+    contents:  VdomNode,
     via:       SetRouteVia = SetRouteVia.HistoryPush
   ): VdomNode =
     <.a(^.href := pageUrl(appTab, programId, focused),
@@ -67,14 +67,16 @@ case class AppContext[F[_]](
           e.preventDefaultCB >> e.stopPropagationCB >>
             setPageVia(appTab, programId, focused, via)
         )
-    )(text)
+    )(contents)
 
   def obsIdRoutingLink(
     programId: Program.Id,
     obsId:     Observation.Id,
-    via:       SetRouteVia = SetRouteVia.HistoryPush
+    via:       SetRouteVia = SetRouteVia.HistoryPush,
+    contents:  Option[VdomNode] = None
   ): VdomNode =
-    routingLink(AppTab.Observations, programId, Focused.singleObs(obsId), obsId.show)
+    val finalContents: VdomNode = contents.getOrElse(obsId.show)
+    routingLink(AppTab.Observations, programId, Focused.singleObs(obsId), finalContents)
 
   given WebSocketJSClient[F, ObservationDB]     = clients.odb
   given WebSocketJSClient[F, UserPreferencesDB] = clients.preferencesDB

--- a/explore/src/main/scala/explore/programs/ConfigurationTableColumnBuilder.scala
+++ b/explore/src/main/scala/explore/programs/ConfigurationTableColumnBuilder.scala
@@ -22,8 +22,6 @@ import lucuma.react.table.ColumnDef
 import lucuma.react.table.ColumnId
 import lucuma.ui.syntax.table.*
 
-import scala.collection.immutable.SortedSet
-
 case class ConfigurationTableColumnBuilder[D, TM](colDef: ColumnDef.Applied[D, TM]):
   import ConfigurationTableColumnBuilder.*
 
@@ -68,15 +66,20 @@ case class ConfigurationTableColumnBuilder[D, TM](colDef: ColumnDef.Applied[D, T
     )
 
   def obsListColumn(
-    accessor:  D => SortedSet[Observation.Id],
+    accessor:  D => List[Observation],
     programId: Program.Id,
     ctx:       AppContext[IO]
   ) =
     colDef(ObservationsColumnId, accessor, ColumnNames(ObservationsColumnId))
       .setCell(c =>
         <.span(
-          c.value.toList
-            .map(obsId => ctx.obsIdRoutingLink(programId, obsId))
+          c.value
+            .sortBy(_.id)
+            .map(obs =>
+              if (obs.isInactive)
+                ctx.obsIdRoutingLink(programId, obs.id, contents = <.s(obs.id.show).some)
+              else ctx.obsIdRoutingLink(programId, obs.id)
+            )
             .mkReactFragment(", ")
         )
       )

--- a/explore/src/main/scala/explore/programs/ProgramConfigRequestsTile.scala
+++ b/explore/src/main/scala/explore/programs/ProgramConfigRequestsTile.scala
@@ -34,8 +34,6 @@ import lucuma.ui.syntax.table.*
 import lucuma.ui.table.*
 import lucuma.ui.table.hooks.*
 
-import scala.collection.immutable.SortedSet
-
 case class ProgramConfigRequestsTile(
   userId:             Option[User.Id],
   programId:          Program.Id,
@@ -51,9 +49,9 @@ object ProgramConfigRequestsTile:
   given Reusability[Map[ConfigurationRequest.Id, List[Observation]]] = Reusability.map
 
   private case class Row(
-    request:    ConfigurationRequest,
-    obsIds:     SortedSet[Observation.Id],
-    targetName: String
+    request:      ConfigurationRequest,
+    observations: List[Observation],
+    targetName:   String
   )
 
   private object Row:
@@ -63,9 +61,8 @@ object ProgramConfigRequestsTile:
       targets:            TargetList
     ): Row =
       val obses      = obs4ConfigRequests.get(request.id).getOrElse(List.empty)
-      val obsIds     = SortedSet.from(obses.map(_.id))
       val targetName = ConfigurationTableColumnBuilder.targetName(obses, targets)
-      Row(request, obsIds, targetName)
+      Row(request, obses, targetName)
 
   private val ColDef        = ColumnDef[Row]
   private val columnBuilder = ConfigurationTableColumnBuilder(ColDef)
@@ -104,7 +101,7 @@ object ProgramConfigRequestsTile:
           columnBuilder.configurationColumns(_.request.configuration) ++
           List(
             columnBuilder
-              .obsListColumn(_.obsIds, props.programId, ctx),
+              .obsListColumn(_.observations, props.programId, ctx),
             rowColumn(StatusColumnId, _.request.status)
               .setCell(c => stateIcon(c.value))
               .setSize(80.toPx)


### PR DESCRIPTION
Calibration observations are ignored for both the `Requested` and `Unrequested` tables since they don't need approval.

Inactive observations are filtered out of the `Unrequested` table so requests can't be generated for a configuration if it only has inactive observations. They are still kept in the list of observation ids in the `Requested` table, but the text in the link is strike throughed (struck through?).