### PR TITLE
F2 Longslit Configuration Panel

### DIFF
--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -129,3 +129,14 @@ extension (vault: Option[UserVault])
 extension [F[_], A](view: ViewF[F, A])
   def zoom[B](getAdjust: GetAdjust[A, B]): ViewF[F, B] =
     view.zoom(getAdjust.get)(getAdjust.mod)
+
+extension [A: Eq](view: View[Option[A]])
+  // If the view contains `none`, `get` returns the defaultDisplay value. When setting,
+  // if the new value is the defaultSet value, set it to none.
+  def withDefault(defaultSet: A, defaultDisplay: A): View[Option[A]] =
+    view.zoom(_.orElse(defaultDisplay.some))(f =>
+      b => f(b).flatMap(newB => if (newB === defaultSet) none else newB.some)
+    )
+
+  def withDefault(default: A): View[Option[A]] =
+    withDefault(default, default)

--- a/explore/src/main/scala/explore/components/CustomizableEnumSelect.scala
+++ b/explore/src/main/scala/explore/components/CustomizableEnumSelect.scala
@@ -6,7 +6,8 @@ package explore.components
 import cats.syntax.all.*
 import crystal.react.View
 import eu.timepit.refined.types.string.NonEmptyString
-import japgolly.scalajs.react.ScalaFnComponent
+import explore.model.Help
+import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.syntax.all.*
 import lucuma.core.util.Display
@@ -14,6 +15,7 @@ import lucuma.core.util.Enumerated
 import lucuma.react.common.ReactFnProps
 import lucuma.react.primereact.PrimeStyles
 import lucuma.ui.primereact.FormEnumDropdownView
+import lucuma.ui.primereact.FormLabel
 import lucuma.ui.primereact.LucumaPrimeStyles
 import lucuma.ui.primereact.given
 import lucuma.ui.syntax.all.given
@@ -29,7 +31,9 @@ final case class CustomizableEnumSelect[A: Enumerated: Display](
   view:         View[A],
   defaultValue: A,
   disabled:     Boolean,
-  exclude:      Set[A] = Set.empty[A]
+  exclude:      Set[A] = Set.empty[A],
+  label:        Option[String] = None,
+  helpId:       Option[Help.Id] = None
 )(using val display: Display[A], val enumerated: Enumerated[A])
     extends ReactFnProps(CustomizableEnumSelect.component)
 
@@ -39,18 +43,21 @@ object CustomizableEnumSelect:
 
     val originalText = props.defaultValue.shortName
 
-    <.span(
-      LucumaPrimeStyles.FormField,
-      PrimeStyles.InputGroup,
-      FormEnumDropdownView(
-        id = props.id,
-        value = props.view,
-        exclude = props.exclude,
-        disabled = props.disabled
-      ),
-      <.span(PrimeStyles.InputGroupAddon,
-             CustomizedGroupAddon(originalText, props.view.set(props.defaultValue))
-      ).when(props.view.get =!= props.defaultValue)
+    React.Fragment(
+      props.label.map(label => FormLabel(htmlFor = props.id)(label, props.helpId.map(HelpIcon(_)))),
+      <.span(
+        LucumaPrimeStyles.FormField,
+        PrimeStyles.InputGroup,
+        FormEnumDropdownView(
+          id = props.id,
+          value = props.view,
+          exclude = props.exclude,
+          disabled = props.disabled
+        ),
+        <.span(PrimeStyles.InputGroupAddon,
+               CustomizedGroupAddon(originalText, props.view.set(props.defaultValue))
+        ).when(props.view.get =!= props.defaultValue)
+      )
     )
   )
 

--- a/explore/src/main/scala/explore/components/CustomizableEnumSelect.scala
+++ b/explore/src/main/scala/explore/components/CustomizableEnumSelect.scala
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import cats.syntax.all.*
+import crystal.react.View
+import eu.timepit.refined.types.string.NonEmptyString
+import japgolly.scalajs.react.ScalaFnComponent
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.syntax.all.*
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
+import lucuma.react.common.ReactFnProps
+import lucuma.react.primereact.PrimeStyles
+import lucuma.ui.primereact.FormEnumDropdownView
+import lucuma.ui.primereact.LucumaPrimeStyles
+import lucuma.ui.primereact.given
+import lucuma.ui.syntax.all.given
+
+/**
+ * An enum select component that allows the user to select an enum value from a list of options. But
+ * it has the concept of a default value that can be reverted to. If the current value is not the
+ * same as the default value, then an addon icon with a tooltip is displayed. Clicking on the icon
+ * reverts the value to the default value.
+ */
+final case class CustomizableEnumSelect[A: Enumerated: Display](
+  id:           NonEmptyString,
+  view:         View[A],
+  defaultValue: A,
+  disabled:     Boolean,
+  exclude:      Set[A] = Set.empty[A]
+)(using val display: Display[A], val enumerated: Enumerated[A])
+    extends ReactFnProps(CustomizableEnumSelect.component)
+
+object CustomizableEnumSelect:
+  private def buildComponent[A] = ScalaFnComponent[CustomizableEnumSelect[A]](props =>
+    import props.given
+
+    val originalText = props.defaultValue.shortName
+
+    <.span(
+      LucumaPrimeStyles.FormField,
+      PrimeStyles.InputGroup,
+      FormEnumDropdownView(
+        id = props.id,
+        value = props.view,
+        exclude = props.exclude,
+        disabled = props.disabled
+      ),
+      <.span(PrimeStyles.InputGroupAddon,
+             CustomizedGroupAddon(originalText, props.view.set(props.defaultValue))
+      ).when(props.view.get =!= props.defaultValue)
+    )
+  )
+
+  private val component = buildComponent[Any]

