### PR TITLE
Perishable type - mark obs and group times as stale instead of pending

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -110,15 +110,16 @@ object ExploreStyles:
 
   val ScienceBandPopupMenu = Css("science-band-popup-menu")
 
-  val GroupEditTile: Css      = Css("group-edit-tile")
-  val GroupEditTitle: Css     = Css("group-edit-title")
-  val GroupTypeSelect: Css    = Css("group-type-select")
-  val GroupChangeButtons: Css = Css("group-change-buttons")
-  val GroupEditNote: Css      = Css("group-edit-note")
-  val GroupForm: Css          = Css("group-form")
-  val GroupDelaysForm: Css    = Css("group-delays-form")
-  val GroupPlannedTime: Css   = Css("group-planned-time")
-  val GroupWarnings: Css      = Css("group-warnings")
+  val GroupEditTile: Css       = Css("group-edit-tile")
+  val GroupEditTitle: Css      = Css("group-edit-title")
+  val GroupEditTitleTimes: Css = Css("group-edit-title-times")
+  val GroupTypeSelect: Css     = Css("group-type-select")
+  val GroupChangeButtons: Css  = Css("group-change-buttons")
+  val GroupEditNote: Css       = Css("group-edit-note")
+  val GroupForm: Css           = Css("group-form")
+  val GroupDelaysForm: Css     = Css("group-delays-form")
+  val GroupPlannedTime: Css    = Css("group-planned-time")
+  val GroupWarnings: Css       = Css("group-warnings")
 
   val ApiKeysPopup          = Css("api-keys-popup")
   val ApiKeysTable          = Css("api-keys-table")
@@ -529,3 +530,4 @@ object ExploreStyles:
   val FocusedInfo: Css = Css("explore-focused-info")
 
   val Hidden: Css = Css("explore-hidden")
+  val Stale: Css  = Css("stale")

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -76,6 +76,7 @@ object reusability:
   given Reusability[BandedProgramTime]       = Reusability.byEq
   given Reusability[Group]                   = Reusability.byEq
   given Reusability[GroupWarning]            = Reusability.byEq
+  given [V: Eq]: Reusability[Perishable[V]]  = Reusability.byEq
 
   /**
    */

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -23,6 +23,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.ExecutionEnvironment
 import lucuma.core.util.NewBoolean
 import lucuma.core.util.TimeSpan
+import lucuma.react.common.style.Css
 import lucuma.ui.components.TimeSpanView
 import lucuma.ui.syntax.all.given
 import lucuma.ui.utils.versionDateFormatter
@@ -141,5 +142,13 @@ def keyedSwitchEvalMap[F[_]: Concurrent, I, O, K](
           .onFinalize(out.close.void)
 }
 
-def timeDisplay(name: String, time: TimeSpan, sep: String = ": ") =
-  <.span(<.span(ExploreStyles.SequenceTileTitleItem)(name, sep), TimeSpanView(time))
+def timeDisplay(
+  name:        String,
+  time:        TimeSpan,
+  sep:         String = ": ",
+  timeClass:   Css = Css.Empty,
+  timeTooltip: Option[VdomNode] = None
+) =
+  <.span(<.span(ExploreStyles.SequenceTileTitleItem)(name, sep),
+         TimeSpanView(time, tooltip = timeTooltip).withMods(timeClass)
+  )

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -1324,6 +1324,10 @@ $search-preview-margin: 5px;
   .explore-sequence-tile-title-item {
     font-weight: bold;
   }
