### PR TITLE
Fix data sharing counter

### DIFF
--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -4,7 +4,7 @@
 package explore.tabs
 
 import cats.data.NonEmptyList
-import cats.syntax.option.*
+import cats.syntax.all.*
 import crystal.Pot
 import crystal.react.View
 import explore.*
@@ -90,10 +90,8 @@ object ProgramTabContents
             )
           )
 
-        val sharingRoles: Set[ProgramUserRole] =
-          Set(ProgramUserRole.Coi, ProgramUserRole.CoiRO, ProgramUserRole.External)
-        val countOfDataAccess                  =
-          props.users.get.count(pu => sharingRoles.contains(pu.role) && pu.hasDataAccess)
+        val countOfDataAccess =
+          props.users.get.count(pu => pu.role =!= ProgramUserRole.Pi && pu.hasDataAccess)
 
         val dataSharingTile =
           Tile(


### PR DESCRIPTION
The counter was not including support users. When I added support users to the table, I neglected to update the counter.