--- a/explore/src/main/scala/explore/components/CustomizableEnumSelectOptional.scala
+++ b/explore/src/main/scala/explore/components/CustomizableEnumSelectOptional.scala
@@ -6,7 +6,8 @@ package explore.components
 import cats.syntax.all.*
 import crystal.react.View
 import eu.timepit.refined.types.string.NonEmptyString
-import japgolly.scalajs.react.ScalaFnComponent
+import explore.model.Help
+import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.syntax.all.*
 import lucuma.core.util.Display
@@ -14,6 +15,7 @@ import lucuma.core.util.Enumerated
 import lucuma.react.common.ReactFnProps
 import lucuma.react.primereact.PrimeStyles
 import lucuma.ui.primereact.FormEnumDropdownOptionalView
+import lucuma.ui.primereact.FormLabel
 import lucuma.ui.primereact.LucumaPrimeStyles
 import lucuma.ui.primereact.given
 import lucuma.ui.syntax.all.given
@@ -29,6 +31,8 @@ final case class CustomizableEnumSelectOptional[A: Enumerated: Display](
   view:            View[Option[A]],
   defaultValue:    Option[A],
   disabled:        Boolean,
+  label:           Option[String] = None,
+  helpId:          Option[Help.Id] = None,
   exclude:         Set[A] = Set.empty[A],
   showClear:       Boolean = false,
   resetToOriginal: Boolean = false, // resets to `none` on false
@@ -42,23 +46,27 @@ object CustomizableEnumSelectOptional:
 
     val originalText = props.defaultValue.map(_.shortName).getOrElse("None")
 
-    <.span(
-      LucumaPrimeStyles.FormField,
-      PrimeStyles.InputGroup,
-      FormEnumDropdownOptionalView(
-        id = props.id,
-        value = props.view,
-        exclude = props.exclude,
-        disabled = props.disabled,
-        showClear = props.showClear
-      )(props.dropdownMods),
+    React.Fragment(
+      props.label.map(label => FormLabel(htmlFor = props.id)(label, props.helpId.map(HelpIcon(_)))),
       <.span(
-        PrimeStyles.InputGroupAddon,
-        CustomizedGroupAddon(originalText,
-                             props.view.set(if (props.resetToOriginal) props.defaultValue else none)
+        LucumaPrimeStyles.FormField,
+        PrimeStyles.InputGroup,
+        FormEnumDropdownOptionalView(
+          id = props.id,
+          value = props.view,
+          exclude = props.exclude,
+          disabled = props.disabled,
+          showClear = props.showClear
+        )(props.dropdownMods),
+        <.span(
+          PrimeStyles.InputGroupAddon,
+          CustomizedGroupAddon(
+            originalText,
+            props.view.set(if (props.resetToOriginal) props.defaultValue else none)
+          )
         )
+          .when(props.view.get =!= props.defaultValue)
       )
-        .when(props.view.get =!= props.defaultValue)
     )
   )
 

--- a/explore/src/main/scala/explore/components/CustomizableEnumSelectOptional.scala
+++ b/explore/src/main/scala/explore/components/CustomizableEnumSelectOptional.scala
@@ -1,0 +1,65 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import cats.syntax.all.*
+import crystal.react.View
+import eu.timepit.refined.types.string.NonEmptyString
+import japgolly.scalajs.react.ScalaFnComponent
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.syntax.all.*
+import lucuma.core.util.Display
+import lucuma.core.util.Enumerated
+import lucuma.react.common.ReactFnProps
+import lucuma.react.primereact.PrimeStyles
+import lucuma.ui.primereact.FormEnumDropdownOptionalView
+import lucuma.ui.primereact.LucumaPrimeStyles
+import lucuma.ui.primereact.given
+import lucuma.ui.syntax.all.given
+
+/**
+ * An enum select component that allows the user to select an optional enum value from a list of
+ * options. But it has the concept of a default value that can be reverted to. If the current value
+ * is not the same as the default value, then an addon icon with a tooltip is displayed. Clicking on
+ * the icon reverts the value to the default value.
+ */
+final case class CustomizableEnumSelectOptional[A: Enumerated: Display](
+  id:              NonEmptyString,
+  view:            View[Option[A]],
+  defaultValue:    Option[A],
+  disabled:        Boolean,
+  exclude:         Set[A] = Set.empty[A],
+  showClear:       Boolean = false,
+  resetToOriginal: Boolean = false, // resets to `none` on false
+  dropdownMods:    TagMod = TagMod.empty
+)(using val display: Display[A], val enumerated: Enumerated[A])
+    extends ReactFnProps(CustomizableEnumSelectOptional.component)
+
+object CustomizableEnumSelectOptional:
+  private def buildComponent[A] = ScalaFnComponent[CustomizableEnumSelectOptional[A]](props =>
+    import props.given
+
+    val originalText = props.defaultValue.map(_.shortName).getOrElse("None")
+
+    <.span(
+      LucumaPrimeStyles.FormField,
+      PrimeStyles.InputGroup,
+      FormEnumDropdownOptionalView(
+        id = props.id,
+        value = props.view,
+        exclude = props.exclude,
+        disabled = props.disabled,
+        showClear = props.showClear
+      )(props.dropdownMods),
+      <.span(
+        PrimeStyles.InputGroupAddon,
+        CustomizedGroupAddon(originalText,
+                             props.view.set(if (props.resetToOriginal) props.defaultValue else none)
+        )
+      )
+        .when(props.view.get =!= props.defaultValue)
+    )
+  )
+
+  private val component = buildComponent[Any]

--- a/explore/src/main/scala/explore/components/CustomizableInputText.scala
+++ b/explore/src/main/scala/explore/components/CustomizableInputText.scala
@@ -1,0 +1,63 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import cats.Eq
+import cats.syntax.all.*
+import crystal.react.View
+import eu.timepit.refined.types.string.NonEmptyString
+import japgolly.scalajs.react.ScalaFnComponent
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.validation.InputValidFormat
+import lucuma.react.common.ReactFnProps
+import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.FormInputTextView
+import lucuma.ui.primereact.given
+import lucuma.ui.syntax.all.given
+
+import scalajs.js.JSConverters.*
+
+/**
+ * An input text component that allows the user to enter a value. But it has the concept of a
+ * default value that can be reverted to. If the current value is not the same as the default value,
+ * then an addon icon with a tooltip is displayed. Clicking on the icon reverts the value to the
+ * default value.
+ */
+final case class CustomizableInputText[A: Eq](
+  id:            NonEmptyString,
+  value:         View[A],
+  validFormat:   InputValidFormat[A],
+  changeAuditor: ChangeAuditor,
+  label:         TagMod,
+  defaultValue:  A,
+  units:         Option[String],
+  disabled:      Boolean
+)(using val eq: Eq[A])
+    extends ReactFnProps(CustomizableInputText.component)
+
+object CustomizableInputText:
+  private def buildComponent[A] = ScalaFnComponent[CustomizableInputText[A]](props =>
+    import props.given
+
+    val isCustom                    = props.value.get =!= props.defaultValue
+    val customAddon: Option[TagMod] =
+      if (isCustom)
+        (CustomizedGroupAddon(props.validFormat.reverseGet(props.defaultValue),
+                              props.value.set(props.defaultValue)
+        ): TagMod).some
+      else none
+
+    FormInputTextView(
+      id = props.id,
+      value = props.value,
+      label = props.label,
+      units = props.units.orUndefined,
+      postAddons = customAddon.toList,
+      validFormat = props.validFormat,
+      changeAuditor = props.changeAuditor,
+      disabled = props.disabled
+    ).withMods(^.autoComplete.off)
+  )
+
+  private val component = buildComponent[Any]

--- a/explore/src/main/scala/explore/components/CustomizableInputTextOptional.scala
+++ b/explore/src/main/scala/explore/components/CustomizableInputTextOptional.scala
@@ -1,0 +1,60 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import cats.Eq
+import cats.syntax.all.*
+import crystal.react.View
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.syntax.ui.*
+import japgolly.scalajs.react.ScalaFnComponent
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.validation.InputValidFormat
+import lucuma.react.common.ReactFnProps
+import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.primereact.*
+import lucuma.ui.primereact.given
+import lucuma.ui.syntax.all.given
+
+import scalajs.js.JSConverters.*
+
+/**
+ * An input text component that allows the user to enter a value. But in this case None represents a
+ * default value. If the current value is not None, then an addon icon with a tooltip is displayed.
+ * Clicking on the icon sets the value to None (which represents the default value). Explicitly
+ * entering the default value will also set it to None.
+ */
+final case class CustomizableInputTextOptional[A: Eq](
+  id:            NonEmptyString,
+  value:         View[Option[A]],
+  validFormat:   InputValidFormat[Option[A]],
+  changeAuditor: ChangeAuditor,
+  label:         TagMod,
+  defaultValue:  A,
+  units:         Option[String],
+  disabled:      Boolean
+)(using val eq: Eq[A])
+    extends ReactFnProps(CustomizableInputTextOptional.component)
+
+object CustomizableInputTextOptional:
+  private def buildComponent[A] = ScalaFnComponent[CustomizableInputTextOptional[A]](props =>
+    import props.given
+
+    val originalText = props.validFormat.reverseGet(props.defaultValue.some)
+    val customAddon  =
+      props.value.get.map(_ => CustomizedGroupAddon(originalText, props.value.set(none)): TagMod)
+
+    FormInputTextView(
+      id = props.id,
+      value = props.value.withDefault(props.defaultValue),
+      label = props.label,
+      units = props.units.orUndefined,
+      postAddons = customAddon.toList,
+      validFormat = props.validFormat,
+      changeAuditor = props.changeAuditor,
+      disabled = props.disabled
+    ).clearable(^.autoComplete.off)
+  )
+
+  private val component = buildComponent[Any]

--- a/explore/src/main/scala/explore/components/CustomizedGroupAddon.scala
+++ b/explore/src/main/scala/explore/components/CustomizedGroupAddon.scala
@@ -10,10 +10,13 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.react.common.ReactFnComponent
 import lucuma.react.common.ReactFnProps
 import lucuma.react.fa.IconSize
+import lucuma.react.primereact.Tooltip
 import lucuma.react.primereact.tooltip.*
 
-private[components] final case class CustomizedGroupAddon(original: String, toRevert: Callback)
-    extends ReactFnProps(CustomizedGroupAddon)
+private[components] final case class CustomizedGroupAddon(
+  original: String,
+  toRevert: Callback
+) extends ReactFnProps(CustomizedGroupAddon)
 
 private[components] object CustomizedGroupAddon
     extends ReactFnComponent[CustomizedGroupAddon](props =>
@@ -23,7 +26,9 @@ private[components] object CustomizedGroupAddon
           .withClass(ExploreStyles.WarningIcon)
           .withSize(IconSize.X1),
         ^.onClick --> props.toRevert
-      ).withTooltip(content =
-        <.div("Customized!", <.br, s"Orginal: ${props.original}", <.br, "Click to revert.")
+      ).withTooltip(
+        content =
+          <.div("Customized!", <.br, s"Orginal: ${props.original}", <.br, "Click to revert."),
+        position = Tooltip.Position.Left // putting it on the left should always work.
       )
     )

--- a/explore/src/main/scala/explore/components/CustomizedGroupAddon.scala
+++ b/explore/src/main/scala/explore/components/CustomizedGroupAddon.scala
@@ -1,0 +1,29 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import explore.Icons
+import explore.components.ui.ExploreStyles
+import japgolly.scalajs.react.Callback
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.ReactFnComponent
+import lucuma.react.common.ReactFnProps
+import lucuma.react.fa.IconSize
+import lucuma.react.primereact.tooltip.*
+
+private[components] final case class CustomizedGroupAddon(original: String, toRevert: Callback)
+    extends ReactFnProps(CustomizedGroupAddon)
+
+private[components] object CustomizedGroupAddon
+    extends ReactFnComponent[CustomizedGroupAddon](props =>
+      <.span(
+        ^.cls := "fa-layers fa-fw",
+        Icons.ExclamationDiamond
+          .withClass(ExploreStyles.WarningIcon)
+          .withSize(IconSize.X1),
+        ^.onClick --> props.toRevert
+      ).withTooltip(content =
+        <.div("Customized!", <.br, s"Orginal: ${props.original}", <.br, "Click to revert.")
+      )
+    )

--- a/explore/src/main/scala/explore/config/AdvancedConfigButtons.scala
+++ b/explore/src/main/scala/explore/config/AdvancedConfigButtons.scala
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.config
+
+import cats.syntax.all.*
+import crystal.react.View
+import explore.Icons
+import explore.components.ui.ExploreStyles
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.ReactFnComponent
+import lucuma.react.common.ReactFnProps
+import lucuma.react.primereact.Button
+import lucuma.ui.primereact.*
+import lucuma.ui.syntax.all.given
+
+final case class AdvancedConfigButtons(
+  editState:            View[ConfigEditState],
+  isCustomized:         Boolean,
+  revertConfig:         Callback,
+  revertCustomizations: Callback,
+  sequenceChanged:      Callback,
+  readonly:             Boolean,
+  showAdvancedButton:   Boolean = true // The "Advanced Customization" button
+) extends ReactFnProps(AdvancedConfigButtons)
+
+object AdvancedConfigButtons
+    extends ReactFnComponent[AdvancedConfigButtons](props =>
+      if (props.readonly) EmptyVdom
+      else
+        <.div(
+          ExploreStyles.AdvancedConfigurationButtons,
+          Button(
+            label = "Revert Configuration",
+            icon = Icons.ListIcon,
+            severity = Button.Severity.Secondary,
+            onClick = props.revertConfig
+          ).compact.small
+            .unless(props.isCustomized),
+          Button(
+            label = "Revert Customizations",
+            icon = Icons.TrashUnstyled,
+            severity = Button.Severity.Danger,
+            onClick = props.sequenceChanged *> props.editState.set(ConfigEditState.View) >>
+              props.revertCustomizations
+          ).compact.small
+            .when(props.isCustomized),
+          Button(
+            label = "Customize",
+            icon = Icons.Edit,
+            severity = Button.Severity.Secondary,
+            onClick = props.editState.set(ConfigEditState.SimpleEdit)
+          ).compact.small
+            .when(props.editState.get === ConfigEditState.View),
+          Button(
+            label = "Advanced Customization",
+            icon = Icons.ExclamationTriangle.withClass(ExploreStyles.WarningIcon),
+            severity = Button.Severity.Secondary,
+            onClick = props.editState.set(ConfigEditState.AdvancedEdit)
+          ).compact.small
+            .when(props.editState.get === ConfigEditState.SimpleEdit && props.showAdvancedButton)
+        )
+    )

--- a/explore/src/main/scala/explore/config/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationTile.scala
@@ -56,7 +56,6 @@ import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Types.*
 import lucuma.schemas.model.ObservingMode
 import lucuma.schemas.odb.input.*
-import lucuma.ui.components.UnderConstruction
 import lucuma.ui.syntax.all.given
 import monocle.Iso
 import queries.common.ObsQueriesGQL
@@ -80,7 +79,8 @@ object ConfigurationTile:
     observingModeGroups:      ObservingModeGroupList,
     sequenceChanged:          Callback,
     readonly:                 Boolean,
-    units:                    WavelengthUnits
+    units:                    WavelengthUnits,
+    isStaff:                  Boolean
   ) =
     Tile(
       ObsTabTileIds.ConfigurationId.id,
@@ -103,7 +103,8 @@ object ConfigurationTile:
           customSedTimestamps,
           sequenceChanged,
           readonly,
-          units
+          units,
+          isStaff
         ),
       (_, _) =>
         Title(obsId,
@@ -231,7 +232,8 @@ object ConfigurationTile:
     customSedTimestamps:      List[Timestamp],
     sequenceChanged:          Callback,
     readonly:                 Boolean,
-    units:                    WavelengthUnits
+    units:                    WavelengthUnits,
+    isStaff:                  Boolean
   ) extends ReactFnProps(Body.component):
     val mode: UndoSetter[Option[ObservingMode]]  =
       pacAndMode.zoom(PosAngleConstraintAndObsMode.observingMode)
