### PR TITLE
Changes to Average Parallactic Angle calculation and obs duration

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -269,6 +269,8 @@ object ExploreStyles:
   val AsterismTable: Css  = Css("target-asterism-table")
   val BrightnessCell: Css = Css("target-brightness-cell")
 
+  val AsterismEditorTileTitle: Css = Css("asterism-editor-tile-title")
+
   val TargetAladinCell: Css          = Css("target-aladin-cell")
   val TargetAladin: Css              = Css("aladin-target")
   val AladinHelpIcon: Css            = Css("aladin-help-icon")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -808,68 +808,85 @@ thead tr th.sticky-header {
   }
 }
 
-.explore-obs-instant-tile-title {
-  justify-content: center;
-  font-size: smaller;
+.asterism-editor-tile-title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
 
-  @include small-tile-title;
-  @include react-datepicker-input;
-  @include react-datepicker-wrapper;
-
-  label:first-child {
-    @include lucumaUICommon.text-ellipsis;
-
-    max-width: 5ch;
+  > * {
+    flex: 0 0 min-content;
   }
 
-  label:nth-last-child(2) {
-    display: none;
-  }
-
-  label[data-abbrv]::after {
-    content: attr(data-abbrv);
-  }
-
-  label[data-abbrv] {
-    display: none;
-  }
-
-  /* stylelint-disable selector-class-pattern */
-  .react-datepicker__input-container {
-    input {
-      font-size: small;
-      width: 16ch; // the date/time format is 15 ch
-    }
-  }
-
-  .target-tile-obs-duration {
-    display: none;
-    justify-content: baseline;
-  }
-}
-
-@container tile (min-width: #{exploreCommon.$tile-small-cutoff}) {
   .explore-obs-instant-tile-title {
+    flex: 1 1 max-content;
+
+    justify-content: center;
+    font-size: smaller;
+
+    @include small-tile-title;
+    @include react-datepicker-input;
+    @include react-datepicker-wrapper;
+
     label:first-child {
-      max-width: unset;
-      display: unset;
-    }
+      @include lucumaUICommon.text-ellipsis;
 
-    label[data-abbrv]::after {
-      content: '';
-    }
-
-    label[data-abbrv] > span {
-      display: unset;
+      max-width: 5ch;
     }
 
     label:nth-last-child(2) {
-      display: inline;
+      display: none;
+    }
+
+    label[data-abbrv]::after {
+      content: attr(data-abbrv);
+    }
+
+    label[data-abbrv] {
+      display: none;
+    }
+
+    /* stylelint-disable selector-class-pattern */
+    .react-datepicker__input-container {
+      input {
+        font-size: small;
+        width: 16ch; // the date/time format is 15 ch
+      }
     }
 
     .target-tile-obs-duration {
-      display: flex;
-      align-items: baseline;
+      display: none;
+      justify-content: baseline;
+
+      > svg.fa-spinner {
+        margin-left: 0.5em;
+      }
+    }
+  }
+
+  @container tile (min-width: #{exploreCommon.$tile-small-cutoff}) {
+    .explore-obs-instant-tile-title {
+      label:first-child {
+        max-width: unset;
+        display: unset;
+      }
+
+      label[data-abbrv]::after {
+        content: '';
+      }
+
+      label[data-abbrv] > span {
+        display: unset;
+      }
+
+      label:nth-last-child(2) {
+        display: inline;
+      }
+
+      .target-tile-obs-duration {
+        display: flex;
+        align-items: baseline;
+      }
     }
   }
 }

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -820,7 +820,6 @@ thead tr th.sticky-header {
 
   .explore-obs-instant-tile-title {
     flex: 1 1 max-content;
-
     justify-content: center;
     font-size: smaller;
 

--- a/explore/src/main/scala/explore/config/ObsTimeEditor.scala
+++ b/explore/src/main/scala/explore/config/ObsTimeEditor.scala
@@ -5,14 +5,18 @@ package explore.config
 
 import cats.data.NonEmptyList
 import cats.syntax.all.*
+import crystal.Pot
 import crystal.react.View
 import explore.Icons
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
+import explore.model.Execution
+import explore.syntax.ui.*
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.util.TimeSpan
+import lucuma.react.common.ReactFnComponent
 import lucuma.react.common.ReactFnProps
 import lucuma.react.datepicker.*
 import lucuma.react.primereact.Button
@@ -27,23 +31,30 @@ import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 import scalajs.js
+import scalajs.js.JSConverters.*
 
 case class ObsTimeEditor(
-  obsTimeView:     View[Option[Instant]],
-  obsDurationView: View[Option[TimeSpan]],
-  pendingTime:     Option[TimeSpan],
-  forMultipleObs:  Boolean
-) extends ReactFnProps(ObsTimeEditor.component)
+  obsTimeView:            View[Option[Instant]],
+  obsDurationView:        View[Option[TimeSpan]],
+  obsTimeAndDurationView: View[(Option[Instant], Option[TimeSpan])],
+  execution:              Pot[Option[Execution]],
+  forMultipleObs:         Boolean
+) extends ReactFnProps(ObsTimeEditor):
+  val optExecution: Option[Execution] = execution.toOption.flatten
+  val pendingTime: Option[TimeSpan]   = optExecution.flatMap(_.remainingObsTime)
+  val setupTime: Option[TimeSpan]     = optExecution.flatMap(_.fullSetupTime)
+  val timesAreLoading: Boolean        = execution.isPending
+  val isReadonly: Boolean             = forMultipleObs || timesAreLoading
 
-object ObsTimeEditor {
-  private type Props = ObsTimeEditor
+object ObsTimeEditor
+    extends ReactFnComponent[ObsTimeEditor](props =>
+      for {
+        ref             <- useRef[Option[ReactDatePicker[Any, Any]]](none)
+        defaultDuration <- useMemo(props.pendingTime)(_.getOrElse(TimeSpan.fromHours(1).get))
+      } yield
+        val nowTooltip =
+          s"Set time to the current time${props.pendingTime.fold("")(_ => " and duration to remaining time")}"
 
-  private val component =
-    ScalaFnComponent
-      .withHooks[Props]
-      .useRef[Option[ReactDatePicker[Any, Any]]](none)
-      .useMemoBy((props, _) => props.pendingTime)((_, _) => _.getOrElse(TimeSpan.fromHours(1).get))
-      .render: (props, ref, defaultDuration) =>
         <.div(ExploreStyles.ObsInstantTileTitle)(
           React.Fragment(
             <.label(
@@ -56,54 +67,76 @@ object ObsTimeEditor {
                 newValue.fromDatePickerToInstantOpt.foldMap: i =>
                   props.obsTimeView.set(i.some)
             )
-              .readOnly(props.forMultipleObs)
+              .readOnly(props.isReadonly)
               .calendarClassName(ExploreStyles.DatePickerWithNowButton.htmlClass)
               .showTimeInput(true)
               .selected(props.obsTimeView.get.getOrElse(Instant.now).toDatePickerJsDate)
               .dateFormat("yyyy-MM-dd HH:mm")(
-                Button(onClick =
-                  props.obsTimeView.set(Instant.now.some) >>
-                    ref.value.map(r => Callback(r.setOpen(false))).orEmpty
+                Button(
+                  onClick = props.pendingTime.fold(props.obsTimeView.set(Instant.now.some))(pt =>
+                    props.obsTimeAndDurationView.set(Instant.now.some, pt.some)
+                  ) >>
+                    ref.value.map(r => Callback(r.setOpen(false))).orEmpty,
+                  tooltip = nowTooltip
                 )("Now")
               )
               .withRef(r => ref.set(r.some).runNow()),
             <.label(ExploreStyles.TargetTileObsUTC, "UTC"),
-            <.span(
-              ExploreStyles.TargetTileObsDuration,
-              if (props.forMultipleObs) TagMod.empty
-              else
-                props.obsDurationView
-                  .mapValue((v: View[TimeSpan]) =>
-                    <.span(
-                      ExploreStyles.TargetTileObsDuration,
-                      FormTimeSpanInput(id = "obsDuration".refined,
-                                        value = v,
-                                        units = NonEmptyList.of(TimeUnit.HOURS, TimeUnit.MINUTES)
-                      ),
-                      Button(
-                        text = true,
-                        clazz = ExploreStyles.DeleteButton,
-                        icon = Icons.Eraser,
-                        tooltip = "Clear explicit duration and use full remaining sequence",
-                        onClick = props.obsDurationView.set(none)
-                      ).tiny.compact
-                    )
+            if (props.forMultipleObs) EmptyVdom
+            else
+              props.obsDurationView
+                .mapValue((v: View[TimeSpan]) =>
+                  val tooltipList               = List(
+                    props.setupTime
+                      .map(st => s"Must be > the setup time of ${st.format}."),
+                    props.pendingTime
+                      .map(pt => s"The current remaining time is ${pt.format}.")
+                  ).flattenOption
+                  val tooltip: Option[VdomNode] =
+                    if (tooltipList.isEmpty) none
+                    else
+                      (tooltipList.mkString(
+                        "",
+                        "\n",
+                        "\nValues entered will be coerced to this range."
+                      ): VdomNode).some
+
+                  <.span(
+                    ExploreStyles.TargetTileObsDuration,
+                    FormTimeSpanInput(
+                      id = "obsDuration".refined,
+                      value = v,
+                      units = NonEmptyList.of(TimeUnit.HOURS, TimeUnit.MINUTES),
+                      min = props.setupTime.map(_ +| TimeSpan.fromSeconds(1).get).orUndefined,
+                      max = props.pendingTime.orUndefined,
+                      tooltip = tooltip.orUndefined,
+                      disabled = props.timesAreLoading
+                    ),
+                    Button(
+                      text = true,
+                      icon = Icons.ClockRotateLeft,
+                      tooltip = "Set duration to full remaining sequence",
+                      onClick = props.obsDurationView.set(props.pendingTime)
+                    ).tiny.compact.when(
+                      props.pendingTime.isDefined && props.obsDurationView.get =!= props.pendingTime
+                    ),
+                    props.execution.orSpinner(_ => EmptyVdom)
                   )
-                  .getOrElse(
-                    React.Fragment(
-                      Button(
-                        icon = Icons.ClockRotateLeft,
-                        onClick = props.obsDurationView.set(defaultDuration.value.some),
-                        tooltip =
-                          "Set an explicit duration instead of using the remaining sequence",
-                        clazz = ExploreStyles.TargetTileObsDuration
-                      ).tiny.compact,
-                      props.pendingTime.map(pt =>
+                )
+                .getOrElse(
+                  React.Fragment(
+                    Button(
+                      icon = Icons.ClockRotateLeft,
+                      onClick = props.obsDurationView.set(defaultDuration.value.some),
+                      tooltip = "Set an explicit duration instead of using the remaining sequence",
+                      clazz = ExploreStyles.TargetTileObsDuration
+                    ).tiny.compact,
+                    props.pendingTime
+                      .map(pt =>
                         <.div(ExploreStyles.TargetObsDefaultDuration, timeDisplay("", pt, ""))
                       )
-                    )
                   )
-            )
+                )
           )
         )
-}
+    )

--- a/explore/src/main/scala/explore/config/PAConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/PAConfigurationPanel.scala
@@ -90,7 +90,11 @@ object PAConfigurationPanel:
                 <.label(a.when.toString),
                 <.label(TimeSpanView(a.duration))
               )
-            .orElse(<.label("Not Visible or observation complete").some)
+            .orElse(
+              <.label(
+                "Not Visible, observation complete, or explicit observation duration is less than setup time."
+              ).some
+            )
         case PosAngleConstraint.AllowFlip(af) if props.selectedPA.exists(_ =!= af) =>
           props.selectedPA
             .map(a => <.label(f"Flipped to ${a.toDoubleDegrees}%.0f °"))

--- a/explore/src/main/scala/explore/config/TimeAndCountEditor.scala
+++ b/explore/src/main/scala/explore/config/TimeAndCountEditor.scala
@@ -10,7 +10,6 @@ import eu.timepit.refined.types.string.NonEmptyString
 import explore.components.ui.ExploreStyles
 import explore.itc.renderRequiredForITCIcon
 import explore.model.Constants
-import explore.model.ExploreModelValidators
 import explore.model.ScienceRequirements
 import explore.model.ScienceRequirements.TimeAndCountModeInfo
 import explore.model.enums.WavelengthUnits
@@ -80,7 +79,7 @@ object TimeAndCountEditor extends ConfigurationFormats:
           id = "count".refined,
           value = count,
           groupClass = ExploreStyles.WarningInput.when_(count.get.isEmpty),
-          validFormat = ExploreModelValidators.nonNegInt.optional,
+          validFormat = InputValidSplitEpi.nonNegInt.optional,
           postAddons =
             count.get.fold(List(props.calibrationRole.renderRequiredForITCIcon))(_ => Nil),
           changeAuditor = ChangeAuditor.int.optional,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -532,7 +532,7 @@ object TargetTabContents extends TwoPanels:
                   none,
                   none
                 ),
-                none,
+                Pot(none), // Execution
                 props.focused.target,
                 setCurrentTarget(idsToEdit.some),
                 onCloneTarget4Asterism,

--- a/model-tests/shared/src/test/scala/explore/model/ExploreModelValidatorsSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/ExploreModelValidatorsSuite.scala
@@ -15,7 +15,6 @@ import lucuma.core.math.arb.ArbOffset.given
 import lucuma.core.math.arb.ArbParallax.given
 import lucuma.core.math.arb.ArbProperMotion.given
 import lucuma.core.math.arb.ArbWavelengthDither.given
-import lucuma.core.optics.laws.discipline.ValidSplitEpiTests
 import lucuma.core.optics.laws.discipline.ValidWedgeTests
 import munit.DisciplineSuite
 import org.scalacheck.Arbitrary
@@ -42,11 +41,6 @@ class ExploreModelValidatorsSuite extends DisciplineSuite:
   checkAll(
     "hoursValidWedge",
     ValidWedgeTests(ExploreModelValidators.hoursValidWedge).validWedgeLaws
-  )
-
-  checkAll(
-    "nonNegInt",
-    ValidSplitEpiTests(ExploreModelValidators.nonNegInt).validSplitEpiLaws
   )
 
   private val perturbations: List[String => Gen[String]] =

--- a/model/shared/src/main/scala/explore/model/Execution.scala
+++ b/model/shared/src/main/scala/explore/model/Execution.scala
@@ -14,7 +14,9 @@ import lucuma.odb.json.sequence.given
 
 case class Execution(digest: Option[ExecutionDigest], programTimeCharge: ProgramTime) derives Eq:
   lazy val programTimeEstimate: Option[TimeSpan] = digest.map(_.fullTimeEstimate.programTime)
-  lazy val fullTimeEstimate: Option[TimeSpan]    = digest.map(_.fullTimeEstimate.sum)
+  lazy val fullSetupTime: Option[TimeSpan]       = digest.map(_.setup.full)
+  lazy val remainingObsTime: Option[TimeSpan]    =
+    digest.map(d => d.science.timeEstimate.sum +| d.setup.full)
 
 object Execution {
   given Decoder[Execution] = Decoder.instance(c =>

--- a/model/shared/src/main/scala/explore/model/ExploreModelValidators.scala
+++ b/model/shared/src/main/scala/explore/model/ExploreModelValidators.scala
@@ -8,9 +8,6 @@ import cats.data.NonEmptyList
 import cats.syntax.all.*
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.collection.NonEmpty
-import eu.timepit.refined.numeric.NonNegative
-import eu.timepit.refined.types.numeric.NonNegBigDecimal
-import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.HourRange
 import explore.model.display.given
@@ -54,15 +51,8 @@ object ExploreModelValidators:
       n => Try(n.shortName).toOption.orEmpty
     )
 
-  // TODO Move to lucuma core
-  val nonNegBigDecimal: InputValidSplitEpi[NonNegBigDecimal] =
-    InputValidSplitEpi.refinedBigDecimal[NonNegative]
-
-  val nonNegInt: InputValidSplitEpi[NonNegInt] =
-    InputValidSplitEpi.refinedInt[NonNegative]
-
   val signalToNoiseValidSplitEpi: InputValidSplitEpi[SignalToNoise] =
-    nonNegBigDecimal.andThen(
+    InputValidSplitEpi.nonNegBigDecimal.andThen(
       SignalToNoise.FromNonNegBigDecimalExact,
       _ => NonEmptyChain("Invalid signal to noise".refined[NonEmpty])
     )


### PR DESCRIPTION
For sc-5061 (https://app.shortcut.com/lucuma/story/5061/average-parallactic-angle-calculation-should-only-include-science-portion) this changes the average parallactic angle calculation to ignore the setup time and calculate with science time (obs time + setup time) and science duration (obs duration - setup time).

For [sc-5193] (https://app.shortcut.com/lucuma/story/5193/do-not-automatically-recalculate-average-parallactic-angles) a number of changes were made so that Explore will not recalculate the average parallactic angle and the available guide stars while an observation is being executed.

On the API side, obs duration is now required and must be greater than the setup time and no greater than the estimated remaining time.

In explore:
1.  the `Now` button for setting the observation time now also sets the observation duration to the remaining estimated time.
2. Once an duration has been set, the button for unsetting the duration has been changed to one that will set it to the remaining time. If it is already set to the remaining time, the button is hidden.
3. The duration editor coerces the value to be in the interval between setup time + 1 second and the remaining time.

There were also some CSS changes to give the time/duration editor more space in the title bar. Prior to this, the add button, the obs time editor, and the column selector split the title bar evenly and the obs time editor could wrap on occassion.