### PR TITLE
Disable editing of observations in an "Executed" state.

### DIFF
--- a/explore/src/main/scala/explore/components/FileUploadButton.scala
+++ b/explore/src/main/scala/explore/components/FileUploadButton.scala
@@ -93,14 +93,17 @@ object FileUploadButton
               )
             ).mini.compact
           ),
-          <.input.withRef(ref)(
-            ExploreStyles.FileUpload,
-            ^.tpe      := "file",
-            ^.onChange ==> uploadFile,
-            ^.id       := s"attachment-upload-$id",
-            ^.name     := "file",
-            ^.accept   := props.attachmentType.accept,
-            ^.readOnly := props.readonly
-          )
+          if (props.readonly)
+            EmptyVdom
+          else
+            <.input.withRef(ref)(
+              ExploreStyles.FileUpload,
+              ^.tpe      := "file",
+              ^.onChange ==> uploadFile,
+              ^.id       := s"attachment-upload-$id",
+              ^.name     := "file",
+              ^.accept   := props.attachmentType.accept,
+              ^.readOnly := props.readonly
+            )
         )
     )

--- a/explore/src/main/scala/explore/findercharts/FinderChartsTile.scala
+++ b/explore/src/main/scala/explore/findercharts/FinderChartsTile.scala
@@ -65,7 +65,6 @@ object FinderChartsTile:
               attachmentIds,
               attachments,
               parallacticAngle,
-              readonly,
               tileState
             )
           .orEmpty,
@@ -86,7 +85,6 @@ object FinderChartsTile:
     attachmentIds:    View[SortedSet[Attachment.Id]],
     attachments:      View[AttachmentList],
     parallacticAngle: Option[Angle],
-    readOnly:         Boolean,
     state:            View[TileState]
   ) extends ReactFnProps(Body.component) {
     val chartSelector = state.zoom(TileState.chartSelector)

--- a/explore/src/main/scala/explore/findercharts/package.scala
+++ b/explore/src/main/scala/explore/findercharts/package.scala
@@ -75,6 +75,7 @@ def attachmentSelector(
       outlined = chartSelector.get.value,
       icon = Icons.Link.withFixedWidth(false).withInverse(chartSelector.get.value),
       onClick = chartSelector.mod(_.flip),
+      disabled = readOnly,
       tooltip = s"Select charts"
     ).tiny.compact,
     FileUploadButton(

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -282,14 +282,16 @@ object ObsTabContents extends TwoPanels:
             props.observations.model
               .zoom(indexValue)
               .mapValue(obsView =>
+                // FIXME Find a better mechanism for this.
+                // Something like .mapValue but for UndoContext
+                val obsUndoSetter =
+                  props.observations.zoom(indexValue.getOption.andThen(_.get), indexValue.modify)
                 ObsTabTiles(
                   props.vault,
                   props.programId,
                   props.modes,
                   backButton,
-                  // FIXME Find a better mechanism for this.
-                  // Something like .mapValue but for UndoContext
-                  props.observations.zoom(indexValue.getOption.andThen(_.get), indexValue.modify),
+                  obsUndoSetter,
                   props.programSummaries
                     .zoom((ProgramSummaries.observations, ProgramSummaries.targets).disjointZip),
                   props.programSummaries.model.zoom(ProgramSummaries.attachments),
@@ -301,7 +303,7 @@ object ObsTabContents extends TwoPanels:
                   resize,
                   props.userPreferences.get,
                   props.globalPreferences,
-                  props.readonly || addingObservation.get.value
+                  props.readonly || addingObservation.get.value || obsUndoSetter.get.isExecuted
                 ).withKey(s"${obsId.show}")
               )
           }


### PR DESCRIPTION
It turns out we were preventing editing of targets and asterisms for executed observations in explore, but not the observations themselves...

Unfortunately, we need to prevent editing the timing windows and constraints for executed observations on their respective tabs. I'll submit a new story for that.