@@ -456,7 +458,21 @@ object ConfigurationTile:
                       )
                   ),
                   // F2 Long Slit
-                  (optF2Aligner, spectroscopyView.asView).mapN((_, _) => UnderConstruction())
+                  (optF2Aligner, spectroscopyView.asView).mapN((f2Aligner, specView) =>
+                    F2LongslitConfigPanel(
+                      props.programId,
+                      props.obsId,
+                      props.obsConf.calibrationRole,
+                      f2Aligner,
+                      specView,
+                      revertConfig,
+                      props.modes,
+                      props.sequenceChanged,
+                      props.readonly,
+                      props.units,
+                      props.isStaff
+                    )
+                  )
                 )
             )
           )

--- a/explore/src/main/scala/explore/config/F2LongslitConfigPanel.scala
+++ b/explore/src/main/scala/explore/config/F2LongslitConfigPanel.scala
@@ -1,0 +1,185 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.config
+
+import cats.syntax.all.*
+import clue.data.syntax.*
+import crystal.react.View
+import crystal.react.hooks.*
+import eu.timepit.refined.api.Refined
+import explore.common.Aligner
+import explore.components.*
+import explore.components.ui.ExploreStyles
+import explore.model.AppContext
+import explore.model.Observation
+import explore.model.ScienceRequirements
+import explore.model.display.given
+import explore.model.enums.WavelengthUnits
+import explore.modes.SpectroscopyModesMatrix
+import explore.syntax.ui.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.util.Effect
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.enums.*
+import lucuma.core.model.Program
+import lucuma.react.common.ReactFnComponent
+import lucuma.react.common.ReactFnProps
+import lucuma.refined.*
+import lucuma.schemas.ObservationDB.Types.*
+import lucuma.schemas.model.ObservingMode
+import lucuma.schemas.odb.input.*
+import lucuma.ui.primereact.*
+import lucuma.ui.syntax.all.given
+
+final case class F2LongslitConfigPanel(
+  programId:                Program.Id,
+  obsId:                    Observation.Id,
+  calibrationRole:          Option[CalibrationRole],
+  observingMode:            Aligner[ObservingMode.F2LongSlit, Flamingos2LongSlitInput],
+  spectroscopyRequirements: View[ScienceRequirements.Spectroscopy],
+  revertConfig:             Callback,
+  confMatrix:               SpectroscopyModesMatrix,
+  sequenceChanged:          Callback,
+  readonly:                 Boolean,
+  units:                    WavelengthUnits,
+  isStaff:                  Boolean
+) extends ReactFnProps(F2LongslitConfigPanel)
+
+object F2LongslitConfigPanel
+    extends ReactFnComponent[F2LongslitConfigPanel](props =>
+      for
+        ctx       <- useContext(AppContext.ctx)
+        modeData  <-
+          useModeData(props.confMatrix, props.spectroscopyRequirements.get, props.observingMode.get)
+        editState <- useStateView(ConfigEditState.View)
+      yield
+        import ctx.given
+
+        val disableAdvancedEdit = editState.get =!= ConfigEditState.AdvancedEdit || props.readonly
+        val disableSimpleEdit   =
+          disableAdvancedEdit && editState.get =!= ConfigEditState.SimpleEdit
+
+        val disperserView: View[F2Disperser] = props.observingMode
+          .zoom(
+            ObservingMode.F2LongSlit.disperser,
+            Flamingos2LongSlitInput.disperser.modify
+          )
+          .view(_.assign)
+
+        val filterView: View[F2Filter] = props.observingMode
+          .zoom(
+            ObservingMode.F2LongSlit.filter,
+            Flamingos2LongSlitInput.filter.modify
+          )
+          .view(_.assign)
+
+        val fpuView: View[F2Fpu] = props.observingMode
+          .zoom(
+            ObservingMode.F2LongSlit.fpu,
+            Flamingos2LongSlitInput.fpu.modify
+          )
+          .view(_.assign)
+
+        val readModeView: View[Option[F2ReadMode]] = props.observingMode
+          .zoom(
+            ObservingMode.F2LongSlit.explicitReadMode,
+            Flamingos2LongSlitInput.explicitReadMode.modify
+          )
+          .view(_.orUnassign)
+
+        val deckerView: View[Option[F2Decker]] = props.observingMode
+          .zoom(
+            ObservingMode.F2LongSlit.explicitDecker,
+            Flamingos2LongSlitInput.explicitDecker.modify
+          )
+          .view(_.orUnassign)
+
+        val defaultReadMode = props.observingMode.get.defaultReadMode
+        val defaultDecker   = props.observingMode.get.defaultDecker
+
+        val exposureTimeModeView = props.spectroscopyRequirements.zoom(
+          ScienceRequirements.Spectroscopy.exposureTimeMode
+        )
+
+        <.div(
+          ExploreStyles.AdvancedConfigurationGrid
+        )(
+          <.div(LucumaPrimeStyles.FormColumnCompact, ExploreStyles.AdvancedConfigurationCol1)(
+            CustomizableEnumSelect(
+              id = "disperser".refined,
+              view = disperserView,
+              defaultValue = props.observingMode.get.initialDisperser,
+              label = "Disperser".some,
+              helpId = Some("configuration/disperser.md".refined),
+              disabled = disableSimpleEdit
+            ),
+            CustomizableEnumSelect(
+              id = "filter".refined,
+              view = filterView,
+              defaultValue = props.observingMode.get.initialFilter,
+              label = "Filter".some,
+              helpId = Some("configuration/filter.md".refined),
+              disabled = disableSimpleEdit
+            ),
+            CustomizableEnumSelect(
+              id = "fpu".refined,
+              view = fpuView,
+              defaultValue = props.observingMode.get.initialFpu,
+              label = "FPU".some,
+              helpId = Some("configuration/fpu.md".refined),
+              disabled = disableSimpleEdit
+            ),
+            CustomizableEnumSelectOptional(
+              id = "read-mode".refined,
+              view = readModeView.withDefault(defaultReadMode),
+              defaultValue = defaultReadMode.some,
+              label = "Read Mode".some,
+              helpId = Some("configuration/read-mode.md".refined),
+              disabled = disableSimpleEdit
+            )
+          ),
+          <.div(LucumaPrimeStyles.FormColumnCompact, ExploreStyles.AdvancedConfigurationCol2)(
+            ExposureTimeModeEditor(
+              props.observingMode.get.instrument.some,
+              props.spectroscopyRequirements.get.wavelength,
+              exposureTimeModeView,
+              props.readonly,
+              props.units,
+              props.calibrationRole
+            )
+          ),
+          <.div(LucumaPrimeStyles.FormColumnCompact, ExploreStyles.AdvancedConfigurationCol3)(
+            FormLabel(htmlFor = "decker".refined)("Decker",
+                                                  HelpIcon("configuration/decker.md".refined)
+            ),
+            if (props.isStaff)
+              CustomizableEnumSelectOptional(
+                id = "decker".refined,
+                view = deckerView.withDefault(defaultDecker),
+                defaultValue = defaultDecker.some,
+                disabled = disableAdvancedEdit
+              )
+            else
+              <.label(^.id := "decker",
+                      ExploreStyles.FormValue,
+                      deckerView.get.getOrElse(defaultDecker).shortName
+              ),
+            // Per Andy, we'll use the wavelength of the filter as the central wavelength
+            LambdaAndIntervalFormValues(
+              modeData = modeData,
+              centralWavelength = filterView.get.wavelength,
+              units = props.units
+            )
+          ),
+          AdvancedConfigButtons(
+            editState = editState,
+            isCustomized = props.observingMode.get.isCustomized,
+            revertConfig = props.revertConfig,
+            revertCustomizations = props.observingMode.view(_.toInput).mod(_.revertCustomizations),
+            sequenceChanged = props.sequenceChanged,
+            readonly = props.readonly,
+            showAdvancedButton = props.isStaff
+          )
+        )
+    )

