### PR TITLE
Fix missing Program tab

### DIFF
--- a/explore/src/clue/scala/queries/common/CallForProposalsSubquery.scala
+++ b/explore/src/clue/scala/queries/common/CallForProposalsSubquery.scala
@@ -1,0 +1,34 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQL
+import explore.model.CallForProposal
+import lucuma.schemas.ObservationDB
+
+@GraphQL
+object CallForProposalsSubquery
+    extends GraphQLSubquery.Typed[ObservationDB, CallForProposal]("CallForProposal"):
+  override val subquery: String = s"""
+    {
+      id
+      semester
+      title
+      cfpType: type
+      nonPartnerDeadline
+      active {
+        start
+        end
+      }
+      partners {
+        partner
+        submissionDeadline
+      }
+      coordinateLimits {
+        north $SiteCoordinatesLimitsSubquery
+        south $SiteCoordinatesLimitsSubquery
+      }
+    }
+  """

--- a/explore/src/clue/scala/queries/common/CallsQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/CallsQueriesGQL.scala
@@ -13,25 +13,7 @@ object CallsQueriesGQL:
     val document: String = s"""
       query {
         callsForProposals(WHERE: {isOpen: {EQ: true}}) {
-          matches {
-            id
-            semester
-            title
-            cfpType: type
-            nonPartnerDeadline
-            active {
-              start
-              end
-            }
-            partners {
-              partner
-              submissionDeadline
-            }
-            coordinateLimits {
-              north $SiteCoordinatesLimitsSubquery
-              south $SiteCoordinatesLimitsSubquery
-            }
-          }
+          matches $CallForProposalsSubquery
         }
       }
     """

