### PR TITLE
Fix position angle of slit overlay in AladinCell

### DIFF
--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -365,14 +365,12 @@ object ObsTabTiles:
 
                     props.posAngleConstraint match
                       case PosAngleConstraint.AverageParallactic =>
-                        val avpa = averageParallacticAngle(
+                        averageParallacticAngle(
                           site.place,
                           asterism.baseTracking,
                           scienceStartTime,
                           scienceDuration
-                        )
-                        flipIfNeeded(avpa)
-                          .map(AveragePABasis(scienceStartTime, scienceDuration, _))
+                        ).map(AveragePABasis(scienceStartTime, scienceDuration, _))
                       case _                                     => none
               .flatten
 
@@ -384,7 +382,7 @@ object ObsTabTiles:
           val pa: Option[Angle] =
             props.posAngleConstraint match
               case PosAngleConstraint.Unbounded                  => paProps.selectedPA
-              case PosAngleConstraint.AverageParallactic         => averagePA.map(_.averagePA)
+              case PosAngleConstraint.AverageParallactic         => flipIfNeeded(averagePA.map(_.averagePA))
               case PosAngleConstraint.Fixed(angle)               => angle.some
               case PosAngleConstraint.AllowFlip(angle)           => flipIfNeeded(angle.some)
               case PosAngleConstraint.ParallacticOverride(angle) => angle.some

--- a/explore/src/main/scala/explore/targeteditor/AladinCell.scala
+++ b/explore/src/main/scala/explore/targeteditor/AladinCell.scala
@@ -73,14 +73,12 @@ case class AladinCell(
 
   val anglesToTest: Option[NonEmptyList[Angle]] =
     for
-      conf          <- obsConf
-      configuration <- conf.configuration
-      obsDuration   <- conf.obsDuration
-      paConstraint  <- conf.posAngleConstraint
-      angles        <-
+      conf         <- obsConf
+      paConstraint <- conf.posAngleConstraint
+      angles       <-
         // For visual mode we want to default to PA 0 if needed e.g. average parallactic not available
         paConstraint
-          .anglesToTestAt(configuration.siteFor, asterism.baseTracking, obsTime, obsDuration)
+          .anglesToTestAt(obsConf.flatMap(_.averagePA).map(_.averagePA))
           .orElse(NonEmptyList.one(Angle.Angle0).some)
     // We sort the angles or we could end up in a loop where the angles are tested back and forth
     // This is rare but can happen if each angle finds an equivalent guide star

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -21,7 +21,7 @@ object Versions {
   val log4Cats               = "2.7.0"
   val log4CatsLogLevel       = "0.3.1"
   val lucumaBC               = "0.4.0"
-  val lucumaCore             = "0.121.1"
+  val lucumaCore             = "0.121.2"
   val lucumaITC              = "0.33.0"
   val lucumaReact            = "0.82.0"
   val lucumaRefined          = "0.1.4"


### PR DESCRIPTION
AladinCell was still using the observation time and duration to calculate the average parallactic angle instead of science start time and science duration. This changes it to use the already calculated APA instead of calculating it itself.

It also always shows the calculated API in the configuration tile instead of the flipped value if the selected GS is flipped. The flipped angle is now (I think) only used by the finder charts tile. For `Allow Flip` constraints, if the GS is flipped, we show `Flipped to ...` next to the position angle constraint. Should we do that for "flipped" APA GS's, too? @andrewwstephens @cquiroz 