### PR TITLE
Default slit observations to use parallactic angle plus more undo/redo

### DIFF
--- a/common/src/main/scala/explore/model/ObsConfiguration.scala
+++ b/common/src/main/scala/explore/model/ObsConfiguration.scala
@@ -47,10 +47,7 @@ case class ObsConfiguration(
         averagePA.map(_.averagePA).orElse(Angle.Angle0.some)
       case _                                               => none
 
-  def posAngleConstraintView: Option[View[PosAngleConstraint]] =
-    posAngleProperties.map(_.constraint)
-
-  def posAngleConstraint: Option[PosAngleConstraint] = posAngleConstraintView.map(_.get)
+  def posAngleConstraint: Option[PosAngleConstraint] = posAngleProperties.map(_.constraint)
 
   def agsState: Option[View[AgsState]] =
     posAngleProperties.map(_.agsState)

--- a/common/src/main/scala/explore/model/PAProperties.scala
+++ b/common/src/main/scala/explore/model/PAProperties.scala
@@ -13,10 +13,10 @@ case class PAProperties(
   oid:                Observation.Id,
   guideStarSelection: View[GuideStarSelection],
   agsState:           View[AgsState],
-  constraint:         View[PosAngleConstraint]
+  constraint:         PosAngleConstraint
 ):
   val selectedPA = guideStarSelection.get.selectedAngle
 
 object PAProperties:
   given Eq[PAProperties] =
-    Eq.by(x => (x.oid, x.guideStarSelection.get, x.agsState.get, x.constraint.get))
+    Eq.by(x => (x.oid, x.guideStarSelection.get, x.agsState.get, x.constraint))

--- a/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -138,7 +138,7 @@ object ObsQueriesGQL:
     """
 
   @GraphQL
-  trait CreateConfigurationMutation extends GraphQLOperation[ObservationDB]:
+  trait UpdateConfigurationMutation extends GraphQLOperation[ObservationDB]:
     val document = s"""
       mutation ($$input: UpdateObservationsInput!){
         updateObservations(input: $$input) {

--- a/explore/src/main/scala/explore/config/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationTile.scala
@@ -33,7 +33,6 @@ import explore.model.PosAngleConstraintAndObsMode
 import explore.model.ScienceRequirements
 import explore.model.ScienceRequirements.Spectroscopy
 import explore.model.TargetList
-import explore.model.enums.AgsState
 import explore.model.enums.PosAngleOptions
 import explore.model.enums.WavelengthUnits
 import explore.model.itc.ItcTarget
@@ -71,7 +70,6 @@ object ConfigurationTile:
     obsId:                    Observation.Id,
     requirements:             UndoSetter[ScienceRequirements],
     pacAndMode:               UndoSetter[PosAngleConstraintAndObsMode],
-    agsState:                 View[AgsState],
     scienceTargetIds:         AsterismIds,
     baseCoordinates:          Option[CoordinatesAtVizTime],
     obsConf:                  ObsConfiguration,
@@ -96,7 +94,6 @@ object ConfigurationTile:
           obsId,
           requirements,
           pacAndMode,
-          agsState,
           obsConf,
           scienceTargetIds.itcTargets(allTargets),
           baseCoordinates,
@@ -223,7 +220,6 @@ object ConfigurationTile:
     obsId:                    Observation.Id,
     requirements:             UndoSetter[ScienceRequirements],
     pacAndMode:               UndoSetter[PosAngleConstraintAndObsMode],
-    agsState:                 View[AgsState],
     obsConf:                  ObsConfiguration,
     itcTargets:               List[ItcTarget],
     baseCoordinates:          Option[CoordinatesAtVizTime],
@@ -304,7 +300,6 @@ object ConfigurationTile:
                 .UpdateObservationMutation[IO]
                 .execute(_)
                 .void
-                .switching(props.agsState.async, AgsState.Saving, AgsState.Idle)
             ).zoom(
               Iso.id,
               UpdateObservationsInput.SET

--- a/explore/src/main/scala/explore/config/PAConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/PAConfigurationPanel.scala
@@ -79,10 +79,10 @@ object PAConfigurationPanel:
           .zoom(PosAngleConstraint.parallacticOverrideAngle)
 
       val selectedAngle = props.posAngleView.get match
-        case PosAngleConstraint.Unbounded          =>
+        case PosAngleConstraint.Unbounded                                          =>
           props.selectedPA
             .map(a => <.label(f"${a.toDoubleDegrees}%.0f °"))
-        case PosAngleConstraint.AverageParallactic =>
+        case PosAngleConstraint.AverageParallactic                                 =>
           props.averagePA
             .map(a =>
               <.div(
@@ -93,7 +93,10 @@ object PAConfigurationPanel:
               )
             )
             .orElse(<.label("Not Visible").some)
-        case _                                     => None
+        case PosAngleConstraint.AllowFlip(af) if props.selectedPA.exists(_ =!= af) =>
+          props.selectedPA
+            .map(a => <.label(f"Flipped to ${a.toDoubleDegrees}%.0f °"))
+        case _                                                                     => None
 
       def posAngleEditor(pa: View[Angle]) =
         <.div(

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -483,7 +483,6 @@ object ObsTabTiles:
                 props.observation.zoom(Observation.scienceRequirements),
                 props.observation
                   .zoom((Observation.posAngleConstraint, Observation.observingMode).disjointZip),
-                agsState,
                 props.observation.get.scienceTargetIds,
                 targetCoords,
                 obsConf,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -74,12 +74,12 @@ import lucuma.schemas.ObservationDB
 import lucuma.schemas.model.BasicConfiguration
 import lucuma.schemas.model.TargetWithId
 import lucuma.schemas.odb.input.*
+import lucuma.ui.optics.*
 import lucuma.ui.reusability.given
 import lucuma.ui.sso.UserVault
 import lucuma.ui.syntax.all.*
 import lucuma.ui.syntax.all.given
 import queries.common.ObsQueriesGQL.*
-import queries.schemas.itc.syntax.*
 import queries.schemas.odb.ObsQueries
 
 import java.time.Instant
@@ -115,6 +115,7 @@ case class ObsTabTiles(
     programSummaries.obsAttachmentAssignments
   val asterismTracking: Option[ObjectTracking]                      =
     observation.get.asterismTracking(obsTargets)
+  val posAngleConstraint: PosAngleConstraint                        = observation.get.posAngleConstraint
 
 object ObsTabTiles:
   private type Props = ObsTabTiles
@@ -238,16 +239,6 @@ object ObsTabTiles:
           import ctx.given
 
           vizTimeOrNowPot.renderPot: vizTimeOrNow =>
-            // This view is shared between AGS and the configuration editor
-            // when PA changes it gets saved to the db
-            val posAngleConstraintView: View[PosAngleConstraint] =
-              props.observation.model
-                .zoom(Observation.posAngleConstraint)
-                .withOnMod: pa =>
-                  ObsQueries
-                    .updatePosAngle[IO](List(props.obsId), pa)
-                    .switching(agsState.async, AgsState.Saving, AgsState.Idle)
-                    .runAsync
 
             val asterismIds: View[AsterismIds] =
               props.observation.model.zoom(Observation.scienceTargetIds)
@@ -281,12 +272,12 @@ object ObsTabTiles:
                 .orElse(pendingTime)
 
             val paProps: PAProperties =
-              PAProperties(props.obsId, guideStarSelection, agsState, posAngleConstraintView)
+              PAProperties(props.obsId, guideStarSelection, agsState, props.posAngleConstraint)
 
             val averagePA: Option[AveragePABasis] =
               (basicConfiguration.map(_.siteFor), asterismAsNel, obsDuration)
                 .mapN: (site, asterism, duration) =>
-                  posAngleConstraintView.get match
+                  props.posAngleConstraint match
                     case PosAngleConstraint.AverageParallactic =>
                       // See also `anglesToTestAt` in AladinCell.scala.
                       averageParallacticAngle(
@@ -303,7 +294,7 @@ object ObsTabTiles:
             // For AverageParllactic constraint, use the average PA (if any), otherwise
             // use the angle specified in the constraint
             val pa: Option[Angle] =
-              posAngleConstraintView.get match
+              props.posAngleConstraint match
                 case PosAngleConstraint.Unbounded                  => paProps.selectedPA
                 case PosAngleConstraint.AverageParallactic         => averagePA.map(_.averagePA)
                 case PosAngleConstraint.Fixed(angle)               => angle.some
@@ -490,8 +481,9 @@ object ObsTabTiles:
                 props.programId,
                 props.obsId,
                 props.observation.zoom(Observation.scienceRequirements),
-                props.observation.zoom(Observation.observingMode),
-                posAngleConstraintView,
+                props.observation
+                  .zoom((Observation.posAngleConstraint, Observation.observingMode).disjointZip),
+                agsState,
                 props.observation.get.scienceTargetIds,
                 targetCoords,
                 obsConf,

--- a/model/shared/src/main/scala/explore/model/ObservingModeSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObservingModeSummary.scala
@@ -6,6 +6,7 @@ package explore.model
 import cats.kernel.Order
 import cats.syntax.order.*
 import clue.data.syntax.*
+import explore.model.enums.PosAngleOptions
 import lucuma.core.enums.GmosAmpReadMode
 import lucuma.core.enums.GmosNorthFilter
 import lucuma.core.enums.GmosNorthFpu
@@ -40,6 +41,16 @@ enum ObservingModeSummary:
     ampReadMode:       GmosAmpReadMode,
     roi:               GmosRoi
   ) extends ObservingModeSummary
+
+  // Currently, everything is long slit and defaults to Average Parallactic.
+  // But as we get new modes, Shortcut 3360 states:
+  // Slit spectroscopy ->  Average Parallactic
+  // MOS -> Fixed
+  // Imaging -> Unconstrained
+  // IFU -> 180 Flip
+  def defaultPosAngleConstrait: PosAngleOptions = this match
+    case GmosNorthLongSlit(_, _, _, _, _, _) => PosAngleOptions.AverageParallactic
+    case GmosSouthLongSlit(_, _, _, _, _, _) => PosAngleOptions.AverageParallactic
 
   def toInput: ObservingModeInput = this match
     case GmosNorthLongSlit(grating, filter, fpu, centralWavelength, ampReadMode, roi) =>

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -15,6 +15,7 @@ import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Group
 import lucuma.core.model.ObsAttachment as ObsAtt
+import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
 import lucuma.core.model.SiderealTracking
 import lucuma.core.model.SourceProfile
@@ -23,6 +24,7 @@ import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.util.NewType
 import lucuma.refined.*
+import lucuma.schemas.model.ObservingMode
 import monocle.Focus
 import monocle.Lens
 
@@ -70,6 +72,14 @@ object ObservationsAndTargets:
   val observations: Lens[ObservationsAndTargets, ObservationList] =
     Focus[ObservationsAndTargets](_._1)
   val targets: Lens[ObservationsAndTargets, TargetList]           = Focus[ObservationsAndTargets](_._2)
+
+type PosAngleConstraintAndObsMode = (PosAngleConstraint, Option[ObservingMode])
+
+object PosAngleConstraintAndObsMode:
+  val posAngleConstraint: Lens[PosAngleConstraintAndObsMode, PosAngleConstraint] =
+    Focus[PosAngleConstraintAndObsMode](_._1)
+  val observingMode: Lens[PosAngleConstraintAndObsMode, Option[ObservingMode]]   =
+    Focus[PosAngleConstraintAndObsMode](_._2)
 
 object ObservationExecutionMap extends PotMap[Observation.Id, Execution]
 type ObservationExecutionMap = ObservationExecutionMap.Type

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -18,6 +18,7 @@ import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.util.Timestamp
+import lucuma.schemas.model.BasicConfiguration
 
 import java.time.Instant
 import java.time.ZoneOffset
@@ -130,3 +131,14 @@ object all:
       case _                        => true
 
   extension (cr: Option[CalibrationRole]) def needsITC: Boolean = cr.fold(true)(_.needsITC)
+
+  extension (bc: BasicConfiguration)
+    // Currently, everything is long slit and defaults to Average Parallactic.
+    // But as we get new modes, Shortcut 3360 states:
+    // Slit spectroscopy ->  Average Parallactic
+    // MOS -> Fixed
+    // Imaging -> Unconstrained
+    // IFU -> 180 Flip
+    def defaultPosAngleConstrait: PosAngleOptions = bc match
+      case BasicConfiguration.GmosNorthLongSlit(_, _, _, _) => PosAngleOptions.AverageParallactic
+      case BasicConfiguration.GmosSouthLongSlit(_, _, _, _) => PosAngleOptions.AverageParallactic

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -197,7 +197,6 @@ object SpectroscopyModeRow {
 
   given Decoder[SpectroscopyModeRow] = c =>
     for {
-      instrument <- c.downField("instrument").as[Instrument]
       name       <- c.downField("name").as[NonEmptyString]
       focalPlane <- c.downField("focalPlane").as[FocalPlane]
       capability <- c.downField("capability").as[Option[SpectroscopyCapabilities]]


### PR DESCRIPTION
In addition to the setting the Position Angle Constraint (PAC) to Average Parallactic when a long slit observation is selecting, and preparing for other modes with other defaults, this PR does a number of other things. Including, but maybe not limited to:

- When a guide star is selected in Allow Flip mode, it does not update the actual PAC if the guide star is for the flipped angle. Instead, this information is shown alongside the PAC in the Configuration Tile.
- PAC now takes part in undo/redo
- Selecting or reverting a configuration via the configurations dropdown now takes part in undo/redo
- Reverting a configuration via the configurations dropdown better supports setting the appropriate line in the spectroscopy table when the revert is done in a different session.
- We were sending 2 requests to the ODB when creating a configuration. It should now only send one request.