### PR TITLE
Change terminology for CoIs

### DIFF
--- a/explore/src/main/scala/explore/users/AddProgramUserButton.scala
+++ b/explore/src/main/scala/explore/users/AddProgramUserButton.scala
@@ -59,7 +59,7 @@ object AddProgramUserButton
           severity = Button.Severity.Secondary,
           loading = isActive.get.value,
           icon = props.icon,
-          tooltip = s"Create ${props.role.shortName} User",
+          tooltip = s"Add ${props.role.longName}",
           tooltipOptions = ttOptions,
           onClick = addProgramUser.runAsync
         ).tiny.compact

--- a/model/shared/src/main/scala/explore/model/display.scala
+++ b/model/shared/src/main/scala/explore/model/display.scala
@@ -223,12 +223,21 @@ trait DisplayImplicits:
     case Gender.Other        => "Other"
     case Gender.NotSpecified => "Not Specified"
 
-  given Display[ProgramUserRole] = Display.byShortName:
-    case ProgramUserRole.Pi               => "PI"
-    case ProgramUserRole.Coi              => "CoI"
-    case ProgramUserRole.CoiRO            => "Observer"
-    case ProgramUserRole.SupportPrimary   => "Principal Support"
-    case ProgramUserRole.SupportSecondary => "Additional Support"
+  extension (pur: ProgramUserRole)
+    private def shortName = pur match
+      case ProgramUserRole.Pi               => "PI"
+      case ProgramUserRole.Coi              => "CoI (full-access)"
+      case ProgramUserRole.CoiRO            => "CoI (read-only)"
+      case ProgramUserRole.SupportPrimary   => "Principal Support"
+      case ProgramUserRole.SupportSecondary => "Additional Support"
+    private def longName  = pur match
+      case ProgramUserRole.Pi               => "Principal Investigator"
+      case ProgramUserRole.Coi              => "Full-Access Co-Investigator"
+      case ProgramUserRole.CoiRO            => "Read-Only Co-Investigator"
+      case ProgramUserRole.SupportPrimary   => "Principal Support"
+      case ProgramUserRole.SupportSecondary => "Additional Support"
+
+  given Display[ProgramUserRole] = Display.by(_.shortName, _.longName)
 
   given Display[ConfigurationRequestStatus] = Display.byShortName(_.tag.capitalize)
   given Display[ObservationWorkflowState]   = Display.byShortName(_.tag.capitalize)


### PR DESCRIPTION
Change requested by Andy because `Observer` has another meaning.