### PR TITLE
Autofocus name field in TargetSelectionPopup

### DIFF
--- a/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
@@ -215,6 +215,7 @@ object TargetSelectionPopup:
         React.Fragment(
           props.trigger.copy(onClick = props.trigger.onClick >> onOpen),
           Dialog(
+            closable = false,
             clazz = ExploreStyles.TargetSearchForm |+| LucumaPrimeStyles.Dialog.Large,
             contentClass = ExploreStyles.TargetSearchContent,
             footer = <.div(


### PR DESCRIPTION
I tried using `Ref`s to focus the input, and nothing would work. Then I set `closable` to false and the Refs worked, but so did the `^.autoFocus`...

The `X` icon in the upper right is now not displayed, and the user can't close it with Escape. But closing by clicking on the close button in the footer or outside of the dialog works.