### PR TITLE
Fix scheduling group update, expand group with focused observation

### DIFF
--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -98,12 +98,11 @@ case class ProgramSummaries(
         .map((c, obsIds) => ObsIdSet.of(obsIds.head, obsIds.tail.toList*) -> c)
 
   lazy val schedulingGroups: SchedulingGroupList =
-    SortedMap.from(
+    SortedMap.from:
       observations.toList
         .map((obsId, obs) => obs.timingWindows.sorted -> obsId)
         .groupMap(_._1)(_._2)
         .map((tws, obsIds) => ObsIdSet.of(obsIds.head, obsIds.tail.toList*) -> tws.sorted)
-    )
 
   lazy val calibrationObservations: Set[Observation.Id] =
     observations.values.filter(_.isCalibration).map(_.id).toSet


### PR DESCRIPTION
The scheduling group update was victim of a memoized callback in the table column definition: since the callback depends on the selected observations, delete operations were always applied to the original selection rather than the current one. Solved it by use of table meta.

Also, it was requested that the focused observation is still shown when edited, even if changes groups. Therefore, logic was added so that when the groups change, the group containing the focused obs is expanded (and a group from which observations are removed is not collapsed).