### PR TITLE
Use stateInViewHandler where possible, enable restore table state

### DIFF
--- a/explore/src/main/scala/explore/constraints/ConstraintsSummaryTile.scala
+++ b/explore/src/main/scala/explore/constraints/ConstraintsSummaryTile.scala
@@ -56,7 +56,8 @@ object ConstraintsSummaryTile:
       canMinimize = false,
       canMaximize = false
     )(
-      tileState => Body(userId, programId, constraintList, expandedIds, tileState.get.value),
+      tileState =>
+        Body(userId, programId, constraintList, expandedIds, tileState.zoom(TileState.value)),
       (tileState, _) =>
         ColumnSelectorInTitle(SelectableColumnNames.toList, tileState.zoom(TileState.value))
     )
@@ -106,7 +107,7 @@ object ConstraintsSummaryTile:
     programId:        Program.Id,
     constraintList:   ConstraintGroupList,
     expandedIds:      View[SortedSet[ObsIdSet]],
-    columnVisibility: ColumnVisibility
+    columnVisibility: View[ColumnVisibility]
   ) extends ReactFnProps(Body.component)
 
   private object Body:
@@ -256,7 +257,8 @@ object ConstraintsSummaryTile:
               enableSorting = true,
               enableColumnResizing = true,
               columnResizeMode = ColumnResizeMode.OnChange,
-              state = PartialTableState(columnVisibility = props.columnVisibility)
+              state = PartialTableState(columnVisibility = props.columnVisibility.get),
+              onColumnVisibilityChange = stateInViewHandler(props.columnVisibility.mod)
             ),
             TableStore(props.userId, TableId.ConstraintsSummary, cols)
           )

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
@@ -111,7 +111,7 @@ object AsterismEditorTile:
             guideStarSelection,
             readonly,
             sequenceChanged,
-            tileState.get.columnVisibility,
+            tileState.zoom(TileState.columnVisibility),
             tileState.zoom(TileState.obsEditInfo)
           ),
       (tileState, tileSize) =>
@@ -161,7 +161,7 @@ object AsterismEditorTile:
     guideStarSelection: View[GuideStarSelection],
     readonly:           Boolean,
     sequenceChanged:    Callback,
-    columnVisibility:   ColumnVisibility,
+    columnVisibility:   View[ColumnVisibility],
     obsEditInfo:        View[Option[ObsIdSetEditInfo]]
   ) extends ReactFnProps(Body.component):
     val allTargets: UndoSetter[TargetList] = obsAndTargets.zoom(ObservationsAndTargets.targets)

--- a/explore/src/main/scala/explore/targeteditor/TargetTable.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetTable.scala
@@ -58,7 +58,7 @@ case class TargetTable(
   vizTime:          Option[Instant],
   fullScreen:       AladinFullScreen,
   readOnly:         Boolean,
-  columnVisibility: ColumnVisibility
+  columnVisibility: View[ColumnVisibility]
 ) extends ReactFnProps(TargetTable.component)
 
 object TargetTable extends AsterismModifier:
@@ -158,8 +158,8 @@ object TargetTable extends AsterismModifier:
             enableSorting = true,
             enableColumnResizing = true,
             columnResizeMode = ColumnResizeMode.OnChange,
-            initialState = TableState(columnVisibility = TargetColumns.DefaultVisibility),
-            state = PartialTableState(columnVisibility = props.columnVisibility),
+            state = PartialTableState(columnVisibility = props.columnVisibility.get),
+            onColumnVisibilityChange = stateInViewHandler(props.columnVisibility.mod),
             meta = TableMeta(props.obsIds, props.obsAndTargets, props.onAsterismUpdate)
           ),
           TableStore(props.userId, TableId.AsterismTargets, cols)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,7 +29,7 @@ object Versions {
   val lucumaSchemas          = "0.107.1"
   val lucumaOdbSchema        = "0.16.1"
   val lucumaSSO              = "0.6.27"
-  val lucumaUI               = "0.122.0"
+  val lucumaUI               = "0.123.0"
   val monocle                = "3.3.0"
   val mouse                  = "1.3.2"
   val mUnit                  = "1.0.2"


### PR DESCRIPTION
This fixes the issue where column selection was lost when navigating away from the table.