### PR TITLE
Prioritize current obsservation configuration mode over the last one selected on the table row

### DIFF
--- a/explore/src/main/scala/explore/config/package.scala
+++ b/explore/src/main/scala/explore/config/package.scala
@@ -46,7 +46,7 @@ trait ConfigurationFormats:
     .fromInputValidWedge(ExploreModelValidators.wavelengthMicroValidWedge)
     .allow(s => s === "0" || s === "0.")
   lazy val wvMicroChangeAuditor          = wvMicroBaseAuditor
-    .decimal(3.refined)
+    .decimal(4.refined)
     .optional
   lazy val snAtWvMicroChangeAuditor      = wvMicroBaseAuditor
     .decimal(4.refined)

--- a/explore/src/main/scala/explore/itc/ItcGraphQuerier.scala
+++ b/explore/src/main/scala/explore/itc/ItcGraphQuerier.scala
@@ -44,8 +44,8 @@ case class ItcGraphQuerier(
   private val constraints = observation.constraints
   private val asterismIds = observation.scienceTargetIds
 
-  // The remote configuration is read in a different query than the itc results
-  // This will work even in the case the user has overriden some parameters
+  // The remote configuration is read in a different query than the itc results.
+  // This will work even in the case the user has overriden some parameters.
   // When we use the remote configuration we don't need the exposure time.
   private val remoteConfig: Option[InstrumentConfigAndItcResult] =
     observation
@@ -53,10 +53,10 @@ case class ItcGraphQuerier(
       .map: row =>
         InstrumentConfigAndItcResult(row, none)
 
-  // The user may select a configuration on the modes tables, we'd prefer than but if not
-  // we can try with the remote confiiguration provided by the database
+  // If the observation has an assigned configuration, we use that one.
+  // Otherwise, we use the one selected in the table.
   val finalConfig: Option[InstrumentConfigAndItcResult] =
-    selectedConfig.orElse(remoteConfig)
+    remoteConfig.orElse(selectedConfig)
 
   val signalToNoise: Option[SignalToNoise] =
     spectroscopyRequirements.flatMap(_.signalToNoise)


### PR DESCRIPTION
This fixes https://app.shortcut.com/lucuma/story/4439/itc-graph-does-not-refresh-when-changing-central-wavelength and also a related problem where the ITC graph was also not refreshed if the modes table had a row selected and then a configuration was selected from the drop-down.

Also, I noticed some wavelengths in micrometers have 4 decimal places.