### PR TITLE
Show warnings for group violations

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -50,7 +50,6 @@ object ExploreStyles:
   val ObsGroupTitleWithWrap: Css = Css("obs-group-title-with-wrap")
   val ObsGroupTitleWithList: Css = Css("obs-group-title-with-list")
   val DeleteButton: Css          = Css("delete-button")
-  val GroupHelp: Css             = Css("group-help")
 
   val MainTitleProgramId: Css = Css("main-title-program-id")
   val ResizeHandle: Css       = Css("resize-handle")
@@ -76,6 +75,8 @@ object ExploreStyles:
   val SelectedObsTreeGroup: Css        = Css("selected-obs-tree-group")
   val UnselectedObsTreeGroup: Css      = Css("unselected-obs-tree-group")
   val ObsTreeGroupHeader: Css          = Css("obs-tree-group-header")
+  val GroupBadgeLeft: Css              = Css("group-badge-left")
+  val GroupBadgeRight: Css             = Css("group-badge-right")
   val ObsTreeItem: Css                 = Css("obs-tree-item")
   val ObsTreeGroupLeaf: Css            = Css("obs-tree-group-leaf")
   val TreeToolbar: Css                 = Css("tree-toolbar")
@@ -117,6 +118,7 @@ object ExploreStyles:
   val GroupForm: Css          = Css("group-form")
   val GroupDelaysForm: Css    = Css("group-delays-form")
   val GroupPlannedTime: Css   = Css("group-planned-time")
