### PR TITLE
Custom Sed selector - Part 1

### DIFF
--- a/common/src/main/scala/explore/model/enums/SEDType.scala
+++ b/common/src/main/scala/explore/model/enums/SEDType.scala
@@ -104,18 +104,18 @@ sealed abstract class SedTypeEnum[T](
 
   def fromSpectralDefinition(spectralDefinition: SpectralDefinition[T]): Option[SedType[T]] =
     spectralDefinition match
-      case BandNormalized(Some(StellarLibrary(_)), _)  => StellarLibraryType.some
-      case BandNormalized(Some(CoolStarModel(_)), _)   => CoolStarModelType.some
-      case BandNormalized(Some(Galaxy(_)), _)          => GalaxyType.some
-      case BandNormalized(Some(Planet(_)), _)          => PlanetType.some
-      case BandNormalized(Some(Quasar(_)), _)          => QuasarType.some
-      case BandNormalized(Some(HIIRegion(_)), _)       => HIIRegionType.some
-      case BandNormalized(Some(PlanetaryNebula(_)), _) => PlanetaryNebulaType.some
-      case EmissionLines(_, _)                         => EmissionLineType.some
-      case BandNormalized(Some(PowerLaw(_)), _)        => PowerLawType.some
-      case BandNormalized(Some(BlackBody(_)), _)       => BlackBodyType.some
-      case BandNormalized(Some(UserDefined(_)), _)     => UserDefinedType.some
-      case BandNormalized(_, _)                        => none
+      case BandNormalized(Some(StellarLibrary(_)), _)        => StellarLibraryType.some
+      case BandNormalized(Some(CoolStarModel(_)), _)         => CoolStarModelType.some
+      case BandNormalized(Some(Galaxy(_)), _)                => GalaxyType.some
+      case BandNormalized(Some(Planet(_)), _)                => PlanetType.some
+      case BandNormalized(Some(Quasar(_)), _)                => QuasarType.some
+      case BandNormalized(Some(HIIRegion(_)), _)             => HIIRegionType.some
+      case BandNormalized(Some(PlanetaryNebula(_)), _)       => PlanetaryNebulaType.some
+      case EmissionLines(_, _)                               => EmissionLineType.some
+      case BandNormalized(Some(PowerLaw(_)), _)              => PowerLawType.some
+      case BandNormalized(Some(BlackBody(_)), _)             => BlackBodyType.some
+      case BandNormalized(Some(UserDefinedAttachment(_)), _) => UserDefinedType.some
+      case BandNormalized(_, _)                              => none
 
   protected val enumSedType: Enumerated[SedType[T]] =
     Enumerated

--- a/common/src/main/scala/explore/model/enums/SEDType.scala
+++ b/common/src/main/scala/explore/model/enums/SEDType.scala
@@ -56,7 +56,6 @@ sealed abstract class SedTypeEnum[T](
       case BandNormalized(_, bs) => BandNormalized(sed.some, bs)
       case EmissionLines(_, _)   => BandNormalized(sed.some, SortedMap.empty)
 
-  // protected sealed abstract class BandNormalizedSED(name: String) extends SedType[T](name)
   protected object BandNormalizedSed {
     sealed abstract class Immediate(
       name: String,

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -25,6 +25,7 @@ import japgolly.scalajs.react.extra.router.*
 import japgolly.scalajs.react.extra.router.StaticDsl.Route
 import japgolly.scalajs.react.vdom.VdomElement
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.enums.AttachmentType
 import lucuma.core.enums.Instrument
 import lucuma.core.model.Group
 import lucuma.core.model.ObservationReference
@@ -98,6 +99,10 @@ object Routing:
                 routingInfo.focused,
                 model.rootModel.zoom(RootModel.searchingTarget),
                 model.rootModel.zoom(RootModel.expandedIds.andThen(ExpandedIds.asterismObsIds)),
+                programSummaries.get.attachments
+                  .map(_._2)
+                  .toList
+                  .filter(_.attachmentType === AttachmentType.CustomSED),
                 programSummaries.get.proposalIsSubmitted || model.userIsReadonlyCoi
               )
             .toOption

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -57,6 +57,7 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.conditions.*
+import lucuma.core.enums.AttachmentType
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.Site
 import lucuma.core.math.Angle
@@ -170,6 +171,9 @@ case class ObsTabTiles(
         site
       )
     )
+
+  val customSedAttachments: List[Attachment] =
+    attachments.get.map(_._2).toList.filter(_.attachmentType === AttachmentType.CustomSED)
 
 object ObsTabTiles:
   private type Props = ObsTabTiles
@@ -525,6 +529,7 @@ object ObsTabTiles:
                 "Targets",
                 props.globalPreferences,
                 guideStarSelection,
+                props.customSedAttachments,
                 props.isDisabled,
                 // Any target changes invalidate the sequence
                 sequenceChanged.set(pending)

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -9,6 +9,7 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.model.AladinFullScreen
 import explore.model.Asterism
+import explore.model.Attachment
 import explore.model.GlobalPreferences
 import explore.model.GuideStarSelection
 import explore.model.ObservationsAndTargets
@@ -23,25 +24,25 @@ import lucuma.core.model.Program
 import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.schemas.model.TargetWithId
-import lucuma.ui.syntax.all.given
 
 object SiderealTargetEditorTile:
 
   def noObsSiderealTargetEditorTile(
-    programId:          Program.Id,
-    userId:             Option[User.Id],
-    targetId:           Target.Id,
-    target:             UndoSetter[Target.Sidereal],
-    obsAndTargets:      UndoSetter[ObservationsAndTargets],
-    searching:          View[Set[Target.Id]],
-    title:              String,
-    fullScreen:         View[AladinFullScreen],
-    globalPreferences:  View[GlobalPreferences],
-    guideStarSelection: View[GuideStarSelection],
-    readonly:           Boolean,
-    obsInfo:            TargetEditObsInfo,
-    onClone:            OnCloneParameters => Callback,
-    backButton:         Option[VdomNode] = none
+    programId:            Program.Id,
+    userId:               Option[User.Id],
+    targetId:             Target.Id,
+    target:               UndoSetter[Target.Sidereal],
+    obsAndTargets:        UndoSetter[ObservationsAndTargets],
+    searching:            View[Set[Target.Id]],
+    title:                String,
+    fullScreen:           View[AladinFullScreen],
+    globalPreferences:    View[GlobalPreferences],
+    guideStarSelection:   View[GuideStarSelection],
+    customSedAttachments: List[Attachment],
+    readonly:             Boolean,
+    obsInfo:              TargetEditObsInfo,
+    onClone:              OnCloneParameters => Callback,
+    backButton:           Option[VdomNode] = none
   ) =
     Tile(
       TargetTabTileIds.AsterismEditor.id,
@@ -68,6 +69,7 @@ object SiderealTargetEditorTile:
               fullScreen = fullScreen,
               globalPreferences = globalPreferences,
               guideStarSelection = guideStarSelection,
+              customSedAttachments = customSedAttachments,
               readonly = readonly
             )
           )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -18,6 +18,7 @@ import explore.components.TileController
 import explore.components.ui.ExploreStyles
 import explore.model.*
 import explore.model.AppContext
+import explore.model.Attachment
 import explore.model.GuideStarSelection
 import explore.model.GuideStarSelection.AgsSelection
 import explore.model.Observation
@@ -64,14 +65,15 @@ import scala.collection.immutable.SortedSet
 import scala.scalajs.LinkingInfo
 
 case class TargetTabContents(
-  programId:        Program.Id,
-  userId:           Option[User.Id],
-  programSummaries: UndoContext[ProgramSummaries],
-  userPreferences:  View[UserPreferences],
-  focused:          Focused,
-  searching:        View[Set[Target.Id]],
-  expandedIds:      View[SortedSet[ObsIdSet]],
-  readonly:         Boolean
+  programId:            Program.Id,
+  userId:               Option[User.Id],
+  programSummaries:     UndoContext[ProgramSummaries],
+  userPreferences:      View[UserPreferences],
+  focused:              Focused,
+  searching:            View[Set[Target.Id]],
+  expandedIds:          View[SortedSet[ObsIdSet]],
+  customSedAttachments: List[Attachment],
+  readonly:             Boolean
 ) extends ReactFnProps(TargetTabContents.component):
   private val targets: UndoSetter[TargetList] = programSummaries.zoom(ProgramSummaries.targets)
 
@@ -542,6 +544,7 @@ object TargetTabContents extends TwoPanels:
                 title,
                 props.globalPreferences,
                 guideStarSelection,
+                props.customSedAttachments,
                 props.readonly,
                 backButton = backButton.some
               )
