### PR TITLE
Fix some glitches when sequence is executing

### DIFF
--- a/explore/src/main/scala/explore/config/sequence/GmosSequenceTable.scala
+++ b/explore/src/main/scala/explore/config/sequence/GmosSequenceTable.scala
@@ -68,8 +68,6 @@ sealed trait GmosSequenceTable[S, D]:
 
   private lazy val currentVisitData: Option[(Visit.Id, SequenceType, Option[Step.Id])] =
     // If the last atom of the last visit is Ongoing, the sequence is executing.
-    // TODO: For extra safety, we could also check that the last atom's original id is the same as
-    // nextAtom. ODB provides this but we are not querying it at the moment.
     visits.lastOption
       .filter:
         _.atoms.lastOption.exists:

--- a/explore/src/main/scala/explore/config/sequence/SequenceTileHelper.scala
+++ b/explore/src/main/scala/explore/config/sequence/SequenceTileHelper.scala
@@ -106,8 +106,10 @@ trait SequenceTileHelper:
             .raiseFirstNoDataError
             .ignoreGraphQLErrors
             .map:
-              _.filter(_.executionEventAdded.value.stepStage === StepStage.EndStep)
-                .evalMap(_ => (refreshSequence >> refreshVisits).to[IO])
+              _.filter: data =>
+                List(StepStage.StartStep, StepStage.EndStep)
+                  .contains_(data.executionEventAdded.value.stepStage)
+              .evalMap(_ => (refreshSequence >> refreshVisits).to[IO])
     yield LiveSequence(
       (visits.value, sequenceData.value).tupled,
       visits.isRunning || sequenceData.isRunning


### PR DESCRIPTION
- Requery visits/sequence also when a step starts. This way, when the sequence moves to science, we can adjust accordingly (mainly hiding acquisition).
- Show the current step from the visits and not from the sequence. Note that this mechanism is failing because we are currently unable to match the `generatedId` of the `StepRecord` with the `id` of the `Step`, since observe seems to be recording outdated `generatedId`s.
- Consider the last step of an executing atom as the current step, even if the step is not executing. The sequence could be paused and therefore the last step could be completed. But if the atom is not complete, we want to show the step from the visits, not from the future sequence.

Last commit is just monadic hook migration.