### PR TITLE
Changes to proposal submission

### DIFF
--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -178,10 +178,10 @@ object Routing:
                 model.rootModel.zoom(RootModel.cfps).get.toOption.orEmpty,
                 programSummaries.model.get.programTimesPot.map(_.timeEstimateRange),
                 programSummaries.model.zoom(ProgramSummaries.attachments),
-                programSummaries.model.get.scienceObsTargets,
                 model.rootModel.zoom(RootModel.otherUndoStacks).zoom(ModelUndoStacks.forProposal),
                 userPreferences(model.rootModel).proposalTabLayout,
-                model.userIsReadonlyCoi
+                model.userIsReadonlyCoi,
+                programSummaries.get.hasProposalObsErrors
               )
       .orEmpty
 

--- a/model/shared/src/main/scala/explore/model/package.scala
+++ b/model/shared/src/main/scala/explore/model/package.scala
@@ -11,7 +11,6 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.api.RefinedTypeOps
 import eu.timepit.refined.numeric.Interval
 import eu.timepit.refined.types.string.NonEmptyString
-import lucuma.core.enums.Site
 import lucuma.core.math.Coordinates
 import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.ConstraintSet
@@ -64,7 +63,6 @@ type SchedulingGroupList        = SortedMap[ObsIdSet, List[TimingWindow]]
 type ObservingModeGroupList     = SortedMap[ObsIdSet, Option[ObservingModeSummary]]
 type AttachmentList             = SortedMap[Attachment.Id, Attachment]
 type ObsAttachmentAssignmentMap = Map[Attachment.Id, SortedSet[Observation.Id]]
-type ObsSiteAndTargets          = Map[Observation.Id, (Site, TargetList)]
 type ProgramInfoList            = SortedMap[Program.Id, ProgramInfo]
 type ConfigurationRequestList   = SortedMap[ConfigurationRequest.Id, ConfigurationRequestWithObsIds]
 


### PR DESCRIPTION
This PR:

- Uses observation validations with a code of `CallForProposalsError` to determine if the user can submit the proposal rather than calculating the coordinates out of range error locally. 
- Adds an error message to the proposals tab for the above condition.
- Fixes an issue where submission errors were not displayed. Although the error message was set, if the proposal status was updated, the components seem to reload so the error message was lost. The status is only set locally (in the view) if there was data in the response.