@@ -596,6 +599,7 @@ object TargetTabContents extends TwoPanels:
                   fullScreen,
                   props.globalPreferences,
                   guideStarSelection,
+                  props.customSedAttachments,
                   props.readonly,
                   getObsInfo(none)(targetId),
                   onCloneTarget4Target

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
@@ -15,6 +15,7 @@ import explore.config.ObsTimeEditor
 import explore.model.AladinFullScreen
 import explore.model.AppContext
 import explore.model.Asterism
+import explore.model.Attachment
 import explore.model.GlobalPreferences
 import explore.model.GuideStarSelection
 import explore.model.ObsConfiguration
@@ -52,28 +53,29 @@ import java.time.Instant
 
 object AsterismEditorTile:
   def apply(
-    userId:             Option[User.Id],
-    tileId:             Tile.TileId,
-    programId:          Program.Id,
-    obsIds:             ObsIdSet,
-    obsAndTargets:      UndoSetter[ObservationsAndTargets],
-    configuration:      Option[BasicConfiguration],
-    obsTime:            View[Option[Instant]],
-    obsDuration:        View[Option[TimeSpan]],
-    obsConf:            ObsConfiguration,
-    pendingTime:        Option[TimeSpan], // estimated remaining execution time.
-    currentTarget:      Option[Target.Id],
-    setTarget:          (Option[Target.Id], SetRouteVia) => Callback,
-    onCloneTarget:      OnCloneParameters => Callback,
-    onAsterismUpdate:   OnAsterismUpdateParams => Callback,
-    obsInfo:            Target.Id => TargetEditObsInfo,
-    searching:          View[Set[Target.Id]],
-    title:              String,
-    globalPreferences:  View[GlobalPreferences],
-    guideStarSelection: View[GuideStarSelection],
-    readonly:           Boolean,
-    sequenceChanged:    Callback = Callback.empty,
-    backButton:         Option[VdomNode] = None
+    userId:               Option[User.Id],
+    tileId:               Tile.TileId,
+    programId:            Program.Id,
+    obsIds:               ObsIdSet,
+    obsAndTargets:        UndoSetter[ObservationsAndTargets],
+    configuration:        Option[BasicConfiguration],
+    obsTime:              View[Option[Instant]],
+    obsDuration:          View[Option[TimeSpan]],
+    obsConf:              ObsConfiguration,
+    pendingTime:          Option[TimeSpan], // estimated remaining execution time.
+    currentTarget:        Option[Target.Id],
+    setTarget:            (Option[Target.Id], SetRouteVia) => Callback,
+    onCloneTarget:        OnCloneParameters => Callback,
+    onAsterismUpdate:     OnAsterismUpdateParams => Callback,
+    obsInfo:              Target.Id => TargetEditObsInfo,
+    searching:            View[Set[Target.Id]],
+    title:                String,
+    globalPreferences:    View[GlobalPreferences],
+    guideStarSelection:   View[GuideStarSelection],
+    customSedAttachments: List[Attachment],
+    readonly:             Boolean,
+    sequenceChanged:      Callback = Callback.empty,
+    backButton:           Option[VdomNode] = None
   )(using FetchClient[IO, ObservationDB], Logger[IO]): Tile[TileState] = {
     // Save the time here. this works for the obs and target tabs
     // It's OK to save the viz time for executed observations, I think.
@@ -109,6 +111,7 @@ object AsterismEditorTile:
             searching,
             globalPreferences,
             guideStarSelection,
+            customSedAttachments,
             readonly,
             sequenceChanged,
             tileState.zoom(TileState.columnVisibility),
@@ -145,24 +148,25 @@ object AsterismEditorTile:
       Focus[TileState](_.obsEditInfo)
 
   private case class Body(
-    programId:          Program.Id,
-    userId:             User.Id,
-    obsIds:             ObsIdSet,
-    obsAndTargets:      UndoSetter[ObservationsAndTargets],
-    obsTime:            View[Option[Instant]],
-    configuration:      ObsConfiguration,
-    focusedTargetId:    Option[Target.Id],
-    setTarget:          (Option[Target.Id], SetRouteVia) => Callback,
-    onCloneTarget:      OnCloneParameters => Callback,
-    onAsterismUpdate:   OnAsterismUpdateParams => Callback,
-    obsInfo:            Target.Id => TargetEditObsInfo,
-    searching:          View[Set[Target.Id]],
-    globalPreferences:  View[GlobalPreferences],
-    guideStarSelection: View[GuideStarSelection],
-    readonly:           Boolean,
-    sequenceChanged:    Callback,
-    columnVisibility:   View[ColumnVisibility],
-    obsEditInfo:        View[Option[ObsIdSetEditInfo]]
+    programId:            Program.Id,
+    userId:               User.Id,
+    obsIds:               ObsIdSet,
+    obsAndTargets:        UndoSetter[ObservationsAndTargets],
+    obsTime:              View[Option[Instant]],
+    configuration:        ObsConfiguration,
+    focusedTargetId:      Option[Target.Id],
+    setTarget:            (Option[Target.Id], SetRouteVia) => Callback,
+    onCloneTarget:        OnCloneParameters => Callback,
+    onAsterismUpdate:     OnAsterismUpdateParams => Callback,
+    obsInfo:              Target.Id => TargetEditObsInfo,
+    searching:            View[Set[Target.Id]],
+    globalPreferences:    View[GlobalPreferences],
+    guideStarSelection:   View[GuideStarSelection],
+    customSedAttachments: List[Attachment],
+    readonly:             Boolean,
+    sequenceChanged:      Callback,
+    columnVisibility:     View[ColumnVisibility],
+    obsEditInfo:          View[Option[ObsIdSetEditInfo]]
   ) extends ReactFnProps(Body.component):
     val allTargets: UndoSetter[TargetList] = obsAndTargets.zoom(ObservationsAndTargets.targets)
 
@@ -254,6 +258,7 @@ object AsterismEditorTile:
                       fullScreen = fullScreen,
                       globalPreferences = props.globalPreferences,
                       guideStarSelection = props.guideStarSelection,
+                      customSedAttachments = props.customSedAttachments,
                       readonly = props.readonly,
                       invalidateSequence = props.sequenceChanged
                     )