--- a/explore/src/main/scala/explore/config/LambdaAndIntervalFormValues.scala
+++ b/explore/src/main/scala/explore/config/LambdaAndIntervalFormValues.scala
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.config
+
+import cats.syntax.all.*
+import explore.components.ui.ExploreStyles
+import explore.model.display.*
+import explore.model.enums.WavelengthUnits
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.math.BoundedInterval
+import lucuma.core.math.Wavelength
+import lucuma.core.syntax.all.*
+import lucuma.core.util.Display
+import lucuma.react.common.ReactFnComponent
+import lucuma.react.common.ReactFnProps
+import lucuma.refined.*
+import lucuma.ui.primereact.FormLabel
+import lucuma.ui.syntax.all.given
+
+final case class LambdaAndIntervalFormValues(
+  modeData:          Option[ModeData],
+  centralWavelength: Option[Wavelength],
+  units:             WavelengthUnits
+) extends ReactFnProps(LambdaAndIntervalFormValues)
+
+object LambdaAndIntervalFormValues
+    extends ReactFnComponent[LambdaAndIntervalFormValues](props =>
+      val adjustedInterval =
+        (props.modeData, props.centralWavelength).flatMapN((md, cw) => md.wavelengthInterval(cw))
+
+      given Display[BoundedInterval[Wavelength]] = wavelengthIntervalDisplay(props.units)
+
+      React.Fragment(
+        FormLabel(htmlFor = "lambda".refined)("λ / Δλ"),
+        <.label(^.id := "lambda",
+                ExploreStyles.FormValue,
+                s"${props.modeData.fold("Unknown")(_.resolution.toString)}"
+        ),
+        FormLabel(htmlFor = "lambdaInterval".refined)("λ Interval"),
+        <.label(^.id := "lambdaInterval",
+                ExploreStyles.FormValue,
+                s"${adjustedInterval.fold("Unknown")(_.shortName)} ${props.units.symbol}"
+        )
+      )
+    )

