### PR TITLE
ObsBadge updates

### DIFF
--- a/explore/src/clue/scala/queries/common/ObservationSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ObservationSubquery.scala
@@ -60,5 +60,8 @@ object ObservationSubquery extends GraphQLSubquery.Typed[ObservationDB, Observat
           workflow $ObservationWorkflowSubquery
           groupId
           groupIndex
+          reference {
+            label
+          }
         }
       """

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -22,7 +22,6 @@ import lucuma.core.enums.ObservationWorkflowState
 import lucuma.core.enums.ScienceBand
 import lucuma.core.syntax.all.*
 import lucuma.core.util.Enumerated
-import lucuma.core.util.Gid
 import lucuma.core.util.TimeSpan
 import lucuma.react.common.ReactFnProps
 import lucuma.react.fa.LayeredIcon
@@ -82,12 +81,12 @@ object ObsBadge:
     <.progress(^.width := "100%", ^.max := all.length - 1, ^.value := all.indexOf(value))
   }
 
-  private val idIso = Gid[Observation.Id].isoPosLong
-
   private val component = ScalaFnComponent[Props]: props =>
     usePopupMenuRef.map: menuRef =>
       val obs    = props.obs
       val layout = props.layout
+
+      val identifierStr = obs.reference.fold(obs.id.show)(_.observationIndex.toString)
 
       val deleteButton =
         Button(
@@ -145,7 +144,7 @@ object ObsBadge:
             <.div(
               ExploreStyles.ObsBadgeId,
               scienceBandButton.when(props.showScienceBand),
-              s"[${idIso.get(obs.id).value.toHexString}]",
+              s"[$identifierStr]",
               props.cloneCB.whenDefined(_ => duplicateButton),
               deleteButton
             )

--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -95,15 +95,15 @@ object ProgramTabContents
         val countOfDataAccess                  =
           props.users.get.count(pu => sharingRoles.contains(pu.role) && pu.hasDataAccess)
 
-        val dataUsersTile =
+        val dataSharingTile =
           Tile(
             ProgramTabTileIds.DataUsers.id,
-            s"Data Users ($countOfDataAccess)"
+            s"Data Sharing ($countOfDataAccess)"
           )(
             _ =>
               ProgramUsersTable(
                 props.users,
-                ProgramUsersTable.Mode.DataUsers(userVault)
+                ProgramUsersTable.Mode.DataSharing(userVault)
               ),
             (_, _) =>
               <.div(
@@ -167,7 +167,7 @@ object ProgramTabContents
             layouts,
             List(
               detailsTile,
-              dataUsersTile,
+              dataSharingTile,
               notesTile,
               configurationRequestsTile,
               unrequestedConfigsTile

--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -90,10 +90,15 @@ object ProgramTabContents
             )
           )
 
+        val sharingRoles: Set[ProgramUserRole] =
+          Set(ProgramUserRole.Coi, ProgramUserRole.CoiRO, ProgramUserRole.External)
+        val countOfDataAccess                  =
+          props.users.get.count(pu => sharingRoles.contains(pu.role) && pu.hasDataAccess)
+
         val dataUsersTile =
           Tile(
             ProgramTabTileIds.DataUsers.id,
-            "Data Users"
+            s"Data Users ($countOfDataAccess)"
           )(
             _ =>
               ProgramUsersTable(

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -407,6 +407,7 @@ object TargetTabContents extends TwoPanels:
                           _,
                           _,
                           _,
+                          _,
                           const,
                           _,
                           _,

--- a/explore/src/main/scala/explore/users/AddProgramUserButton.scala
+++ b/explore/src/main/scala/explore/users/AddProgramUserButton.scala
@@ -49,11 +49,15 @@ object AddProgramUserButton
             .flatMap(pu => props.users.mod(_ :+ pu).to[IO])
             .switching(isActive.async, IsActive(_))
 
+        val toolTip = props.role match
+          case ProgramUserRole.External => "Share data with a new user"
+          case _                        => s"Add ${props.role.longName}"
+
         Button(
           severity = Button.Severity.Secondary,
           loading = isActive.get.value,
           icon = Icons.UserPlus,
-          tooltip = s"Add ${props.role.longName}",
+          tooltip = toolTip,
           onClick = addProgramUser.runAsync
         ).tiny.compact
     )

--- a/explore/src/main/scala/explore/users/ProgramUsersTable.scala
+++ b/explore/src/main/scala/explore/users/ProgramUsersTable.scala
@@ -3,6 +3,7 @@
 
 package explore.users
 
+import cats.Order.given
 import cats.data.NonEmptySet
 import cats.effect.IO
 import cats.syntax.all.*
@@ -60,6 +61,8 @@ import monocle.function.Each.*
 import queries.common.InvitationQueriesGQL.RevokeInvitationMutation
 import queries.common.ProposalQueriesGQL.DeleteProgramUser
 
+import scala.collection.immutable.SortedSet
+
 case class ProgramUsersTable(
   users: View[List[ProgramUser]],
   mode:  ProgramUsersTable.Mode
@@ -72,8 +75,10 @@ case class ProgramUsersTable(
       NonEmptySet.of(ProgramUserRole.Pi, ProgramUserRole.Coi, ProgramUserRole.CoiRO)
     case Mode.SupportPrimary   => NonEmptySet.of(ProgramUserRole.SupportPrimary)
     case Mode.SupportSecondary => NonEmptySet.of(ProgramUserRole.SupportSecondary)
-    case Mode.DataUsers(_)     =>
-      NonEmptySet.of(ProgramUserRole.Coi, ProgramUserRole.CoiRO, ProgramUserRole.External)
+    case Mode.DataSharing(_)   =>
+      NonEmptySet.fromSetUnsafe(
+        SortedSet.from(Enumerated[ProgramUserRole].all) - ProgramUserRole.Pi
+      )
 
   private val hiddenColumns: Set[ProgramUsersTable.Column] = mode match
     case Mode.CoIs(_, proposalIsRo, userIsRoCoi)     =>
@@ -91,7 +96,7 @@ case class ProgramUsersTable(
         Column.DataAccess,
         Column.Actions
       )
-    case Mode.DataUsers(_)                           =>
+    case Mode.DataSharing(_)                         =>
       Set(
         Column.Partner,
         Column.EducationalStatus,
@@ -104,7 +109,7 @@ object ProgramUsersTable:
     case CoIs(vault: UserVault, proposalIsReadonly: Boolean, userIsReadonlyCoi: Boolean)
     case SupportPrimary
     case SupportSecondary
-    case DataUsers(vault: UserVault)
+    case DataSharing(vault: UserVault)
 
   private case class TableMeta(
     users:              View[List[ProgramUser]],
@@ -117,7 +122,7 @@ object ProgramUsersTable:
     val userId: Option[User.Id] = mode match
       case Mode.CoIs(vault, _, _)                      => vault.user.id.some
       case Mode.SupportPrimary | Mode.SupportSecondary => none
-      case Mode.DataUsers(vault)                       => vault.user.id.some
+      case Mode.DataSharing(vault)                     => vault.user.id.some
 
     val userIsPi: Boolean = userId.fold(false)(id =>
       users.get.exists(pu => pu.user.exists(_.id === id) && pu.role === ProgramUserRole.Pi)
@@ -128,7 +133,7 @@ object ProgramUsersTable:
       case Mode.CoIs(_, proposalIsRo, userIsRoCoi)     =>
         !proposalIsRo && !userIsRoCoi && pu.role =!= ProgramUserRole.Pi
       case Mode.SupportPrimary | Mode.SupportSecondary => false
-      case Mode.DataUsers(_)                           => userIsPi && pu.role === ProgramUserRole.External
+      case Mode.DataSharing(_)                         => userIsPi && pu.role === ProgramUserRole.External
 
     def isCurrentUser(pu: ProgramUser): Boolean =
       (userId, pu.user).mapN((uid, p) => uid === p.id).getOrElse(false)
@@ -138,18 +143,18 @@ object ProgramUsersTable:
       case Mode.CoIs(_, proposalIsRo, userIsRoCoi)     =>
         !proposalIsRo && (!userIsRoCoi || isCurrentUser(pu))
       case Mode.SupportPrimary | Mode.SupportSecondary => false
-      case Mode.DataUsers(_)                           => userIsPi && pu.role === ProgramUserRole.External
+      case Mode.DataSharing(_)                         => userIsPi && pu.role === ProgramUserRole.External
 
     val userCanChangeCoiAccess: Boolean = mode match
       case Mode.CoIs(vault, proposalIsRo, userIsRoCoi) =>
         !proposalIsRo && (vault.isStaff || userIsPi)
       case Mode.SupportPrimary | Mode.SupportSecondary => false
-      case Mode.DataUsers(_)                           => false
+      case Mode.DataSharing(_)                         => false
 
     val canChangeDataAccess: Boolean = mode match
       case Mode.CoIs(_, _, _)                          => false
       case Mode.SupportPrimary | Mode.SupportSecondary => false
-      case Mode.DataUsers(_)                           => userIsPi
+      case Mode.DataSharing(_)                         => userIsPi
 
   private val ColDef = ColumnDef.WithTableMeta[View[ProgramUser], TableMeta]
 
@@ -476,7 +481,7 @@ object ProgramUsersTable:
                 clazz = ExploreStyles.PartnerSelector
               ): VdomNode
             else currentRole.shortName: VdomNode
-      ).sortableBy(_.get.shortName),
+      ).sortableBy(_.get),
       ColDef(
         Column.DataAccess.id,
         _.zoom(ProgramUser.hasDataAccess),
@@ -495,7 +500,7 @@ object ProgramUsersTable:
               disabled = !meta.canChangeDataAccess || meta.isActive.get.value,
               onChange = r => view.set(r)
             )
-      ),
+      ).sortableBy(_.get),
       ColDef(
         Column.Status.id,
         _.get.status,
@@ -549,9 +554,13 @@ object ProgramUsersTable:
         isActive           <- useStateView(IsActive(false))
         cols               <- useMemo(()): _ =>
                                 columns(using ctx)
-        rows               <- useMemo(props.users.reuseByValue)(
-                                _.toListOfViews.filter(row => props.filterRoles.contains_(row.get.role))
-                              )
+        rows               <- useMemo(props.users.reuseByValue): users =>
+                                val rows =
+                                  users.toListOfViews.filter(row => props.filterRoles.contains_(row.get.role))
+                                // for the data sharing table, sort by role so the support roles are last
+                                props.mode match
+                                  case Mode.DataSharing(_) => rows.sortBy(_.get.role)
+                                  case _                   => rows
         overlayPanelRef    <- useOverlayPanelRef
         currentProgUser    <- useStateView(none[View[ProgramUser]])
         _                  <- useEffectWithDeps(rows): rows =>

--- a/explore/src/main/scala/explore/users/ProgramUsersTable.scala
+++ b/explore/src/main/scala/explore/users/ProgramUsersTable.scala
@@ -96,8 +96,7 @@ case class ProgramUsersTable(
         Column.Partner,
         Column.EducationalStatus,
         Column.Thesis,
-        Column.Gender,
-        Column.Role
+        Column.Gender
       )
 
 object ProgramUsersTable:

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
@@ -15,6 +15,7 @@ import lucuma.core.math.arb.ArbWavelength.given
 import lucuma.core.model.Attachment
 import lucuma.core.model.Configuration
 import lucuma.core.model.ConstraintSet
+import lucuma.core.model.ObservationReference
 import lucuma.core.model.ObservationValidation
 import lucuma.core.model.ObservationWorkflow
 import lucuma.core.model.PosAngleConstraint
@@ -22,6 +23,7 @@ import lucuma.core.model.Target
 import lucuma.core.model.TimingWindow
 import lucuma.core.model.arb.ArbConfiguration.given
 import lucuma.core.model.arb.ArbConstraintSet.given
+import lucuma.core.model.arb.ArbObservationReference.given
 import lucuma.core.model.arb.ArbObservationValidation.given
 import lucuma.core.model.arb.ArbObservationWorkflow.given
 import lucuma.core.model.arb.ArbPosAngleConstraint.given
@@ -53,6 +55,7 @@ trait ArbObservation:
     Arbitrary(
       for
         id                  <- arbitrary[Observation.Id]
+        reference           <- arbitrary[Option[ObservationReference]]
         title               <- arbitrary[String]
         subtitle            <- arbitrary[Option[NonEmptyString]]
         scienceTargetIds    <- arbitrary[Set[Target.Id]]
@@ -76,6 +79,7 @@ trait ArbObservation:
         groupIndex          <- arbitrary[NonNegShort]
       yield Observation(
         id,
+        reference,
         title,
         subtitle,
         SortedSet.from(scienceTargetIds),
@@ -102,6 +106,7 @@ trait ArbObservation:
   given Cogen[Observation] =
     Cogen[
       (Observation.Id,
+       Option[ObservationReference],
        String,
        Option[String],
        List[Target.Id],
@@ -126,6 +131,7 @@ trait ArbObservation:
     ]
       .contramap(o =>
         (o.id,
+         o.reference,
          o.title,
          o.subtitle.map(_.value),
          o.scienceTargetIds.toList,

--- a/model/shared/src/main/scala/explore/model/ObservingModeSummary.scala
+++ b/model/shared/src/main/scala/explore/model/ObservingModeSummary.scala
@@ -146,11 +146,13 @@ object ObservingModeSummary:
 
   given Display[ObservingModeSummary] = Display.byShortName:
     case GmosNorthLongSlit(grating, filter, fpu, centralWavelength, ampReadMode, roi) =>
-      s"GMOS-N Longslit ${grating.shortName} ${filter.map(_.shortName).getOrElse("None")} ${fpu.shortName} " +
-        s"${centralWavelength.value.toNanometers}nm ${ampReadMode.shortName} ${roi.shortName}"
+      val cwvStr    = "%.1fnm".format(centralWavelength.value.toNanometers)
+      val filterStr = filter.fold("None")(_.shortName)
+      s"GMOS-N Longslit ${grating.shortName} @ $cwvStr $filterStr  ${fpu.shortName} ${ampReadMode.shortName} ${roi.shortName}"
     case GmosSouthLongSlit(grating, filter, fpu, centralWavelength, ampReadMode, roi) =>
-      s"GMOS-S Longslit ${grating.shortName} ${filter.map(_.shortName).getOrElse("None")} ${fpu.shortName} " +
-        s"${centralWavelength.value.toNanometers}nm ${ampReadMode.shortName} ${roi.shortName}"
+      val cwvStr    = "%.1fnm".format(centralWavelength.value.toNanometers)
+      val filterStr = filter.fold("None")(_.shortName)
+      s"GMOS-S Longslit ${grating.shortName} @ $cwvStr $filterStr  ${fpu.shortName} ${ampReadMode.shortName} ${roi.shortName}"
 
   object GmosNorthLongSlit:
     given Order[GmosNorthLongSlit] =


### PR DESCRIPTION
- [sc-4777] Displays the `ObservationReference` index in the ObsBadge when it is available, instead of the Observation.Id
- [sc-4774] Displays the filter and central wavelength in the configuration summary of the ObsBadge. Also changes the string in the configuration selection dropdown in the configuration tile title to match.
- [sc-3897] For the Data Users table, adds the count of users who have data access in the tile title. Also adds the role column which I omitted by accident.