### PR TITLE
Unify program name/description and proposal title/abstract.

### DIFF
--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -445,7 +445,7 @@ object ExploreGridLayouts:
   end overview
 
   object proposal:
-    private lazy val DetailsHeight: NonNegInt     = 7.refined
+    private lazy val DetailsHeight: NonNegInt     = 8.refined
     private lazy val UsersHeight: NonNegInt       = 6.refined
     private lazy val AbstractHeight: NonNegInt    = 8.refined
     private lazy val AttachmentsHeight: NonNegInt = 8.refined

--- a/common/src/main/scala/explore/model/ModelUndoStacks.scala
+++ b/common/src/main/scala/explore/model/ModelUndoStacks.scala
@@ -8,7 +8,7 @@ import explore.undo.UndoStacks
 import monocle.Focus
 
 case class ModelUndoStacks[F[_]](
-  forProposal: UndoStacks[F, Proposal] = UndoStacks.empty[F, Proposal]
+  forProposal: UndoStacks[F, ProgramDetails] = UndoStacks.empty[F, ProgramDetails]
 )
 
 object ModelUndoStacks:

--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -12,6 +12,7 @@ import crystal.syntax.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.modes.SpectroscopyModesMatrix
+import explore.syntax.ui.*
 import explore.undo.UndoStacks
 import lucuma.core.model.GuestUser
 import lucuma.core.model.ServiceUser
@@ -36,7 +37,8 @@ case class RootModel(
   cfps:                 Pot[List[CallForProposal]] = pending,
   undoStacks:           UndoStacks[IO, ProgramSummaries] = UndoStacks.empty[IO, ProgramSummaries],
   otherUndoStacks:      ModelUndoStacks[IO] = ModelUndoStacks[IO]()
-) derives Eq
+) derives Eq:
+  lazy val isStaff = vault.isStaff
 
 object RootModel:
   val vault                = Focus[RootModel](_.vault)

--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -23,6 +23,7 @@ import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.Partner
 import lucuma.core.enums.TimeAccountingCategory
+import lucuma.core.model.Access
 import lucuma.core.model.GuestRole
 import lucuma.core.model.User
 import lucuma.core.util.Enumerated
@@ -62,6 +63,8 @@ extension (vault: UserVault)
       vault.authorizationHeader.credentials.renderString
     )
     request
+
+  def isStaff: Boolean = vault.user.role.access === Access.Staff
 
 extension [F[_]: ApplicativeThrow: ToastCtx, A](f: F[A])
   def toastErrors: F[A] =
@@ -122,6 +125,7 @@ extension (tac: TimeAccountingCategory)
 extension (vault: Option[UserVault])
   def userId: Option[User.Id] = vault.map(_.user).map(_.id)
   def isGuest: Boolean        = vault.map(_.user).map(_.role === GuestRole).getOrElse(true)
+  def isStaff: Boolean        = vault.exists(_.isStaff)
 
 extension [F[_], A](view: ViewF[F, A])
   def zoom[B](getAdjust: GetAdjust[A, B]): ViewF[F, B] =

--- a/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
@@ -13,6 +13,8 @@ object ProgramDetailsSubquery
     extends GraphQLSubquery.Typed[ObservationDB, ProgramDetails]("Program"):
   override val subquery: String = s"""
     {
+      name
+      description
       type
       pi $ProgramUserSubquery
       proposal $ProposalSubquery

--- a/explore/src/clue/scala/queries/common/ProgramInfoSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramInfoSubquery.scala
@@ -14,6 +14,21 @@ object ProgramInfoSubquery extends GraphQLSubquery.Typed[ObservationDB, ProgramI
     {
       id
       name
+      pi $ProgramUserSubquery,
+      users {
+        user {
+          id
+        }
+        role
+      }
+      type
+      reference $ProgramReferenceSubquery
+      proposal {
+        reference {
+          label
+        }
+      }
+      proposalStatus
       existence
     }
   """

--- a/explore/src/clue/scala/queries/common/ProposalQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProposalQueriesGQL.scala
@@ -7,8 +7,6 @@ import clue.GraphQLOperation
 import clue.annotation.GraphQL
 import lucuma.schemas.ObservationDB
 
-// gql: import io.circe.refined.*
-
 object ProposalQueriesGQL:
   @GraphQL
   trait CreateProposalMutation extends GraphQLOperation[ObservationDB]:
@@ -16,7 +14,7 @@ object ProposalQueriesGQL:
       mutation($$input: CreateProposalInput!) {
         createProposal(input: $$input) {
           proposal {
-            title
+            category
           }
         }
       }

