### PR TITLE
Handle target cloning on target replacement better.

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -177,6 +177,7 @@ object ObsTabContents extends TwoPanels:
             callbacks
           )
       .useStateView(DeckShown.Shown)
+      .useStateView(AddingObservation(false))   // adding new observation or duplicating
       .render:
         (
           props,
@@ -188,7 +189,8 @@ object ObsTabContents extends TwoPanels:
           selectedOrFocusedObsIds, // Mixes focused obs and selected obs in table
           copyCallback,
           pasteCallback,
-          deckShown
+          deckShown,
+          addingObservation
         ) =>
           val observationsTree: VdomNode =
             if (deckShown.get === DeckShown.Shown) {
@@ -211,6 +213,7 @@ object ObsTabContents extends TwoPanels:
                 pasteCallback,
                 shadowClipboardObs.value,
                 props.programSummaries.get.allocatedScienceBands,
+                addingObservation,
                 props.readonly
               )
             } else
@@ -312,7 +315,7 @@ object ObsTabContents extends TwoPanels:
                   props.userPreferences.get.observationsTabLayout,
                   resize,
                   props.globalPreferences,
-                  props.readonly
+                  props.readonly || addingObservation.get.value
                 ).withKey(s"${obsId.show}")
               )
           }

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -337,7 +337,8 @@ object SiderealTargetEditor:
                 nameView,
                 allView.set,
                 props.searching,
-                props.readonly || props.obsInfo.isReadonly
+                props.readonly || props.obsInfo.isReadonly,
+                cloning.get
               ),
               FormInputTextView(
                 id = "ra".refined,


### PR DESCRIPTION
[sc-4277]
The cloning of the target when editing a shared target was causing the issues. These became apparent now that odb-dev is slower. This fixes that by delaying the cloning of the target until necessary. Also, in the current code, the target name was changed, and THEN the target was replaced - so it was 2 steps. This eliminates the first step.

Readonly state of the target editor and other obs tiles was improved when an observation is being added/duplicated or a target is being cloned.