--- a/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
+++ b/explore/src/main/scala/explore/config/SpectroscopyModesTable.scala
@@ -446,7 +446,7 @@ private object SpectroscopyModesTable:
                              row,
                              Pot.fromOption(result),
                              s.wavelength.flatMap: w =>
-                               ModeCommonWavelengths.wavelengthInterval(w)(row),
+                               row.wavelengthInterval(w),
                              row.instrument.shortName.some
                            )
         itcProgress <- useState(none[Progress])

--- a/explore/src/main/scala/explore/config/package.scala
+++ b/explore/src/main/scala/explore/config/package.scala
@@ -4,13 +4,25 @@
 package explore.config
 
 import cats.syntax.all.*
+import eu.timepit.refined.types.numeric.PosInt
 import explore.model.ExploreModelValidators
+import explore.model.ScienceRequirements
 import explore.model.enums.WavelengthUnits
+import explore.modes.ItcInstrumentConfig
+import explore.modes.ModeCommonWavelengths
+import explore.modes.ModeSlitSize
+import explore.modes.ModeWavelength
+import explore.modes.SlitLength
+import explore.modes.SpectroscopyModeRow
+import explore.modes.SpectroscopyModesMatrix
+import japgolly.scalajs.react.*
 import lucuma.core.math.Wavelength
 import lucuma.core.math.WavelengthDelta
 import lucuma.core.validation.*
 import lucuma.refined.*