--- a/explore/src/clue/scala/queries/common/ProposalSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProposalSubquery.scala
@@ -16,8 +16,6 @@ object ProposalSubquery extends GraphQLSubquery.Typed[ObservationDB, Proposal]("
       call {
         id
       }
-      title
-      abstract
       category
       reference {
         label

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -23,6 +23,7 @@ import explore.model.enums.AppTab
 import explore.programs.ProgramsPopup
 import explore.shortcuts.*
 import explore.shortcuts.given
+import explore.syntax.ui.*
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.ResolutionWithProps
@@ -287,41 +288,47 @@ object ExploreLayout:
                               onLogout >> view.zoom(RootModel.vault).set(none).toAsync,
                               prefs
                             )
-                          )
-                      ),
-                    showProgsPopupPot.renderPot: showProgsPopup =>
-                      if (showProgsPopup)
-                        ProgramsPopup(
-                          currentProgramId = none,
-                          props.model.programSummaries.throttlerView
-                            .zoom(Pot.readyPrism)
-                            .zoom(ProgramSummaries.programs),
-                          undoStacks = view.zoom(RootModel.undoStacks),
-                          message = msg
-                        ): VdomElement
-                      else
-                        React.Fragment(
-                          SideTabs(
-                            "side-tabs".refined,
-                            routingInfoView.zoom(RoutingInfo.appTab),
-                            tab =>
-                              ctx.pageUrl((tab, routingInfo.programId, routingInfo.focused).some),
-                            _.separatorAfter,
-                            tab =>
-                              programSummaries.toOption
-                                .flatMap(_.optProgramDetails)
-                                .forall: program =>
-                                  // Only show Program and Proposal tabs for Science proposals, and Program only for Accepted ones
-                                  (tab =!= AppTab.Proposal && tab =!= AppTab.Program) ||
-                                    program.programType === ProgramType.Science &&
-                                    (tab === AppTab.Proposal || program.proposalStatus === ProposalStatus.Accepted)
                           ),
-                          <.div(LayoutStyles.MainBody, LayoutStyles.WithMessage.when(isSubmitted))(
-                            props.resolution.renderP(props.model),
-                            TagMod.when(isSubmitted):
-                              SubmittedProposalMessage(proposalReference, deadline)
-                          )
-                        )
+                        showProgsPopupPot.renderPot: showProgsPopup =>
+                          if (showProgsPopup)
+                            ProgramsPopup(
+                              currentProgramId = none,
+                              vault.get.user.id,
+                              vault.get.isStaff,
+                              props.model.programSummaries.throttlerView
+                                .zoom(Pot.readyPrism)
+                                .zoom(ProgramSummaries.programs),
+                              undoStacks = view.zoom(RootModel.undoStacks),
+                              message = msg
+                            ): VdomElement
+                          else
+                            React.Fragment(
+                              SideTabs(
+                                "side-tabs".refined,
+                                routingInfoView.zoom(RoutingInfo.appTab),
+                                tab =>
+                                  ctx.pageUrl(
+                                    (tab, routingInfo.programId, routingInfo.focused).some
+                                  ),
+                                _.separatorAfter,
+                                tab =>
+                                  programSummaries.toOption
+                                    .flatMap(_.optProgramDetails)
+                                    .forall: program =>
+                                      // Only show Program and Proposal tabs for Science proposals, and Program only for Accepted ones
+                                      (tab =!= AppTab.Proposal && tab =!= AppTab.Program) ||
+                                        program.programType === ProgramType.Science &&
+                                        (tab === AppTab.Proposal || program.proposalStatus === ProposalStatus.Accepted)
+                              ),
+                              <.div(LayoutStyles.MainBody,
+                                    LayoutStyles.WithMessage.when(isSubmitted)
+                              )(
+                                props.resolution.renderP(props.model),
+                                TagMod.when(isSubmitted):
+                                  SubmittedProposalMessage(proposalReference, deadline)
+                              )
+                            )
+                      )
                   )
                 )
               }

--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -17,6 +17,7 @@ import explore.model.GlobalPreferences
 import explore.model.ProgramInfoList
 import explore.model.ProgramSummaries
 import explore.programs.ProgramsPopup
+import explore.syntax.ui.*
 import explore.undo.UndoStacks
 import explore.users.RedeemInvitationsPopup
 import explore.users.UserPreferencesPopup
