### PR TITLE
Fix duration used for parallactic angle calculation

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -324,10 +324,14 @@ object ObsTabTiles:
               obsEditAttachments(props.obsId, ids).runAsync
             }
 
-          val pendingTime = props.obsExecution.toOption.flatMap(_.programTimeEstimate)
+          val pendingTime = props.obsExecution.toOption.flatMap(_.fullTimeEstimate)
           val obsDuration =
             props.observation.get.observationDuration
               .orElse(pendingTime)
+
+          println(
+            s"obsDuration: $obsDuration, pendingTime: $pendingTime, explicit: ${props.observation.get.observationDuration}"
+          )
 
           val paProps: PAProperties =
             PAProperties(props.obsId, guideStarSelection, agsState, props.posAngleConstraint)

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -329,10 +329,6 @@ object ObsTabTiles:
             props.observation.get.observationDuration
               .orElse(pendingTime)
 
-          println(
-            s"obsDuration: $obsDuration, pendingTime: $pendingTime, explicit: ${props.observation.get.observationDuration}"
-          )
-
           val paProps: PAProperties =
             PAProperties(props.obsId, guideStarSelection, agsState, props.posAngleConstraint)
 

--- a/model/shared/src/main/scala/explore/model/Execution.scala
+++ b/model/shared/src/main/scala/explore/model/Execution.scala
@@ -14,6 +14,7 @@ import lucuma.odb.json.sequence.given
 
 case class Execution(digest: Option[ExecutionDigest], programTimeCharge: ProgramTime) derives Eq:
   lazy val programTimeEstimate: Option[TimeSpan] = digest.map(_.fullTimeEstimate.programTime)
+  lazy val fullTimeEstimate: Option[TimeSpan]    = digest.map(_.fullTimeEstimate.sum)
 
 object Execution {
   given Decoder[Execution] = Decoder.instance(c =>


### PR DESCRIPTION
When an observation duration was not explicitly set, the program time was used instead of the full remaining time.