### PR TITLE
Allow accessing menu when no program selected

### DIFF
--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -104,18 +104,21 @@ object TopBar:
                 props.preferences.copy(level = l)
               ) *> IO(window.location.reload())).runAsync
 
-          val firstItems = List(
+          val firstItems =
             MenuItem.Item(
               label = "About Explore",
               icon = Icons.Info,
               command = isAboutOpen.set(IsAboutOpen(true))
-            ),
-            MenuItem.Item(
-              label = "Manage Programs",
-              icon = Icons.ListCheck,
-              command = isProgramsOpen.setState(IsProgramOpen(true))
-            )
-          )
+            ) +:
+              (if (props.programId.isDefined)
+                 List(
+                   MenuItem.Item(
+                     label = "Manage Programs",
+                     icon = Icons.ListCheck,
+                     command = isProgramsOpen.setState(IsProgramOpen(true))
+                   )
+                 )
+               else List.empty)
 
           val lastItems = List(
             MenuItem.Separator.some,

--- a/explore/src/main/scala/explore/programs/ProgramTable.scala
+++ b/explore/src/main/scala/explore/programs/ProgramTable.scala
@@ -40,7 +40,6 @@ case class ProgramTable(
   selectProgram:    Program.Id => Callback,
   isRequired:       Boolean,
   onClose:          Option[Callback],
-  onLogout:         Option[IO[Unit]],
   virtualizerRef:   UseRef[Option[HTMLTableVirtualizer]]
 ) extends ReactFnProps(ProgramTable.component)
 

--- a/explore/src/main/scala/explore/programs/ProgramsPopup.scala
+++ b/explore/src/main/scala/explore/programs/ProgramsPopup.scala
@@ -48,7 +48,6 @@ case class ProgramsPopup(
   programInfos:     ViewOpt[ProgramInfoList],
   undoStacks:       View[UndoStacks[IO, ProgramSummaries]],
   onClose:          Option[Callback] = none,
-  onLogout:         Option[IO[Unit]] = none,
   message:          Option[String] = none
 ) extends ReactFnProps(ProgramsPopup.component)
 
@@ -112,16 +111,6 @@ object ProgramsPopup:
           ).small.compact.some
         )
 
-      val logoutButton =
-        props.onLogout.fold(none)(io =>
-          Button(
-            label = "Logout",
-            icon = Icons.Logout,
-            severity = Button.Severity.Danger,
-            onClick = (ctx.sso.logout >> io).runAsync
-          ).small.compact.some
-        )
-
       val programInfosViewOpt: Option[View[ProgramInfoList]] =
         props.programInfos.toOptionView
 
@@ -148,6 +137,7 @@ object ProgramsPopup:
         position = DialogPosition.Top,
         closeOnEscape = props.onClose.isDefined,
         closable = props.onClose.isDefined,
+        modal = props.onClose.isDefined,
         dismissableMask = props.onClose.isDefined,
         resizable = false,
         clazz = LucumaPrimeStyles.Dialog.Small |+| ExploreStyles.ProgramsPopup,
@@ -167,8 +157,7 @@ object ProgramsPopup:
               value = showDeleted.zoom(ShowDeleted.value.asLens),
               label = "Show deleted"
             ),
-            closeButton,
-            logoutButton
+            closeButton
           )
       )(
         programInfoViewListOpt.toPot
@@ -179,7 +168,6 @@ object ProgramsPopup:
               selectProgram = selectProgram(props.onClose, props.undoStacks, ctx),
               props.onClose.isEmpty,
               onHide,
-              props.onLogout,
               virtualizerRef
             ),
         props.message.map(msg =>


### PR DESCRIPTION
This PR makes the program selection non modal when no program is defined.

This allows users to access the menu, and therefore change roles, logout, redeem invitations, etc. without the need to select a program. Consequently, the logout button is removed from the program selection popup.

The popup is still modal when accessed from "Manage programs" from inside a program. BTW, "Manage programs" is hidden when no program is defined.