--- a/explore/src/clue/scala/queries/common/ProposalSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProposalSubquery.scala
@@ -13,9 +13,7 @@ import lucuma.schemas.ObservationDB
 object ProposalSubquery extends GraphQLSubquery.Typed[ObservationDB, Proposal]("Proposal"):
   override val subquery: String = s"""
     {
-      call {
-        id
-      }
+      call $CallForProposalsSubquery
       category
       reference {
         label

--- a/explore/src/main/scala/explore/ExploreLayout.scala
+++ b/explore/src/main/scala/explore/ExploreLayout.scala
@@ -222,12 +222,12 @@ object ExploreLayout:
                 val deadline: Option[Timestamp] =
                   programSummaries.toOption
                     .flatMap: programSummaries =>
-                      (ProgramSummaries.proposal.getOption(programSummaries).flatten,
-                       RootModel.cfps.get(view.get).toOption
-                      ).mapN: (p, c) =>
-                        val piP = ProgramSummaries.piPartner.getOption(programSummaries)
-                        p.deadline(c, piP)
-                      .flatten
+                      ProgramSummaries.proposal
+                        .getOption(programSummaries)
+                        .flatten
+                        .flatMap: p =>
+                          val piP = ProgramSummaries.piPartner.getOption(programSummaries)
+                          p.deadline(piP)
 
                 val cacheKey: String =
                   userVault.get

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -194,9 +194,6 @@ object Routing:
             programDetails <-
               programSummaries.model.zoom(ProgramSummaries.optProgramDetails).toOptionView
             proposal       <- programDetails.get.proposal
-            callId         <- proposal.callId
-            cfps           <- model.rootModel.get.cfps.toOption
-            cfp            <- cfps.find(_.id === callId)
           yield ProgramTabContents(
             routingInfo.programId,
             programDetails,
@@ -207,7 +204,6 @@ object Routing:
             programSummaries.get.targets,
             model.rootModel.zoom(RootModel.vault).get,
             programSummaries.get.programTimesPot,
-            cfp.semester,
             userPreferences(model.rootModel),
             model.userIsReadonlyCoi
           )

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -284,7 +284,7 @@ object ProgramCacheController
             ProgramQueriesGQL.ProgramEditDetailsSubscription.Data,
             ProgramSummaries => ProgramSummaries
           ] =
-            _.map(_.programEdit.value.proposal.flatMap(_.callId)).changes.void
+            _.map(_.programEdit.value.proposal.flatMap(_.call.map(_.id))).changes.void
               .evalMap(_ => updateObservationsWorkflows(props.programId.toWhereObservation))
 
           val updateProgramDetails: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =

--- a/explore/src/main/scala/explore/common/ProposalQueries.scala
+++ b/explore/src/main/scala/explore/common/ProposalQueries.scala
@@ -113,7 +113,7 @@ trait ProposalQueries:
   extension (proposal: Proposal)
     def toInput: ProposalPropertiesInput =
       ProposalPropertiesInput(
-        callId = proposal.callId.orUnassign,
+        callId = proposal.call.map(_.id).orUnassign,
         category = proposal.category.orUnassign,
         `type` = proposal.proposalType.map(_.toInput).orUnassign
       )

--- a/explore/src/main/scala/explore/programs/ProgramDetailsTile.scala
+++ b/explore/src/main/scala/explore/programs/ProgramDetailsTile.scala
@@ -20,102 +20,101 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
 import lucuma.core.syntax.display.*
 import lucuma.core.util.DateInterval
+import lucuma.react.common.ReactFnComponent
 import lucuma.react.common.ReactFnProps
 import lucuma.refined.*
 import lucuma.ui.primereact.CheckboxView
 import lucuma.ui.primereact.FormInfo
 import lucuma.ui.primereact.given
 
-import java.time.LocalDate
-
 case class ProgramDetailsTile(
   programId:         Program.Id,
   programDetails:    View[ProgramDetails],
   programTimes:      Pot[ProgramTimes],
   userIsReadonlyCoi: Boolean
-) extends ReactFnProps(ProgramDetailsTile.component)
+) extends ReactFnProps(ProgramDetailsTile)
 
-object ProgramDetailsTile:
-  private type Props = ProgramDetailsTile
+object ProgramDetailsTile
+    extends ReactFnComponent[ProgramDetailsTile](props =>
+      useContext(AppContext.ctx).map: ctx =>
+        import ctx.given
 
-  private val component = ScalaFnComponent[Props]: props =>
-    useContext(AppContext.ctx).map: ctx =>
-      import ctx.given
+        val details: ProgramDetails        = props.programDetails.get
+        val thesis: Boolean                = details.allUsers.exists(_.thesis.exists(_ === true))
+        val users: View[List[ProgramUser]] = props.programDetails.zoom(ProgramDetails.allUsers)
+        val newDataNotificationView        =
+          props.programDetails
+            .zoom(ProgramDetails.shouldNotify)
+            .withOnMod(b => ProgramQueries.updateGoaShouldNotify[IO](props.programId, b).runAsync)
 
-      val details: ProgramDetails               = props.programDetails.get
-      val thesis: Boolean                       = details.allUsers.exists(_.thesis.exists(_ === true))
-      val users: View[List[ProgramUser]]        = props.programDetails.zoom(ProgramDetails.allUsers)
-      val newDataNotificationView               =
-        props.programDetails
-          .zoom(ProgramDetails.shouldNotify)
-          .withOnMod(b => ProgramQueries.updateGoaShouldNotify[IO](props.programId, b).runAsync)
-      val cfpActivePeriod: Option[DateInterval] = details.proposal.flatMap(_.call).map(_.active)
+        // Since the program tab is for Accepted proposals only, we should always have a CfP.
+        val cfpActivePeriod: Option[DateInterval] = details.proposal.flatMap(_.call).map(_.active)
 
-      // We `should` always have a call for proposal if we get here, but...
-      def dateOrMissing(o: Option[LocalDate], label: String) =
-        val s = o.fold("Missing!")(Constants.GppDateFormatter.format)
-        FormInfo(s, label)
-
-      <.div(ExploreStyles.ProgramDetailsTile)(
-        <.div(ExploreStyles.ProgramDetailsInfoArea, ExploreStyles.ProgramDetailsLeft)(
-          FormInfo(details.reference.map(_.label).getOrElse("---"), "Reference"),
-          dateOrMissing(cfpActivePeriod.map(_.start), "Start"),
-          dateOrMissing(cfpActivePeriod.map(_.end), "End"),
-          // Thesis should be set True if any of the investigators will use the proposal as part of their thesis (3390)
-          FormInfo(if (thesis) "Yes" else "No", "Thesis"),
-          FormInfo(s"${details.proprietaryMonths} months", "Proprietary")
-        ),
-        <.div(
-          TimeAwardTable(details.allocations),
-          TimeAccountingTable(props.programTimes)
-        ),
-        <.div(ExploreStyles.ProgramDetailsInfoArea)(
-          SupportUsers(
-            props.programId,
-            users,
-            "Principal Support",
-            SupportUsers.SupportRole.Primary
+        <.div(ExploreStyles.ProgramDetailsTile)(
+          <.div(ExploreStyles.ProgramDetailsInfoArea, ExploreStyles.ProgramDetailsLeft)(
+            FormInfo(details.reference.map(_.label).getOrElse("---"), "Reference"),
+            cfpActivePeriod.map(di =>
+              React.Fragment(
+                FormInfo(Constants.GppDateFormatter.format(di.start), "Start"),
+                FormInfo(Constants.GppDateFormatter.format(di.end), "End")
+              )
+            ),
+            // Thesis should be set True if any of the investigators will use the proposal as part of their thesis (3390)
+            FormInfo(if (thesis) "Yes" else "No", "Thesis"),
+            FormInfo(s"${details.proprietaryMonths} months", "Proprietary")
           ),
-          SupportUsers(
-            props.programId,
-            users,
-            "Additional Support",
-            SupportUsers.SupportRole.Secondary
-          ),
-
-          // The two Notifications flags are user-settable and determine whether the archive sends email notifications for new data and whether the ODB sends notifications for expired timing windows (3388, 3389)
           <.div(
-            ExploreStyles.ProgramDetailsRight,
-            FormInfo(
-              CheckboxView(
-                id = "shouldNotify".refined,
-                value = newDataNotificationView,
-                label = "New Science Data",
-                disabled = props.userIsReadonlyCoi
-              ),
-              "Notifications"
+            TimeAwardTable(details.allocations),
+            TimeAccountingTable(props.programTimes)
+          ),
+          <.div(ExploreStyles.ProgramDetailsInfoArea)(
+            SupportUsers(
+              props.programId,
+              users,
+              "Principal Support",
+              SupportUsers.SupportRole.Primary
+            ),
+            SupportUsers(
+              props.programId,
+              users,
+              "Additional Support",
+              SupportUsers.SupportRole.Secondary
+            ),
+
+            // The two Notifications flags are user-settable and determine whether the archive sends email notifications for new data and whether the ODB sends notifications for expired timing windows (3388, 3389)
+            <.div(
+              ExploreStyles.ProgramDetailsRight,
+              FormInfo(
+                CheckboxView(
+                  id = "shouldNotify".refined,
+                  value = newDataNotificationView,
+                  label = "New Science Data",
+                  disabled = props.userIsReadonlyCoi
+                ),
+                "Notifications"
+              )
+              // FormInfo(
+              //   CheckboxView(
+              //     id = "expiredTimingWindows".refined,
+              //     value = ???,
+              //     label = "Expired Timing Windows"
+              //   ),
+              //   ""
+              // )
             )
-            // FormInfo(
-            //   CheckboxView(
-            //     id = "expiredTimingWindows".refined,
-            //     value = ???,
-            //     label = "Expired Timing Windows"
-            //   ),
-            //   ""
+
+            // The Eavesdropping` UI will allow PIs of accepted programs to select dates when they are available for eavesdropping. This is not needed for XT. (NEED TICKET)
+            // <.div(
+            //   ExploreStyles.ProgramDetailsRight,
+            //   FormInfo(
+            //     CheckboxView(
+            //       id = "eavesdropping".refined,
+            //       value = ???,
+            //       label = ??? // instead of a label there will be a date picker or something?
+            //     ),
+            //     "Eavesdropping"
+            //   )
             // )
           )
-
-          // The Eavesdropping` UI will allow PIs of accepted programs to select dates when they are available for eavesdropping. This is not needed for XT. (NEED TICKET)
-          // <.div(
-          //   ExploreStyles.ProgramDetailsRight,
-          //   FormInfo(
-          //     CheckboxView(
-          //       id = "eavesdropping".refined,
-          //       value = ???,
-          //       label = ??? // instead of a label there will be a date picker or something?
-          //     ),
-          //     "Eavesdropping"
-          //   )
-          // )
         )
-      )
+    )

--- a/explore/src/main/scala/explore/proposal/ProposalDetailsTile.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalDetailsTile.scala
@@ -157,7 +157,6 @@ object ProposalDetailsBody:
   private def renderFn(
     props:      Props,
     totalHours: View[Hours],
-    // minPct2:           View[IntPercent],
     showDialog: View[Visible],
     splitsList: View[List[PartnerSplit]]
   )(using Logger[IO]): VdomNode = {
@@ -446,80 +445,41 @@ object ProposalDetailsBody:
     )
   }
 
-  private val component =
-    ScalaFnComponent
-      .withHooks[Props]
-      .useContext(AppContext.ctx)
-      // total time - we need `Hours` for editing and also to preserve if
-      // the user switches between classes with and without total time.
-      .useStateViewBy: (props, _) =>
-        props.proposal.proposalType
-          .flatMap(ProposalType.totalTime.getOption)
-          .map(toHours)
-          .getOrElse(Hours.unsafeFrom(0))
-      // .useStateViewBy((props, _, _, _) =>
-      //   // mininum percent total time = need to preserve between class switches
-      //   props.proposal
-      //     .zoom(Proposal.proposalClass.andThen(ProposalClass.minPercentTotalTime))
-      //     .get
-      //     .getOrElse(IntPercent.unsafeFrom(80))
-      // )
-      .useStateView(Visible.Hidden)           // show partner splits modal
-      .useStateView(List.empty[PartnerSplit]) // partner splits modal
-      // Update the partner splits when a new callId is set
-      .useEffectWithDepsBy((props, _, _, _, _) => (props.proposal.callId, props.cfps)):
-        (props, _, _, _, ps) =>
-          (callId, cfps) =>
-            callId.foldMap(cid =>
-              val currentSplits    = Proposal.proposalType.some
-                .andThen(ProposalType.partnerSplits)
-                .getOption(props.proposal)
-              val cfpPartners      = cfps
-                .find(_.id === cid)
-                .foldMap(_.partners.map(_.partner))
-              val proposalPartners = currentSplits.orEmpty.filter(_._2 > 0).map(_.partner)
+  private val component = ScalaFnComponent[Props](props =>
+    for {
+      ctx        <- useContext(AppContext.ctx)
+      totalHours <- useStateView:
+                      // we need `Hours` for editing
+                      props.proposal.proposalType
+                        .flatMap(ProposalType.totalTime.getOption)
+                        .map(toHours)
+                        .getOrElse(Hours.unsafeFrom(0))
+      showDialog <- useStateView(Visible.Hidden)           // show partner splits modal
+      splitsList <- useStateView(List.empty[PartnerSplit]) // partner splits modal
+      _          <- useEffectWithDeps((props.proposal.callId, props.cfps)):
+                      // Update the partner splits when a new callId is set
+                      (callId, cfps) =>
+                        callId.foldMap(cid =>
+                          val currentSplits    = Proposal.proposalType.some
+                            .andThen(ProposalType.partnerSplits)
+                            .getOption(props.proposal)
+                          val cfpPartners      = cfps
+                            .find(_.id === cid)
+                            .foldMap(_.partners.map(_.partner))
+                          val proposalPartners = currentSplits.orEmpty.filter(_._2 > 0).map(_.partner)
 
-              if (proposalPartners.nonEmpty && proposalPartners.forall(cfpPartners.contains))
-                ps.set(currentSplits.orEmpty)
-              else
-                ps.set(cfpPartners.map(p => PartnerSplit(p, 0.refined)))
-            )
-      // .useEffectWithDepsBy((props, _, _, _, _, _, _, _, _) => props.proposal.get.proposalClass)(
-      //   // Deal with changes to the ProposalClass.
-      //   (props, _, _, totalHours, minPct2, classType, _, _, oldClass) =>
-      //     newClass => {
-      //       val setClass =
-      //         if (oldClass.get === newClass) Callback.empty
-      //         else props.proposal.zoom(Proposal.proposalClass).set(newClass)
-      //       val newType  = ProposalClassType.fromProposalClass(newClass)
-      //       val setType  = if (classType.get === newType) Callback.empty else classType.set(newType)
-      //       val newHours = ProposalClass.totalTime.getOption(newClass).map(toHours)
-      //       val setHours = newHours
-      //         .flatMap(h => if (h === totalHours.get) none else h.some)
-      //         .foldMap(totalHours.set)
-      //       val newPct2  = ProposalClass.minPercentTotalTime.getOption(newClass)
-      //       val setPct2  =
-      //         newPct2.flatMap(p => if (p === minPct2.get) none else p.some).foldMap(minPct2.set)
-      //       setClass >> setType >> setHours >> setPct2
-      //     }
-      // )
-      .render:
-        (
-          props,
-          ctx,
-          totalHours,
-          // minPct2,
-          showDialog,
-          splitsList
-        ) =>
-          renderFn(
-            props,
-            totalHours,
-            // minPct2,
-            showDialog,
-            splitsList
-          )(using ctx.logger)
-
+                          if (proposalPartners.nonEmpty && proposalPartners.forall(cfpPartners.contains))
+                            splitsList.set(currentSplits.orEmpty)
+                          else
+                            splitsList.set(cfpPartners.map(p => PartnerSplit(p, 0.refined)))
+                        )
+    } yield renderFn(
+      props,
+      totalHours,
+      showDialog,
+      splitsList
+    )(using ctx.logger)
+  )
 case class ProposalDetailsTitle(undoer: Undoer, tileSize: TileSizeState, readonly: Boolean)
     extends ReactFnProps(ProposalDetailsTitle.component)
 

--- a/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
@@ -154,6 +154,10 @@ object ProposalSubmissionBar:
                 props.canSubmit && props.proposalStatus.get === ProposalStatus.Submitted && !isDueDeadline
             ,
             errorMessage.get
-              .map(r => Message(text = r, severity = Message.Severity.Error))
+              .map(r =>
+                <.span(ExploreStyles.ProposalDeadline)(
+                  Message(text = r, severity = Message.Severity.Error)
+                )
+              )
           )
         )

--- a/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -112,7 +112,7 @@ object ProposalTabContents:
               props.programDetails.zoom(ProgramDetails.piPartner.some).get
 
             val deadline: Option[Timestamp] =
-              proposal.get.deadline(props.cfps, piPartner)
+              proposal.get.deadline(piPartner)
 
             <.div(ExploreStyles.ProposalTab)(
               ProposalEditor(
@@ -133,7 +133,7 @@ object ProposalTabContents:
                 props.programId,
                 props.programDetails.zoom(ProgramDetails.proposalStatus),
                 deadline,
-                proposal.get.callId,
+                proposal.get.call.map(_.id),
                 isStdUser && !props.userIsReadonlyCoi,
                 props.hasUndefinedObservations
               )

--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -33,7 +33,6 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Configuration
 import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.Program
-import lucuma.core.model.Semester
 import lucuma.core.model.User
 import lucuma.react.common.ReactFnProps
 import lucuma.react.resizeDetector.*
@@ -51,7 +50,6 @@ case class ProgramTabContents(
   targets:                TargetList,
   userVault:              Option[UserVault],
   programTimes:           Pot[ProgramTimes],
-  semester:               Semester,
   userPreferences:        UserPreferences,
   userIsReadonlyCoi:      Boolean
 ) extends ReactFnProps(ProgramTabContents.component)
@@ -82,7 +80,6 @@ object ProgramTabContents:
               props.programId,
               props.programDetails,
               props.programTimes,
-              props.semester,
               props.userIsReadonlyCoi
             )
           )

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposal.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposal.scala
@@ -4,17 +4,17 @@
 package explore.model.arb
 
 import lucuma.core.enums.TacCategory
+import explore.model.CallForProposal
 import explore.model.Proposal
 import lucuma.core.util.arb.ArbEnumerated.given
-import lucuma.core.util.arb.ArbGid.given
 import lucuma.core.model.arb.ArbProposalReference.given
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
 
+import explore.model.arb.ArbCallForProposal.given
 import explore.model.arb.ArbProposalType.given
 import explore.model.ProposalType
-import lucuma.core.model.CallForProposals
 import lucuma.core.model.ProposalReference
 
 trait ArbProposal:
@@ -22,21 +22,21 @@ trait ArbProposal:
   given Arbitrary[Proposal] =
     Arbitrary {
       for {
-        callId       <- arbitrary[Option[CallForProposals.Id]]
+        call         <- arbitrary[Option[CallForProposal]]
         category     <- arbitrary[Option[TacCategory]]
         proposalType <- arbitrary[Option[ProposalType]]
         reference    <- arbitrary[Option[ProposalReference]]
-      } yield Proposal(callId, category, proposalType, reference)
+      } yield Proposal(call, category, proposalType, reference)
     }
 
   given Cogen[Proposal] =
     Cogen[
       (
-        Option[CallForProposals.Id],
+        Option[CallForProposal],
         Option[TacCategory],
         Option[ProposalType],
         Option[ProposalReference]
       )
-    ].contramap(p => (p.callId, p.category, p.proposalType, p.reference))
+    ].contramap(p => (p.call, p.category, p.proposalType, p.reference))
 
 object ArbProposal extends ArbProposal


### PR DESCRIPTION
The Program tab was not displaying because it required the semester from the call for proposals. We looked up the CfP using the id in the proposal of the program details, but since we were only downloading the `open` CfPs, if the proposal specified a CfP whose deadline had passed we wouldn't find it and wouldn't display the tab.

I initially just downloaded all the CfP (didn't filter for open in the query) and filtered for `open` locally. Then I realized it was silly to download an ever expanding list of CfPs that we didn't really need, and just downloaded the whole CfP for the proposal instead of just the CfP Id.

The first commit just switches to monadic style hooks and cleans up some commented out code. The second is where the real changes are.