+import lucuma.schemas.model.ObservingMode
 import lucuma.ui.input.ChangeAuditor
+import lucuma.ui.reusability.given
 
 trait ConfigurationFormats:
   private lazy val slitLengthBaseAuditor = ChangeAuditor
@@ -50,3 +62,95 @@ trait ConfigurationFormats:
         case WavelengthUnits.Nanometers  => wvDeltaNanoInput
 
 object ConfigurationFormats extends ConfigurationFormats
+
+case class ModeData private (
+  resolution: PosInt,
+  λmin:       ModeWavelength,
+  λmax:       ModeWavelength,
+  λdelta:     WavelengthDelta
+) extends ModeCommonWavelengths
+
+object ModeData {
+  def build(row: SpectroscopyModeRow, reqWavelength: Option[Wavelength]): Option[ModeData] =
+    reqWavelength.flatMap { rw =>
+      if (rw >= row.λmin.value && rw <= row.λmax.value)
+        ModeData(
+          row.resolution,
+          row.λmin,
+          row.λmax,
+          row.λdelta
+        ).some
+      else
+        none
+    }
+}
+
+def useModeData(
+  confMatrix:               SpectroscopyModesMatrix,
+  spectroscopyRequirements: ScienceRequirements.Spectroscopy,
+  obsMode:                  ObservingMode
+): HookResult[Option[ModeData]] =
+  // a reusablity based only on what is used here
+  given Reusability[ObservingMode] = Reusability:
+    // TODO: change to named tuples with scala 3.7
+    case (x: ObservingMode.GmosNorthLongSlit, y: ObservingMode.GmosNorthLongSlit) =>
+      x.grating === y.grating && x.filter === y.filter && x.fpu === y.fpu
+    case (x: ObservingMode.GmosSouthLongSlit, y: ObservingMode.GmosSouthLongSlit) =>
+      x.grating === y.grating && x.filter === y.filter && x.fpu === y.fpu
+    case (x: ObservingMode.F2LongSlit, y: ObservingMode.F2LongSlit)               =>
+      x.disperser === y.disperser && x.filter === y.filter && x.fpu === y.fpu
+    case _                                                                        => false
+
+  def findMatrixDataFromRow(
+    reqsWavelength: Option[Wavelength],
+    row:            SpectroscopyModeRow
+  ): Option[ModeData] =
+    reqsWavelength.flatMap(_ =>
+      (obsMode, row.instrument) match
+        // TODO: change to named tuples with scala 3.7
+        case (m: ObservingMode.GmosNorthLongSlit,
+              ItcInstrumentConfig.GmosNorthSpectroscopy(rGrating, rFpu, rFilter, _)
+            ) if m.grating === rGrating && m.filter === rFilter && m.fpu === rFpu =>
+          ModeData.build(row, reqsWavelength)
+        case (m: ObservingMode.GmosSouthLongSlit,
+              ItcInstrumentConfig.GmosSouthSpectroscopy(rGrating, rFpu, rFilter, _)
+            ) if m.grating === rGrating && m.filter === rFilter && m.fpu === rFpu =>
+          ModeData.build(row, reqsWavelength)
+        case (m: ObservingMode.F2LongSlit,
+              ItcInstrumentConfig.Flamingos2Spectroscopy(rGrating, rFilter, rFpu)
+            ) if m.disperser === rGrating && m.filter === rFilter && m.fpu === rFpu =>
+          ModeData.build(row, reqsWavelength)
+        case _ => none
+    )
+
+  def findMatrixData(
+    reqsWavelength: Option[Wavelength],
+    rows:           List[SpectroscopyModeRow]
+  ): Option[ModeData] =
+    rows.collectFirstSome(row => findMatrixDataFromRow(reqsWavelength, row))
+  for {
+    // filter the spectroscopy matrix by the requirements that don't get overridden
+    // by the advanced config (wavelength, for example).
+    rows     <- useMemo(
+                  (spectroscopyRequirements.focalPlane,
+                   spectroscopyRequirements.capability,
+                   spectroscopyRequirements.focalPlaneAngle,
+                   spectroscopyRequirements.resolution,
+                   spectroscopyRequirements.wavelengthCoverage,
+                   confMatrix.matrix.length
+                  )
+                ) { (fp, cap, fpa, res, rng, _) =>
+                  confMatrix.filtered(
+                    focalPlane = fp,
+                    capability = cap,
+                    slitLength = fpa.map(s => SlitLength(ModeSlitSize(s))),
+                    resolution = res,
+                    range = rng
+                  )
+                }
+    // Try to find the mode row from the spectroscopy matrix
+    modeData <-
+      useMemo((spectroscopyRequirements.wavelength, rows, obsMode)) { (reqsWavelength, rows, _) =>
+        findMatrixData(reqsWavelength, rows)
+      }
+  } yield modeData

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -586,7 +586,8 @@ object ObsTabTiles:
                 case x        => x
               ,
               props.isDisabled,