+
+  .stale {
+    opacity: 0.5;
+  }
 }
 
 @container tile (min-width: #{exploreCommon.$tile-xtra-small-cutoff}) {
@@ -1532,6 +1536,10 @@ svg.fa-check.explore-success-icon {
     .obs-state-select-wrapper {
       flex-grow: 2;
     }
+
+    .stale {
+      opacity: 0.5;
+    }
   }
 
   .obs-badge-subtitle {
@@ -1598,6 +1606,10 @@ svg.fa-check.explore-success-icon {
   .explore-tile-control-buttons {
     margin-left: auto;
   }
+}
+
+.group-edit-title-times.stale {
+  opacity: 0.5;
 }
 
 .group-edit-tile {
@@ -1679,6 +1691,10 @@ svg.fa-check.explore-success-icon {
     grid-template-columns: repeat(2, auto);
     align-items: center;
     margin-right: auto;
+
+    .stale {
+      opacity: 0.5;
+    }
   }
 
   .group-warnings {
@@ -3358,6 +3374,10 @@ a.explore-upgrade-link {
   td .observations-summary-index-col {
     width: 100px;
     text-align: right;
+  }
+
+  .stale {
+    opacity: 0.5;
   }
 }
 

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryRow.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryRow.scala
@@ -4,11 +4,11 @@
 package explore.observationtree
 
 import cats.syntax.all.*
-import crystal.Pot
 import explore.model.Asterism
 import explore.model.Execution
 import explore.model.Group
 import explore.model.Observation
+import explore.model.PerishablePot
 import lucuma.core.math.Coordinates
 import lucuma.core.model.Target
 import lucuma.schemas.model.TargetWithId
@@ -31,7 +31,7 @@ enum ObsSummaryRow:
     targetWithId: Option[TargetWithId],
     asterism:     Option[Asterism],
     group:        Option[Group],
-    execution:    Pot[Execution]
+    execution:    PerishablePot[Execution]
   ) extends ObsSummaryRow
 
   def fold[A](f: ExpandedTargetRow => A, g: ObsRow => A): A =

--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTile.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTile.scala
@@ -4,7 +4,6 @@
 package explore.observationtree
 
 import cats.syntax.all.*
-import crystal.Pot
 import crystal.react.*
 import crystal.react.hooks.*
 import crystal.react.syntax.pot.given

--- a/explore/src/main/scala/explore/observationtree/ObsTree.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsTree.scala
@@ -23,6 +23,7 @@ import explore.model.ObsIdSet
 import explore.model.Observation
 import explore.model.ObservationExecutionMap
 import explore.model.ObservationList
+import explore.model.PerishablePot.*
 import explore.model.enums.AppTab
 import explore.model.enums.GroupWarning
 import explore.syntax.ui.*
@@ -315,7 +316,7 @@ object ObsTree:
               )(
                 ObsBadge(
                   obs,
-                  props.obsExecutionTimes.getPot(obs.id).map(_.programTimeEstimate),
+                  props.obsExecutionTimes.getPot(obs.id).mapPerishable(_.programTimeEstimate),
                   ObsBadge.Layout.ObservationsTab,
                   selected = selected,
                   setStateCB = ObsActions

--- a/explore/src/main/scala/explore/observationtree/ViewCommon.scala
+++ b/explore/src/main/scala/explore/observationtree/ViewCommon.scala
@@ -12,6 +12,7 @@ import explore.model.ObsIdSet
 import explore.model.Observation
 import explore.model.ObservationExecutionMap
 import explore.model.ObservationList
+import explore.model.PerishablePot.*
 import explore.undo.UndoSetter
 import explore.utils.*
 import japgolly.scalajs.react.*
@@ -42,7 +43,7 @@ trait ViewCommon {
   ): TagMod =
     ObsBadge(
       obs,
-      obsExecutions.getPot(obs.id).map(_.programTimeEstimate),
+      obsExecutions.getPot(obs.id).mapPerishable(_.programTimeEstimate),
       layout,
       selected = forceHighlight || (highlightSelected && focusedObsSet.exists(_.contains(obs.id))),
       readonly = readonly,

--- a/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsGroupTiles.scala
@@ -11,6 +11,7 @@ import explore.components.TileController
 import explore.components.ui.ExploreStyles
 import explore.model.Group
 import explore.model.GroupEditTileIds
+import explore.model.Perishable
 import explore.model.ProgramTimeRange
 import explore.model.enums.GridLayoutSection
 import explore.model.enums.GroupWarning
@@ -27,7 +28,7 @@ case class ObsGroupTiles(
   group:             UndoSetter[Group],
   groupWarnings:     Option[NonEmptySet[GroupWarning]],
   childCount:        Int,
-  timeEstimateRange: Pot[Option[ProgramTimeRange]],
+  timeEstimateRange: Pot[Perishable[Option[ProgramTimeRange]]],
   resize:            UseResizeDetectorReturn,
   defaultLayouts:    LayoutsMap,
   layouts:           LayoutsMap,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -27,6 +27,7 @@ import explore.itc.ItcGraphQuerier
 import explore.itc.ItcTile
 import explore.model.*
 import explore.model.GuideStarSelection.*
+import explore.model.PerishablePot.*
 import explore.model.display.given
 import explore.model.enums.AgsState
 import explore.model.enums.AppTab
@@ -116,7 +117,8 @@ case class ObsTabTiles(
   val targetObservations: Map[Target.Id, SortedSet[Observation.Id]] =
     programSummaries.targetObservations
 
-  val obsExecution: Pot[Execution] = programSummaries.obsExecutionPots.getPot(obsId)
+  val obsExecution: PerishablePot[Execution] =
+    programSummaries.obsExecutionPots.getPot(obsId)
 
   val obsTargets: TargetList = programSummaries.obsTargets.get(obsId).getOrElse(SortedMap.empty)
 
@@ -333,8 +335,8 @@ object ObsTabTiles:
               obsEditAttachments(props.obsId, ids).runAsync
             }
 
-          val pendingTime = props.obsExecution.toOption.flatMap(_.remainingObsTime)
-          val setupTime   = props.obsExecution.toOption.flatMap(_.fullSetupTime)
+          val pendingTime = props.obsExecution.asValuePot.toOption.flatMap(_.remainingObsTime)
+          val setupTime   = props.obsExecution.asValuePot.toOption.flatMap(_.fullSetupTime)
           val obsDuration =
             props.observation.get.observationDuration
               .orElse(pendingTime)
@@ -514,7 +516,7 @@ object ObsTabTiles:
               obsTimeView,
               obsDurationView,
               obsConf,
-              props.obsExecution.map(_.some),
+              props.obsExecution.mapPerishable(_.some),
               props.focusedTarget,
               setCurrentTarget,
               onCloneTarget,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -532,7 +532,7 @@ object TargetTabContents extends TwoPanels:
                   none,
                   none
                 ),
-                Pot(none), // Execution
+                PerishablePot(none), // Execution
                 props.focused.target,
                 setCurrentTarget(idsToEdit.some),
                 onCloneTarget4Asterism,

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
@@ -6,7 +6,6 @@ package explore.targeteditor
 import cats.effect.IO
 import cats.syntax.all.*
 import clue.FetchClient
-import crystal.Pot
 import crystal.react.*
 import crystal.react.hooks.*
 import eu.timepit.refined.types.string.NonEmptyString
@@ -27,6 +26,7 @@ import explore.model.ObsIdSetEditInfo
 import explore.model.ObservationsAndTargets
 import explore.model.OnAsterismUpdateParams
 import explore.model.OnCloneParameters
+import explore.model.PerishablePot
 import explore.model.TargetEditObsInfo
 import explore.model.TargetList
 import explore.model.enums.TileSizeState
@@ -65,7 +65,7 @@ object AsterismEditorTile:
     obsTime:            View[Option[Instant]],
     obsDuration:        View[Option[TimeSpan]],
     obsConf:            ObsConfiguration,
-    execution:          Pot[Option[Execution]],
+    execution:          PerishablePot[Option[Execution]],
     currentTarget:      Option[Target.Id],
     setTarget:          (Option[Target.Id], SetRouteVia) => Callback,
     onCloneTarget:      OnCloneParameters => Callback,
@@ -296,7 +296,7 @@ object AsterismEditorTile:
     obsTimeView:            View[Option[Instant]],
     obsDurationView:        View[Option[TimeSpan]],
     obsTimeAndDurationView: View[(Option[Instant], Option[TimeSpan])],
-    execution:              Pot[Option[Execution]],
+    execution:              PerishablePot[Option[Execution]],
     columnVisibility:       View[ColumnVisibility],
     obsEditInfo:            Option[ObsIdSetEditInfo],
     tileSize:               TileSizeState

--- a/model/shared/src/main/scala/explore/model/Perishable.scala
+++ b/model/shared/src/main/scala/explore/model/Perishable.scala
@@ -1,0 +1,21 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import cats.Eq
+
+// A value, A, that can be marked as stale or errored.
+opaque type Perishable[A] = (A, Boolean)
+
+object Perishable:
+  // it is fresh when created
+  def apply[A](a: A): Perishable[A] = (a, false)
+  given [A: Eq]: Eq[Perishable[A]]  = Eq.by(e => (e._1, e._2))
+
+  extension [A](entry: Perishable[A])
+    def value: A                              = entry._1
+    def isStale: Boolean                      = entry._2
+    def map[B](f:      A => B): Perishable[B] = (f(value), entry._2)
+    def mapValue[B](f: A => B): B             = f(value)
+    def setStale: Perishable[A]               = (value, true)

--- a/model/shared/src/main/scala/explore/model/PerishablePot.scala
+++ b/model/shared/src/main/scala/explore/model/PerishablePot.scala
@@ -1,0 +1,20 @@
+// Copyright (c) 2016-2023 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model
+
+import crystal.Pot
+
+type PerishablePot[A] = Pot[Perishable[A]]
+
+object PerishablePot:
+  def apply[A](a: A): PerishablePot[A]         = Pot(Perishable(a))
+  def error[A](e: Throwable): PerishablePot[A] = Pot.error(e)
+
+  extension [A](pot: PerishablePot[A])
+    def isStale: Boolean                                = pot.fold(false, _ => false, _.isStale)
+    def isStaleOrPending: Boolean                       = pot.fold(true, _ => true, _.isStale)
+    def setStale: Pot[Perishable[A]]                    = pot.map(_.setStale)
+    def mapPerishable[B](f: A => B): Pot[Perishable[B]] = pot.map(_.map(f))
+    def asValuePot: Pot[A]                              = pot.map(_.value)
+    def error: Option[Throwable]                        = pot.fold(None, Some(_), _ => None)

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -40,6 +40,7 @@ case class ProgramSummaries(
   groups:                GroupList,
   attachments:           AttachmentList,
   programs:              ProgramInfoList,
+  // TODO: Persihable: make this a PerishablePot[ProgramTimes]
   programTimesPot:       Pot[ProgramTimes],
   obsExecutionPots:      ObservationExecutionMap,
   groupTimeRangePots:    GroupTimeRangeMap,
@@ -317,16 +318,14 @@ object ProgramSummaries:
       .andThen(ProgramDetails.piPartner.some)
 
   def fromLists(
-    optProgramDetails:  Option[ProgramDetails],
-    targetList:         List[TargetWithId],
-    obsList:            List[Observation],
-    groupList:          List[Group],
-    attachments:        List[Attachment],
-    programs:           List[ProgramInfo],
-    programTimesPot:    Pot[ProgramTimes],
-    obsExecutionPots:   Map[Observation.Id, Pot[Execution]],
-    groupTimeRangePots: Map[Group.Id, Pot[Option[ProgramTimeRange]]],
-    configRequests:     List[ConfigurationRequestWithObsIds]
+    optProgramDetails: Option[ProgramDetails],
+    targetList:        List[TargetWithId],
+    obsList:           List[Observation],
+    groupList:         List[Group],
+    attachments:       List[Attachment],
+    programs:          List[ProgramInfo],
+    programTimesPot:   Pot[ProgramTimes],
+    configRequests:    List[ConfigurationRequestWithObsIds]
   ): ProgramSummaries =
     ProgramSummaries(
       optProgramDetails,
@@ -336,7 +335,7 @@ object ProgramSummaries:
       attachments.toSortedMap(_.id),
       programs.toSortedMap(_.id),
       programTimesPot,
-      ObservationExecutionMap(obsExecutionPots),
-      GroupTimeRangeMap(groupTimeRangePots),
+      ObservationExecutionMap(Map.empty),
+      GroupTimeRangeMap(Map.empty),
       configRequests.toSortedMap(_.id)
     )

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -28,7 +28,7 @@ object Versions {
   val lucumaSchemas          = "0.130.0"
   val lucumaOdbSchema        = "0.19.3"
   val lucumaSSO              = "0.8.9"
-  val lucumaUI               = "0.137.0"
+  val lucumaUI               = "0.138.0"
   val monocle                = "3.3.0"
   val mouse                  = "1.3.2"
   val mUnit                  = "1.1.0"


### PR DESCRIPTION
This PR introduces a `Perishable` type that represents a value that can be marked as stale. There is also a type alias `PerishablePot` for `Pot[Perishable[A]]` that provides helpful syntax and is used in the observation and group times maps. 

The initial impetus for this was the comment in [sc-5193] regarding the average parallactic angle going invalid while waiting for new execution times to arrive from the ODB. Now, instead of setting the execution values to pending while waiting, they are marked stale. The values are still displayed in the UI, but in most cases they are grayed out and a tooltip provided stating that it is waiting for new data. The APA remains based on the stale values until new data arrives. If there is an error with the execution times query, the PerishablePot is set to Error so that it can be displayed in the UI.

Some work that will be done in future PRs:
1. Improve the display of the errors. They are displayed now and it is better than previously, but is not always pretty.
2. Apply the same PerishablePot treatment to the program execution times.
3. Possibly improve the ergonomics of using PerishablePot.