### PR TITLE
Implement AsyncAction, use Toast.showDuring for pasting observations

### DIFF
--- a/UNDO.md
+++ b/UNDO.md
@@ -64,6 +64,25 @@ You then pass an `UndoContext[M]` to its `set` and `mod` methods:
 
 This approach allows you to invert the logic and have a clean wrapper of the 4 parameters without the need for an `UndoContext`. This is especially useful for complex operations, like insertions and deletions in lists.
 
+## `AsyncAction`
+
+`AsyncAction[M, K, A]` wraps the same 4 parameters as an `Action[M, A]`, plus an async effect which will actually return the value of `A` to set in the model. This is particularly useful when creating new objects (or cloning) and we need to invoke the DB before being able to insert them in the local model.
+
+The remote invocation can also return a `K`, which can be used to build the 4 parameters. In an insertion, `K` should be the id(s) of the new object(s), and `A` an `Option` containing the actual objects or `None` to delete them.
+
+Therefore, `AsyncAction` signature looks like this:
+
+```scala
+case class AsyncAction[M, K, A](
+  asyncGet:  DefaultA[(K, A)],
+  getter:    K => M => A,
+  setter:    K => A => M => M,
+  onSet:     K => (M, A) => DefaultA[Unit],
+  onRestore: K => (M, A) => DefaultA[Unit]
+):
+  def apply(undoSetter: UndoSetter[M]): DefaultA[Unit]
+```
+
 ## `Aligner`
 
 ### Motivation

--- a/common/src/main/scala/explore/undo/AsyncAction.scala
+++ b/common/src/main/scala/explore/undo/AsyncAction.scala
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.undo
+
+import crystal.react.*
+import japgolly.scalajs.react.util.DefaultEffects.Async as DefaultA
+
+case class AsyncAction[M, K, A](
+  asyncGet:  DefaultA[(K, A)],
+  getter:    K => M => A,
+  setter:    K => A => M => M,
+  onSet:     K => (M, A) => DefaultA[Unit],
+  onRestore: K => (M, A) => DefaultA[Unit]
+):
+  def apply(undoSetter: UndoSetter[M]): DefaultA[Unit] =
+    asyncGet.flatMap: (k, a) =>
+      undoSetter.set(getter(k), setter(k), onSet(k), onRestore(k))(a).to[DefaultA]

--- a/common/src/main/scala/explore/utils/ToastCtx.scala
+++ b/common/src/main/scala/explore/utils/ToastCtx.scala
@@ -4,9 +4,12 @@
 package explore.utils
 
 import cats.Applicative
+import cats.Monoid
 import cats.effect.Deferred
+import cats.effect.Resource
 import cats.effect.Sync
-import cats.syntax.all.given
+import cats.effect.std.UUIDGen
+import cats.syntax.all.*
 import crystal.react.*
 import lucuma.react.primereact.Message
 import lucuma.react.primereact.MessageItem
@@ -19,17 +22,55 @@ class ToastCtx[F[_]: Sync](toastRef: Deferred[F, ToastRef]):
     severity: Message.Severity = Message.Severity.Info,
     sticky:   Boolean = false
   ): F[Unit] =
-    toastRef.tryGet.flatMap(
-      _.map(_.show(text, severity, sticky).to[F]).getOrElse(Applicative[F].unit)
-    )
+    toastRef.tryGet.flatMap:
+      _.map:
+        _.show(text, severity, sticky).to[F]
+      .getOrElse:
+        Applicative[F].unit
 
   def showToast(messages: MessageItem*): F[Unit] =
-    toastRef.tryGet.flatMap(
-      _.map(_.show(messages*).to[F]).getOrElse(Applicative[F].unit)
-    )
+    toastRef.tryGet.flatMap:
+      _.map:
+        _.show(messages*).to[F]
+      .getOrElse:
+        Applicative[F].unit
+
+  def replaceToast(message: MessageItem): F[Unit] =
+    toastRef.tryGet.flatMap:
+      _.map:
+        _.remove(message).to[F]
+      .getOrElse:
+        Applicative[F].unit
+
+  def removeToast(message: MessageItem): F[Unit] =
+    toastRef.tryGet.flatMap:
+      _.map:
+        _.remove(message).to[F]
+      .getOrElse:
+        Applicative[F].unit
 
   def clear(): F[Unit] =
-    toastRef.tryGet.flatMap(_.map(_.clear().to[F]).getOrElse(Applicative[F].unit))
+    toastRef.tryGet.flatMap:
+      _.map:
+        _.clear().to[F]
+      .getOrElse:
+        Applicative[F].unit
+
+  def showToastDuring(
+    text:         String,
+    completeText: Option[String] = none,
+    errorText:    Option[String] = none
+  )(using
+    UUIDGen[F],
+    Monoid[F[Unit]]
+  ): Resource[F, Unit] =
+    Resource
+      .eval(toastRef.tryGet)
+      .flatMap:
+        _.map:
+          _.showDuring(text, completeText, errorText)
+        .getOrElse:
+          Resource.unit[F]
 
 object ToastCtx:
   def apply[F[_]](using ToastCtx[F]): ToastCtx[F] = summon[ToastCtx[F]]

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -6,9 +6,11 @@ package explore.utils
 import cats.Applicative
 import cats.Endo
 import cats.FlatMap
