### PR TITLE
Remove AddProgramUserButton for support users

### DIFF
--- a/explore/src/main/scala/explore/programs/ProgramDetailsTile.scala
+++ b/explore/src/main/scala/explore/programs/ProgramDetailsTile.scala
@@ -13,7 +13,6 @@ import explore.model.ProgramTimes
 import explore.model.ProgramUser
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.core.model.Access
 import lucuma.core.model.Program
 import lucuma.core.model.Semester
 import lucuma.core.syntax.display.*
@@ -21,23 +20,19 @@ import lucuma.react.common.ReactFnProps
 import lucuma.ui.primereact.FormInfo
 
 case class ProgramDetailsTile(
-  programId:         Program.Id,
-  programDetails:    View[ProgramDetails],
-  programTimes:      Pot[ProgramTimes],
-  semester:          Semester,
-  currentUserAccess: Access
+  programId:      Program.Id,
+  programDetails: View[ProgramDetails],
+  programTimes:   Pot[ProgramTimes],
+  semester:       Semester
 ) extends ReactFnProps(ProgramDetailsTile.component)
 
 object ProgramDetailsTile:
   private type Props = ProgramDetailsTile
 
-  private val EditSupportAccesses: Set[Access] = Set(Access.Admin, Access.Staff)
-
   private val component = ScalaFnComponent[Props]: props =>
     val details: ProgramDetails        = props.programDetails.get
     val thesis: Boolean                = details.allUsers.exists(_.thesis.exists(_ === true))
     val users: View[List[ProgramUser]] = props.programDetails.zoom(ProgramDetails.allUsers)
-    val readonly: Boolean              = !EditSupportAccesses.contains_(props.currentUserAccess)
 
     <.div(ExploreStyles.ProgramDetailsTile)(
       <.div(ExploreStyles.ProgramDetailsInfoArea, ExploreStyles.ProgramDetailsLeft)(
@@ -57,15 +52,13 @@ object ProgramDetailsTile:
           props.programId,
           users,
           "Principal Support",
-          SupportUsers.SupportRole.Primary,
-          readonly
+          SupportUsers.SupportRole.Primary
         ),
         SupportUsers(
           props.programId,
           users,
           "Additional Support",
-          SupportUsers.SupportRole.Secondary,
-          readonly
+          SupportUsers.SupportRole.Secondary
         )
         // The two Notifications flags are user-settable and determine whether the archive sends email notifications for new data and whether the ODB sends notifications for expired timing windows (3388, 3389)
         // FormInfo("", "Notifications")

--- a/explore/src/main/scala/explore/programs/SupportUsers.scala
+++ b/explore/src/main/scala/explore/programs/SupportUsers.scala
@@ -7,7 +7,6 @@ import cats.data.NonEmptySet
 import crystal.react.View
 import explore.components.ui.ExploreStyles
 import explore.model.ProgramUser
-import explore.users.AddProgramUserButton
 import explore.users.ProgramUsersTable
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -19,8 +18,7 @@ case class SupportUsers(
   programId:   Program.Id,
   users:       View[List[ProgramUser]],
   title:       String,
-  supportRole: SupportUsers.SupportRole,
-  readonly:    Boolean
+  supportRole: SupportUsers.SupportRole
 ) extends ReactFnProps(SupportUsers.component)
 
 object SupportUsers:
@@ -33,24 +31,20 @@ object SupportUsers:
   private val component = ScalaFnComponent[Props]: props =>
     <.div(ExploreStyles.ProgramDetailsUsers)(
       <.label(
-        props.title,
-        AddProgramUserButton(
-          props.programId,
-          props.supportRole.role,
-          props.users
-        ).unless(props.readonly)
+        props.title
       ),
       ProgramUsersTable(
         props.users,
         NonEmptySet.one(props.supportRole.role),
-        props.readonly,
+        readonly = true,
         hiddenColumns = Set(
           ProgramUsersTable.Column.Partner,
           ProgramUsersTable.Column.EducationalStatus,
           ProgramUsersTable.Column.Thesis,
           ProgramUsersTable.Column.Gender,
           ProgramUsersTable.Column.Role,
-          ProgramUsersTable.Column.OrcidId
+          ProgramUsersTable.Column.OrcidId,
+          ProgramUsersTable.Column.Status
         )
       )
     )

--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -82,8 +82,7 @@ object ProgramTabContents:
               props.programId,
               props.programDetails,
               props.programTimes,
-              props.semester,
-              userVault.user.role.access
+              props.semester
             )
           )
 