-              props.globalPreferences.get.wavelengthUnits
+              props.globalPreferences.get.wavelengthUnits,
+              props.vault.isStaff
             )
 
           val alltiles =

--- a/model/shared/src/main/scala/explore/model/display.scala
+++ b/model/shared/src/main/scala/explore/model/display.scala
@@ -160,7 +160,7 @@ trait DisplayImplicits:
 
   given Display[F2Fpu] = Display.by(_.shortName, _.longName)
 
-  given Display[F2ReadMode] = Display.by(_.shortName, _.longName)
+  given Display[F2ReadMode] = Display.by(_.shortName.capitalize, _.longName)
 
   given Display[F2Decker] = Display.by(_.shortName, _.longName)
 

--- a/model/shared/src/main/scala/explore/model/display.scala
+++ b/model/shared/src/main/scala/explore/model/display.scala
@@ -154,6 +154,16 @@ trait DisplayImplicits:
 
   given Display[GmosRoi] = Display.byShortName(_.longName)
 
+  given Display[F2Disperser] = Display.by(_.shortName, _.longName)
+
+  given Display[F2Filter] = Display.by(_.shortName, _.longName)
+
+  given Display[F2Fpu] = Display.by(_.shortName, _.longName)
+
+  given Display[F2ReadMode] = Display.by(_.shortName, _.longName)
+
+  given Display[F2Decker] = Display.by(_.shortName, _.longName)
+
   given Display[SequenceType] = Display.byShortName:
     case SequenceType.Acquisition => "Acquisition"
     case SequenceType.Science     => "Science"

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -44,30 +44,28 @@ trait ModeCommonWavelengths {
   val λmin: ModeWavelength
   val λmax: ModeWavelength
   val λdelta: WavelengthDelta
-}
 
