### PR TITLE
Move queries to API layer

### DIFF
--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -7,8 +7,11 @@ import cats.Order.given
 import cats.syntax.all.*
 import crystal.syntax.*
 import explore.givens.given
+import explore.model.Attachment
+import explore.model.ConfigurationRequestWithObsIds
 import explore.model.GroupList
 import explore.model.Observation
+import explore.model.ProgramInfo
 import explore.model.ProgramSummaries
 import explore.model.syntax.all.*
 import lucuma.core.model.Group
@@ -16,10 +19,7 @@ import lucuma.schemas.ObservationDB.Enums.EditType
 import lucuma.schemas.ObservationDB.Enums.EditType.*
 import lucuma.schemas.ObservationDB.Enums.Existence
 import queries.common.ObsQueriesGQL.ProgramObservationsDelta.Data.ObservationEdit
-import queries.common.ProgramQueriesGQL.ConfigurationRequestSubscription.Data.ConfigurationRequestEdit
 import queries.common.ProgramQueriesGQL.GroupEditSubscription.Data.GroupEdit
-import queries.common.ProgramQueriesGQL.ProgramEditAttachmentSubscription.Data.ProgramEdit as AttachmentProgramEdit
-import queries.common.ProgramQueriesGQL.ProgramInfoDelta.Data.ProgramEdit
 import queries.common.TargetQueriesGQL.ProgramTargetsDelta.Data.TargetEdit
 
 /**
@@ -118,23 +118,18 @@ trait CacheModifierUpdaters {
       }.orEmpty
 
   protected def modifyAttachments(
-    programEdit: AttachmentProgramEdit
-  ): ProgramSummaries => ProgramSummaries = {
-    val attachments = programEdit.value.attachments.toSortedMap(_.id)
-    ProgramSummaries.attachments.replace(attachments)
-  }
+    attachments: List[Attachment]
+  ): ProgramSummaries => ProgramSummaries =
+    ProgramSummaries.attachments.replace(attachments.toSortedMap(_.id))
 
-  protected def modifyPrograms(programEdit: ProgramEdit): ProgramSummaries => ProgramSummaries =
-    ProgramSummaries.programs
-      .modify(_.updated(programEdit.value.id, programEdit.value))
+  protected def modifyPrograms(programInfo: ProgramInfo): ProgramSummaries => ProgramSummaries =
+    ProgramSummaries.programs.modify(_.updated(programInfo.id, programInfo))
 
   protected def modifyConfigurationRequests(
-    crEdit: ConfigurationRequestEdit
+    cr: ConfigurationRequestWithObsIds
   ): ProgramSummaries => ProgramSummaries =
-    crEdit.configurationRequest.foldMap: cr =>
-      ProgramSummaries.configurationRequests
-        .modify: crs =>
-          crs.updated(cr.id, cr)
+    ProgramSummaries.configurationRequests.modify: crs =>
+      crs.updated(cr.id, cr)
 
   /**
    * Reset the time range pots for all parent groups of the given id

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -3,13 +3,9 @@
 
 package explore.cache
 
-import cats.data.Ior
 import cats.effect.IO
 import cats.effect.Resource
 import cats.syntax.all.*
-import clue.ResponseException
-import clue.StreamingClient
-import clue.data.syntax.*
 import crystal.Pot
 import crystal.Throttler
 import crystal.syntax.*
@@ -22,115 +18,75 @@ import explore.model.ObservationExecutionMap
 import explore.model.ProgramDetails
 import explore.model.ProgramInfo
 import explore.model.ProgramSummaries
+import explore.services.OdbApi
+import explore.services.OdbGroupApi
+import explore.services.OdbObservationApi
+import explore.services.OdbProgramApi
 import explore.utils.*
 import fs2.Pipe
 import fs2.Stream
 import fs2.concurrent.Channel
 import japgolly.scalajs.react.*
-import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.Program
-import lucuma.core.model.Target
 import lucuma.react.common.ReactFnProps
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Enums.Existence
-import lucuma.schemas.ObservationDB.Types.ConfigurationRequestEditInput
 import lucuma.schemas.ObservationDB.Types.WhereObservation
 import lucuma.schemas.model.TargetWithId
 import lucuma.schemas.odb.input.*
 import org.typelevel.log4cats.Logger
-import queries.common.ObsQueriesGQL
-import queries.common.ProgramQueriesGQL
-import queries.common.ProgramSummaryQueriesGQL
-import queries.common.TargetQueriesGQL
+import queries.common.ObsQueriesGQL.ProgramObservationsDelta
+import queries.common.ProgramQueriesGQL.GroupEditSubscription
 
 import scala.concurrent.duration.*
 
 case class ProgramCacheController(
   programId:           Program.Id,
   modProgramSummaries: (Pot[ProgramSummaries] => Pot[ProgramSummaries]) => IO[Unit]
-)(using client: StreamingClient[IO, ObservationDB], logger: Logger[IO])
+)(using val odbApi: OdbApi[IO])(using logger: Logger[IO])
 // Do not remove the explicit type parameter below, it confuses the compiler.
     extends ReactFnProps[ProgramCacheController](ProgramCacheController.component)
     with CacheControllerComponent.Props[ProgramSummaries]:
-  val modState                             = modProgramSummaries
-  given StreamingClient[IO, ObservationDB] = client
-  given Logger[IO]                         = logger
+  val modState     = modProgramSummaries
+  // given StreamingClient[IO, ObservationDB] = client
+  given Logger[IO] = logger
 
 object ProgramCacheController
     extends CacheControllerComponent[ProgramSummaries, ProgramCacheController]
     with CacheModifierUpdaters:
 
-  private def drain[A, Id, R](
-    fetch:      Option[Id] => IO[R],
-    getList:    R => List[A],
-    getHasMore: R => Boolean,
-    getId:      A => Id
-  ): IO[List[A]] = {
-    def go(id: Option[Id], accum: List[A]): IO[List[A]] =
-      fetch(id).flatMap(result =>
-        val list = getList(result)
-        if (getHasMore(result)) go(list.lastOption.map(getId), list)
-        // Fetching with offset includes the offset, so .dropRight(1) ensures we don't include it twice.
-        else (accum.dropRight(1) ++ list).pure[IO]
-      )
-
-    go(none, List.empty)
-  }
-
   private def updateProgramTimes(
     programId: Program.Id
-  )(using StreamingClient[IO, ObservationDB]): IO[ProgramSummaries => ProgramSummaries] =
-    ProgramSummaryQueriesGQL
-      .ProgramTimesQuery[IO]
-      .query(programId)
-      .raiseGraphQLErrors
+  )(using odbApi: OdbProgramApi[IO]): IO[ProgramSummaries => ProgramSummaries] =
+    odbApi
+      .programTimes(programId)
       .map:
-        _.program.fold(identity[ProgramSummaries]): times =>
+        _.fold(identity[ProgramSummaries]): times =>
           ProgramSummaries.programTimesPot.replace(Pot(times))
 
   private def updateObservationExecution(
     obsId: Observation.Id
-  )(using StreamingClient[IO, ObservationDB]): IO[ProgramSummaries => ProgramSummaries] =
-    ProgramSummaryQueriesGQL
-      .ObservationExecutionQuery[IO]
-      .query(obsId)
-      // This no longer raises an error on no data, rather the error is put in the pot.
-      .map(_.result match {
-        case Ior.Right(r)   => r.asRight
-        case Ior.Both(_, r) => r.asRight
-        case Ior.Left(e)    => ResponseException(e, none).asLeft
-      })
+  )(using odbApi: OdbObservationApi[IO]): IO[ProgramSummaries => ProgramSummaries] =
+    odbApi
+      .observationExecution(obsId)
       .map:
-        case Left(e)     =>
-          val t = new Exception("Error getting observation execution information.", e)
-          ProgramSummaries.obsExecutionPots.modify(_.setError(obsId, t))
-        case Right(data) =>
-          data.observation
-            .map(_.execution)
-            .fold(identity[ProgramSummaries]): execution =>
-              ProgramSummaries.obsExecutionPots.modify(_.updated(obsId, execution))
+        _.fold(identity[ProgramSummaries]): execution =>
+          ProgramSummaries.obsExecutionPots.modify(_.updated(obsId, execution))
+      .handleError: e =>
+        val t = new Exception("Error getting observation execution information.", e)
+        ProgramSummaries.obsExecutionPots.modify(_.setError(obsId, t))
 
   private def updateGroupTimeRange(groupId: Group.Id)(using
-    StreamingClient[IO, ObservationDB]
+    odbApi: OdbGroupApi[IO]
   ): IO[ProgramSummaries => ProgramSummaries] =
-    ProgramSummaryQueriesGQL
-      .GroupTimeRangeQuery[IO]
-      .query(groupId)
-      // This no longer raises an error for graphql errors, rather the error is put in the pot.
-      .map(_.result match {
-        case Ior.Right(r)   => r.asRight
-        case Ior.Both(e, r) => ResponseException(e, r.some).asLeft
-        case Ior.Left(e)    => ResponseException(e, none).asLeft
-      })
+    odbApi
+      .groupTimeRange(groupId)
       .map:
-        case Left(e)     =>
-          val t = new Exception("Error getting group time range information.", e)
-          ProgramSummaries.groupTimeRangePots.modify(_.setError(groupId, t))
-        case Right(data) =>
-          data.group
-            .map(_.timeEstimateRange)
-            .fold(identity[ProgramSummaries]): timeRange =>
-              ProgramSummaries.groupTimeRangePots.modify(_.updated(groupId, timeRange))
+        _.fold(identity[ProgramSummaries]): timeRange =>
+          ProgramSummaries.groupTimeRangePots.modify(_.updated(groupId, timeRange))
+      .handleError: e =>
+        val t = new Exception("Error getting group time range information.", e)
+        ProgramSummaries.groupTimeRangePots.modify(_.setError(groupId, t))
 
   override protected val initial: ProgramCacheController => IO[
     (ProgramSummaries, Stream[IO, ProgramSummaries => ProgramSummaries])
@@ -138,82 +94,27 @@ object ProgramCacheController
     import props.given
 
     val optProgramDetails: IO[Option[ProgramDetails]] =
-      ProgramSummaryQueriesGQL
-        .ProgramDetailsQuery[IO]
-        .query(props.programId)
-        .raiseGraphQLErrors
-        .map(_.program)
-        .logTime("ProgramDetailsQuery")
+      props.odbApi.programDetails(props.programId).logTime("ProgramDetailsQuery")
 
     val targets: IO[List[TargetWithId]] =
-      drain[TargetWithId, Target.Id, ProgramSummaryQueriesGQL.AllProgramTargets.Data](
-        offset =>
-          ProgramSummaryQueriesGQL
-            .AllProgramTargets[IO]
-            .query(props.programId.toWhereTarget, offset.orUnassign)
-            .raiseGraphQLErrors,
-        _.targets.matches,
-        _.targets.hasMore,
-        _.id
-      ).logTime("AllProgramTargets")
+      props.odbApi.allProgramTargets(props.programId).logTime("AllProgramTargets")
 
     val observations: IO[List[Observation]] =
-      drain[Observation, Observation.Id, ProgramSummaryQueriesGQL.AllProgramObservations.Data](
-        offset =>
-          ProgramSummaryQueriesGQL
-            .AllProgramObservations[IO]
-            .query(props.programId.toWhereObservation, offset.orUnassign)
-            // We need this because we currently get errors for things like having no targets
-            .raiseGraphQLErrorsOnNoData,
-        _.observations.matches,
-        _.observations.hasMore,
-        _.id
-      ).logTime("AllProgramObservations")
+      props.odbApi.allProgramObservations(props.programId).logTime("AllProgramObservations")
 
     val configurationRequests: IO[List[ConfigurationRequestWithObsIds]] =
-      drain[ConfigurationRequestWithObsIds,
-            ConfigurationRequest.Id,
-            ProgramSummaryQueriesGQL.AllProgramConfigurationRequests.Data
-      ](
-        offset =>
-          ProgramSummaryQueriesGQL
-            .AllProgramConfigurationRequests[IO]
-            .query(props.programId, offset.orUnassign)
-            .raiseGraphQLErrors,
-        _.program.foldMap(_.configurationRequests.matches),
-        _.program.fold(false)(_.configurationRequests.hasMore),
-        _.id
-      ).logTime("AllProgramConfigurationRequests")
+      props.odbApi
+        .allProgramConfigurationRequests(props.programId)
+        .logTime("AllProgramConfigurationRequests")
 
     val groups: IO[List[Group]] =
-      ProgramQueriesGQL
-        .ProgramGroupsQuery[IO]
-        .query(props.programId)
-        .raiseGraphQLErrors
-        .map(_.program.toList.flatMap(_.allGroupElements.map(_.group).flattenOption))
-        .logTime("ProgramGroupsQuery")
+      props.odbApi.allProgramGroups(props.programId).logTime("AllProgramGroups")
 
     val attachments: IO[List[Attachment]] =
-      ProgramSummaryQueriesGQL
-        .AllProgramAttachments[IO]
-        .query(props.programId)
-        .raiseGraphQLErrors
-        .map:
-          _.program.fold(List.empty)(_.attachments)
-        .logTime("AllProgramAttachments")
+      props.odbApi.allProgramAttachments(props.programId).logTime("AllProgramAttachments")
 
     val programs: IO[List[ProgramInfo]] =
-      drain[ProgramInfo, Program.Id, ProgramSummaryQueriesGQL.AllPrograms.Data](
-        offset =>
-          ProgramSummaryQueriesGQL
-            .AllPrograms[IO]
-            .query(offset.orUnassign)
-            .raiseGraphQLErrors,
-        _.programs.matches,
-        _.programs.hasMore,
-        _.id
-      )
-        .logTime("AllPrograms")
+      props.odbApi.allPrograms.logTime("AllPrograms")
 
     def initializeSummaries(
       observations: List[Observation],
@@ -273,85 +174,68 @@ object ProgramCacheController
 
             def updateObservationsWorkflows(
               whereObservation: WhereObservation
-            )(using StreamingClient[IO, ObservationDB]): IO[ProgramSummaries => ProgramSummaries] =
-              drain[
-                ProgramSummaryQueriesGQL.ObservationsWorkflowQuery.Data.Observations.Matches,
-                Observation.Id,
-                ProgramSummaryQueriesGQL.ObservationsWorkflowQuery.Data
-              ](
-                offset =>
-                  ProgramSummaryQueriesGQL
-                    .ObservationsWorkflowQuery[IO]
-                    .query(whereObservation, offset.orUnassign)
-                    .raiseGraphQLErrors,
-                _.observations.matches,
-                _.observations.hasMore,
-                _.id
-              ).map:
-                _.map: m =>
-                  ProgramSummaries.observations
-                    .modify:
-                      _.updatedWith(m.id)(_.map(Observation.workflow.replace(m.workflow)))
-                .combineAll
+            ): IO[ProgramSummaries => ProgramSummaries] =
+              odbApi
+                .observationWorkflows(whereObservation)
+                .map:
+                  _.map: m =>
+                    ProgramSummaries.observations
+                      .modify:
+                        _.updatedWith(m.id)(_.map(Observation.workflow.replace(m.workflow)))
+                  .combineAll
 
             // Changing the proposal's CfP can change the validations for observations,
             // eg: coordinates bounds, so we requery them all.
             // https://app.shortcut.com/lucuma/story/4412/update-warnings-without-page-reload
             val allObservationsValidationsUpdate: Pipe[
               IO,
-              ProgramQueriesGQL.ProgramEditDetailsSubscription.Data,
+              ProgramDetails,
               ProgramSummaries => ProgramSummaries
             ] =
-              _.map(_.programEdit.value.proposal.flatMap(_.call.map(_.id))).changes.void
+              _.map(_.proposal.flatMap(_.call.map(_.id))).changes.void
                 .throttle(5.seconds)
                 .evalMap(_ => updateObservationsWorkflows(props.programId.toWhereObservation))
 
             val updateProgramDetails
               : Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
-              ProgramQueriesGQL.ProgramEditDetailsSubscription
-                .subscribe[IO](props.programId.toProgramEditInput)
-                .logGraphQLErrors(_ => "Error in ProgramEditDetailsSubscription subscription")
+              props.odbApi
+                .programEditsSubscription(props.programId)
                 .map:
                   _.broadcastThrough(
-                    _.map: data => // Replace program.
-                      ProgramSummaries.optProgramDetails.replace(data.programEdit.value.some),
+                    _.map: programDetails => // Replace program.
+                      ProgramSummaries.optProgramDetails.replace(programDetails.some),
                     allObservationsValidationsUpdate
                   )
 
             val updateTargets: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
-              TargetQueriesGQL.ProgramTargetsDelta
-                .subscribe[IO](props.programId.toTargetEditInput)
-                .logGraphQLErrors(_ => "Error in ProgramTargetsDelta subscription")
-                .map(_.map(data => modifyTargets(data.targetEdit)))
+              props.odbApi
+                .programTargetsDeltaSubscription(props.programId)
+                .map(_.map(modifyTargets(_)))
 
             val onlyExistingObs: Pipe[
               IO,
-              ObsQueriesGQL.ProgramObservationsDelta.Data,
-              ObsQueriesGQL.ProgramObservationsDelta.Data
+              ProgramObservationsDelta.Data.ObservationEdit,
+              ProgramObservationsDelta.Data.ObservationEdit
             ] =
-              _.filter(_.observationEdit.meta.exists(_.existence === Existence.Present))
+              _.filter(_.meta.exists(_.existence === Existence.Present))
 
             val onlyExistingGroups: Pipe[
               IO,
-              ProgramQueriesGQL.GroupEditSubscription.Data,
-              ProgramQueriesGQL.GroupEditSubscription.Data
+              GroupEditSubscription.Data.GroupEdit,
+              GroupEditSubscription.Data.GroupEdit
             ] =
-              _.filter(_.groupEdit.meta.exists(_.existence === Existence.Present))
+              _.filter(_.meta.exists(_.existence === Existence.Present))
 
             val obsTimesUpdates: Pipe[
               IO,
-              ObsQueriesGQL.ProgramObservationsDelta.Data,
+              ProgramObservationsDelta.Data.ObservationEdit,
               ProgramSummaries => ProgramSummaries
-            ] = keyedSwitchEvalMap(
-              _.observationEdit.observationId,
-              data =>
-                updateObservationExecution(data.observationEdit.observationId) <* queryProgramTimes
-            )
-
-            extension (data: ProgramQueriesGQL.ConfigurationRequestSubscription.Data)
-              private def obsIdList: List[Observation.Id] =
-                data.configurationRequestEdit.configurationRequest.toList
-                  .flatMap(_.applicableObservations)
+            ] =
+              keyedSwitchEvalMap(
+                _.observationId,
+                observationEdit =>
+                  updateObservationExecution(observationEdit.observationId) <* queryProgramTimes
+              )
 
             // We'll request updates to all the workflows at once. Since this
             // is being updated due to the configuration request change, the workflows
@@ -360,56 +244,53 @@ object ProgramCacheController
             // of ids as a key should be OK.
             val obsWorkflowUpdates: Pipe[
               IO,
-              ProgramQueriesGQL.ConfigurationRequestSubscription.Data,
+              ConfigurationRequestWithObsIds,
               ProgramSummaries => ProgramSummaries
             ] = keyedSwitchEvalMap(
-              _.obsIdList.toSet,
-              _.obsIdList match
+              _.applicableObservations.toSet,
+              _.applicableObservations match
                 case Nil             => IO.pure(identity)
                 case nonEmptyObsList =>
                   updateObservationsWorkflows(nonEmptyObsList.toWhereObservation)
             )
 
-            val groupTimeRangeUpdate: Pipe[
-              IO,
-              ProgramQueriesGQL.GroupEditSubscription.Data,
-              ProgramSummaries => ProgramSummaries
-            ] = keyedSwitchEvalMap(
-              _.groupEdit.value.map(_.id),
-              _.groupEdit.value
-                .map: group =>
-                  updateGroupTimeRange(group.id) <* queryProgramTimes
-                .getOrElse(IO(identity))
-            )
+            val groupTimeRangeUpdate: Pipe[IO,
+                                           GroupEditSubscription.Data.GroupEdit,
+                                           ProgramSummaries => ProgramSummaries
+            ] =
+              keyedSwitchEvalMap(
+                _.value.map(_.id),
+                _.value
+                  .map: group =>
+                    updateGroupTimeRange(group.id) <* queryProgramTimes
+                  .getOrElse(IO(identity))
+              )
 
             val updateObservations: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
-              ObsQueriesGQL.ProgramObservationsDelta
-                .subscribe[IO](props.programId.toObservationEditInput)
-                .handleGraphQLErrors(IO.println(_))
+              props.odbApi
+                .programObservationsDeltaSubscription(props.programId)
                 .map:
                   _.broadcastThrough(
-                    _.map(data => modifyObservations(data.observationEdit)),
+                    _.map(modifyObservations(_)),
                     onlyExistingObs.andThen(obsTimesUpdates)
                   )
 
             val updateGroups: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
-              ProgramQueriesGQL.GroupEditSubscription
-                .subscribe[IO](props.programId.toProgramEditInput)
-                .logGraphQLErrors(_ => "Error in GroupEditSubscription subscription")
+              props.odbApi
+                .programGroupsDeltaEdits(props.programId)
                 .map:
                   _.broadcastThrough(
-                    _.map(data => modifyGroups(data.groupEdit)),
+                    _.map(modifyGroups(_)),
                     onlyExistingGroups.andThen(groupTimeRangeUpdate)
                   )
 
             val updateConfigurationRequests
               : Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
-              ProgramQueriesGQL.ConfigurationRequestSubscription
-                .subscribe[IO](ConfigurationRequestEditInput(props.programId.assign))
-                .logGraphQLErrors(_ => "Error in ConfigurationRequestSubscription subscription")
+              props.odbApi
+                .programConfigurationRequestsDeltaSubscription(props.programId)
                 .map:
                   _.broadcastThrough(
-                    _.map(data => modifyConfigurationRequests(data.configurationRequestEdit)),
+                    _.map(modifyConfigurationRequests(_)),
                     obsWorkflowUpdates
                   )
 
@@ -417,17 +298,14 @@ object ProgramCacheController
             // differentiate what got updated, so we alway update all the attachments.
             // Hopefully this will change in the future.
             val updateAttachments: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
-              ProgramQueriesGQL.ProgramEditAttachmentSubscription
-                .subscribe[IO](props.programId.toProgramEditInput)
-                .logGraphQLErrors(_ => "Error in ProgramEditAttachmentSubscription subscription")
-                .map(_.map(data => modifyAttachments(data.programEdit)))
+              props.odbApi
+                .programAttachmentsDeltaSubscription(props.programId)
+                .map(_.map(modifyAttachments(_)))
 
             val updatePrograms: Resource[IO, Stream[IO, ProgramSummaries => ProgramSummaries]] =
-              ProgramQueriesGQL.ProgramInfoDelta
-                .subscribe[IO]()
-                .logGraphQLErrors(_ => "Error in ProgramInfoDelta subscription")
-                .map:
-                  _.map(data => modifyPrograms(data.programEdit))
+              props.odbApi
+                .programDeltaSubscription(props.programId)
+                .map(_.map(modifyPrograms(_)))
 
             // TODO Handle errors, disable transparent resubscription upon connection loss.
             List(

--- a/explore/src/main/scala/explore/services/OdbConfigApi.scala
+++ b/explore/src/main/scala/explore/services/OdbConfigApi.scala
@@ -3,7 +3,16 @@
 
 package explore.services
 
+import cats.effect.Resource
+import explore.model.ConfigurationRequestWithObsIds
 import explore.modes.SpectroscopyModesMatrix
+import lucuma.core.model.Program
 
 trait OdbConfigApi[F[_]]:
   def spectroscopyModes: F[SpectroscopyModesMatrix]
+  def allProgramConfigurationRequests(
+    programId: Program.Id
+  ): F[List[ConfigurationRequestWithObsIds]]
+  def programConfigurationRequestsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ConfigurationRequestWithObsIds]]

--- a/explore/src/main/scala/explore/services/OdbGroupApi.scala
+++ b/explore/src/main/scala/explore/services/OdbGroupApi.scala
@@ -3,11 +3,14 @@
 
 package explore.services
 
+import cats.effect.Resource
 import eu.timepit.refined.types.numeric.NonNegShort
 import explore.model.Group
+import explore.model.ProgramTimeRange
 import lucuma.core.model.Program
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Types.*
+import queries.common.ProgramQueriesGQL.GroupEditSubscription
 
 trait OdbGroupApi[F[_]]:
   /**
@@ -24,7 +27,12 @@ trait OdbGroupApi[F[_]]:
     parentGroup:      Option[Group.Id],
     parentGroupIndex: NonNegShort
   ): F[Unit]
-  def updateGroup(groupId:   Group.Id, set:        GroupPropertiesInput): F[Unit]
-  def createGroup(programId: Program.Id, parentId: Option[Group.Id]): F[Group]
-  def deleteGroup(groupId:   Group.Id): F[Unit]
-  def undeleteGroup(groupId: Group.Id): F[Unit]
+  def updateGroup(groupId:        Group.Id, set:        GroupPropertiesInput): F[Unit]
+  def createGroup(programId:      Program.Id, parentId: Option[Group.Id]): F[Group]
+  def deleteGroup(groupId:        Group.Id): F[Unit]
+  def undeleteGroup(groupId:      Group.Id): F[Unit]
+  def groupTimeRange(groupId:     Group.Id): F[Option[Option[ProgramTimeRange]]]
+  def allProgramGroups(programId: Program.Id): F[List[Group]]
+  def programGroupsDeltaEdits(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, GroupEditSubscription.Data.GroupEdit]]

--- a/explore/src/main/scala/explore/services/OdbGroupApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbGroupApiImpl.scala
@@ -4,19 +4,26 @@
 package explore.services
 
 import cats.MonadThrow
+import cats.effect.Resource
 import cats.syntax.all.*
-import clue.FetchClient
+import clue.StreamingClient
 import clue.data.syntax.*
 import clue.syntax.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import explore.model.Group
+import explore.model.ProgramTimeRange
 import lucuma.core.model.Program
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Enums.Existence
 import lucuma.schemas.ObservationDB.Types.*
+import lucuma.schemas.odb.input.*
+import org.typelevel.log4cats.Logger
 import queries.common.GroupQueriesGQL.*
+import queries.common.ProgramQueriesGQL.GroupEditSubscription
+import queries.common.ProgramQueriesGQL.ProgramGroupsQuery
+import queries.common.ProgramSummaryQueriesGQL.GroupTimeRangeQuery
 
-trait OdbGroupApiImpl[F[_]: MonadThrow](using FetchClient[F, ObservationDB]):
+trait OdbGroupApiImpl[F[_]: MonadThrow](using StreamingClient[F, ObservationDB], Logger[F]):
   def moveGroup(
     groupId:          Group.Id,
     parentGroup:      Option[Group.Id],
@@ -63,3 +70,23 @@ trait OdbGroupApiImpl[F[_]: MonadThrow](using FetchClient[F, ObservationDB]):
 
   def undeleteGroup(groupId: Group.Id): F[Unit] =
     updateGroup(groupId, GroupPropertiesInput(existence = Existence.Present.assign))
+
+  def groupTimeRange(groupId: Group.Id): F[Option[Option[ProgramTimeRange]]] =
+    GroupTimeRangeQuery[F]
+      .query(groupId)
+      .raiseGraphQLErrors
+      .map(_.group.map(_.timeEstimateRange))
+
+  def allProgramGroups(programId: Program.Id): F[List[Group]] =
+    ProgramGroupsQuery[F]
+      .query(programId)
+      .raiseGraphQLErrors
+      .map(_.program.toList.flatMap(_.allGroupElements.map(_.group).flattenOption))
+
+  def programGroupsDeltaEdits(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, GroupEditSubscription.Data.GroupEdit]] =
+    GroupEditSubscription
+      .subscribe[F](programId.toProgramEditInput)
+      .logGraphQLErrors(_ => "Error in GroupEditSubscription subscription")
+      .map(_.map(_.groupEdit))

--- a/explore/src/main/scala/explore/services/OdbObservationApi.scala
+++ b/explore/src/main/scala/explore/services/OdbObservationApi.scala
@@ -9,6 +9,7 @@ import clue.data.Input
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.ConfigurationRequestWithObsIds
+import explore.model.Execution
 import explore.model.ExecutionOffsets
 import explore.model.Observation
 import lucuma.core.enums.ObservationWorkflowState
@@ -22,7 +23,8 @@ import lucuma.core.model.TimingWindow
 import lucuma.core.util.TimeSpan
 import lucuma.schemas.ObservationDB.Types.*
 import lucuma.schemas.model.ObservingMode
-import queries.common.ObsQueriesGQL.ObservationEditSubscription
+import queries.common.ObsQueriesGQL.ProgramObservationsDelta
+import queries.common.ProgramSummaryQueriesGQL.ObservationsWorkflowQuery
 
 import java.time.Instant
 
@@ -93,6 +95,12 @@ trait OdbObservationApi[F[_]]:
     obsRef: ObservationReference
   ): F[Option[(Program.Id, Observation.Id)]]
   def sequenceOffsets(obsId:             Observation.Id): F[Option[ExecutionOffsets]]
-  def observationEditSubscription(
-    obsId: Observation.Id
-  ): Resource[F, fs2.Stream[F, ObservationEditSubscription.Data]]
+  def observationEditSubscription(obsId: Observation.Id): Resource[F, fs2.Stream[F, Unit]]
+  def programObservationsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ProgramObservationsDelta.Data.ObservationEdit]]
+  def observationExecution(obsId:        Observation.Id): F[Option[Execution]]
+  def allProgramObservations(programId:  Program.Id): F[List[Observation]]
+  def observationWorkflows(
+    whereObservation: WhereObservation
+  ): F[List[ObservationsWorkflowQuery.Data.Observations.Matches]]

--- a/explore/src/main/scala/explore/services/OdbProgramApi.scala
+++ b/explore/src/main/scala/explore/services/OdbProgramApi.scala
@@ -3,14 +3,17 @@
 
 package explore.services
 
+import cats.effect.Resource
 import eu.timepit.refined.types.string.NonEmptyString
+import explore.model.Attachment
+import explore.model.ProgramDetails
 import explore.model.ProgramInfo
 import explore.model.ProgramNote
+import explore.model.ProgramTimes
 import explore.model.ProgramUser
 import explore.model.RedeemInvitationResult
 import lucuma.core.data.EmailAddress
 import lucuma.core.enums.ConfigurationRequestStatus
-import lucuma.core.model.Attachment
 import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.PartnerLink
 import lucuma.core.model.Program
@@ -55,3 +58,12 @@ trait OdbProgramApi[F[_]]:
   ): F[CreateUserInvitation]
   def revokeUserInvitation(userInvitationId: String): F[Unit]
   def redeemUserInvitation(key:              String): F[RedeemInvitationResult]
+  def programTimes(programId:                Program.Id): F[Option[ProgramTimes]]
+  def programDetails(programId:              Program.Id): F[Option[ProgramDetails]]
+  def allPrograms: F[List[ProgramInfo]]
+  def allProgramAttachments(programId:       Program.Id): F[List[Attachment]]
+  def programEditsSubscription(programId:    Program.Id): Resource[F, fs2.Stream[F, ProgramDetails]]
+  def programAttachmentsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, List[Attachment]]]
+  def programDeltaSubscription(programId:    Program.Id): Resource[F, fs2.Stream[F, ProgramInfo]]

--- a/explore/src/main/scala/explore/services/OdbTargetApi.scala
+++ b/explore/src/main/scala/explore/services/OdbTargetApi.scala
@@ -12,18 +12,18 @@ import lucuma.core.model.Target
 import lucuma.schemas.ObservationDB.Enums.Existence
 import lucuma.schemas.ObservationDB.Types.UpdateTargetsInput
 import lucuma.schemas.model.TargetWithId
-import queries.common.TargetQueriesGQL.TargetEditSubscription
+import queries.common.TargetQueriesGQL.ProgramTargetsDelta
 
 trait OdbTargetApi[F[_]]:
-  def insertTarget(programId:    Program.Id, target:         Target.Sidereal): F[Target.Id]
-  def updateTarget(targetId:     Target.Id, input:           UpdateTargetsInput): F[Unit]
+  def insertTarget(programId:      Program.Id, target:         Target.Sidereal): F[Target.Id]
+  def updateTarget(targetId:       Target.Id, input:           UpdateTargetsInput): F[Unit]
   def setTargetExistence(
     programId: Program.Id,
     targetId:  Target.Id,
     existence: Existence
   ): F[Unit]
-  def deleteTargets(targetIds:   List[Target.Id], programId: Program.Id): F[Unit]
-  def undeleteTargets(targetIds: List[Target.Id], programId: Program.Id): F[Unit]
+  def deleteTargets(targetIds:     List[Target.Id], programId: Program.Id): F[Unit]
+  def undeleteTargets(targetIds:   List[Target.Id], programId: Program.Id): F[Unit]
   def cloneTarget(
     targetId:  Target.Id,
     replaceIn: ObsIdSet,
@@ -31,8 +31,12 @@ trait OdbTargetApi[F[_]]:
   ): F[TargetWithId]
   def targetEditSubscription(
     targetId: Target.Id
-  ): Resource[F, fs2.Stream[F, TargetEditSubscription.Data]]
+  ): Resource[F, fs2.Stream[F, Unit]]
+  def programTargetsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ProgramTargetsDelta.Data.TargetEdit]]
   def searchTargetsByNamePrefix(
     programId: Program.Id,
     name:      NonEmptyString
   ): F[List[TargetSearchResult]]
+  def allProgramTargets(programId: Program.Id): F[List[TargetWithId]]

--- a/explore/src/main/scala/explore/services/package.scala
+++ b/explore/src/main/scala/explore/services/package.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.services
+
+import cats.Monad
+import cats.syntax.all.*
+
+private def drain[F[_]: Monad, A, Id, R](
+  fetch:      Option[Id] => F[R],
+  getList:    R => List[A],
+  getHasMore: R => Boolean,
+  getId:      A => Id
+): F[List[A]] = {
+  def go(id: Option[Id], accum: List[A]): F[List[A]] =
+    fetch(id).flatMap(result =>
+      val list = getList(result)
+      if (getHasMore(result)) go(list.lastOption.map(getId), list)
+      // Fetching with offset includes the offset, so .dropRight(1) ensures we don't include it twice.
+      else (accum.dropRight(1) ++ list).pure[F]
+    )
+
+  go(none, List.empty)
+}


### PR DESCRIPTION
This PR finishes the migration of all queries, mutations and subscriptions to the API layer.