@@ -229,6 +230,8 @@ object TopBar:
             if (isProgramsOpen.value.value)
               ProgramsPopup(
                 props.programId,
+                user.id,
+                props.vault.get.isStaff,
                 props.programInfos,
                 props.undoStacks,
                 isProgramsOpen.setState(IsProgramOpen(false)).some

--- a/explore/src/main/scala/explore/common/ProgramQueries.scala
+++ b/explore/src/main/scala/explore/common/ProgramQueries.scala
@@ -57,17 +57,19 @@ object ProgramQueries:
       .raiseGraphQLErrors
       .void
 
+  def updateProgram[F[_]: Async](input: UpdateProgramsInput)(using
+    FetchClient[F, ObservationDB]
+  ): F[Unit] =
+    UpdateProgramsMutation[F].execute(input).raiseGraphQLErrors.void
+
   def updateProgramName[F[_]: Async](id: Program.Id, name: Option[NonEmptyString])(using
     FetchClient[F, ObservationDB]
   ): F[Unit] =
-    UpdateProgramsMutation[F]
-      .execute:
-        UpdateProgramsInput(
-          WHERE = id.toWhereProgram.assign,
-          SET = ProgramPropertiesInput(name = name.orUnassign)
-        )
-      .raiseGraphQLErrors
-      .void
+    updateProgram:
+      UpdateProgramsInput(
+        WHERE = id.toWhereProgram.assign,
+        SET = ProgramPropertiesInput(name = name.orUnassign)
+      )
 
   def updateAttachmentDescription[F[_]: Async](
     oid:  Attachment.Id,

--- a/explore/src/main/scala/explore/common/ProposalQueries.scala
+++ b/explore/src/main/scala/explore/common/ProposalQueries.scala
@@ -114,9 +114,7 @@ trait ProposalQueries:
     def toInput: ProposalPropertiesInput =
       ProposalPropertiesInput(
         callId = proposal.callId.orUnassign,
-        title = proposal.title.orUnassign,
         category = proposal.category.orUnassign,
-        `abstract` = proposal.abstrakt.orUnassign,
         `type` = proposal.proposalType.map(_.toInput).orUnassign
       )
 

--- a/explore/src/main/scala/explore/programs/ProgramTable.scala
+++ b/explore/src/main/scala/explore/programs/ProgramTable.scala
@@ -9,7 +9,6 @@ import cats.syntax.all.*
 import clue.FetchClient
 import crystal.react.*
 import crystal.react.reuse.*
-import eu.timepit.refined.types.string.NonEmptyString
 import explore.*
 import explore.EditableLabel
 import explore.Icons
@@ -24,6 +23,7 @@ import japgolly.scalajs.react.hooks.Hooks.UseRef
 import japgolly.scalajs.react.vdom.VdomNode
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
+import lucuma.core.model.User
 import lucuma.react.common.ReactFnProps
 import lucuma.react.primereact.Button
 import lucuma.react.syntax.*
@@ -36,6 +36,8 @@ import org.typelevel.log4cats.Logger
 
 case class ProgramTable(
   currentProgramId: Option[Program.Id],
+  userId:           User.Id,
+  isStaff:          Boolean,
   programInfos:     List[View[ProgramInfo]],
   selectProgram:    Program.Id => Callback,
   isRequired:       Boolean,
@@ -49,6 +51,8 @@ object ProgramTable:
 
   private case class TableMeta(
     currentProgramId: Option[Program.Id],
+    userId:           User.Id,
+    isStaff:          Boolean,
     newProgramId:     Option[Program.Id],
     programCount:     Int
   )
@@ -76,105 +80,149 @@ object ProgramTable:
   ): Callback =
     ProgramQueries.updateProgramName[IO](pinf.id, pinf.name).runAsync
 
-  private val ActionsColumnId: ColumnId = ColumnId("actions")
-  private val IdColumnId: ColumnId      = ColumnId("id")
-  private val NameColumnId: ColumnId    = ColumnId("name")
+  private val ActionsColumnId: ColumnId   = ColumnId("actions")
+  private val IdColumnId: ColumnId        = ColumnId("id")
+  private val ReferenceColumnId: ColumnId = ColumnId("reference")
+  private val StatusColumnId: ColumnId    = ColumnId("status")
+  private val PiColumnId: ColumnId        = ColumnId("pi")
+  private val NameColumnId: ColumnId      = ColumnId("name")
 
-  private val component = ScalaFnComponent
-    .withHooks[Props]
-    .useContext(AppContext.ctx)
-    .useMemoBy((_, _) => ()): (props, ctx) => // Columns
-      _ =>
-        import ctx.given
+  private val component = ScalaFnComponent[Props](props =>
+    for {
+      ctx   <- useContext(AppContext.ctx)
+      cols  <-
+        useMemo(()): _ =>
+          import ctx.given
 
-        List(
-          ColDef(
-            ActionsColumnId,
-            identity[View[ProgramInfo]],
-            "Actions",
-            cell = cell =>
-              cell.table.options.meta.map: meta =>
-                val programId = cell.value.get.id
-                val isDeleted = cell.value.get.deleted
+          List(
+            ColDef(
+              ActionsColumnId,
+              identity[View[ProgramInfo]],
+              "Actions",
+              cell = cell =>
+                cell.table.options.meta.map: meta =>
+                  val programId = cell.value.get.id
+                  val isDeleted = cell.value.get.deleted
+                  val canDelete = cell.value.get.canDelete(meta.userId, meta.isStaff)
 
-                <.div(
-                  Button(
-                    label = "Select",
-                    icon = Icons.Checkmark,
-                    severity = Button.Severity.Secondary,
-                    disabled = meta.currentProgramId.exists(_ === programId),
-                    onClick = props.selectProgram(programId)
-                  ).compact.mini.unless(cell.row.original.get.deleted),
-                  Button(
-                    icon = Icons.Trash,
-                    severity = Button.Severity.Secondary,
-                    disabled =
-                      meta.currentProgramId.exists(_ === programId) || meta.programCount < 2,
-                    onClick = deleteProgram(cell.value).runAsync,
-                    tooltip = "Delete program"
-                  ).mini.compact.unless(isDeleted),
-                  Button(
-                    label = "Undelete",
-                    icon = Icons.TrashUndo,
-                    severity = Button.Severity.Secondary,
-                    onClick = undeleteProgram(cell.value).runAsync,
-                    tooltip = "Undelete program"
-                  ).mini.compact.when(isDeleted)
-                )
-            ,
-            size = 100.toPx,
-            minSize = 100.toPx,
-            maxSize = 120.toPx
-          ).sortableBy(_.get.deleted),
-          ColDef(
-            IdColumnId,
-            _.get.id,
-            "Id",
-            _.value.toString,
-            size = 60.toPx,
-            minSize = 60.toPx,
-            maxSize = 70.toPx
-          ).sortable,
-          ColDef(
-            NameColumnId,
-            _.withOnMod(onModName).zoom(ProgramInfo.name),
-            "Name",
-            cell =>
-              EditableLabel
-                .fromView(
-                  value = cell.value,
-                  forceEditing = cell.table.options.meta
-                    .flatMap(_.newProgramId)
-                    .contains_(cell.row.original.get.id),
-                  addButtonLabel = ("Add program name": VdomNode).reuseAlways,
-                  textClass = ExploreStyles.ProgramName,
-                  inputClass = ExploreStyles.ProgramNameInput,
-                  editButtonTooltip = "Edit program name".some,
-                  deleteButtonTooltip = "Delete program name".some,
-                  okButtonTooltip = "Accept".some,
-                  discardButtonTooltip = "Discard".some
-                ),
-            size = 500.toPx,
-            minSize = 200.toPx,
-            maxSize = 1000.toPx
-          ).sortableBy(_.get.foldMap(_.value))
-        )
-    .useMemoBy((props, _, _) => props.programInfos)((_, _, _) => identity) // Rows
-    .useReactTableBy: (props, _, cols, rows) =>
-      TableOptions(
-        cols,
-        rows,
-        enableSorting = true,
-        enableColumnResizing = false,
-        meta = TableMeta(props.currentProgramId, props.newProgramId, props.programInfos.size)
-      )
-    .render: (props, ctx, _, _, table) =>
-      PrimeAutoHeightVirtualizedTable(
-        table,
-        estimateSize = _ => 32.toPx,
-        striped = true,
-        compact = Compact.Very,
-        tableMod = ExploreStyles.ExploreTable |+| ExploreStyles.ExploreBorderTable,
-        virtualizerRef = props.virtualizerRef,
-        emptyMessage = "No programs available"
-      )
+                  <.div(
+                    Button(
+                      label = "Select",
+                      icon = Icons.Checkmark,
+                      severity = Button.Severity.Secondary,
+                      disabled = meta.currentProgramId.exists(_ === programId),
+                      onClick = props.selectProgram(programId)
+                    ).compact.mini.unless(cell.row.original.get.deleted),
+                    Button(
+                      icon = Icons.Trash,
+                      severity = Button.Severity.Secondary,
+                      disabled = meta.currentProgramId.exists(
+                        _ === programId
+                      ) || meta.programCount < 2,
+                      onClick = deleteProgram(cell.value).runAsync,
+                      tooltip = "Delete program"
+                    ).mini.compact.unless(isDeleted || !canDelete),
+                    Button(
+                      label = "Undelete",
+                      icon = Icons.TrashUndo,
+                      severity = Button.Severity.Secondary,
+                      onClick = undeleteProgram(cell.value).runAsync,
+                      tooltip = "Undelete program"
+                    ).mini.compact.when(isDeleted && canDelete)
+                  )
+              ,
+              size = 100.toPx,
+              minSize = 100.toPx,
+              maxSize = 120.toPx
+            ).sortableBy(_.get.deleted),
+            ColDef(
+              IdColumnId,
+              _.get.id,
+              "Id",
+              _.value.toString,
+              size = 60.toPx,
+              minSize = 60.toPx,
+              maxSize = 70.toPx
+            ).sortable,
+            ColDef(
+              ReferenceColumnId,
+              v =>
+                v.get.programReference
+                  .map(_.label)
+                  .orElse(v.get.proposalReference.map(_.label))
+                  .orEmpty,
+              "Reference"
+            ).sortable,
+            ColDef(
+              StatusColumnId,
+              v =>
+                if (v.get.hasProposal)
+                  v.get.proposalStatus.name
+                else "",
+              "Status"
+            ).sortable,
+            ColDef(
+              PiColumnId,
+              _.get.pi.map(_.lastName).orEmpty,
+              "PI"
+            ).sortable,
+            ColDef(
+              NameColumnId,
+              identity[View[ProgramInfo]],
+              "Name",
+              cell =>
+                cell.table.options.meta.map: meta =>
+                  val pid          = cell.row.original.get.id
+                  val isNewProgram = meta.newProgramId.contains(pid)
+                  // for a new program, we'll select it once it is named.
+                  val selectCB     =
+                    if (isNewProgram) props.selectProgram(pid) else Callback.empty
+                  if (cell.value.get.canRename(meta.userId, meta.isStaff))
+                    val nameView =
+                      cell.value
+                        .withOnMod(pinf => onModName(pinf) >> selectCB)
+                        .zoom(ProgramInfo.name)
+                    EditableLabel
+                      .fromView(
+                        value = nameView,
+                        forceEditing = isNewProgram,
+                        addButtonLabel = ("Add program name": VdomNode).reuseAlways,
+                        textClass = ExploreStyles.ProgramName,
+                        inputClass = ExploreStyles.ProgramNameInput,
+                        editButtonTooltip = "Edit program name".some,
+                        deleteButtonTooltip = "Delete program name".some,
+                        okButtonTooltip = "Accept".some,
+                        discardButtonTooltip = "Discard".some
+                      ): VdomNode
+                  else <.span(cell.value.get.name.map(_.value))
+              ,
+              size = 400.toPx,
+              minSize = 200.toPx,
+              maxSize = 1000.toPx
+            ).sortableBy(_.get.name.foldMap(_.value))
+          )
+      rows  <- useMemo(props.programInfos)(identity)
+      table <- useReactTable(
+                 TableOptions(
+                   cols,
+                   rows,
+                   enableSorting = true,
+                   enableColumnResizing = false,
+                   meta = TableMeta(props.currentProgramId,
+                                    props.userId,
+                                    props.isStaff,
+                                    props.newProgramId,
+                                    props.programInfos.size
+                   )
+                 )
+               )
+    } yield PrimeAutoHeightVirtualizedTable(
+      table,
+      estimateSize = _ => 32.toPx,
+      striped = true,
+      compact = Compact.Very,
+      tableMod = ExploreStyles.ExploreTable |+| ExploreStyles.ExploreBorderTable,
+      virtualizerRef = props.virtualizerRef,
+      emptyMessage = "No programs available"
+    )
+  )

--- a/explore/src/main/scala/explore/programs/ProgramsPopup.scala
+++ b/explore/src/main/scala/explore/programs/ProgramsPopup.scala
@@ -27,6 +27,7 @@ import explore.undo.UndoStacks
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
+import lucuma.core.model.User
 import lucuma.core.util.NewType
 import lucuma.react.common.ReactFnProps
 import lucuma.react.primereact.Button
@@ -46,6 +47,8 @@ import org.typelevel.log4cats.Logger
 
 case class ProgramsPopup(
   currentProgramId: Option[Program.Id],
+  userId:           User.Id,
+  isStaff:          Boolean,
   programInfos:     ViewOpt[ProgramInfoList],
   undoStacks:       View[UndoStacks[IO, ProgramSummaries]],
   onClose:          Option[Callback] = none,
@@ -124,7 +127,7 @@ object ProgramsPopup:
       val programInfoViewListOpt: Option[List[View[ProgramInfo]]] =
         programInfosViewOpt.map:
           _.toListOfViews
-            .map(_._2.withOnMod(pi => newProgramId.set(none) >> doSelectProgram(pi.id)))
+            .map(_._2.withOnMod(pi => newProgramId.set(none)))
             .filter(vpi => showDeleted.get.value || !vpi.get.deleted)
             .sortBy(_.get.id)
 
@@ -146,8 +149,8 @@ object ProgramsPopup:
         closable = props.onClose.isDefined,
         modal = props.onClose.isDefined,
         dismissableMask = props.onClose.isDefined,
-        resizable = false,
-        clazz = LucumaPrimeStyles.Dialog.Small |+| ExploreStyles.ProgramsPopup,
+        resizable = true,
+        clazz = LucumaPrimeStyles.Dialog.Large |+| ExploreStyles.ProgramsPopup,
         header = "Programs",
         footer = programInfosViewOpt.map: pis =>
           React.Fragment(
@@ -175,6 +178,8 @@ object ProgramsPopup:
           .renderPot: pis =>
             ProgramTable(
               props.currentProgramId,
+              props.userId,
+              props.isStaff,
               pis,
               selectProgram = doSelectProgram,
               props.onClose.isEmpty,

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposal.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposal.scala
@@ -3,8 +3,6 @@
 
 package explore.model.arb
 
-import eu.timepit.refined.scalacheck.all.*
-import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.TacCategory
 import explore.model.Proposal
 import lucuma.core.util.arb.ArbEnumerated.given
@@ -25,24 +23,20 @@ trait ArbProposal:
     Arbitrary {
       for {
         callId       <- arbitrary[Option[CallForProposals.Id]]
-        title        <- arbitrary[Option[NonEmptyString]]
         category     <- arbitrary[Option[TacCategory]]
-        abstrakt     <- arbitrary[Option[NonEmptyString]]
         proposalType <- arbitrary[Option[ProposalType]]
         reference    <- arbitrary[Option[ProposalReference]]
-      } yield Proposal(callId, title, category, abstrakt, proposalType, reference)
+      } yield Proposal(callId, category, proposalType, reference)
     }
 
   given Cogen[Proposal] =
     Cogen[
       (
         Option[CallForProposals.Id],
-        Option[NonEmptyString],
         Option[TacCategory],
-        Option[NonEmptyString],
         Option[ProposalType],
         Option[ProposalReference]
       )
-    ].contramap(p => (p.callId, p.title, p.category, p.abstrakt, p.proposalType, p.reference))
+    ].contramap(p => (p.callId, p.category, p.proposalType, p.reference))
 
 object ArbProposal extends ArbProposal

--- a/model/shared/src/main/scala/explore/Proposal.scala
+++ b/model/shared/src/main/scala/explore/Proposal.scala
@@ -6,10 +6,7 @@ package explore.model
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
-import eu.timepit.refined.cats.given
-import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
-import io.circe.refined.*
 import lucuma.core.enums.TacCategory
 import lucuma.core.model.CallForProposals
 import lucuma.core.model.PartnerLink
@@ -24,9 +21,7 @@ import java.time.LocalDateTime
 
 case class Proposal(
   callId:       Option[CallForProposals.Id],
-  title:        Option[NonEmptyString],
   category:     Option[TacCategory],
-  abstrakt:     Option[NonEmptyString],
   proposalType: Option[ProposalType],
   reference:    Option[ProposalReference]
 ) derives Eq:
@@ -36,12 +31,8 @@ case class Proposal(
 object Proposal:
   val callId: Lens[Proposal, Option[CallForProposals.Id]]  =
     Focus[Proposal](_.callId)
-  val title: Lens[Proposal, Option[NonEmptyString]]        =
-    Focus[Proposal](_.title)
   val category: Lens[Proposal, Option[TacCategory]]        =
     Focus[Proposal](_.category)
-  val abstrakt: Lens[Proposal, Option[NonEmptyString]]     =
-    Focus[Proposal](_.abstrakt)
   val proposalType: Lens[Proposal, Option[ProposalType]]   =
     Focus[Proposal](_.proposalType)
   val callWithType: Lens[Proposal, Option[ProposalType]]   =
@@ -53,18 +44,16 @@ object Proposal:
     for {
       callId   <-
         c.downField("call").downField("id").success.traverse(_.as[Option[CallForProposals.Id]])
-      title    <- c.downField("title").as[Option[NonEmptyString]]
       category <- c.downField("category").as[Option[TacCategory]]
-      abstrakt <- c.downField("abstract").as[Option[NonEmptyString]]
       pte      <- c.downField("type").as[Option[ProposalType]]
       r        <-
         c.downField("reference")
           .downField("label")
           .success
           .traverse(_.as[Option[ProposalReference]])
-    } yield Proposal(callId.flatten, title, category, abstrakt, pte, r.flatten)
+    } yield Proposal(callId.flatten, category, pte, r.flatten)
 
-  val Default = Proposal(None, None, None, None, None, None)
+  val Default = Proposal(None, None, None, None)
 
   def deadlineAndTimeLeft(now: Timestamp, deadline: Timestamp): (String, Option[String]) = {
     val deadlineLDT: LocalDateTime = deadline.toLocalDateTime

--- a/model/shared/src/main/scala/explore/model/ProgramInfo.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramInfo.scala
@@ -10,14 +10,61 @@ import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe.Decoder
 import io.circe.refined.given
+import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.ProgramType
+import lucuma.core.enums.ProgramUserRole
 import lucuma.core.model.Program
+import lucuma.core.model.ProgramReference
+import lucuma.core.model.ProposalReference
+import lucuma.schemas.enums.ProposalStatus
 import lucuma.schemas.ObservationDB.Enums.Existence
 import monocle.Focus
 import monocle.Lens
 
-case class ProgramInfo(id: Program.Id, name: Option[NonEmptyString], deleted: Boolean) derives Eq
+case class ProgramInfo(
+  id:                Program.Id,
+  name:              Option[NonEmptyString],
+  pi:                Option[ProgramUser],
+  userRoles:         List[ProgramInfo.UserIdAndRole],
+  programType:       ProgramType,
+  programReference:  Option[ProgramReference],
+  proposalReference: Option[ProposalReference],
+  proposalStatus:    ProposalStatus,
+  hasProposal:       Boolean,
+  calibrationRole:   Option[CalibrationRole],
+  deleted:           Boolean
+) derives Eq:
+  def roles(currentUserId: User.Id): List[ProgramUserRole] =
+    userRoles.filter(u => u.id.contains(currentUserId)).map(_.role)
+
+  // If the user is also support, they should be able to delete/edit
+  def isReadonlyCoI(currentUserId: User.Id): Boolean =
+    val rs = roles(currentUserId)
+    rs.contains(ProgramUserRole.CoiRO) && !(rs.contains(ProgramUserRole.SupportPrimary) ||
+      rs.contains(ProgramUserRole.SupportSecondary))
+
+  def roleIsOK(currentUserId: User.Id, isStaff: Boolean): Boolean =
+    isStaff || !isReadonlyCoI(currentUserId)
+
+  lazy val isSystemProgram = calibrationRole.isDefined || programType === ProgramType.System
+
+  def canDelete(currentUserId: User.Id, isStaff: Boolean): Boolean =
+    val hasBeenSubmitted = proposalStatus >= ProposalStatus.Submitted
+    !isSystemProgram && !hasBeenSubmitted && roleIsOK(currentUserId, isStaff)
+
+  def canRename(currentUserId: User.Id, isStaff: Boolean): Boolean =
+    !deleted && !isSystemProgram && !hasProposal && roleIsOK(currentUserId, isStaff)
 
 object ProgramInfo:
+  case class UserIdAndRole(id: Option[User.Id], role: ProgramUserRole) derives Decoder
+
+  given Decoder[UserIdAndRole] = Decoder.instance(c =>
+    for {
+      id   <- c.downField("user").downField("id").success.traverse(_.as[User.Id])
+      role <- c.get[ProgramUserRole]("role")
+    } yield UserIdAndRole(id, role)
+  )
+
   val id: Lens[ProgramInfo, Program.Id]               = Focus[ProgramInfo](_.id)
   val name: Lens[ProgramInfo, Option[NonEmptyString]] = Focus[ProgramInfo](_.name)
   val deleted: Lens[ProgramInfo, Boolean]             = Focus[ProgramInfo](_.deleted)
@@ -26,6 +73,30 @@ object ProgramInfo:
     for {
       id        <- c.get[Program.Id]("id")
       name      <- c.get[Option[NonEmptyString]]("name")
+      pi        <- c.downField("pi").as[Option[ProgramUser]]
+      roles     <- c.get[List[UserIdAndRole]]("users")
+      pType     <- c.get[ProgramType]("type")
+      progRef   <-
+        c.downField("reference").downField("label").success.traverse(_.as[Option[ProgramReference]])
+      propRef   <- c.downField("proposal")
+                     .downField("reference")
+                     .success
+                     .flatMap(_.downField("label").success)
+                     .traverse(_.as[Option[ProposalReference]])
+      propStat  <- c.get[ProposalStatus]("proposalStatus")
+      hasProp    = c.downField("proposal").downField("reference").success.isDefined
+      calibRole <- c.get[Option[CalibrationRole]]("calibrationRole")
       existence <- c.get[Existence]("existence")
-    } yield ProgramInfo(id, name, existence === Existence.Deleted)
+    } yield ProgramInfo(id,
+                        name,
+                        pi,
+                        roles,
+                        pType,
+                        progRef.flatten,
+                        propRef.flatten,
+                        propStat,
+                        hasProp,
+                        calibRole,
+                        existence === Existence.Deleted
+    )
   )

--- a/model/shared/src/main/scala/explore/model/ProgramInfo.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramInfo.scala
@@ -16,8 +16,8 @@ import lucuma.core.enums.ProgramUserRole
 import lucuma.core.model.Program
 import lucuma.core.model.ProgramReference
 import lucuma.core.model.ProposalReference
-import lucuma.schemas.enums.ProposalStatus
 import lucuma.schemas.ObservationDB.Enums.Existence
+import lucuma.schemas.enums.ProposalStatus
 import monocle.Focus
 import monocle.Lens
 

--- a/model/shared/src/main/scala/explore/model/ProgramUser.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramUser.scala
@@ -34,6 +34,10 @@ case class ProgramUser(
     user.fold(fallbackProfile.displayName.orEmpty)(_.name)
   val email: Option[String] =
     user.flatMap(_.profile.flatMap(_.email)).orElse(fallbackProfile.email)
+  // Try to get only a last name and fallback to display name. If there is a User, we'll
+  // assume it has one of the names we can use.
+  lazy val lastName: String =
+    user.fold(fallbackProfile.familyName.orElse(fallbackProfile.displayName).orEmpty)(_.lastName)
 
   // should only ever be one non-revoked invitation
   val activeInvitation: Option[UserInvitation] =

--- a/model/shared/src/main/scala/explore/model/User.scala
+++ b/model/shared/src/main/scala/explore/model/User.scala
@@ -12,13 +12,15 @@ import lucuma.core.model.UserProfile
 import lucuma.sso.client.codec.userProfile.given
 
 // Case class for the 'pi' and `users` in the Program. These must be
-// actual users, not service users.
+// actual users, not service users. But, can be guests.
 case class User(
   id:      User.Id,
   orcidId: Option[OrcidId],
-  profile: Option[UserProfile] // TODO: Can this be non-optional? ie. does it include guests?
+  profile: Option[UserProfile]
 ) derives Eq:
   lazy val name: String = profile.fold("Guest User")(_.displayName.orEmpty)
+
+  lazy val lastName: String = profile.flatMap(p => p.familyName.orElse(p.displayName)).orEmpty
 
   lazy val nameWithEmail: String =
     name + profile.flatMap(_.email).foldMap(email => s" ($email)")

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -26,7 +26,7 @@ object Versions {
   val lucumaITC              = "0.25.1"
   val lucumaReact            = "0.78.2"
   val lucumaRefined          = "0.1.3"
-  val lucumaSchemas          = "0.114.2"
+  val lucumaSchemas          = "0.114.2-1-acc3ca5-SNAPSHOT"
   val lucumaOdbSchema        = "0.18.2"
   val lucumaSSO              = "0.8.1"
   val lucumaUI               = "0.128.5"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -26,7 +26,7 @@ object Versions {
   val lucumaITC              = "0.25.1"
   val lucumaReact            = "0.78.2"
   val lucumaRefined          = "0.1.3"
-  val lucumaSchemas          = "0.114.2-1-acc3ca5-SNAPSHOT"
+  val lucumaSchemas          = "0.115.0"
   val lucumaOdbSchema        = "0.18.2"
   val lucumaSSO              = "0.8.1"
   val lucumaUI               = "0.128.5"


### PR DESCRIPTION
This will need Shane's ODB PR and a schemas update in order to compile.

In a separate PR I will add the ability to edit the program description on the overview tab for non-science programs.  I will probably convert more components to the new hooks style at that time, but this seemed enough to review in one bite. This will make everything work and unblock Shane's PR.

This also makes significant updates to the programs popup. Some changes were needed in order to make programs undeleteable or unrenameable under various conditions, so I talked to Andy and also added some more columns to make it more useful until the mythical `Browse` is available.