--- a/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SiderealTargetEditor.scala
@@ -18,6 +18,7 @@ import explore.components.ui.ExploreStyles
 import explore.model.AladinFullScreen
 import explore.model.AppContext
 import explore.model.Asterism
+import explore.model.Attachment
 import explore.model.ExploreModelValidators
 import explore.model.GlobalPreferences
 import explore.model.GuideStarSelection
@@ -60,21 +61,22 @@ import queries.common.TargetQueriesGQL
 import java.time.Instant
 
 case class SiderealTargetEditor(
-  programId:          Program.Id,
-  userId:             User.Id,
-  target:             UndoSetter[Target.Sidereal],
-  obsAndTargets:      UndoSetter[ObservationsAndTargets],
-  asterism:           Asterism, // This is passed through to Aladin, to plot the entire Asterism.
-  obsTime:            Option[Instant],
-  obsConf:            Option[ObsConfiguration],
-  searching:          View[Set[Target.Id]],
-  obsInfo:            TargetEditObsInfo,
-  onClone:            OnCloneParameters => Callback,
-  fullScreen:         View[AladinFullScreen],
-  globalPreferences:  View[GlobalPreferences],
-  guideStarSelection: View[GuideStarSelection],
-  readonly:           Boolean,
-  invalidateSequence: Callback = Callback.empty
+  programId:            Program.Id,
+  userId:               User.Id,
+  target:               UndoSetter[Target.Sidereal],
+  obsAndTargets:        UndoSetter[ObservationsAndTargets],
+  asterism:             Asterism, // This is passed through to Aladin, to plot the entire Asterism.
+  obsTime:              Option[Instant],
+  obsConf:              Option[ObsConfiguration],
+  searching:            View[Set[Target.Id]],
+  obsInfo:              TargetEditObsInfo,
+  onClone:              OnCloneParameters => Callback,
+  fullScreen:           View[AladinFullScreen],
+  globalPreferences:    View[GlobalPreferences],
+  guideStarSelection:   View[GuideStarSelection],
+  customSedAttachments: List[Attachment],
+  readonly:             Boolean,
+  invalidateSequence:   Callback = Callback.empty
 ) extends ReactFnProps(SiderealTargetEditor.component)
 
 object SiderealTargetEditor:
@@ -414,8 +416,9 @@ object SiderealTargetEditor:
               SourceProfileEditor(
                 sourceProfileAligner,
                 props.target.get.catalogInfo,
-                disabled,
-                props.obsConf.flatMap(_.calibrationRole)
+                props.customSedAttachments,
+                props.obsConf.flatMap(_.calibrationRole),
+                disabled
               ).withKey(obsToCloneTo.get.fold("none")(_.show))
             )
           )

--- a/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/SourceProfileEditor.scala
@@ -4,10 +4,12 @@
 package explore.targeteditor
 
 import clue.data.syntax.*
+import crystal.react.View
 import crystal.react.hooks.*
 import explore.common.*
 import explore.components.HelpIcon
 import explore.model.AppContext
+import explore.model.Attachment
 import explore.model.enums.SourceProfileType
 import explore.utils.*
 import japgolly.scalajs.react.*
@@ -32,10 +34,11 @@ import lucuma.ui.syntax.all.given
 import spectralDefinition.{IntegratedSpectralDefinitionEditor, SurfaceSpectralDefinitionEditor}
 
 case class SourceProfileEditor(
-  sourceProfile:   Aligner[SourceProfile, SourceProfileInput],
-  catalogInfo:     Option[CatalogInfo],
-  disabled:        Boolean,
-  calibrationRole: Option[CalibrationRole]
+  sourceProfile:        Aligner[SourceProfile, SourceProfileInput],
+  catalogInfo:          Option[CatalogInfo],
+  customSedAttachments: List[Attachment],
+  calibrationRole:      Option[CalibrationRole],
+  disabled:             Boolean
 ) extends ReactFnProps(SourceProfileEditor.component)
 
 object SourceProfileEditor:
@@ -77,6 +80,7 @@ object SourceProfileEditor:
                 pointSpectralDefinitionAccess,
                 props.catalogInfo,
                 brightnessExpanded,
+                props.customSedAttachments,
                 props.disabled,
                 props.calibrationRole
               )
@@ -91,6 +95,7 @@ object SourceProfileEditor:
                 uniformSpectralDefinitionAccess,
                 props.catalogInfo,
                 brightnessExpanded,
+                props.customSedAttachments,
                 props.disabled,
                 props.calibrationRole
               )
@@ -121,6 +126,7 @@ object SourceProfileEditor:
                   ),
                   props.catalogInfo,
                   brightnessExpanded,
+                  props.customSedAttachments,
                   props.disabled,
                   props.calibrationRole
                 )

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
@@ -9,8 +9,8 @@ import clue.data.syntax.*
 import crystal.react.View
 import explore.*
 import explore.common.*
-import explore.model.enums.IntegratedSEDType
-import explore.model.enums.IntegratedSEDType.given
+import explore.model.enums.IntegratedSedType
+import explore.model.enums.IntegratedSedType.given
 import explore.model.enums.SedType
 import explore.utils.*
 import japgolly.scalajs.react.*
@@ -29,7 +29,6 @@ import lucuma.schemas.odb.input.*
 import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
 
-import scala.collection.immutable.HashSet
 import scala.collection.immutable.SortedMap
 
 import brightnessesEditor.IntegratedBrightnessEditor
