### PR TITLE
Don't allow decimal for exposure time on gmos

### DIFF
--- a/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigurationPanel.scala
@@ -84,6 +84,7 @@ sealed trait AdvancedConfigurationPanel[T <: ObservingMode, Input]:
   def sequenceChanged: Callback
   def readonly: Boolean
   def units: WavelengthUnits
+  def instrument = observingMode.get.instrument
 
 sealed abstract class AdvancedConfigurationPanelBuilder[
   T <: ObservingMode,
@@ -540,7 +541,8 @@ sealed abstract class AdvancedConfigurationPanelBuilder[
               disabled = disableSimpleEdit
             ),
             dithersControl(props.sequenceChanged),
-            ExposureTimeModeEditor(exposureTimeMode,
+            ExposureTimeModeEditor(props.instrument,
+                                   exposureTimeMode,
                                    props.readonly,
                                    props.units,
                                    props.calibrationRole

--- a/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
@@ -100,7 +100,8 @@ private object BasicConfigurationPanel:
             // ),
             props.spectroscopyView
               .mapValue(
-                SpectroscopyConfigurationPanel(_,
+                SpectroscopyConfigurationPanel(props.selectedConfig.get.map(_.instrument),
+                                               _,
                                                props.readonly,
                                                props.units,
                                                props.calibrationRole

--- a/explore/src/main/scala/explore/config/ExposureTimeModeEditor.scala
+++ b/explore/src/main/scala/explore/config/ExposureTimeModeEditor.scala
@@ -14,6 +14,7 @@ import japgolly.scalajs.react.*
 import japgolly.scalajs.react.feature.ReactFragment
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.CalibrationRole
+import lucuma.core.enums.Instrument
 import lucuma.react.common.Css
 import lucuma.react.common.ReactFnProps
 import lucuma.refined.*
@@ -23,6 +24,7 @@ import lucuma.ui.syntax.all.given
 import monocle.Lens
 
 case class ExposureTimeModeEditor(
+  instrument:      Instrument,
   options:         View[ExposureTimeModeInfo],
   readonly:        Boolean,
   units:           WavelengthUnits,
@@ -62,5 +64,12 @@ object ExposureTimeModeEditor:
         snMode.asView.map(
           SignalToNoiseAtEditor(_, props.readonly, props.units, props.calibrationRole)
         ),
-        tcMode.asView.map(TimeAndCountEditor(_, props.readonly, props.units, props.calibrationRole))
+        tcMode.asView.map(
+          TimeAndCountEditor(props.instrument,
+                             _,
+                             props.readonly,
+                             props.units,
+                             props.calibrationRole
+          )
+        )
       )

--- a/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyConfigurationPanel.scala
@@ -19,6 +19,7 @@ import japgolly.scalajs.react.feature.ReactFragment
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.CalibrationRole
 import lucuma.core.enums.FocalPlane
+import lucuma.core.enums.Instrument
 import lucuma.core.math.Wavelength
 import lucuma.core.validation.*
 import lucuma.react.common.Css
@@ -30,6 +31,7 @@ import lucuma.ui.primereact.given
 import lucuma.ui.syntax.all.given
 
 case class SpectroscopyConfigurationPanel(
+  instrument:      Option[Instrument],
   options:         View[ScienceRequirements.Spectroscopy],
   readonly:        Boolean,
   units:           WavelengthUnits,
@@ -88,7 +90,9 @@ object SpectroscopyConfigurationPanel extends ConfigurationFormats:
             changeAuditor = ChangeAuditor.posInt.optional,
             disabled = p.readonly
           ).clearable(^.autoComplete.off),
-          ExposureTimeModeEditor(exposureTimeMode, p.readonly, p.units, p.calibrationRole),
+          p.instrument.map(
+            ExposureTimeModeEditor(_, exposureTimeMode, p.readonly, p.units, p.calibrationRole)
+          ),
           FormInputTextView(
             id = "wavelength-range".refined,
             value = wavelengthDelta,

--- a/model-tests/shared/src/test/scala/explore/model/FormatsSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/FormatsSuite.scala
@@ -40,6 +40,29 @@ class FormatsSuite extends munit.DisciplineSuite:
       }
       .flatMapOneOf(Gen.const, (((_: String) => finiteDurationsHM) :: perturbations)*)
 
+  // Tests durationS
+  assertEquals(parsers.durationS.parseAll("00.001").toOption,
+               TimeSpan.unsafeFromDuration(Duration.ofSeconds(0)).some
+  )
+  assertEquals(parsers.durationS.parseAll("45").toOption,
+               TimeSpan.unsafeFromDuration(Duration.ofSeconds(45)).some
+  )
+  assertEquals(parsers.durationS.parseAll("45.0").toOption,
+               TimeSpan.unsafeFromDuration(Duration.ofSeconds(45)).some
+  )
+  assertEquals(parsers.durationS.parseAll("45.034").toOption,
+               TimeSpan.unsafeFromDuration(Duration.ofSeconds(45)).some
+  )
+  assertEquals(parsers.durationS.parseAll("0.005046").toOption,
+               TimeSpan.unsafeFromDuration(Duration.ofSeconds(0)).some
+  )
+  assertEquals(parsers.durationS.parseAll("35").toOption,
+               TimeSpan.unsafeFromDuration(Duration.ofSeconds(35)).some
+  )
+  assertEquals(parsers.durationS.parseAll("0").toOption,
+               TimeSpan.unsafeFromDuration(Duration.ofSeconds(0)).some
+  )
+  // Test durationMs
   assertEquals(parsers.durationMs.parseAll("00.001").toOption,
                TimeSpan.unsafeFromDuration(Duration.ofMillis(1)).some
   )
@@ -125,4 +148,8 @@ class FormatsSuite extends munit.DisciplineSuite:
   checkAll(
     "durationMsWedge",
     ValidWedgeTests(durationMs).validWedgeLaws
+  )
+  checkAll(
+    "durationSWedge",
+    ValidWedgeTests(durationS).validWedgeLaws
   )

--- a/model/shared/src/main/scala/explore/model/InstrumentConfigAndItcResult.scala
+++ b/model/shared/src/main/scala/explore/model/InstrumentConfigAndItcResult.scala
@@ -10,6 +10,7 @@ import cats.syntax.all.*
 import explore.model.itc.ItcResult
 import explore.model.itc.ItcTargetProblem
 import explore.modes.InstrumentConfig
+import lucuma.core.enums.Instrument
 import lucuma.schemas.model.BasicConfiguration
 import monocle.Focus
 import monocle.Lens
@@ -18,6 +19,8 @@ case class InstrumentConfigAndItcResult(
   instrumentConfig: InstrumentConfig,
   itcResult:        Option[EitherNec[ItcTargetProblem, ItcResult]]
 ) derives Eq:
+  def instrument: Instrument = instrumentConfig.instrument
+
   def toBasicConfiguration: Option[BasicConfiguration] =
     instrumentConfig match
       case InstrumentConfig.GmosNorthSpectroscopy(grating, fpu, filter, Some(cw, _, _)) =>

--- a/model/shared/src/main/scala/explore/model/formats.scala
+++ b/model/shared/src/main/scala/explore/model/formats.scala
@@ -147,4 +147,16 @@ trait formats:
       ts => f"${ts.toSeconds}%.2f"
     )
 
+  val durationS: InputValidWedge[TimeSpan] =
+    InputValidWedge(
+      s =>
+        parsers.durationS
+          .parseAll(s)
+          .leftMap { e =>
+            "Duration parsing errors".refined[NonEmpty]
+          }
+          .toEitherErrors,
+      _.toSecondsPart.toString
+    )
+
 object formats extends formats

--- a/model/shared/src/main/scala/explore/model/parsers.scala
+++ b/model/shared/src/main/scala/explore/model/parsers.scala
@@ -70,6 +70,15 @@ trait parsers:
       }
       .withContext("duration_s")
 
+  // Duration in the form of secs
+  val durationS: Parser0[TimeSpan] =
+    (digits.? ~ (char('.') ~ digits.?).?)
+      .map { case (s, _) =>
+        val seconds = s.foldMap(_.toLong)
+        TimeSpan.unsafeFromDuration(Duration.ofSeconds(seconds))
+      }
+      .withContext("duration_s")
+
   // Parse a non-negative integer
   val nonNegInt: Parser[NonNegInt] =
     digits


### PR DESCRIPTION
I can foresee different instruments will have different rules, thus the format is instrument-dependent.