-object ModeCommonWavelengths:
   def wavelengthInterval(
     λ: Wavelength
-  ): ModeCommonWavelengths => Option[BoundedInterval[Wavelength]] =
-    r =>
-      val λr      = r.λdelta
-      // Coverage of allowed wavelength
-      // Can be simplified once coulomb-refined is available
-      val λmin    = r.λmin.value
-      val λmax    = r.λmax.value
-      val range   = λr.centeredAt(λ)
-      // if we are below min clip but shift the range
-      // same if we are above max
-      // At any event we clip at min/max
-      val shifted =
-        if (range.lower < λmin)
-          λr.startingAt(λmin)
-        else if (range.upper > λmax)
-          λr.endingAt(λmax)
-        else
-          range
-      shifted.intersect(BoundedInterval.unsafeClosed(λmin, λmax))
+  ): Option[BoundedInterval[Wavelength]] =
+    val λr      = λdelta
+    // Coverage of allowed wavelength
+    // Can be simplified once coulomb-refined is available
+    val λminV   = λmin.value
+    val λmaxV   = λmax.value
+    val range   = λr.centeredAt(λ)
+    // if we are below min clip but shift the range
+    // same if we are above max
+    // At any event we clip at min/max
+    val shifted =
+      if (range.lower < λminV)
+        λr.startingAt(λminV)
+      else if (range.upper > λmaxV)
+        λr.endingAt(λmaxV)
+      else
+        range
+    shifted.intersect(BoundedInterval.unsafeClosed(λminV, λmaxV))
+}
 
 object SlitLength extends NewType[ModeSlitSize] {
   given Order[SlitLength] = Order.by(_.value.value.toMicroarcseconds)
@@ -106,7 +104,7 @@ case class SpectroscopyModeRow(
   // Range of wavelengths for this row. It takes the min/max and adjust it for the requested
   // wavelength
   def range(cw: Wavelength): Option[BoundedInterval[Wavelength]] =
-    ModeCommonWavelengths.wavelengthInterval(cw)(this)
+    wavelengthInterval(cw)
 
   def withModeOverridesFor(
     wavelength:   Option[Wavelength],


### PR DESCRIPTION
As per requirements, staff users can edit the `Decker`
![image](https://github.com/user-attachments/assets/89811775-1363-4605-8750-81c4b20008ed)
This requires clicking `Customize` and then `Advanced Customization`.

For non-staff, Decker shows up as a static field.
![image](https://github.com/user-attachments/assets/e197f512-58ef-4226-9968-ca96d0c607f2)

All the values in the leftmost column are editable by pressing the `Customize` button.

One slight oddity is that if the staff modifies the `Decker` value, non-staff will still have the option to `Revert Modifications`.  Since reverting modifications is a pre-requisite to be able to `Revert Configuration`, I'm not sure what, if anything, to do about it. We can start here and modify as we figure things out.

Since `AdvancedConfigurationPanel` is really specific to GMOS longslit, I will submit a separate PR renaming it and it's contents.