### PR TITLE
Process subscription errors, remove reset on some errors

### DIFF
--- a/explore/src/main/scala/explore/services/OdbConfigApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbConfigApiImpl.scala
@@ -8,7 +8,6 @@ import cats.effect.Resource
 import cats.syntax.all.*
 import clue.StreamingClient
 import clue.data.syntax.*
-import clue.model.GraphQLResponse.*
 import explore.model.ConfigurationRequestWithObsIds
 import explore.model.SupportedInstruments
 import explore.modes.ImagingModeRow
@@ -70,5 +69,5 @@ trait OdbConfigApiImpl[F[_]: MonadThrow](using
   ): Resource[F, fs2.Stream[F, ConfigurationRequestWithObsIds]] =
     ConfigurationRequestSubscription
       .subscribe[F](ConfigurationRequestEditInput(programId.assign))
-      .logGraphQLErrors(_ => "Error in ConfigurationRequestSubscription subscription")
+      .processErrors("ConfigurationRequestSubscription")
       .map(_.map(_.configurationRequestEdit.configurationRequest).unNone)

--- a/explore/src/main/scala/explore/services/OdbGroupApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbGroupApiImpl.scala
@@ -8,7 +8,6 @@ import cats.effect.Resource
 import cats.syntax.all.*
 import clue.StreamingClient
 import clue.data.syntax.*
-import clue.syntax.*
 import eu.timepit.refined.types.numeric.NonNegShort
 import explore.model.Group
 import lucuma.core.model.Program
@@ -89,5 +88,5 @@ trait OdbGroupApiImpl[F[_]: MonadThrow](using StreamingClient[F, ObservationDB],
   ): Resource[F, fs2.Stream[F, GroupEditSubscription.Data.GroupEdit]] =
     GroupEditSubscription
       .subscribe[F](programId.toProgramEditInput)
-      .logGraphQLErrors(_ => "Error in GroupEditSubscription subscription")
+      .processErrors("GroupEditSubscription")
       .map(_.map(_.groupEdit))

--- a/explore/src/main/scala/explore/services/OdbProgramApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbProgramApiImpl.scala
@@ -8,7 +8,6 @@ import cats.effect.Resource
 import cats.implicits.*
 import clue.StreamingClient
 import clue.data.syntax.*
-import clue.syntax.*
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.model.Attachment
 import explore.model.ProgramDetails
@@ -274,7 +273,7 @@ trait OdbProgramApiImpl[F[_]: MonadThrow](using StreamingClient[F, ObservationDB
   def programEditsSubscription(programId: Program.Id): Resource[F, fs2.Stream[F, ProgramDetails]] =
     ProgramEditDetailsSubscription
       .subscribe[F](programId.toProgramEditInput)
-      .logGraphQLErrors(_ => "Error in ProgramEditDetailsSubscription subscription")
+      .processErrors("ProgramEditDetailsSubscription")
       .map(_.map(_.programEdit.value))
 
   def programAttachmentsDeltaSubscription(
@@ -282,7 +281,7 @@ trait OdbProgramApiImpl[F[_]: MonadThrow](using StreamingClient[F, ObservationDB
   ): Resource[F, fs2.Stream[F, List[Attachment]]] =
     ProgramEditAttachmentSubscription
       .subscribe[F](programId.toProgramEditInput)
-      .logGraphQLErrors(_ => "Error in ProgramEditAttachmentSubscription subscription")
+      .processErrors("ProgramEditAttachmentSubscription")
       .map(_.map(_.programEdit.value.attachments))
 
   def programDeltaSubscription(
@@ -290,5 +289,5 @@ trait OdbProgramApiImpl[F[_]: MonadThrow](using StreamingClient[F, ObservationDB
   ): Resource[F, fs2.Stream[F, ProgramInfo]] =
     ProgramInfoDelta
       .subscribe[F]()
-      .logGraphQLErrors(_ => "Error in ProgramInfoDelta subscription")
+      .processErrors("ProgramInfoDelta")
       .map(_.map(_.programEdit.value))

--- a/explore/src/main/scala/explore/services/OdbTargetApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbTargetApiImpl.scala
@@ -118,7 +118,7 @@ trait OdbTargetApiImpl[F[_]: Sync](using
   ): Resource[F, fs2.Stream[F, ProgramTargetsDelta.Data.TargetEdit]] =
     ProgramTargetsDelta
       .subscribe[F](programId.toTargetEditInput)
-      .logGraphQLErrors(_ => "Error in ProgramTargetsDelta subscription")
+      .processErrors("ProgramTargetsDelta")
       .map(_.map(_.targetEdit))
 
   def searchTargetsByNamePrefix(


### PR DESCRIPTION
This is the final PR in the series.

Some queries should not trigger a cache reload, this addresses it; as well as triggering a reset on errors in cache subscriptions.