### PR TITLE
Add Program Notes tile to Program tab

### DIFF
--- a/common/src/main/scala/explore/Icons.scala
+++ b/common/src/main/scala/explore/Icons.scala
@@ -362,6 +362,10 @@ object Icons {
   @JSImport("@fortawesome/pro-solid-svg-icons", "faBookOpen")
   val faBookOpen: FAIcon = js.native
 
+  @js.native
+  @JSImport("@fortawesome/pro-solid-svg-icons", "faLockKeyhole")
+  val faLockKeyhole: FAIcon = js.native
+
   // This is tedious but lets us do proper tree-shaking
   FontAwesome.library.add(
     faArrowDownLeft,
@@ -450,7 +454,8 @@ object Icons {
     faSquarePlus,
     faCloudArrowUp,
     faArrowUpRightFromSquare,
-    faBookOpen
+    faBookOpen,
+    faLockKeyhole
   )
 
   val ArrowDownLeft          = FontAwesomeIcon(faArrowDownLeft)
@@ -542,6 +547,7 @@ object Icons {
   val CloudArrowUp           = FontAwesomeIcon(faCloudArrowUp)
   val ArrowUpRightFromSquare = FontAwesomeIcon(faArrowUpRightFromSquare)
   val BookOpen               = FontAwesomeIcon(faBookOpen)
+  val LockKeyhole            = FontAwesomeIcon(faLockKeyhole)
 
   val MissingInfoIcon  = ExclamationTriangle.withClass(ExploreStyles.WarningIcon)
   val ErrorIcon        = ExclamationTriangle.withClass(ExploreStyles.ErrorIcon)

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -136,11 +136,7 @@ object ExploreStyles:
   val ProgramName      = Css("program-name")
   val ProgramNameInput = Css("program-name-input")
 
-  val ObserverNotes: Css = Css("observer-notes")
-  val NotesTile: Css     = Css("observer-notes-tile")
-  val NotesEditor: Css   = Css("observer-notes-editor")
-  val NotesControls: Css = Css("observer-notes-controls")
-  val NoNotes: Css       = Css("observer-notes-empty")
+  val NotesTile: Css = Css("observer-notes-tile")
 
   val FinderChartsTile: Css          = Css("finder-charts-tile")
   val FinderChartsBody: Css          = Css("finder-charts-body")
@@ -514,6 +510,19 @@ object ExploreStyles:
   val ProgramDetailsRight: Css    = Css("program-details-right")
   val ProgramTabTable: Css        = Css("program-tab-table")
   val ProgramDetailsUsers: Css    = Css("program-details-users")
+
+  val ProgramNotesTileBody: Css         = Css("program-notes-tile-body")
+  val ProgramNotesTileTitleButtons: Css = Css("program-notes-tile-title-buttons")
+  val ProgramNoteEditor: Css            = Css("program-note-editor")
+  val ProgramNoteHeader: Css            = Css("program-note-header")
+  val ProgramNoteTitle: Css             = Css("program-note-title")
+
+  // Markdown Editor
+  val MarkdownEditor: Css      = Css("markdown-editor")
+  val MarkdownPlaceholder: Css = Css("markdown-placeholder")
+
+  // Make a tabview take up the full height available
+  val FullHeightTabView: Css = Css("full-height-tab-view")
 
   val FocusedInfo: Css = Css("explore-focused-info")
 

--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -363,7 +363,7 @@ object ExploreGridLayouts:
   object programs:
     private lazy val DetailsHeight: NonNegInt            = 10.refined
     private lazy val DataUsersHeight: NonNegInt          = 6.refined
-    private lazy val NotesHeight: NonNegInt              = 6.refined
+    private lazy val NotesHeight: NonNegInt              = 8.refined
     private lazy val ChangeRequestsHeight: NonNegInt     = 6.refined
     private lazy val UnrequestedConfigsHeight: NonNegInt = 6.refined
 

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -127,6 +127,7 @@ object reusability:
   given [F[_]]: Reusability[OdbRestClient[F]]           = Reusability.by(_.authToken)
   given [D: Eq]: Reusability[Atom[D]]                   = Reusability.byEq
   given Reusability[ExecutionVisits]                    = Reusability.byEq
+  given Reusability[ProgramNote]                        = Reusability.byEq
   given Reusability[ProgramUser]                        = Reusability.byEq
   given Reusability[UserInvitation]                     = Reusability.byEq
   given Reusability[IsActive]                           = Reusability.byEq

--- a/common/src/main/scala/explore/undo/AsyncAction.scala
+++ b/common/src/main/scala/explore/undo/AsyncAction.scala
@@ -13,6 +13,6 @@ case class AsyncAction[M, K, A](
   onSet:     K => (M, A) => DefaultA[Unit],
   onRestore: K => (M, A) => DefaultA[Unit]
 ):
-  def apply(undoSetter: UndoSetter[M]): DefaultA[Unit] =
+  def apply(undoSetter: UndoSetter[M]): DefaultA[(K, A)] =
     asyncGet.flatMap: (k, a) =>
-      undoSetter.set(getter(k), setter(k), onSet(k), onRestore(k))(a).to[DefaultA]
+      undoSetter.set(getter(k), setter(k), onSet(k), onRestore(k))(a).to[DefaultA].as((k, a))

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -2701,51 +2701,7 @@ $help-title-height: 40px;
 // Observer-notes
 // --------------
 .observer-notes-tile {
-  display: flex;
-}
-
-.observer-notes-controls {
-  display: flex;
-  gap: 0.5em;
-  align-items: center;
-}
-
-.observer-notes {
-  flex-grow: 1;
-  display: flex;
-
-  .markdown-body {
-    flex-grow: 1;
-    padding: 0.5em;
-    overflow: auto;
-    color: var(--site-text-color);
-  }
-}
-
-.observer-notes-empty {
-  flex-grow: 1;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: stretch;
-
-  div {
-    // to center the no notes message
-    align-self: center;
-  }
-}
-
-.observer-notes,
-.observer-notes-empty {
-  .pl-form-field {
-    width: 100%;
-    height: 100%;
-
-    .observer-notes-editor {
-      width: 100%;
-      height: 100%;
-    }
-  }
+  width: 100%;
 }
 
 // --------------
@@ -3444,6 +3400,69 @@ a.explore-upgrade-link {
         align-items: center;
       }
     }
+  }
+}
+
+.program-notes-tile-body {
+  .program-note-header {
+    display: flex;
+    gap: 0.5em;
+  }
+
+  .program-note-editor {
+    height: 100%;
+    display: grid;
+    grid-template-rows: auto 1fr;
+    grid-gap: 1em;
+
+    .program-note-title {
+      display: flex;
+      gap: 1em;
+      align-items: center;
+    }
+  }
+}
+
+.program-notes-tile-title-buttons {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+}
+
+// Markdown Editor
+.markdown-editor {
+  height: 100%;
+
+  .markdown-body {
+    padding: 0.5em;
+    height: 100%;
+    border: 1px solid var(--site-border-color);
+
+    &.markdown-placeholder {
+      opacity: 0.5;
+    }
+  }
+
+  .pl-form-field {
+    height: 100%;
+    width: 100%;
+
+    textarea {
+      height: 100%;
+      width: 100%;
+      resize: none;
+    }
+  }
+}
+
+.p-tabview.full-height-tab-view {
+  height: 100%;
+  display: grid;
+  grid-template-rows: auto 1fr;
+
+  .p-tabview-panel {
+    height: 100%;
   }
 }
 

