### PR TITLE
Remove notes tile for groups

### DIFF
--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -451,13 +451,6 @@ object ExploreGridLayouts:
           y = 0,
           w = DefaultWidth.value,
           h = GroupEditHeight.value
-        ),
-        LayoutItem(
-          i = GroupEditTileIds.GroupNotesId.id.value,
-          x = 0,
-          y = GroupEditHeight.value,
-          w = DefaultWidth.value,
-          h = NotesHeight.value
         )
       )
     )

--- a/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
@@ -61,25 +61,12 @@ object ObsGroupTiles:
           (_, _) => GroupEditTitle(props.group, props.childCount, props.timeEstimateRange)
         )
 
-      val notesTile = Tile(
-        GroupEditTileIds.GroupNotesId.id,
-        s"Note for Observer"
-      )(_ =>
-        <.div(
-          ExploreStyles.NotesTile,
-          <.div(
-            ExploreStyles.ObserverNotes,
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus maximus hendrerit lacinia. Etiam dapibus blandit ipsum sed rhoncus."
-          )
-        )
-      )
-
       TileController(
         props.userId,
         props.resize.width.orEmpty,
         props.defaultLayouts,
         props.layouts,
-        List(editTile, notesTile),
+        List(editTile),
         GridLayoutSection.GroupEditLayout,
         props.backButton.some
       )

--- a/model/shared/src/main/scala/explore/model/TileIds.scala
+++ b/model/shared/src/main/scala/explore/model/TileIds.scala
@@ -50,11 +50,10 @@ enum ProposalTabTileIds:
     case AttachmentsId => "proposalAttachments".refined
 
 enum GroupEditTileIds:
-  case GroupEditId, GroupNotesId
+  case GroupEditId
 
   def id: NonEmptyString = this match
-    case GroupEditId  => "groupEdit".refined
-    case GroupNotesId => "groupNotes".refined
+    case GroupEditId => "groupEdit".refined
 
 enum TargetTabTileIds(val id: NonEmptyString):
   case Summary        extends TargetTabTileIds("targetSummary".refined)


### PR DESCRIPTION
Removed as per the discussion with @andrewwstephens in the shortcut story.

I kept the time manager, etc. for the groups even though there is only one tile left, but we seem to have a habit of adding more things to the UI...