+  val GroupWarnings: Css      = Css("group-warnings")
 
   val ApiKeysPopup          = Css("api-keys-popup")
   val ApiKeysTable          = Css("api-keys-table")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1587,7 +1587,10 @@ svg.fa-check.explore-success-icon {
 }
 
 .group-edit-tile {
-  margin: 16px;
+  padding: 16px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   .group-type-select {
     display: flex;
@@ -1662,6 +1665,16 @@ svg.fa-check.explore-success-icon {
     grid-template-columns: repeat(2, auto);
     align-items: center;
     margin-right: auto;
+  }
+
+  .group-warnings {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+
+    .p-inline-message {
+      justify-content: left;
+    }
   }
 }
 
@@ -2560,19 +2573,31 @@ input[type='file'].explore-fileupload {
   .obs-tree-group-leaf {
     display: flex;
     flex-direction: row;
+    justify-content: space-between;
     align-items: center;
     gap: 8px;
     width: 100%;
     color: var(--site-text-color);
 
-    .delete-button,
-    :has(.delete-button) {
-      margin-left: auto;
+    .group-badge-left {
+      display: flex;
+      gap: 1rem;
+    }
 
-      &.p-button {
-        // Reduce padding to make the button fit inside the row
-        padding-top: 1px;
-        padding-bottom: 1px;
+    .group-badge-right {
+      justify-self: end;
+      display: flex;
+      align-items: center;
+
+      ul {
+        list-style-type: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      .p-button {
+        padding: 0;
+        margin: 0;
       }
     }
   }
@@ -3528,8 +3553,4 @@ a.explore-upgrade-link {
   position: absolute;
   top: -20px;
   left: 0;
-}
-
-.group-help {
-  margin-left: auto;
 }

--- a/explore/src/main/scala/explore/observationtree/ObsTree.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsTree.scala
@@ -3,6 +3,7 @@
 
 package explore.observationtree
 
+import cats.data.NonEmptySet
 import cats.effect.IO
 import cats.syntax.all.*
 import crystal.react.*
@@ -23,6 +24,7 @@ import explore.model.Observation
 import explore.model.ObservationExecutionMap
 import explore.model.ObservationList
 import explore.model.enums.AppTab
+import explore.model.enums.GroupWarning
 import explore.syntax.ui.*
 import explore.tabs.DeckShown
 import explore.undo.UndoSetter
@@ -65,6 +67,7 @@ case class ObsTree(
   groups:                UndoSetter[GroupList],
   groupsChildren:        Map[Option[Group.Id], List[Either[Observation, Group]]],
   parentGroups:          Either[Observation.Id, Group.Id] => List[Group.Id],
+  groupWarnings:         Map[Group.Id, NonEmptySet[GroupWarning]],
   obsExecutionTimes:     ObservationExecutionMap,
   undoer:                Undoer,
   focusedObs:            Option[Observation.Id], // obs explicitly selected for editing
@@ -353,6 +356,7 @@ object ObsTree:
 
               GroupBadge(
                 group,
+                props.groupWarnings.get(group.id),
                 selected = props.focusedGroup.contains_(group.id),
                 onClickCB = linkOverride:
                   focusGroup(props.programId, group.id.some, ctx)

--- a/explore/src/main/scala/explore/tabs/GroupEditBody.scala
+++ b/explore/src/main/scala/explore/tabs/GroupEditBody.scala
@@ -3,6 +3,7 @@
 
 package explore.tabs
 
+import cats.data.NonEmptySet
 import cats.effect.IO
 import cats.syntax.all.*
 import clue.data.syntax.*
@@ -18,6 +19,7 @@ import explore.components.ui.ExploreStyles
 import explore.model.AppContext
 import explore.model.Group
 import explore.model.ProgramTimeRange
+import explore.model.enums.GroupWarning
 import explore.syntax.ui.*
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
@@ -43,6 +45,7 @@ import scala.scalajs.js
 
 case class GroupEditBody(
   group:             UndoSetter[Group],
+  warnings:          Option[NonEmptySet[GroupWarning]],
   elementsLength:    Int,
   timeEstimateRange: Pot[Option[ProgramTimeRange]],
   readonly:          Boolean
@@ -228,7 +231,17 @@ object GroupEditBody:
       React.Fragment(
         <.div(ExploreStyles.GroupEditTile)(
           selectGroupForm,
-          groupTypeSpecificForms
+          groupTypeSpecificForms,
+          props.warnings.map: nes =>
+            <.div(
+              ExploreStyles.GroupWarnings,
+              nes.toList.toTagMod(w =>
+                Message(id = s"${group.id}-${w.shortMsg}",
+                        text = w.longMsg,
+                        severity = Message.Severity.Warning
+                )
+              )
+            )
         )
       )
 

--- a/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
@@ -3,6 +3,7 @@
 
 package explore.tabs
 
+import cats.data.NonEmptySet
 import cats.syntax.all.*
 import crystal.Pot
 import explore.components.Tile
@@ -12,6 +13,7 @@ import explore.model.Group
 import explore.model.GroupEditTileIds
 import explore.model.ProgramTimeRange
 import explore.model.enums.GridLayoutSection
+import explore.model.enums.GroupWarning
 import explore.model.layout.LayoutsMap
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
@@ -24,6 +26,7 @@ import lucuma.react.resizeDetector.UseResizeDetectorReturn
 case class ObsGroupTiles(
   userId:            Option[User.Id],
   group:             UndoSetter[Group],
+  groupWarnings:     Option[NonEmptySet[GroupWarning]],
   childCount:        Int,
   timeEstimateRange: Pot[Option[ProgramTimeRange]],
   resize:            UseResizeDetectorReturn,
@@ -52,6 +55,7 @@ object ObsGroupTiles:
           _ =>
             GroupEditBody(
               props.group,
+              props.groupWarnings,
               props.childCount,
               props.timeEstimateRange,
               props.group.get.system

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -199,6 +199,7 @@ object ObsTabContents extends TwoPanels:
                 props.groups,
                 props.programSummaries.get.groupsChildren,
                 props.programSummaries.get.parentGroups(_),
+                props.programSummaries.get.groupWarnings,
                 props.obsExecutions,
                 props.programSummaries: Undoer,
                 props.focusedObs,
@@ -325,6 +326,7 @@ object ObsTabContents extends TwoPanels:
                 ObsGroupTiles(
                   props.vault.userId,
                   group,
+                  props.programSummaries.get.groupWarnings.get(group.get.id),
                   props.programSummaries.get.groupsChildren.get(groupId.some).map(_.length).orEmpty,
                   props.groupTimeRanges.getPot(groupId),
                   resize,

--- a/model/shared/src/main/scala/explore/model/enums/GroupWarning.scala
+++ b/model/shared/src/main/scala/explore/model/enums/GroupWarning.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.enums
+
+import cats.Order
+import cats.derived.*
+
+enum GroupWarning(val shortMsg: String, val longMsg: String) derives Order:
+  case BandMismatch
+      extends GroupWarning("Mismatched Science Bands",
+                           "All observations in an AND group must have the same science band."
+      )
+  case SiteMismatch
+      extends GroupWarning("Mismatched Sites",
+                           "All observations in a consecutive AND group must be at the same site."
+      )
+  case UndefinedObservations
+      extends GroupWarning("Undefined Observations", "Group contains undefined observations.")
+  case UnapprovedObservations
+      extends GroupWarning("Unapproved Observations", "Group contains unapproved observations.")


### PR DESCRIPTION
Recursively calculates warnings for observation groups according to SC-3328. It displays a warning icon in the Group "Badge" like this 
![image](https://github.com/user-attachments/assets/dedd81c0-3833-47b1-b699-664109ca2429)
And messages at the bottom of the group editor like this
![image](https://github.com/user-attachments/assets/d6bbd1ff-6e0e-4a69-ba68-af3b92dd4f2d)
