### PR TITLE
Allow setting X and Y Binning independently

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -346,6 +346,7 @@ object ExploreStyles:
   val AdvancedConfigurationCol2: Css    = Css("explore-advanced-configuration-col2")
   val AdvancedConfigurationCol3: Css    = Css("explore-advanced-configuration-col3")
   val AdvancedConfigurationButtons: Css = Css("explore-advanced-configuration-buttons")
+  val AdvancedConfigurationBinning: Css = Css("explore-advanced-configuration-binning")
   val ConfigurationFilter: Css          = Css("explore-configuration-filter") |+| Css("field")
   val ExploreTable: Css                 = Css("explore-table")
   val ExploreTableEmpty: Css            = Css("explore-table-emptymessage")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1734,6 +1734,21 @@ svg.fa-triangle-exclamation.explore-error-icon {
   grid-area: col3;
 }
 
+.explore-advanced-configuration-binning {
+  display: flex;
+  place-items: baseline stretch;
+  grid-gap: 0.5em;
+  width: 100%;
+
+  div:first-child {
+    flex-grow: 1;
+  }
+
+  div:last-child {
+    flex-grow: 1;
+  }
+}
+
 // ------
 // Constraints
 // ------

--- a/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
@@ -301,7 +301,8 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
     disabled:        Boolean,
     exclude:         Set[A] = Set.empty[A],
     showClear:       Boolean = false,
-    resetToOriginal: Boolean = false // resets to `none` on false
+    resetToOriginal: Boolean = false, // resets to `none` on false
+    dropdownMods:    TagMod = TagMod.empty
   ) =
     val originalText = original.map(_.shortName).getOrElse("None")
     <.span(
@@ -313,7 +314,7 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
         exclude = exclude,
         disabled = disabled,
         showClear = showClear
-      ),
+      )(dropdownMods),
       <.span(PrimeStyles.InputGroupAddon,
              customized(originalText, view.set(if (resetToOriginal) original else none))
       )
@@ -685,7 +686,10 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
             //   )
           ),
           <.div(LucumaPrimeStyles.FormColumnCompact, ExploreStyles.AdvancedConfigurationCol3)(
-            FormLabel(htmlFor = "explicitXBin".refined)(
+            // Provide better accessibility by using aria-label directly
+            // on the dropdowns so X and Y binning are correctly labeled.
+            <.label(
+              LucumaPrimeStyles.FormFieldLabel,
               "Binning",
               HelpIcon("configuration/binning.md".refined)
             ),
@@ -695,14 +699,16 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
                 id = "explicitXBin".refined,
                 view = explicitXBinning(props.observingMode).withDefault(defaultXBinning),
                 original = defaultXBinning.some,
-                disabled = disableAdvancedEdit
+                disabled = disableAdvancedEdit,
+                dropdownMods = ^.aria.label := "X Binning"
               ),
-              FormLabel(htmlFor = "explicitYBin".refined)("x"),
+              <.label("x"),
               customizableEnumSelectOptional(
                 id = "explicitYBin".refined,
                 view = explicitYBinning(props.observingMode).withDefault(defaultYBinning),
                 original = defaultYBinning.some,
-                disabled = disableAdvancedEdit
+                disabled = disableAdvancedEdit,
+                dropdownMods = ^.aria.label := "Y Binning"
               )
             ),
             FormLabel(htmlFor = "explicitReadMode".refined)(


### PR DESCRIPTION
<img width="369" alt="image" src="https://github.com/user-attachments/assets/cdeb5c46-aa50-41df-ad8a-73200492d2f5">

The `Read Mode` now also handles when either `AmpReadMode` or `AmpGain` is explicitly set via the API and the other is not. It does not allow for setting them independently - if the Read Mode is set via Explore, both are explicitly set.