--- a/explore/src/main/scala/explore/users/AddProgramUserButton.scala
+++ b/explore/src/main/scala/explore/users/AddProgramUserButton.scala
@@ -4,7 +4,6 @@
 package explore.users
 
 import cats.effect.IO
-import cats.syntax.all.*
 import crystal.react.*
 import crystal.react.hooks.*
 import explore.Icons
@@ -42,11 +41,6 @@ object AddProgramUserButton
       } yield
         import ctx.given
 
-        val ttOptions =
-          if (props.role === ProgramUserRole.Coi || props.role === ProgramUserRole.CoiRO)
-            TooltipOptions.Right
-          else TooltipOptions.Left
-
         def addProgramUser: IO[Unit] =
           val input = AddProgramUserInput(programId = props.programId, role = props.role)
           AddProgramUser[IO]
@@ -60,7 +54,6 @@ object AddProgramUserButton
           loading = isActive.get.value,
           icon = props.icon,
           tooltip = s"Add ${props.role.longName}",
-          tooltipOptions = ttOptions,
           onClick = addProgramUser.runAsync
         ).tiny.compact
     )

--- a/explore/src/main/scala/explore/users/ProgramUsersTable.scala
+++ b/explore/src/main/scala/explore/users/ProgramUsersTable.scala
@@ -252,7 +252,9 @@ object ProgramUsersTable:
             // AND the fallback display name is the same as the credit name.
             // In explore, we'll always set the credit name, but a user could have
             // updated the fallback profile via the API, and we won't mess with that.
-            if (pu.user.isEmpty && pu.fallbackProfile.creditName === pu.fallbackProfile.displayName)
+            if (
+              !meta.readOnly && pu.user.isEmpty && pu.fallbackProfile.creditName === pu.fallbackProfile.displayName
+            )
               val view = c.value
                 .zoom(ProgramUser.fallbackCreditName)
                 .withOnMod(ones =>
@@ -261,7 +263,7 @@ object ProgramUsersTable:
               FormInputTextView(
                 id = NonEmptyString.unsafeFrom(s"${programUserId}-name"),
                 value = view,
-                disabled = meta.readOnly,
+                disabled = meta.isActive.get.value,
                 validFormat = InputValidSplitEpi.nonEmptyString.optional
               ): VdomNode
             else pu.name: VdomNode
@@ -276,7 +278,7 @@ object ProgramUsersTable:
             val programUserId: ProgramUser.Id = pu.id
             // We'll allow editing the email if there is no REAL user
             // or the real email address is empty
-            if (pu.user.flatMap(_.profile).flatMap(_.email).isEmpty)
+            if (!meta.readOnly && pu.user.flatMap(_.profile).flatMap(_.email).isEmpty)
               val view = c.value
                 .zoom(ProgramUser.fallbackEmail)
                 .withOnMod(oe =>
@@ -285,7 +287,7 @@ object ProgramUsersTable:
               FormInputTextView(
                 id = NonEmptyString.unsafeFrom(s"${programUserId}-email"),
                 value = view,
-                disabled = meta.readOnly,
+                disabled = meta.isActive.get.value,
                 validFormat = ExploreModelValidators.MailValidator.optional
               ): VdomNode
             else pu.email.getOrElse("-"): VdomNode


### PR DESCRIPTION
Andy says the support users will be managed directly via the API or via the mythical `Admin UI` without the use of invitations, so he wanted the buttons for adding users removed for support users. I also made the table readonly and made a few minor changes to the users table.