+import cats.Monoid
 import cats.Semigroup
 import cats.effect.*
 import cats.effect.Temporal
+import cats.effect.std.UUIDGen
 import cats.effect.syntax.all.*
 import cats.syntax.all.*
 import clue.data.*
@@ -112,6 +114,13 @@ extension [F[_]: Sync: ToastCtx](f: F[Unit])
     sticky:   Boolean = false
   ): F[Unit] =
     ToastCtx[F].showToast(text, severity, sticky) *> f
+
+  def withToastDuring(
+    text:         String,
+    completeText: Option[String] = none,
+    errorText:    Option[String] = none
+  )(using UUIDGen[F], Monoid[F[Unit]]): F[Unit] =
+    ToastCtx[F].showToastDuring(text, completeText, errorText).use(_ => f)
 
   def clearToastsAfter: F[Unit] =
     f <* ToastCtx[F].clear()

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "highcharts": "11.4.8",
         "loglevel": "1.9.2",
         "primeicons": "^7.0.0",
-        "primereact": "10.8.3",
+        "primereact": "10.9.1",
         "prop-types": "15.8.1",
         "react": "18.3.1",
         "react-circular-progressbar": "^2.1.0",
@@ -8541,9 +8541,9 @@
       "license": "MIT"
     },
     "node_modules/primereact": {
-      "version": "10.8.3",
-      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.8.3.tgz",
-      "integrity": "sha512-LYa7DL1TDmWWrPCeh3CMsx89LXgcf4+rYhJ6YiA7z164WsdzJK388Bp1Qdv5cfpyL/Nm0eIWxIApxwWBv8kwuA==",
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/primereact/-/primereact-10.9.1.tgz",
+      "integrity": "sha512-mq5Pr6/zySO913RlL5oUWD+n1ygTjJjhhxBoRWhLNKx7Na8pHpswh/QCesShFXlfYyCjDOVXFVT6J2sSDceF1g==",
       "license": "MIT",
       "dependencies": {
         "@types/react-transition-group": "^4.4.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "highcharts": "11.4.8",
     "loglevel": "1.9.2",
     "primeicons": "^7.0.0",
-    "primereact": "10.8.3",
+    "primereact": "10.9.1",
     "prop-types": "15.8.1",
     "react": "18.3.1",
     "react-circular-progressbar": "^2.1.0",

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,7 +29,7 @@ object Versions {
   val lucumaSchemas          = "0.111.0"
   val lucumaOdbSchema        = "0.17.3"
   val lucumaSSO              = "0.7.2"
-  val lucumaUI               = "0.128.0-17-359b094-20250108T001240Z-SNAPSHOT"
+  val lucumaUI               = "0.128.1"
   val monocle                = "3.3.0"
   val mouse                  = "1.3.2"
   val mUnit                  = "1.0.4"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,7 +29,7 @@ object Versions {
   val lucumaSchemas          = "0.111.0"
   val lucumaOdbSchema        = "0.17.3"
   val lucumaSSO              = "0.7.2"
-  val lucumaUI               = "0.128.0"
+  val lucumaUI               = "0.128.0-17-359b094-20250108T001240Z-SNAPSHOT"
   val monocle                = "3.3.0"
   val mouse                  = "1.3.2"
   val mUnit                  = "1.0.4"
@@ -41,5 +41,5 @@ object Versions {
   val sbtLucuma              = "0.12.4"
   val scalaCollectionContrib = "0.4.0"
   val scalaJsDom             = "2.8.0"
-  val scalaJsReact           = "3.0.0-beta8"
+  val scalaJsReact           = "3.0.0-beta10"
 }


### PR DESCRIPTION
This PR introduces `AsyncAction`. It is very similar to `Action` but allows to run an effect to obtain the value to set. This attempts to be useful for operations where we don't know the whole data to add to the model until we have a response from the server. For example, we don't know the new ids of observations or targets when adding or cloning them.
 
`AsyncAction` allows us to define an effect to run initially and its result will determine the definition of the `getter`/ `setter`/`onSet`/`onRestore` regularly used in `Action`. This way, we can encapsulate the whole logic for insert and clone operations in an `AsyncAction` instead of it being scattered between components and `Action`s. Note that I only migrated one such action so far, the rest are pending.

Also, we now have a `effect.showToastDuring(...)` which will show an uncloseable toast before running the `effect`, replacing it with a regular toast when the operation completes or fails. Again, this is only called once for the moment, there are other instances where this can be used. We probably want to use it everywhere we end up using an `AsyncAction`.

Finally, this PR also fixes https://app.shortcut.com/lucuma/story/4421/copying-observations-onto-targets-yields-wrong-name-fixed-by-reload.

![Kapture 2025-01-07 at 19 51 15](https://github.com/user-attachments/assets/2d513ea4-c121-4e3a-9390-ce71d1bda815)
