### PR TITLE
Fix transition from emission lines -> custom sed

### DIFF
--- a/common/src/main/scala/explore/model/enums/SEDType.scala
+++ b/common/src/main/scala/explore/model/enums/SEDType.scala
@@ -49,7 +49,7 @@ sealed abstract class SedTypeEnum[T](
   import UnnormalizedSED.*
   import SpectralDefinition.*
 
-  private def toBandNormalized[T](
+  def toBandNormalized[T](
     sed: UnnormalizedSED
   ): SpectralDefinition[T] => SpectralDefinition[T] =
     _ match
@@ -116,7 +116,7 @@ sealed abstract class SedTypeEnum[T](
       case BandNormalized(Some(UserDefinedAttachment(_)), _) => UserDefinedType.some
       case BandNormalized(_, _)                              => none
 
-  protected val enumSedType: Enumerated[SedType[T]] =
+  given Enumerated[SedType[T]] =
     Enumerated
       .from[SedType[T]](
         StellarLibraryType,
@@ -133,23 +133,17 @@ sealed abstract class SedTypeEnum[T](
       )
       .withTag(_.name)
 
-  protected val displaySedType: Display[SedType[T]] = Display.byShortName(_.name)
+  given Display[SedType[T]] = Display.byShortName(_.name)
 }
 
 object IntegratedSedType
     extends SedTypeEnum[Integrated](
       summon[TaggedUnit[ErgsPerSecondCentimeter2Angstrom, FluxDensityContinuum[Integrated]]].unit
-    ) {
-  given Enumerated[SedType[Integrated]] = enumSedType
-  given Display[SedType[Integrated]]    = displaySedType
-}
+    )
 
 object SurfaceSedType
     extends SedTypeEnum[Surface](
       summon[
         TaggedUnit[ErgsPerSecondCentimeter2AngstromArcsec2, FluxDensityContinuum[Surface]]
       ].unit
-    ) {
-  given Enumerated[SedType[Surface]] = enumSedType
-  given Display[SedType[Surface]]    = displaySedType
-}
+    )

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/IntegratedSpectralDefinitionEditor.scala
@@ -12,7 +12,6 @@ import explore.*
 import explore.common.*
 import explore.model.AttachmentList
 import explore.model.enums.IntegratedSedType
-import explore.model.enums.IntegratedSedType.given
 import explore.model.enums.SedType
 import explore.utils.*
 import japgolly.scalajs.react.*
@@ -119,7 +118,7 @@ object IntegratedSpectralDefinitionEditor
       Integrated,
       SpectralDefinitionIntegratedInput,
       IntegratedSpectralDefinitionEditor
-    ] {
+    ](IntegratedSedType) {
 
   override protected val currentType
     : SpectralDefinition[Integrated] => Option[SedType[Integrated]] =

--- a/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
+++ b/explore/src/main/scala/explore/targeteditor/spectralDefinition/SurfaceSpectralDefinitionEditor.scala
@@ -13,7 +13,6 @@ import explore.common.*
 import explore.model.AttachmentList
 import explore.model.enums.SedType
 import explore.model.enums.SurfaceSedType
-import explore.model.enums.SurfaceSedType.given
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -113,7 +112,7 @@ object SurfaceSpectralDefinitionEditor
       Surface,
       SpectralDefinitionSurfaceInput,
       SurfaceSpectralDefinitionEditor
-    ] {
+    ](SurfaceSedType) {
   override protected val currentType: SpectralDefinition[Surface] => Option[SedType[Surface]] =
     SurfaceSedType.fromSpectralDefinition
 


### PR DESCRIPTION
Also, when choosing the "User Defined" option now, the brightness editor will disappear until an the attachment is chosen. This is because internally we can't assign a new SED value until we have an attachment and therefore the old value is still recorded.