### PR TITLE
Fix change editor

### DIFF
--- a/explore/src/main/scala/explore/config/package.scala
+++ b/explore/src/main/scala/explore/config/package.scala
@@ -115,7 +115,7 @@ object SignalToNoiseAt extends ConfigurationFormats {
               signalToNoise.get.fold(List(props.calibrationRole.renderRequiredForITCIcon))(_ =>
                 Nil
               ),
-            changeAuditor = ChangeAuditor.posBigDecimal(1.refined).optional,
+            changeAuditor = ChangeAuditor.posBigDecimal(3.refined).optional,
             disabled = props.readonly
           ).withMods(^.autoComplete.off),
           FormLabel("signal-to-noise-at".refined)("at"),

--- a/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
+++ b/explore/src/main/scala/explore/targets/TargetSelectionPopup.scala
@@ -251,7 +251,7 @@ object TargetSelectionPopup:
               <.span(ExploreStyles.TargetSearchTop)(
                 <.form(ExploreStyles.TargetSearchInput)(
                   FormInputTextView(
-                    id = "name".refined,
+                    id = "target-search-name".refined,
                     placeholder = "Name",
                     value = inputValue,
                     preAddons =


### PR DESCRIPTION
This is an odd bug, it manifest itself in safari, where the signal to noise fields gets right away the focus and you can't jump to another control, After checking a bit I think the problem as on the text input with a change  auditor
Now the change auditor has a different set of decimals than the validator and fixing that solves the proble