--- a/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramDetailsSubquery.scala
@@ -22,6 +22,7 @@ object ProgramDetailsSubquery
       users $ProgramUserSubquery
       reference $ProgramReferenceSubquery
       allocations $AllocationSubquery
+      notes $ProgramNoteSubquery
       goa {
         proprietaryMonths
         shouldNotify

--- a/explore/src/clue/scala/queries/common/ProgramNoteSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProgramNoteSubquery.scala
@@ -1,0 +1,22 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQL
+import explore.model.ProgramNote
+import lucuma.schemas.ObservationDB
+
+@GraphQL
+object ProgramNoteSubquery
+    extends GraphQLSubquery.Typed[ObservationDB, ProgramNote]("ProgramNote") {
+  override val subquery: String = """
+    {
+      id
+      title
+      text
+      isPrivate
+    }
+  """
+}

--- a/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramQueriesGQL.scala
@@ -171,3 +171,27 @@ object ProgramQueriesGQL:
         }
       }
     """
+
+  @GraphQL
+  trait CreateProgramNoteMutation extends GraphQLOperation[ObservationDB]:
+    val document = s"""
+      mutation($$input: CreateProgramNoteInput!) {
+        createProgramNote(input: $$input) {
+          programNote {
+            id
+          }
+        }
+      }
+    """
+
+  @GraphQL
+  trait UpdateProgramNotesMutation extends GraphQLOperation[ObservationDB]:
+    val document = s"""
+      mutation($$input: UpdateProgramNotesInput!) {
+        updateProgramNotes(input: $$input) {
+          programNotes {
+            id
+          }
+        }
+      }
+    """

--- a/explore/src/main/scala/explore/Routing.scala
+++ b/explore/src/main/scala/explore/Routing.scala
@@ -15,6 +15,7 @@ import explore.modes.SpectroscopyModesMatrix
 import explore.proposal.ProposalTabContents
 import explore.tabs.*
 import explore.undo.UndoContext
+import explore.undo.Undoer
 import japgolly.scalajs.react.React
 import japgolly.scalajs.react.ReactMonocle.*
 import japgolly.scalajs.react.extra.router.*
@@ -191,11 +192,11 @@ object Routing:
       .map: routingInfo =>
         withProgramSummaries(model): programSummaries =>
           for
-            programDetails <-
-              programSummaries.model.zoom(ProgramSummaries.optProgramDetails).toOptionView
+            programDetails <- programSummaries.zoom(ProgramSummaries.optProgramDetails.some)
             proposal       <- programDetails.get.proposal
           yield ProgramTabContents(
             routingInfo.programId,
+            programSummaries: Undoer,
             programDetails,
             programSummaries.model.zoom(ProgramSummaries.configurationRequests),
             programSummaries.model.zoom(ProgramSummaries.observations),

--- a/explore/src/main/scala/explore/components/MarkdownEditor.scala
+++ b/explore/src/main/scala/explore/components/MarkdownEditor.scala
@@ -1,0 +1,61 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import cats.syntax.all.*
+import crystal.react.*
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.components.ui.ExploreStyles
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.*
+import lucuma.react.markdown.ReactMarkdown
+import lucuma.react.markdown.RehypePlugin
+import lucuma.react.markdown.RemarkPlugin
+import lucuma.react.primereact.*
+import lucuma.react.primereact.tooltip.*
+import lucuma.ui.optics.*
+import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
+
+case class MarkdownEditor(
+  value:       View[Option[NonEmptyString]],
+  readonly:    Boolean = false,
+  placeholder: String = "Use Edit tab to edit note. Markdown is supported."
+) extends ReactFnProps(MarkdownEditor)
+
+object MarkdownEditor
+    extends ReactFnComponent[MarkdownEditor](props =>
+      for {
+        id <- useId
+      } yield {
+        val placeholder    = if (props.readonly) "" else props.placeholder
+        val markdownViewer = ReactMarkdown(
+          content = props.value.get.map(_.value).getOrElse(placeholder),
+          clazz = ExploreStyles.HelpMarkdownBody |+|
+            ExploreStyles.MarkdownPlaceholder.when_(props.value.get.isEmpty),
+          remarkPlugins = List(RemarkPlugin.RemarkMath, RemarkPlugin.RemarkGFM),
+          rehypePlugins = List(RehypePlugin.RehypeExternalLinks, RehypePlugin.RehypeKatex)
+        )
+
+        <.div(
+          ExploreStyles.MarkdownEditor,
+          markdownViewer.when(props.readonly),
+          TabView(
+            clazz = ExploreStyles.FullHeightTabView,
+            panels = List(
+              TabPanel(header = "View")(markdownViewer),
+              TabPanel(header =
+                <.span("Edit").withTooltip(content = "Edit note. Markdown is supported.")
+              )(
+                FormInputTextAreaView(
+                  id = NonEmptyString.unsafeFrom(id),
+                  value = props.value.as(OptionNonEmptyStringIso)
+                )
+              )
+            )
+          ).unless(props.readonly)
+        )
+      }
+    )

--- a/explore/src/main/scala/explore/notes/NotesTile.scala
+++ b/explore/src/main/scala/explore/notes/NotesTile.scala
@@ -24,31 +24,9 @@ object NotesTile:
       ObsTabTileIds.NotesId.id,
       s"Note for Observer",
       bodyClass = ExploreStyles.NotesTile
-    )(_ => NotesTileBody(notes), (_, tileSize) => NotesTileTitle(notes, tileSize))
-
-case class NotesTileBody(
-  notes: View[Option[NonEmptyString]]
-) extends ReactFnProps(NotesTileBody.component)
-
-object NotesTileBody:
-  private type Props = NotesTileBody
-
-  val themeAttr = VdomAttr("data-theme")
-
-  private val component =
-    ScalaFnComponent[Props]: props =>
-      MarkdownEditor(props.notes)
-
-case class NotesTileTitle(
-  notes:    View[Option[NonEmptyString]],
-  tileSize: TileSizeState
-) extends ReactFnProps(NotesTileTitle.component)
-
-object NotesTileTitle:
-  private type Props = NotesTileTitle
-
-  private val component =
-    ScalaFnComponent[Props]: props =>
-      Option.unless(props.tileSize === TileSizeState.Minimized)(
-        HelpIcon("observer-notes.md".refined)
-      )
+    )(_ => MarkdownEditor(notes),
+      (_, tileSize) =>
+        Option.unless(tileSize === TileSizeState.Minimized)(
+          HelpIcon("observer-notes.md".refined)
+        )
+    )

--- a/explore/src/main/scala/explore/notes/NotesTile.scala
+++ b/explore/src/main/scala/explore/notes/NotesTile.scala
@@ -6,54 +6,29 @@ package explore.tabs
 import cats.syntax.all.*
 import crystal.react.*
 import eu.timepit.refined.types.string.NonEmptyString
-import explore.Icons
 import explore.components.HelpIcon
+import explore.components.MarkdownEditor
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.model.ObsTabTileIds
-import explore.model.Observation
 import explore.model.enums.TileSizeState
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
-import lucuma.core.util.NewType
 import lucuma.react.common.*
-import lucuma.react.markdown.ReactMarkdown
-import lucuma.react.markdown.RehypePlugin
-import lucuma.react.markdown.RemarkPlugin
-import lucuma.react.primereact.*
 import lucuma.refined.*
-import lucuma.ui.primereact.*
-import lucuma.ui.primereact.given
-import monocle.Focus
-import monocle.Lens
 
 object NotesTile:
 
-  def notesTile(obsId: Observation.Id, notes: View[Option[NonEmptyString]]) =
+  def notesTile(notes: View[Option[NonEmptyString]]): Tile[Unit] =
     Tile(
       ObsTabTileIds.NotesId.id,
       s"Note for Observer",
-      NotesTileState(notes.get.foldMap(_.value), Editing.NotEditing),
       bodyClass = ExploreStyles.NotesTile
-    )(NotesTileBody(obsId, notes, _), NotesTileTitle(obsId, notes, _, _))
-
-case class NotesTileState(notes: String, editing: Editing)
-
-object NotesTileState:
-  val notes: Lens[NotesTileState, String]    = Focus[NotesTileState](_.notes)
-  val editing: Lens[NotesTileState, Editing] = Focus[NotesTileState](_.editing)
+    )(_ => NotesTileBody(notes), (_, tileSize) => NotesTileTitle(notes, tileSize))
 
 case class NotesTileBody(
-  obsId: Observation.Id,
-  notes: View[Option[NonEmptyString]],
-  state: View[NotesTileState]
+  notes: View[Option[NonEmptyString]]
 ) extends ReactFnProps(NotesTileBody.component)
-
-type Editing = Editing.Type
-object Editing extends NewType[Boolean]:
-  inline def NotEditing       = Editing(false)
-  inline def InEdition        = Editing(true)
-  inline def flip(e: Editing) = Editing(!e.value)
 
 object NotesTileBody:
   private type Props = NotesTileBody
@@ -61,41 +36,11 @@ object NotesTileBody:
   val themeAttr = VdomAttr("data-theme")
 
   private val component =
-    ScalaFnComponent[Props] { props =>
-      val notesView = props.state.zoom(NotesTileState.notes)
-      val editing   = props.state.zoom(NotesTileState.editing)
-
-      val editor = FormInputTextAreaView("notes".refined, notesView)(
-        ExploreStyles.NotesEditor
-      )
-
-      props.notes.get
-        .map(_.value)
-        .map(noteMd =>
-          <.div(
-            ExploreStyles.ObserverNotes,
-            themeAttr := "dark",
-            if (editing.get.value) editor
-            else
-              ReactMarkdown(
-                content = noteMd,
-                clazz = ExploreStyles.HelpMarkdownBody,
-                remarkPlugins = List(RemarkPlugin.RemarkMath, RemarkPlugin.RemarkGFM),
-                rehypePlugins = List(RehypePlugin.RehypeExternalLinks, RehypePlugin.RehypeKatex)
-              )
-          )
-        )
-        .getOrElse(
-          <.div(ExploreStyles.NoNotes,
-                if (editing.get.value) editor else <.div("No notes available")
-          )
-        )
-    }
+    ScalaFnComponent[Props]: props =>
+      MarkdownEditor(props.notes)
 
 case class NotesTileTitle(
-  obsId:    Observation.Id,
   notes:    View[Option[NonEmptyString]],
-  state:    View[NotesTileState],
   tileSize: TileSizeState
 ) extends ReactFnProps(NotesTileTitle.component)
 
@@ -104,30 +49,6 @@ object NotesTileTitle:
 
   private val component =
     ScalaFnComponent[Props]: props =>
-      val editing = props.state.zoom(NotesTileState.editing)
-
-      val notesView = props.state.zoom(NotesTileState.notes)
-
-      val editButton = Button("Edit",
-                              severity = Button.Severity.Success,
-                              disabled = editing.get.value,
-                              icon = Icons.Edit,
-                              onClick = editing.mod(Editing.flip)
-      ).tiny.compact
-
-      val save = editing.mod(Editing.flip) *>
-        props.notes.set(NonEmptyString.from(notesView.get).toOption)
-
-      val saveButton = Button(
-        "Save",
-        severity = Button.Severity.Success,
-        icon = Icons.CloudArrowUp,
-        onClick = save
-      ).tiny.compact
-
-      if (props.tileSize === TileSizeState.Minimized) <.div(ExploreStyles.NotesControls)
-      else
-        <.div(ExploreStyles.NotesControls,
-              HelpIcon("observer-notes.md".refined),
-              if (editing.get.value) saveButton else editButton
-        )
+      Option.unless(props.tileSize === TileSizeState.Minimized)(
+        HelpIcon("observer-notes.md".refined)
+      )

--- a/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/AsterismGroupObsList.scala
@@ -214,6 +214,7 @@ object AsterismGroupObsList:
         selectTargetOrSummary(_).toAsync,
         ToastCtx[IO].showToast(_)
       )(undoCtx)
+      .void
       .switching(adding.async, AddingTargetOrObs(_))
       .withToastDuring("Creating target")
 

--- a/explore/src/main/scala/explore/observationtree/package.scala
+++ b/explore/src/main/scala/explore/observationtree/package.scala
@@ -62,6 +62,7 @@ def cloneObs(
       focusObs = obsId => focusObs(programId, obsId.some, ctx),
       postMessage = ToastCtx[IO].showToast(_)
     )(observations)
+    .void
 
 private def obsWithId(obsId: Observation.Id): Lens[ObservationList, Option[Observation]] =
   Iso.id[ObservationList].at(obsId)
@@ -103,6 +104,7 @@ def insertObs(
       focusObs = obsId => focusObs(programId, obsId.some, ctx),
       postMessage = ToastCtx[IO].showToast(_)
     )(observations)
+    .void
     .switching(adding.zoom(AddingObservation.value.asLens).async)
     .withToastDuring("Creating observation")
 

--- a/explore/src/main/scala/explore/programs/ProgramNoteEditor.scala
+++ b/explore/src/main/scala/explore/programs/ProgramNoteEditor.scala
@@ -1,0 +1,94 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.programs
+
+import cats.effect.IO
+import cats.syntax.all.*
+import clue.data.syntax.*
+import eu.timepit.refined.cats.given
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.common.Aligner
+import explore.components.MarkdownEditor
+import explore.components.ui.ExploreStyles
+import explore.model.AppContext
+import explore.model.ProgramNote
+import explore.undo.UndoSetter
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.validation.InputValidSplitEpi
+import lucuma.react.common.ReactFnComponent
+import lucuma.react.common.ReactFnProps
+import lucuma.refined.*
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.ObservationDB.Types.*
+import lucuma.schemas.odb.input.*
+import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
+import lucuma.ui.reusability.given
+import monocle.Iso
+import org.scalajs.dom
+import queries.common.ProgramQueriesGQL
+
+final case class ProgramNoteEditor(
+  note:              UndoSetter[ProgramNote],
+  userIsReadonlyCoi: Boolean,
+  userIsStaff:       Boolean
+) extends ReactFnProps(ProgramNoteEditor)
+
+object ProgramNoteEditor
+    extends ReactFnComponent[ProgramNoteEditor](props =>
+      for {
+        ctx      <- useContext(AppContext.ctx)
+        inputRef <- useRefToVdom[dom.HTMLInputElement]
+        _        <- useEffectWithDeps((props.note.get.id, inputRef)): (_, ref) =>
+                      ref.get
+                        .flatMap(_.foldMap(i => Callback(i.select()).delayMs(50).toCallback))
+                        .when_(props.note.get.title === ProgramNote.NewProgramNoteTitle)
+      } yield
+        import ctx.given
+
+        val aligner: Aligner[ProgramNote, ProgramNotePropertiesInput] = Aligner(
+          props.note,
+          UpdateProgramNotesInput(
+            WHERE = props.note.get.id.toWhereProgramNote.assign,
+            SET = ProgramNotePropertiesInput()
+          ),
+          ProgramQueriesGQL.UpdateProgramNotesMutation[IO].execute(_).void
+        ).zoom(Iso.id[ProgramNote].asLens, UpdateProgramNotesInput.SET.modify)
+
+        val titleView =
+          aligner
+            .zoom(ProgramNote.title, ProgramNotePropertiesInput.title.modify)
+            .view(_.assign)
+
+        val isPrivateView = aligner
+          .zoom(ProgramNote.isPrivate, ProgramNotePropertiesInput.isPrivate.modify)
+          .view(_.assign)
+
+        val textView =
+          aligner.zoom(ProgramNote.text, ProgramNotePropertiesInput.text.modify).view(_.orUnassign)
+
+        <.div(
+          ExploreStyles.ProgramNoteEditor,
+          <.div(
+            ExploreStyles.ProgramNoteTitle,
+            <.div(
+              LucumaPrimeStyles.FormColumn,
+              FormInputTextView(
+                id = "title".refined,
+                label = "Title",
+                value = titleView,
+                validFormat = InputValidSplitEpi.nonEmptyString,
+                disabled = props.userIsReadonlyCoi
+              ).withMods(^.untypedRef := inputRef)
+            ),
+            CheckboxView(
+              id = "is-private".refined,
+              label = "Private",
+              value = isPrivateView
+            ).when(props.userIsStaff)
+          ),
+          MarkdownEditor(textView, props.userIsReadonlyCoi)
+        )
+    )

--- a/explore/src/main/scala/explore/programs/ProgramNotesTile.scala
+++ b/explore/src/main/scala/explore/programs/ProgramNotesTile.scala
@@ -3,14 +3,202 @@
 
 package explore.programs
 
+import cats.Order.*
+import cats.effect.IO
+import cats.syntax.all.*
+import clue.FetchClient
+import crystal.react.*
+import crystal.react.hooks.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.Icons
+import explore.common.ProgramQueries
+import explore.components.HelpIcon
+import explore.components.Tile
+import explore.components.ui.ExploreStyles
+import explore.components.undo.UndoButtons
+import explore.model.AppContext
+import explore.model.IsActive
+import explore.model.ProgramNote
+import explore.model.ProgramTabTileIds
+import explore.model.enums.TileSizeState
+import explore.model.reusability.given
+import explore.syntax.ui.*
+import explore.undo.*
+import explore.utils.*
 import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.model.Program
+import lucuma.react.common.ReactFnComponent
 import lucuma.react.common.ReactFnProps
-import lucuma.ui.components.UnderConstruction
-
-case class ProgramNotesTile() extends ReactFnProps(ProgramNotesTile.component)
+import lucuma.react.primereact.*
+import lucuma.refined.*
+import lucuma.schemas.ObservationDB
+import lucuma.ui.primereact.*
+import lucuma.ui.reusability.given
 
 object ProgramNotesTile:
-  private type Props = ProgramNotesTile
+  def apply(
+    programId:         Program.Id,
+    undoer:            Undoer,
+    notes:             UndoSetter[List[ProgramNote]],
+    userIsReadonlyCoi: Boolean,
+    userIsStaff:       Boolean
+  ): Tile[Option[ProgramNote.Id]] =
+    Tile(
+      ProgramTabTileIds.NotesId.id,
+      "Notes",
+      initialState = none,
+      bodyClass = ExploreStyles.ProgramNotesTileBody
+    )(Body(notes, userIsReadonlyCoi, userIsStaff, _),
+      Title(programId, undoer, notes, userIsReadonlyCoi, _, _)
+    )
 
-  private val component = ScalaFnComponent[Props]: _ =>
-    UnderConstruction()
+  private case class Body(
+    notes:             UndoSetter[List[ProgramNote]],
+    userIsReadonlyCoi: Boolean,
+    userIsStaff:       Boolean,
+    selectedId:        View[Option[ProgramNote.Id]]
+  ) extends ReactFnProps(Body)
+
+  private object Body
+      extends ReactFnComponent[Body](props =>
+        for {
+          ctx       <- useContext(AppContext.ctx)
+          noteViews <- useMemo(props.notes.get): _ =>
+                         props.notes.toListOfUndoSetters.sortBy(_.get.title)
+          _         <- useEffectWithDeps((props.notes.get.map(_.id), props.selectedId.reuseByValue)):
+                         (ids, optId) =>
+                           optId.get.fold(
+                             optId.set(noteViews.headOption.map(_.get.id))
+                           )(id =>
+                             if (ids.contains(id)) Callback.empty
+                             else optId.set(none)
+                           )
+        } yield props.selectedId.get
+          .map: id =>
+            // We use the selected note id to find the active tab because the list of notes
+            // is sorted by title, which may change
+            TabView(
+              clazz = ExploreStyles.FullHeightTabView,
+              activeIndex = noteViews.value.indexWhere(_.get.id == id),
+              onTabChange = idx => props.selectedId.set(noteViews.value(idx).get.id.some),
+              panels = noteViews.value.map: noteView =>
+                TabPanel(header =
+                  <.span(
+                    ExploreStyles.ProgramNoteHeader,
+                    Icons.LockKeyhole.when(noteView.get.isPrivate),
+                    noteView.get.title.value
+                  )
+                )(
+                  ProgramNoteEditor(
+                    noteView,
+                    props.userIsReadonlyCoi,
+                    props.userIsStaff
+                  )
+                )
+            ): VdomNode
+          .getOrElse(<.div("No notes have been created."))
+      )
+
+  private case class Title(
+    programId:         Program.Id,
+    undoer:            Undoer,
+    notes:             UndoSetter[List[ProgramNote]],
+    userIsReadonlyCoi: Boolean,
+    selectedId:        View[Option[ProgramNote.Id]],
+    tileSize:          TileSizeState
+  ) extends ReactFnProps(Title)
+
+  private object Title
+      extends ReactFnComponent[Title](props =>
+        for {
+          ctx  <- useContext(AppContext.ctx)
+          busy <- useStateView(IsActive(false))
+        } yield
+          import ctx.given
+
+          def createProgramNote(title: NonEmptyString): IO[Unit] =
+            createProgramNoteAction(props.programId, title)(props.notes)
+              .flatMap: (id, _) =>
+                props.selectedId.async.set(id.some)
+              .switching(busy.async, IsActive(_))
+              .withToastDuring("Creating note")
+
+          def deleteProgramNote(noteId: ProgramNote.Id) =
+            deleteNoteAction(noteId, props.selectedId.async.set)
+              .mod(props.notes)(_ => none)
+
+          val helpIcon = HelpIcon("program/program-notes.md".refined)
+
+          if (props.userIsReadonlyCoi || props.tileSize === TileSizeState.Minimized)
+            helpIcon
+          else
+            <.div(
+              ExploreStyles.ProgramNotesTileTitleButtons,
+              helpIcon,
+              <.div(
+                Button(
+                  severity = Button.Severity.Success,
+                  tooltip = "Add Note",
+                  icon = Icons.New,
+                  onClick = createProgramNote(ProgramNote.NewProgramNoteTitle).runAsync,
+                  disabled = busy.get.value
+                ).small.compact,
+                props.selectedId.get
+                  .flatMap(id => props.notes.get.find(_.id == id))
+                  .map: currentNote =>
+                    Button(
+                      text = true,
+                      clazz = ExploreStyles.DeleteButton,
+                      tooltip = s"Delete '${currentNote.title}'",
+                      icon = Icons.Trash,
+                      onClick = deleteProgramNote(currentNote.id),
+                      disabled = busy.get.value
+                    ).small.compact
+              ),
+              UndoButtons(props.undoer)
+            )
+      )
+
+  private def noteGetter(noteId: ProgramNote.Id): List[ProgramNote] => Option[ProgramNote] =
+    _.find(_.id == noteId)
+
+  private def noteSetter(noteId: ProgramNote.Id)(
+    optNote: Option[ProgramNote]
+  ): (List[ProgramNote]) => List[ProgramNote] =
+    notes => optNote.fold(notes.filterNot(_.id == noteId))(notes :+ _)
+
+  private def createProgramNoteAction(
+    programId: Program.Id,
+    title:     NonEmptyString
+  )(using
+    FetchClient[IO, ObservationDB]
+  ): AsyncAction[List[ProgramNote], ProgramNote.Id, Option[ProgramNote]] =
+    AsyncAction[List[ProgramNote], ProgramNote.Id, Option[ProgramNote]](
+      asyncGet = ProgramQueries
+        .createProgramNote[IO](programId, title)
+        .map(id => (id, ProgramNote.newProgramNote(id, title).some)),
+      getter = id => noteGetter(id),
+      setter = id => noteSetter(id),
+      onSet =
+        id => (_, oNote) => oNote.fold(ProgramQueries.deleteProgramNote[IO](id))(_ => IO.unit),
+      onRestore = id =>
+        (_, oNote) =>
+          oNote.fold(ProgramQueries.deleteProgramNote[IO](id))(_ =>
+            ProgramQueries.undeleteProgramNote[IO](id)
+          )
+    )
+
+  private def deleteNoteAction(noteId: ProgramNote.Id, setId: Option[ProgramNote.Id] => IO[Unit])(
+    using FetchClient[IO, ObservationDB]
+  ): Action[List[ProgramNote], Option[ProgramNote]] =
+    Action(
+      getter = noteGetter(noteId),
+      setter = noteSetter(noteId)
+    )(
+      onSet = (_, oNote) =>
+        oNote.fold(ProgramQueries.deleteProgramNote[IO](noteId))(_ =>
+          setId(noteId.some) >> ProgramQueries.undeleteProgramNote[IO](noteId)
+        )
+    )

--- a/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
@@ -115,7 +115,7 @@ object ConstraintsTabContents extends TwoPanels:
                   ObservationPasteIntoConstraintSetAction(
                     obsAndConstraints,
                     props.expandedIds.async.mod
-                  )(props.programSummaries)
+                  )(props.programSummaries).void
                     .withToastDuring(
                       s"Pasting obs ${copiedObsIdSet.idSet.toList.mkString(", ")} into active constraint set",
                       s"Pasted obs ${copiedObsIdSet.idSet.toList.mkString(", ")} into active constraint set".some

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -394,7 +394,7 @@ object ObsTabTiles:
               props.programSummaries.optProgramDetails
                 .exists(_.programType =!= ProgramType.Science)
             )
-              NotesTile.notesTile(props.obsId, notesView)
+              NotesTile.notesTile(notesView)
             else Tile(ObsTabTileIds.NotesId.id, "", hidden = true)(_ => EmptyVdom)
 
           val sequenceTile =

--- a/explore/src/main/scala/explore/tabs/SchedulingTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/SchedulingTabContents.scala
@@ -113,7 +113,7 @@ object SchedulingTabContents extends TwoPanels:
                   ObservationPasteIntoSchedulingGroupAction(
                     obsAndConstraints,
                     props.expandedIds.async.mod
-                  )(props.programSummaries)
+                  )(props.programSummaries).void
                     .withToastDuring(
                       s"Pasting obs ${copiedObsIdSet.idSet.toList.mkString(", ")} into active scheduling group",
                       s"Pasted obs ${copiedObsIdSet.idSet.toList.mkString(", ")} into active scheduling group".some

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -196,7 +196,7 @@ object TargetTabContents extends TwoPanels:
                 IO.whenA(obsAndTargets.nonEmpty): // Apply the obs to selected targets on the tree
                   ObservationPasteIntoAsterismAction(obsAndTargets, props.expandedIds.async.mod)(
                     props.programSummaries
-                  ).withToastDuring(
+                  ).void.withToastDuring(
                     s"Pasting obs ${copiedObsIdSet.idSet.toList.mkString(", ")} into ${selTargetIds.length} target(s)",
                     s"Pasted obs ${copiedObsIdSet.idSet.toList.mkString(", ")} into ${selTargetIds.length} target(s)".some
                   )

--- a/model/shared/src/main/scala/explore/model/ProgramDetails.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramDetails.scala
@@ -31,6 +31,7 @@ case class ProgramDetails(
   users:             List[ProgramUser],
   reference:         Option[ProgramReference],
   allocations:       CategoryAllocationList,
+  notes:             List[ProgramNote],
   proprietaryMonths: NonNegInt,
   shouldNotify:      Boolean,
   active:            DateInterval
@@ -48,6 +49,7 @@ object ProgramDetails:
       b => b.copy(pi = a.headOption, users = a.tail)
     )
   val reference: Lens[ProgramDetails, Option[ProgramReference]] = Focus[ProgramDetails](_.reference)
+  val notes: Lens[ProgramDetails, List[ProgramNote]]            = Focus[ProgramDetails](_.notes)
   val pi: Lens[ProgramDetails, Option[ProgramUser]]             = Focus[ProgramDetails](_.pi)
   val piPartner: Optional[ProgramDetails, Option[PartnerLink]]  =
     pi.some.andThen(ProgramUser.partnerLink)
@@ -55,18 +57,19 @@ object ProgramDetails:
 
   given Decoder[ProgramDetails] = Decoder.instance(c =>
     for {
-      n  <- c.downField("name").as[Option[NonEmptyString]]
-      d  <- c.downField("description").as[Option[NonEmptyString]]
-      t  <- c.get[ProgramType]("type")
-      p  <- c.get[Option[Proposal]]("proposal")
-      ps <- c.get[ProposalStatus]("proposalStatus")
-      pi <- c.downField("pi").as[Option[ProgramUser]]
-      us <- c.get[List[ProgramUser]]("users")
-      r  <-
+      n     <- c.downField("name").as[Option[NonEmptyString]]
+      d     <- c.downField("description").as[Option[NonEmptyString]]
+      t     <- c.get[ProgramType]("type")
+      p     <- c.get[Option[Proposal]]("proposal")
+      ps    <- c.get[ProposalStatus]("proposalStatus")
+      pi    <- c.downField("pi").as[Option[ProgramUser]]
+      us    <- c.get[List[ProgramUser]]("users")
+      r     <-
         c.downField("reference").downField("label").success.traverse(_.as[Option[ProgramReference]])
-      as <- c.downField("allocations").as[CategoryAllocationList]
-      pm <- c.downField("goa").downField("proprietaryMonths").as[NonNegInt]
-      sn <- c.downField("goa").downField("shouldNotify").as[Boolean]
-      ac <- c.downField("active").as[DateInterval]
-    } yield ProgramDetails(n, d, t, p, ps, pi, us, r.flatten, as, pm, sn, ac)
+      as    <- c.downField("allocations").as[CategoryAllocationList]
+      notes <- c.downField("notes").as[List[ProgramNote]]
+      pm    <- c.downField("goa").downField("proprietaryMonths").as[NonNegInt]
+      sn    <- c.downField("goa").downField("shouldNotify").as[Boolean]
+      ac    <- c.downField("active").as[DateInterval]
+    } yield ProgramDetails(n, d, t, p, ps, pi, us, r.flatten, as, notes, pm, sn, ac)
   )

--- a/model/shared/src/main/scala/explore/model/ProgramNote.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramNote.scala
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+import cats.derived.*
+import eu.timepit.refined.cats.*
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Decoder
+import io.circe.refined.given
+import lucuma.refined.*
+import monocle.Focus
+import monocle.Lens
+
+final case class ProgramNote(
+  id:        ProgramNote.Id,
+  title:     NonEmptyString,
+  text:      Option[NonEmptyString],
+  isPrivate: Boolean
+) derives Eq,
+      Decoder
+
+object ProgramNote:
+  type Id = lucuma.core.model.ProgramNote.Id
+  val Id = lucuma.core.model.ProgramNote.Id
+
+  val NewProgramNoteTitle: NonEmptyString = "<New Note>".refined
+
+  def newProgramNote(id: ProgramNote.Id, title: NonEmptyString): ProgramNote =
+    ProgramNote(id, title, None, false)
+
+  val id: Lens[ProgramNote, ProgramNote.Id]           = Focus[ProgramNote](_.id)
+  val title: Lens[ProgramNote, NonEmptyString]        = Focus[ProgramNote](_.title)
+  val text: Lens[ProgramNote, Option[NonEmptyString]] = Focus[ProgramNote](_.text)
+  val isPrivate: Lens[ProgramNote, Boolean]           = Focus[ProgramNote](_.isPrivate)

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -26,7 +26,7 @@ object Versions {
   val lucumaITC              = "0.31.0"
   val lucumaReact            = "0.80.0"
   val lucumaRefined          = "0.1.3"
-  val lucumaSchemas          = "0.123.0"
+  val lucumaSchemas          = "0.123.1"
   val lucumaOdbSchema        = "0.18.6"
   val lucumaSSO              = "0.8.5"
   val lucumaUI               = "0.133.2"


### PR DESCRIPTION
The notes support markdown and the markdown editor uses a tabbed view, similar to on github or shortcut. 
![image](https://github.com/user-attachments/assets/eecf5bc0-3d01-4abd-aa46-ee6aa17b6971)
The notes are sorted by title so that the user has a way to hack a specific order for notes if they desire.

The observer notes tile has also been updated to use the tabbed markdown editor.
[sc-2419]