### PR TITLE
Rename AdvancedConfigurationPanel to GmosLongslitConfigPanel

### DIFF
--- a/explore/src/main/scala/explore/config/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationTile.scala
@@ -427,7 +427,7 @@ object ConfigurationTile:
                 React.Fragment(
                   // Gmos North Long Slit
                   (optGmosNorthAligner, spectroscopyView.asView).mapN((northAligner, specView) =>
-                    AdvancedConfigurationPanel
+                    GmosLongslitConfigPanel
                       .GmosNorthLongSlit(
                         props.programId,
                         props.obsId,
@@ -443,7 +443,7 @@ object ConfigurationTile:
                   ),
                   // Gmos South Long Slit
                   (optGmosSouthAligner, spectroscopyView.asView).mapN((southAligner, specView) =>
-                    AdvancedConfigurationPanel
+                    GmosLongslitConfigPanel
                       .GmosSouthLongSlit(
                         props.programId,
                         props.obsId,


### PR DESCRIPTION
I spoke with Andy and verified that it is highly unlikely we'll have another instrument with the same configuration parameters as Gmos Longslit, so I renamed `AdvancedConfigurationPanel` to `GmosLongslitConfigPanel` to reflect this fact, and removed a no longer necessary level of abstraction. 

(Probably best viewed with `ignore whitespace`.