### PR TITLE
Update lucuma-ui to 0.129.2

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -29,7 +29,7 @@ object Versions {
   val lucumaSchemas          = "0.116.0"
   val lucumaOdbSchema        = "0.18.3"
   val lucumaSSO              = "0.8.1"
-  val lucumaUI               = "0.129.1"
+  val lucumaUI               = "0.129.2"
   val monocle                = "3.3.0"
   val mouse                  = "1.3.2"
   val mUnit                  = "1.1.0"


### PR DESCRIPTION
Needed to fix problem with user login in explore. The UserSelectionForm in lucuma-ui was not calling `value` on the result of a `useEffectResultOnMount` which was throwing an exception because it could not be cast to a `Pot`