### PR TITLE
Gracefully handle errors in subscriptions.

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -7,7 +7,7 @@ object Versions {
   val circe                  = "0.14.10"
   val circeGolden            = "0.3.0"
   val coulomb                = "0.8.0"
-  val clue                   = "0.40.0"
+  val clue                   = "0.40.0-38-7fe0340-20250110T021650Z-SNAPSHOT"
   val crystal                = "0.47.3"
   val discipline             = "1.7.0"
   val disciplineMUnit        = "2.0.0"


### PR DESCRIPTION
If this seems like a good approach we could apply it to other subscriptions as well. Maybe pop a toast if there is no data so the user knows they might be out of date and could reload?

For subscriptions where we regularly expect data + errors, like observations, we could only log in the case of no data. That would clean up the console. Maybe we want to only log for no data for all subscriptions? If there is data, we'll assume we're OK?

I don't expect this situation to happen often (no data). If the ODB is sending a subscription event, it seems like there should be data. But, it was happening for awhile until a bug got fixed in the ODB. Just suddenly going to a big screen of spinning planets is not very user friendly behavior. 😄 