### PR TITLE
Select new observation on creation

### DIFF
--- a/explore/src/main/scala/explore/observationtree/ObsTree.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsTree.scala
@@ -336,8 +336,7 @@ object ObsTree:
                     props.observations,
                     ctx
                   ).switching(adding.async, AddingObservation(_))
-                    .withToastBefore(s"Duplicating obs ${obs.id}", sticky = true)
-                    .clearToastsAfter
+                    .withToastDuring(s"Duplicating obs ${obs.id}")
                     .runAsync
                     .some,
                   setScienceBandCB = (

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -152,8 +152,7 @@ object ObsTabContents extends TwoPanels:
                   activeGroup,
                   observations,
                   ctx
-                ).void
-                  .withToast(s"Duplicating obs ${obsIdSet.idSet.mkString_(", ")}")
+                ).withToastDuring(s"Duplicating obs ${obsIdSet.idSet.mkString_(", ")}")
               case _                                           => IO.unit
             .runAsync
             .unless_(readonly)

--- a/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
+++ b/explore/src/main/scala/queries/schemas/odb/ObsQueries.scala
@@ -160,7 +160,7 @@ object ObsQueries:
             .map(gId => ObservationPropertiesInput(groupId = gId.assign))
             .orIgnore
         )
-      .raiseGraphQLErrors
+      .raiseGraphQLErrorsOnNoData
       .map: result =>
         result.createObservation.observation
 
@@ -193,7 +193,7 @@ object ObsQueries:
           observationId = obsId.assign,
           SET = ObservationPropertiesInput(groupId = newGroupId.orUnassign).assign
         )
-      .raiseGraphQLErrors
+      .raiseGraphQLErrorsOnNoData
       .map(_.cloneObservation.newObservation)
 
   def applyObservation[F[_]: Async](


### PR DESCRIPTION
This PR changes both observation creation and cloning to use `AsyncAction`s instead of the `Action` that required calls to the API outside of the action. There is also a little cleanup on toasts 