@@ -115,9 +114,12 @@ object IntegratedSpectralDefinitionEditor
       SpectralDefinitionIntegratedInput,
       IntegratedSpectralDefinitionEditor
     ] {
+
   override protected val currentType
     : SpectralDefinition[Integrated] => Option[SedType[Integrated]] =
-    IntegratedSEDType.fromSpectralDefinition
+    IntegratedSedType.fromSpectralDefinition
+
+  override protected val userDefinedType: SedType[Integrated] = IntegratedSedType.UserDefinedType
 
   override protected val brightnessEditor: (
     View[SortedMap[Band, BrightnessMeasure[Integrated]]],

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
@@ -9,6 +9,7 @@ import clue.data.syntax.*
 import crystal.react.View
 import explore.*
 import explore.common.*
+import explore.model.Attachment
 import explore.model.enums.IntegratedSedType
 import explore.model.enums.IntegratedSedType.given
 import explore.model.enums.SedType
@@ -35,11 +36,12 @@ import brightnessesEditor.IntegratedBrightnessEditor
 import emissionLineEditor.IntegratedEmissionLineEditor
 
 case class IntegratedSpectralDefinitionEditor(
-  spectralDefinition: Aligner[SpectralDefinition[Integrated], SpectralDefinitionIntegratedInput],
-  catalogInfo:        Option[CatalogInfo],
-  brightnessExpanded: View[IsExpanded],
-  disabled:           Boolean,
-  calibrationRole:    Option[CalibrationRole]
+  spectralDefinition:   Aligner[SpectralDefinition[Integrated], SpectralDefinitionIntegratedInput],
+  catalogInfo:          Option[CatalogInfo],
+  brightnessExpanded:   View[IsExpanded],
+  customSedAttachments: List[Attachment],
+  disabled:             Boolean,
+  calibrationRole:      Option[CalibrationRole]
 )(using Logger[IO])
     extends ReactFnProps[IntegratedSpectralDefinitionEditor](
       IntegratedSpectralDefinitionEditor.component

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
@@ -119,9 +119,6 @@ object IntegratedSpectralDefinitionEditor
     : SpectralDefinition[Integrated] => Option[SedType[Integrated]] =
     IntegratedSEDType.fromSpectralDefinition
 
-  override protected val disabledItems: HashSet[SedType[Integrated]] =
-    HashSet(IntegratedSEDType.UserDefinedType)
-
   override protected val brightnessEditor: (
     View[SortedMap[Band, BrightnessMeasure[Integrated]]],
     View[IsExpanded],

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditor.scala
@@ -6,6 +6,7 @@ package explore.targeteditor.spectralDefinition
 import crystal.react.View
 import explore.*
 import explore.common.*
+import explore.model.Attachment
 import explore.utils.*
 import lucuma.core.enums.Band
 import lucuma.core.enums.CalibrationRole
@@ -24,6 +25,7 @@ private trait SpectralDefinitionEditor[T, S]:
   def catalogInfo: Option[CatalogInfo]
   def calibrationRole: Option[CalibrationRole]
   def brightnessExpanded: View[IsExpanded]
+  def customSedAttachments: List[Attachment]
   def disabled: Boolean
 
   def toInput: SpectralDefinition[T] => S

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditor.scala
@@ -33,3 +33,9 @@ private trait SpectralDefinitionEditor[T, S]:
   def bandBrightnessesViewOpt: Option[View[SortedMap[Band, BrightnessMeasure[T]]]]
   def emissionLinesViewOpt: Option[View[SortedMap[Wavelength, EmissionLine[T]]]]
   def fluxDensityContinuumOpt: Option[View[FluxDensityContinuumMeasure[T]]]
+
+  protected[spectralDefinition] def currentCustomSedAttachmentId: Option[Attachment.Id] =
+    SpectralDefinition.unnormalizedSED.some
+      .andThen(UnnormalizedSED.userDefinedAttachment)
+      .andThen(UnnormalizedSED.UserDefinedAttachment.attachmentId)
+      .getOption(spectralDefinition.get)

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditorBuilder.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditorBuilder.scala
@@ -9,6 +9,7 @@ import clue.data.syntax.*
 import coulomb.*
 import coulomb.units.si.Kelvin
 import crystal.react.View
+import crystal.react.hooks.*
 import eu.timepit.refined.auto.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.numeric.PosInt
@@ -60,6 +61,7 @@ import lucuma.ui.utils.*
 
 import scala.collection.immutable.HashSet
 import scala.collection.immutable.SortedMap
+import lucuma.core.model.Attachment
 
 private abstract class SpectralDefinitionEditorBuilder[
   T,
@@ -76,10 +78,12 @@ private abstract class SpectralDefinitionEditorBuilder[
     : (View[SortedMap[Wavelength, EmissionLine[T]]], View[IsExpanded], Boolean) => VdomNode
 
   protected def currentType: SpectralDefinition[T] => Option[SedType[T]]
-  protected def disabledItems: HashSet[SedType[T]]
 
   val component = ScalaFnComponent[Props]: props =>
-    for ctx <- useContext(AppContext.ctx)
+    for
+      ctx                   <- useContext(AppContext.ctx)
+      sedType               <- useStateView(currentType(props.spectralDefinition.get))
+      customSedAttachmentId <- useStateView(none[Attachment.Id])
     yield
       import ctx.given
 
@@ -201,7 +205,6 @@ private abstract class SpectralDefinitionEditorBuilder[
               props.spectralDefinition
                 .view(props.toInput)
                 .mod(sed.fold(SpectralDefinition.unnormalizedSED.replace(None))(_.convert)),
-            disabledItems = disabledItems,
             clazz = LucumaPrimeStyles.FormField,
             disabled = props.disabled
           ),

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditorBuilder.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SpectralDefinitionEditorBuilder.scala
@@ -258,45 +258,47 @@ private abstract class SpectralDefinitionEditorBuilder[
                     units = "°K",
                     disabled = props.disabled
                   )
-                ),
-              props.bandBrightnessesViewOpt
-                .map(bandBrightnessesView =>
-                  <.div(ExploreStyles.BrightnessesTableWrapper)(
-                    brightnessEditor(bandBrightnessesView, props.brightnessExpanded, props.disabled)
-                  )
-                ),
-              props.fluxDensityContinuumOpt
-                .map(fluxDensityContinuum =>
-                  React.Fragment(
-                    FormLabel(htmlFor = "fluxValue".refined)("Continuum"),
-                    <.div(
-                      ExploreStyles.FlexContainer |+| LucumaPrimeStyles.FormField,
-                      FormInputTextView(
-                        id = "fluxValue".refined,
-                        value = fluxDensityContinuum.zoom(Measure.valueTagged),
-                        validFormat = InputValidSplitEpi
-                          .refinedBigDecimalWithScientificNotation[
-                            FluxDensityContinuumValueRefinement
-                          ]
-                          .andThen(FluxDensityContinuumValue.value.reverse),
-                        changeAuditor = ChangeAuditor.posScientificNotation(),
-                        disabled = props.disabled
-                      ),
-                      EnumDropdownView(
-                        id = "Units".refined,
-                        value = fluxDensityContinuum.zoom(Measure.unitsTagged),
-                        disabled = props.disabled
-                      )
-                    )
-                  )
-                ),
-              props.emissionLinesViewOpt
-                .map(e =>
-                  <.div(ExploreStyles.BrightnessesTableWrapper)(
-                    emissionLineEditor(e, props.brightnessExpanded, props.disabled)
-                  )
                 )
             )
-          else EmptyVdom
+          else EmptyVdom,
+          React.Fragment(
+            props.bandBrightnessesViewOpt
+              .map(bandBrightnessesView =>
+                <.div(ExploreStyles.BrightnessesTableWrapper)(
+                  brightnessEditor(bandBrightnessesView, props.brightnessExpanded, props.disabled)
+                )
+              ),
+            props.fluxDensityContinuumOpt
+              .map(fluxDensityContinuum =>
+                React.Fragment(
+                  FormLabel(htmlFor = "fluxValue".refined)("Continuum"),
+                  <.div(
+                    ExploreStyles.FlexContainer |+| LucumaPrimeStyles.FormField,
+                    FormInputTextView(
+                      id = "fluxValue".refined,
+                      value = fluxDensityContinuum.zoom(Measure.valueTagged),
+                      validFormat = InputValidSplitEpi
+                        .refinedBigDecimalWithScientificNotation[
+                          FluxDensityContinuumValueRefinement
+                        ]
+                        .andThen(FluxDensityContinuumValue.value.reverse),
+                      changeAuditor = ChangeAuditor.posScientificNotation(),
+                      disabled = props.disabled
+                    ),
+                    EnumDropdownView(
+                      id = "Units".refined,
+                      value = fluxDensityContinuum.zoom(Measure.unitsTagged),
+                      disabled = props.disabled
+                    )
+                  )
+                )
+              ),
+            props.emissionLinesViewOpt
+              .map(e =>
+                <.div(ExploreStyles.BrightnessesTableWrapper)(
+                  emissionLineEditor(e, props.brightnessExpanded, props.disabled)
+                )
+              )
+          )
         )
 }

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
@@ -9,6 +9,7 @@ import clue.data.syntax.*
 import crystal.react.View
 import explore.*
 import explore.common.*
+import explore.model.Attachment
 import explore.model.enums.SedType
 import explore.model.enums.SurfaceSedType
 import explore.model.enums.SurfaceSedType.given
@@ -35,11 +36,12 @@ import brightnessesEditor.SurfaceBrightnessEditor
 import emissionLineEditor.SurfaceEmissionLineEditor
 
 case class SurfaceSpectralDefinitionEditor(
-  spectralDefinition: Aligner[SpectralDefinition[Surface], SpectralDefinitionSurfaceInput],
-  catalogInfo:        Option[CatalogInfo],
-  brightnessExpanded: View[IsExpanded],
-  disabled:           Boolean,
-  calibrationRole:    Option[CalibrationRole]
+  spectralDefinition:   Aligner[SpectralDefinition[Surface], SpectralDefinitionSurfaceInput],
+  catalogInfo:          Option[CatalogInfo],
+  brightnessExpanded:   View[IsExpanded],
+  customSedAttachments: List[Attachment],
+  disabled:             Boolean,
+  calibrationRole:      Option[CalibrationRole]
 )(using Logger[IO])
     extends ReactFnProps[SurfaceSpectralDefinitionEditor](
       SurfaceSpectralDefinitionEditor.component

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
@@ -112,9 +112,6 @@ object SurfaceSpectralDefinitionEditor
   override protected val currentType: SpectralDefinition[Surface] => Option[SedType[Surface]] =
     SurfaceSEDType.fromSpectralDefinition
 
-  override protected val disabledItems: HashSet[SedType[Surface]] =
-    HashSet(SurfaceSEDType.UserDefinedType)
-
   override protected val brightnessEditor
     : (View[SortedMap[Band, BrightnessMeasure[Surface]]], View[IsExpanded], Boolean) => VdomNode =
     (brightnessesView, expanded, disabled) =>

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
@@ -10,8 +10,8 @@ import crystal.react.View
 import explore.*
 import explore.common.*
 import explore.model.enums.SedType
-import explore.model.enums.SurfaceSEDType
-import explore.model.enums.SurfaceSEDType.given
+import explore.model.enums.SurfaceSedType
+import explore.model.enums.SurfaceSedType.given
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -29,7 +29,6 @@ import lucuma.schemas.odb.input.*
 import lucuma.ui.syntax.all.given
 import org.typelevel.log4cats.Logger
 
-import scala.collection.immutable.HashSet
 import scala.collection.immutable.SortedMap
 
 import brightnessesEditor.SurfaceBrightnessEditor
@@ -110,7 +109,9 @@ object SurfaceSpectralDefinitionEditor
       SurfaceSpectralDefinitionEditor
     ] {
   override protected val currentType: SpectralDefinition[Surface] => Option[SedType[Surface]] =
-    SurfaceSEDType.fromSpectralDefinition
+    SurfaceSedType.fromSpectralDefinition
+
+  override protected val userDefinedType: SedType[Surface] = SurfaceSedType.UserDefinedType
 
   override protected val brightnessEditor
     : (View[SortedMap[Band, BrightnessMeasure[Surface]]], View[IsExpanded], Boolean) => VdomNode =

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -26,7 +26,7 @@ object Versions {
   val lucumaITC              = "0.27.0"
   val lucumaReact            = "0.78.2"
   val lucumaRefined          = "0.1.3"
-  val lucumaSchemas          = "0.122.0"
+  val lucumaSchemas          = "0.122.1"
   val lucumaOdbSchema        = "0.18.4"
   val lucumaSSO              = "0.8.3"
   val lucumaUI               = "0.131.1"


### PR DESCRIPTION
This was a bit challenging since the SED selector used to directly show and edit the model we have in memory (and send mutations to the server).

However, we cannot do this anymore because when selecting a custom SED we may have an inconsistent state in the UI while the user selects and/or uploads a new SED. Therefore, state was created in the component: we now edit that state and forward it to the model and ODB when it's well defined.

This PR just presents the user with a dropdown showing all the custom SED attachments currently in the program. There's no functionality yet to upload new ones (that can be done via the REST API for testing purposes). I'll implement upload in a next PR, but this one's complex enough as it is, so I decided to split them.

<img width="533" alt="image" src="https://github.com/user-attachments/assets/8a7ae54a-a97f-4b4b-a974-de34ec7fee23" />
