### PR TITLE
Move queries to API layer (take 2)

### DIFF
--- a/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
+++ b/explore/src/main/scala/explore/cache/CacheModifierUpdaters.scala
@@ -6,8 +6,11 @@ package explore.cache
 import cats.Order.given
 import cats.syntax.all.*
 import explore.givens.given
+import explore.model.Attachment
+import explore.model.ConfigurationRequestWithObsIds
 import explore.model.GroupList
 import explore.model.Observation
+import explore.model.ProgramInfo
 import explore.model.ProgramSummaries
 import explore.model.syntax.all.*
 import lucuma.core.model.Group
@@ -15,10 +18,7 @@ import lucuma.schemas.ObservationDB.Enums.EditType
 import lucuma.schemas.ObservationDB.Enums.EditType.*
 import lucuma.schemas.ObservationDB.Enums.Existence
 import queries.common.ObsQueriesGQL.ProgramObservationsDelta.Data.ObservationEdit
-import queries.common.ProgramQueriesGQL.ConfigurationRequestSubscription.Data.ConfigurationRequestEdit
 import queries.common.ProgramQueriesGQL.GroupEditSubscription.Data.GroupEdit
-import queries.common.ProgramQueriesGQL.ProgramEditAttachmentSubscription.Data.ProgramEdit as AttachmentProgramEdit
-import queries.common.ProgramQueriesGQL.ProgramInfoDelta.Data.ProgramEdit
 import queries.common.TargetQueriesGQL.ProgramTargetsDelta.Data.TargetEdit
 
 /**
@@ -106,22 +106,17 @@ trait CacheModifierUpdaters {
       }.orEmpty
 
   protected def modifyAttachments(
-    programEdit: AttachmentProgramEdit
-  ): ProgramSummaries => ProgramSummaries = {
-    val attachments = programEdit.value.attachments.toSortedMap(_.id)
-    ProgramSummaries.attachments.replace(attachments)
-  }
+    attachments: List[Attachment]
+  ): ProgramSummaries => ProgramSummaries =
+    ProgramSummaries.attachments.replace(attachments.toSortedMap(_.id))
 
-  protected def modifyPrograms(programEdit: ProgramEdit): ProgramSummaries => ProgramSummaries =
-    ProgramSummaries.programs
-      .modify(_.updated(programEdit.value.id, programEdit.value))
+  protected def modifyPrograms(programInfo: ProgramInfo): ProgramSummaries => ProgramSummaries =
+    ProgramSummaries.programs.modify(_.updated(programInfo.id, programInfo))
 
   protected def modifyConfigurationRequests(
-    crEdit: ConfigurationRequestEdit
+    cr: ConfigurationRequestWithObsIds
   ): ProgramSummaries => ProgramSummaries =
-    crEdit.configurationRequest.foldMap: cr =>
-      ProgramSummaries.configurationRequests
-        .modify: crs =>
-          crs.updated(cr.id, cr)
+    ProgramSummaries.configurationRequests.modify: crs =>
+      crs.updated(cr.id, cr)
 
 }

--- a/explore/src/main/scala/explore/services/OdbConfigApi.scala
+++ b/explore/src/main/scala/explore/services/OdbConfigApi.scala
@@ -3,7 +3,16 @@
 
 package explore.services
 
+import cats.effect.Resource
+import explore.model.ConfigurationRequestWithObsIds
 import explore.modes.SpectroscopyModesMatrix
+import lucuma.core.model.Program
 
 trait OdbConfigApi[F[_]]:
   def spectroscopyModes: F[SpectroscopyModesMatrix]
+  def allProgramConfigurationRequests(
+    programId: Program.Id
+  ): F[List[ConfigurationRequestWithObsIds]]
+  def programConfigurationRequestsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ConfigurationRequestWithObsIds]]

--- a/explore/src/main/scala/explore/services/OdbGroupApi.scala
+++ b/explore/src/main/scala/explore/services/OdbGroupApi.scala
@@ -3,11 +3,14 @@
 
 package explore.services
 
+import cats.effect.Resource
 import eu.timepit.refined.types.numeric.NonNegShort
 import explore.model.Group
 import lucuma.core.model.Program
 import lucuma.schemas.ObservationDB
 import lucuma.schemas.ObservationDB.Types.*
+import queries.common.ProgramQueriesGQL.GroupEditSubscription
+import queries.common.ProgramSummaryQueriesGQL.GroupTimeRangeQuery
 
 trait OdbGroupApi[F[_]]:
   /**
@@ -24,7 +27,12 @@ trait OdbGroupApi[F[_]]:
     parentGroup:      Option[Group.Id],
     parentGroupIndex: NonNegShort
   ): F[Unit]
-  def updateGroup(groupId:   Group.Id, set:        GroupPropertiesInput): F[Unit]
-  def createGroup(programId: Program.Id, parentId: Option[Group.Id]): F[Group]
-  def deleteGroup(groupId:   Group.Id): F[Unit]
-  def undeleteGroup(groupId: Group.Id): F[Unit]
+  def updateGroup(groupId:        Group.Id, set:        GroupPropertiesInput): F[Unit]
+  def createGroup(programId:      Program.Id, parentId: Option[Group.Id]): F[Group]
+  def deleteGroup(groupId:        Group.Id): F[Unit]
+  def undeleteGroup(groupId:      Group.Id): F[Unit]
+  def groupTimeRange(groupId:     Group.Id): F[Option[GroupTimeRangeQuery.Data.Group]]
+  def allProgramGroups(programId: Program.Id): F[List[Group]]
+  def programGroupsDeltaEdits(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, GroupEditSubscription.Data.GroupEdit]]

--- a/explore/src/main/scala/explore/services/OdbObservationApi.scala
+++ b/explore/src/main/scala/explore/services/OdbObservationApi.scala
@@ -23,6 +23,7 @@ import lucuma.core.model.TimingWindow
 import lucuma.core.util.TimeSpan
 import lucuma.schemas.ObservationDB.Types.*
 import lucuma.schemas.model.ObservingMode
+import queries.common.ObsQueriesGQL.ObsCalcSubscription
 import queries.common.ObsQueriesGQL.ProgramObservationsDelta
 import queries.common.ProgramSummaryQueriesGQL.ObservationsWorkflowQuery
 
@@ -104,3 +105,6 @@ trait OdbObservationApi[F[_]]:
   def observationWorkflows(
     whereObservation: WhereObservation
   ): F[List[ObservationsWorkflowQuery.Data.Observations.Matches]]
+  def obsCalcSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ObsCalcSubscription.Data.ObscalcUpdate]]

--- a/explore/src/main/scala/explore/services/OdbObservationApi.scala
+++ b/explore/src/main/scala/explore/services/OdbObservationApi.scala
@@ -9,6 +9,7 @@ import clue.data.Input
 import eu.timepit.refined.types.numeric.NonNegShort
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.ConfigurationRequestWithObsIds
+import explore.model.Execution
 import explore.model.ExecutionOffsets
 import explore.model.Observation
 import lucuma.core.enums.ObservationWorkflowState
@@ -22,7 +23,8 @@ import lucuma.core.model.TimingWindow
 import lucuma.core.util.TimeSpan
 import lucuma.schemas.ObservationDB.Types.*
 import lucuma.schemas.model.ObservingMode
-import queries.common.ObsQueriesGQL.ObservationEditSubscription
+import queries.common.ObsQueriesGQL.ProgramObservationsDelta
+import queries.common.ProgramSummaryQueriesGQL.ObservationsWorkflowQuery
 
 import java.time.Instant
 
@@ -93,6 +95,12 @@ trait OdbObservationApi[F[_]]:
     obsRef: ObservationReference
   ): F[Option[(Program.Id, Observation.Id)]]
   def sequenceOffsets(obsId:             Observation.Id): F[Option[ExecutionOffsets]]
-  def observationEditSubscription(
-    obsId: Observation.Id
-  ): Resource[F, fs2.Stream[F, ObservationEditSubscription.Data]]
+  def observationEditSubscription(obsId: Observation.Id): Resource[F, fs2.Stream[F, Unit]]
+  def programObservationsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ProgramObservationsDelta.Data.ObservationEdit]]
+  def observationExecution(obsId:        Observation.Id): F[Option[Execution]]
+  def allProgramObservations(programId:  Program.Id): F[List[Observation]]
+  def observationWorkflows(
+    whereObservation: WhereObservation
+  ): F[List[ObservationsWorkflowQuery.Data.Observations.Matches]]

--- a/explore/src/main/scala/explore/services/OdbObservationApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbObservationApiImpl.scala
@@ -417,3 +417,11 @@ trait OdbObservationApiImpl[F[_]: Async](using StreamingClient[F, ObservationDB]
       _.hasMore,
       _.id
     )
+
+  def obsCalcSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ObsCalcSubscription.Data.ObscalcUpdate]] =
+    ObsCalcSubscription
+      .subscribe[F](ObscalcUpdateInput(programId.assign))
+      .logGraphQLErrors(_ => "Error in ObsCalcSubscription subscription")
+      .map(_.map(_.obscalcUpdate))

--- a/explore/src/main/scala/explore/services/OdbProgramApi.scala
+++ b/explore/src/main/scala/explore/services/OdbProgramApi.scala
@@ -3,14 +3,17 @@
 
 package explore.services
 
+import cats.effect.Resource
 import eu.timepit.refined.types.string.NonEmptyString
+import explore.model.Attachment
+import explore.model.ProgramDetails
 import explore.model.ProgramInfo
 import explore.model.ProgramNote
+import explore.model.ProgramTimes
 import explore.model.ProgramUser
 import explore.model.RedeemInvitationResult
 import lucuma.core.data.EmailAddress
 import lucuma.core.enums.ConfigurationRequestStatus
-import lucuma.core.model.Attachment
 import lucuma.core.model.ConfigurationRequest
 import lucuma.core.model.PartnerLink
 import lucuma.core.model.Program
@@ -55,3 +58,12 @@ trait OdbProgramApi[F[_]]:
   ): F[CreateUserInvitation]
   def revokeUserInvitation(userInvitationId: String): F[Unit]
   def redeemUserInvitation(key:              String): F[RedeemInvitationResult]
+  def programTimes(programId:                Program.Id): F[Option[ProgramTimes]]
+  def programDetails(programId:              Program.Id): F[Option[ProgramDetails]]
+  def allPrograms: F[List[ProgramInfo]]
+  def allProgramAttachments(programId:       Program.Id): F[List[Attachment]]
+  def programEditsSubscription(programId:    Program.Id): Resource[F, fs2.Stream[F, ProgramDetails]]
+  def programAttachmentsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, List[Attachment]]]
+  def programDeltaSubscription(programId:    Program.Id): Resource[F, fs2.Stream[F, ProgramInfo]]

--- a/explore/src/main/scala/explore/services/OdbTargetApi.scala
+++ b/explore/src/main/scala/explore/services/OdbTargetApi.scala
@@ -12,18 +12,18 @@ import lucuma.core.model.Target
 import lucuma.schemas.ObservationDB.Enums.Existence
 import lucuma.schemas.ObservationDB.Types.UpdateTargetsInput
 import lucuma.schemas.model.TargetWithId
-import queries.common.TargetQueriesGQL.TargetEditSubscription
+import queries.common.TargetQueriesGQL.ProgramTargetsDelta
 
 trait OdbTargetApi[F[_]]:
-  def insertTarget(programId:    Program.Id, target:         Target.Sidereal): F[Target.Id]
-  def updateTarget(targetId:     Target.Id, input:           UpdateTargetsInput): F[Unit]
+  def insertTarget(programId:      Program.Id, target:         Target.Sidereal): F[Target.Id]
+  def updateTarget(targetId:       Target.Id, input:           UpdateTargetsInput): F[Unit]
   def setTargetExistence(
     programId: Program.Id,
     targetId:  Target.Id,
     existence: Existence
   ): F[Unit]
-  def deleteTargets(targetIds:   List[Target.Id], programId: Program.Id): F[Unit]
-  def undeleteTargets(targetIds: List[Target.Id], programId: Program.Id): F[Unit]
+  def deleteTargets(targetIds:     List[Target.Id], programId: Program.Id): F[Unit]
+  def undeleteTargets(targetIds:   List[Target.Id], programId: Program.Id): F[Unit]
   def cloneTarget(
     targetId:  Target.Id,
     replaceIn: ObsIdSet,
@@ -31,8 +31,12 @@ trait OdbTargetApi[F[_]]:
   ): F[TargetWithId]
   def targetEditSubscription(
     targetId: Target.Id
-  ): Resource[F, fs2.Stream[F, TargetEditSubscription.Data]]
+  ): Resource[F, fs2.Stream[F, Unit]]
+  def programTargetsDeltaSubscription(
+    programId: Program.Id
+  ): Resource[F, fs2.Stream[F, ProgramTargetsDelta.Data.TargetEdit]]
   def searchTargetsByNamePrefix(
     programId: Program.Id,
     name:      NonEmptyString
   ): F[List[TargetSearchResult]]
+  def allProgramTargets(programId: Program.Id): F[List[TargetWithId]]

--- a/explore/src/main/scala/explore/services/package.scala
+++ b/explore/src/main/scala/explore/services/package.scala
@@ -1,0 +1,24 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.services
+
+import cats.Monad
+import cats.syntax.all.*
+
+private def drain[F[_]: Monad, A, Id, R](
+  fetch:      Option[Id] => F[R],
+  getList:    R => List[A],
+  getHasMore: R => Boolean,
+  getId:      A => Id
+): F[List[A]] = {
+  def go(id: Option[Id], accum: List[A]): F[List[A]] =
+    fetch(id).flatMap(result =>
+      val list = getList(result)
+      if (getHasMore(result)) go(list.lastOption.map(getId), list)
+      // Fetching with offset includes the offset, so .dropRight(1) ensures we don't include it twice.
+      else (accum.dropRight(1) ++ list).pure[F]
+    )
+
+  go(none, List.empty)
+}


### PR DESCRIPTION
This PR finishes the migration of all queries, mutations and subscriptions to the API layer.