### PR TITLE
Add Imaging Modes Table - Step 1

### DIFF
--- a/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
@@ -135,6 +135,8 @@ private object BasicConfigurationPanel:
               )
             )
             .when(isSpectroscopy),
+          ImagingModesTable(props.userId, props.confMatrix.imaging, props.units)
+            .unless(isSpectroscopy),
           <.div(ExploreStyles.BasicConfigurationButtons)(
             message.map(Tag(_, severity = Tag.Severity.Success)),
             Button(

--- a/explore/src/main/scala/explore/config/ImagingModesTable.scala
+++ b/explore/src/main/scala/explore/config/ImagingModesTable.scala
@@ -1,0 +1,227 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.config
+
+import cats.Order
+import cats.data.EitherNec
+import cats.implicits.catsKernelOrderingForOrder
+import cats.syntax.all.*
+import crystal.Pot
+import explore.common.UserPreferencesQueries.TableStore
+import explore.components.HelpIcon
+import explore.components.ui.ExploreStyles
+import explore.model.AppContext
+import explore.model.Progress
+import explore.model.display.*
+import explore.model.enums.TableId
+import explore.model.enums.WavelengthUnits
+import explore.model.itc.*
+import explore.modes.*
+import explore.syntax.ui.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.enums.*
+import lucuma.core.math.Angle
+import lucuma.core.math.BoundedInterval
+import lucuma.core.math.BoundedInterval.*
+import lucuma.core.math.SignalToNoise
+import lucuma.core.math.Wavelength
+import lucuma.core.math.WavelengthDelta
+import lucuma.core.model.User
+import lucuma.core.syntax.all.*
+import lucuma.core.util.Display
+import lucuma.core.util.TimeSpan
+import lucuma.react.common.ReactFnProps
+import lucuma.react.syntax.*
+import lucuma.react.table.*
+import lucuma.refined.*
+import lucuma.ui.reusability.given
+import lucuma.ui.table.*
+import lucuma.ui.table.ColumnSize.*
+import lucuma.ui.table.hooks.*
+
+final case class ImagingModesTable(
+  userId: Option[User.Id],
+  matrix: ImagingModesMatrix,
+  units:  WavelengthUnits
+) extends ReactFnProps(ImagingModesTable.component)
+
+object ImagingModesTable extends ModesTableCommon:
+
+  private given Reusability[ImagingModesMatrix] = Reusability.by(_.matrix.length)
+
+  extension (interval: BoundedInterval[Wavelength])
+    // The 'z' filter, at least, has an upper bound of Int.MaxValue picometers. However,
+    // the practical range is limited by things like the detector. According to Andy,
+    // the upper limit is 1100 nm.
+    private def clipForGmos: BoundedInterval[Wavelength] =
+      interval
+        .intersect(
+          BoundedInterval.unsafeClosed(Wavelength.Min, Wavelength.fromIntNanometers(1100).get)
+        )
+        .getOrElse(interval)
+    private def toWavelengthDelta: Option[WavelengthDelta] =
+      // will be 'none' for Point BoundedIntervals (upper === lower)
+      WavelengthDelta.fromIntPicometers(
+        interval.upper.pm.value.value - interval.lower.pm.value.value
+      )
+
+  extension (filter: ItcInstrumentConfig#Filter)
+    private def wavelength: Option[Wavelength] =
+      filter match
+        case g: GmosNorthFilter => g.wavelength.some
+        case g: GmosSouthFilter => g.wavelength.some
+        case _                  => None
+
+    private def wavelengthRangeAndDelta
+      : (Option[BoundedInterval[Wavelength]], Option[WavelengthDelta]) =
+      def forGmos(
+        interval: BoundedInterval[Wavelength]
+      ): (Option[BoundedInterval[Wavelength]], Option[WavelengthDelta]) =
+        val clipped = interval.clipForGmos
+        (clipped.some, clipped.toWavelengthDelta)
+
+      filter match
+        case g: GmosNorthFilter => forGmos(g.width)
+        case g: GmosSouthFilter => forGmos(g.width)
+        case _                  => (None, None)
+
+  private case class ImagingModeRowWithResult(
+    entry:  ImagingModeRow,
+    result: Pot[EitherNec[ItcTargetProblem, ItcResult]]
+  ) extends TableRowWithResult:
+    val rowId: RowId = RowId(entry.id.orEmpty.toString)
+
+  private val ColDef = ColumnDef[ImagingModeRowWithResult].WithTableMeta[TableMeta]
+
+  private val InstrumentColumnId: ColumnId  = ColumnId("instrument")
+  private val TimeColumnId: ColumnId        = ColumnId("time")
+  private val SNColumnId: ColumnId          = ColumnId("sn")
+  private val FilterColumnId: ColumnId      = ColumnId("filter")
+  private val LambdaColumnId: ColumnId      = ColumnId("lambda")
+  private val DeltaLambdaColumnId: ColumnId = ColumnId("delta_lambda")
+  private val FovColumnId: ColumnId         = ColumnId("fov")
+
+  private val columnNames: Map[ColumnId, String] =
+    Map(
+      InstrumentColumnId  -> "Instrument",
+      TimeColumnId        -> "Time",
+      SNColumnId          -> "S/N",
+      FilterColumnId      -> "Filter",
+      LambdaColumnId      -> "λ",
+      DeltaLambdaColumnId -> "Δλ",
+      FovColumnId         -> "FoV"
+    )
+
+  private def column[V](
+    id:       ColumnId,
+    accessor: ImagingModeRowWithResult => V
+  ): ColumnDef.Single.WithTableMeta[ImagingModeRowWithResult, V, TableMeta] =
+    ColDef(id, accessor, columnNames.getOrElse(id, id.value))
+
+  private def columns(units: WavelengthUnits) =
+    given Display[BoundedInterval[Wavelength]] = wavelengthIntervalDisplay(units)
+    given Display[WavelengthDelta]             = wavelengthDeltaDisplay(units)
+    given Display[Wavelength]                  = wavelengthDisplay(units)
+
+    given Order[Angle] = Angle.AngleOrder
+
+    List(
+      column(InstrumentColumnId, row => ImagingModeRow.instrument.get(row.entry).longName)
+        .withCell(_.value: String)
+        .withColumnSize(Resizable(120.toPx, min = 50.toPx, max = 150.toPx))
+        .sortable,
+      column(TimeColumnId, _.totalItcTime)
+        .withHeader(progressingCellHeader("Time"))
+        .withCell: cell =>
+          itcCell(cell.row.original.result, TimeOrSNColumn.Time)
+        .withColumnSize(FixedSize(85.toPx))
+        .withSortUndefined(UndefinedPriority.Last)
+        .sortable,
+      column(SNColumnId, _.totalSN)
+        .withHeader(progressingCellHeader("S/N"))
+        .withCell: cell =>
+          itcCell(cell.row.original.result, TimeOrSNColumn.SN)
+        .withColumnSize(FixedSize(85.toPx))
+        .withSortUndefined(UndefinedPriority.Last)
+        .sortable,
+      column(FilterColumnId, row => ImagingModeRow.instrumentConfig.get(row.entry))
+        .withCell(_.value.filterStr)
+        .withColumnSize(FixedSize(69.toPx))
+        .sortableBy(_.filterStr),
+      column(LambdaColumnId, row => ImagingModeRow.filter.get(row.entry).wavelength)
+        .withHeader(s"λ ${units.symbol}")
+        .withCell(_.value.fold("-")(_.shortName))
+        .withColumnSize(FixedSize(75.toPx))
+        .sortable,
+      column(
+        DeltaLambdaColumnId,
+        row => ImagingModeRow.filter.get(row.entry).wavelengthRangeAndDelta
+      )
+        .withHeader(s"Δλ ${units.symbol}")
+        .withCell: cell =>
+          val (range, delta) = cell.value
+          <.span(delta.fold("-")(_.shortName))
+            .withOptionalTooltip(range.map(r => s"${r.shortName} ${units.symbol}"))
+        .withColumnSize(FixedSize(100.toPx))
+        .sortableBy(_._2),
+      column(FovColumnId, _.entry.fov)
+        .withCell: cell =>
+          val arcSeconds = Angle.arcseconds.get(cell.value)
+          f"$arcSeconds%.0f\""
+        .withColumnSize(FixedSize(75.toPx))
+        .sortable
+    )
+
+  private val component = ScalaFnComponent[ImagingModesTable]: props =>
+    for {
+      ctx         <- useContext(AppContext.ctx)
+      rows        <- useMemo(props.matrix): matrix =>
+                       matrix.matrix.map: row =>
+                         ImagingModeRowWithResult(
+                           row,
+                           Pot.Pending
+                         )
+      cols        <- useMemo(props.units): units =>
+                       columns(units).filterNot(_.id.value === SNColumnId.value)
+      itcProgress <- useState(none[Progress])
+      table       <- useReactTableWithStateStore:
+                       import ctx.given
+
+                       TableOptionsWithStateStore(
+                         TableOptions(
+                           cols,
+                           rows,
+                           getRowId = (row, _, _) => row.rowId,
+                           enableSorting = true,
+                           meta = TableMeta(itcProgress.value)
+                         ),
+                         TableStore(props.userId, TableId.ImagingModes, cols)
+                       )
+
+      virtualizerRef <- useRef(none[HTMLTableVirtualizer])
+    } yield React.Fragment(
+      <.div(ExploreStyles.ModesTableTitle)(
+        <.label(
+          ExploreStyles.ModesTableCount,
+          s"${rows.length} available configurations",
+          HelpIcon("configuration/imaging_table.md".refined)
+        )
+      ),
+      <.div(
+        ExploreStyles.ExploreTable,
+        ExploreStyles.ExploreBorderTable,
+        ExploreStyles.ModesTable
+      )(
+        PrimeAutoHeightVirtualizedTable(
+          table,
+          estimateSize = _ => 32.toPx,
+          striped = true,
+          compact = Compact.Very,
+          containerMod = ^.overflow.auto,
+          virtualizerRef = virtualizerRef,
+          emptyMessage = <.div(ExploreStyles.SpectroscopyTableEmpty, "No matching modes")
+        )
+      )
+    )

--- a/explore/src/main/scala/explore/config/ModesTableCommon.scala
+++ b/explore/src/main/scala/explore/config/ModesTableCommon.scala
@@ -1,0 +1,125 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.config
+
+import cats.data.EitherNec
+import cats.syntax.all.*
+import crystal.Pot
+import eu.timepit.refined.types.string.NonEmptyString
+import explore.Icons
+import explore.components.ui.ExploreStyles
+import explore.model.Progress
+import explore.model.display.given
+import explore.model.itc.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.math.SignalToNoise
+import lucuma.core.syntax.all.*
+import lucuma.core.util.NewBoolean
+import lucuma.core.util.TimeSpan
+import lucuma.react.circularprogressbar.CircularProgressbar
+import lucuma.react.floatingui.Placement
+import lucuma.react.floatingui.syntax.*
+import lucuma.react.table.HeaderContext
+import lucuma.ui.components.ThemeIcons
+import lucuma.ui.syntax.all.given
+import lucuma.ui.utils.*
+
+import scala.collection.decorators.*
+
+trait ModesTableCommon:
+  protected case class TableMeta(itcProgress: Option[Progress])
+
+  protected trait TableRowWithResult:
+    val result: Pot[EitherNec[ItcTargetProblem, ItcResult]]
+
+    lazy val totalItcTime: Option[TimeSpan] =
+      result.toOption
+        .collect { case Right(ItcResult.Result(e, t, _, _)) => e *| t.value }
+
+    lazy val totalSN: Option[SignalToNoise] =
+      result.toOption.collect { case Right(ItcResult.Result(_, _, _, s)) =>
+        s.map(_.total.value)
+      }.flatten
+
+  protected object ScrollTo extends NewBoolean:
+    inline def Scroll = True; inline def NoScroll = False
+
+  protected enum TimeOrSNColumn:
+    case Time, SN
+
+  protected def progressingCellHeader(txt: String)(
+    header: HeaderContext[?, ?, TableMeta, ?, ?, ?, ?]
+  ) =
+    <.div(ExploreStyles.ITCHeaderCell)(
+      txt,
+      header.table.options.meta
+        .flatMap(_.itcProgress)
+        .map(p =>
+          CircularProgressbar(
+            p.percentage.value.value,
+            strokeWidth = 15,
+            className = "explore-modes-table-itc-circular-progressbar"
+          )
+        )
+    )
+
+  protected def itcCell(
+    c:   Pot[EitherNec[ItcTargetProblem, ItcResult]],
+    col: TimeOrSNColumn
+  ): VdomElement = {
+    val content: TagMod = c.toOption match
+      case Some(Left(errors))               =>
+        if (errors.exists(_.problem === ItcQueryProblem.UnsupportedMode))
+          <.span(Icons.Ban(^.color.red))
+            .withTooltip(tooltip = "Mode not supported", placement = Placement.RightStart)
+        else
+          import ItcQueryProblem.*
+
+          def renderName(name: Option[NonEmptyString]): String =
+            name.fold("")(n => s"$n: ")
+
+          val content: List[TagMod] =
+            errors
+              .collect:
+                case ItcTargetProblem(name, s @ SourceTooBright(_)) =>
+                  <.span(ThemeIcons.SunBright.addClass(ExploreStyles.ItcSourceTooBrightIcon))(
+                    renderName(name) + (s: ItcQueryProblem).shortName
+                  )
+                case ItcTargetProblem(name, GenericError(e))        =>
+                  e.split("\n")
+                    .map(u => <.span(u))
+                    .mkTagMod(<.span(renderName(name)), <.br, EmptyVdom)
+                case ItcTargetProblem(name, problem)                =>
+                  <.span(s"${renderName(name)}${problem.message}")
+              .toList
+              .intersperse(<.br: VdomNode)
+
+          <.span(Icons.TriangleSolid.addClass(ExploreStyles.ItcErrorIcon))
+            .withTooltip(tooltip = <.div(content.mkTagMod(<.span)), placement = Placement.RightEnd)
+      case Some(Right(r: ItcResult.Result)) =>
+        val content = col.match
+          case TimeOrSNColumn.Time =>
+            formatDurationHours(r.duration)
+          case TimeOrSNColumn.SN   =>
+            r.snAt.map(_.total.value).foldMap(formatSN)
+
+        val tooltipText = col match
+          case TimeOrSNColumn.Time =>
+            s"${r.exposures} × ${formatDurationSeconds(r.exposureTime)}"
+          case TimeOrSNColumn.SN   =>
+            s"${r.snAt.map(_.single.value).foldMap(formatSN)} / exposure"
+
+        <.span(content)
+          .withTooltip(
+            placement = Placement.RightStart,
+            tooltip = tooltipText
+          )
+      case Some(Right(ItcResult.Pending))   =>
+        Icons.Spinner.withSpin(true)
+      case _                                =>
+        "-"
+
+    <.div(ExploreStyles.ITCCell, content)
+  }

--- a/hasura/user-prefs/migrateDev.sh
+++ b/hasura/user-prefs/migrateDev.sh
@@ -2,6 +2,6 @@
 
 # WARNING: This will apply CURRENT LOCAL migrations
  unset NODE_OPTIONS
- hasura migrate apply --endpoint https://user-prefs-development.herokuapp.com --database-name default
- hasura metadata apply --endpoint https://user-prefs-development.herokuapp.com
- hasura metadata reload --endpoint https://user-prefs-development.herokuapp.com
+ hasura migrate apply --endpoint https://gpp-prefs-dev.lucuma.xyz --database-name default
+ hasura metadata apply --endpoint https://gpp-prefs-dev.lucuma.xyz
+ hasura metadata reload --endpoint https://gpp-prefs-dev.lucuma.xyz

--- a/hasura/user-prefs/migrations/default/1747426679451_imaging_modes_table/down.sql
+++ b/hasura/user-prefs/migrations/default/1747426679451_imaging_modes_table/down.sql
@@ -1,0 +1,1 @@
+DELETE FROM "public"."lucumaTableIds" WHERE "id" = 'imaging_modes';

--- a/hasura/user-prefs/migrations/default/1747426679451_imaging_modes_table/up.sql
+++ b/hasura/user-prefs/migrations/default/1747426679451_imaging_modes_table/up.sql
@@ -1,0 +1,1 @@
+INSERT INTO "public"."lucumaTableIds"("id") VALUES (E'imaging_modes');

--- a/model/shared/src/main/scala/explore/model/display.scala
+++ b/model/shared/src/main/scala/explore/model/display.scala
@@ -13,6 +13,7 @@ import lucuma.core.math.BoundedInterval
 import lucuma.core.math.BoundedInterval.*
 import lucuma.core.math.BrightnessValue
 import lucuma.core.math.Wavelength
+import lucuma.core.math.WavelengthDelta
 import lucuma.core.model.CloudExtinction
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ElevationRange
@@ -178,19 +179,33 @@ trait DisplayImplicits:
     case ScienceSubtype.DemoScience        => "Demo Science"
     case ScienceSubtype.SystemVerification => "System Verification"
 
+  private def formatWavelength(units: WavelengthUnits, q: Wavelength) =
+    units match
+      case WavelengthUnits.Nanometers  =>
+        val v = q.toNanometers.value.value.setScale(1, BigDecimal.RoundingMode.DOWN)
+        "%.1f".format(v)
+      case WavelengthUnits.Micrometers =>
+        val v = q.toMicrometers.value.value.setScale(3, BigDecimal.RoundingMode.DOWN)
+        "%.3f".format(v)
+
+  def wavelengthDisplay(units: WavelengthUnits): Display[Wavelength] =
+    Display.byShortName(formatWavelength(units, _))
+
   def wavelengthIntervalDisplay(units: WavelengthUnits): Display[BoundedInterval[Wavelength]] =
     Display.byShortName: interval =>
       List(interval.lower, interval.upper)
-        .map { q =>
-          units match
-            case WavelengthUnits.Nanometers  =>
-              val v = q.toNanometers.value.value.setScale(1, BigDecimal.RoundingMode.DOWN)
-              "%.1f".format(v)
-            case WavelengthUnits.Micrometers =>
-              val v = q.toMicrometers.value.value.setScale(3, BigDecimal.RoundingMode.DOWN)
-              "%.3f".format(v)
-        }
+        .map(formatWavelength(units, _))
         .mkString(" - ")
+
+  def wavelengthDeltaDisplay(units: WavelengthUnits): Display[WavelengthDelta] =
+    Display.byShortName: delta =>
+      units match
+        case WavelengthUnits.Nanometers  =>
+          val v = delta.toNanometers.value.value.setScale(1, BigDecimal.RoundingMode.DOWN)
+          "%.1f".format(v)
+        case WavelengthUnits.Micrometers =>
+          val v = delta.toMicrometers.value.value.setScale(3, BigDecimal.RoundingMode.DOWN)
+          "%.3f".format(v)
 
   given Display[CatalogName] = Display.byShortName:
     case CatalogName.Simbad => "SIMBAD"

--- a/model/shared/src/main/scala/explore/model/enums/TableIds.scala
+++ b/model/shared/src/main/scala/explore/model/enums/TableIds.scala
@@ -18,3 +18,4 @@ enum TableId(val tag: String) derives Enumerated:
   case RequestedConfigs       extends TableId("requested_configs")
   case UnrequestedConfigs     extends TableId("unrequested_configs")
   case GroupWarnings          extends TableId("group_warnings")
+  case ImagingModes           extends TableId("imaging_modes")

--- a/model/shared/src/main/scala/explore/modes/ImagingModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/ImagingModesMatrix.scala
@@ -10,6 +10,7 @@ import io.circe.Decoder
 import lucuma.core.enums.*
 import lucuma.core.math.Angle
 import lucuma.odb.json.angle.decoder.given
+import monocle.Getter
 import monocle.Lens
 import monocle.macros.GenLens
 
@@ -24,11 +25,18 @@ object ImagingModeRow {
 
   val id: Lens[ImagingModeRow, Option[Int]] = GenLens[ImagingModeRow](_.id)
 
-  val instrument: Lens[ImagingModeRow, ItcInstrumentConfig] = GenLens[ImagingModeRow](_.instrument)
+  val instrumentConfig: Lens[ImagingModeRow, ItcInstrumentConfig] =
+    GenLens[ImagingModeRow](_.instrument)
+
+  val instrument: Getter[ImagingModeRow, Instrument] =
+    instrumentConfig.andThen(ItcInstrumentConfig.instrument)
 
   val ao: Lens[ImagingModeRow, ModeAO] = GenLens[ImagingModeRow](_.ao)
 
   val fov: Lens[ImagingModeRow, Angle] = GenLens[ImagingModeRow](_.fov)
+
+  def filter: Getter[ImagingModeRow, ItcInstrumentConfig#Filter] =
+    instrumentConfig.andThen(ItcInstrumentConfig.filter)
 
   // decoders for instruments are used locally as they are not lawful
   private given Decoder[ItcInstrumentConfig.GmosNorthImaging] =

--- a/model/shared/src/main/scala/explore/modes/ItcInstrumentConfig.scala
+++ b/model/shared/src/main/scala/explore/modes/ItcInstrumentConfig.scala
@@ -24,6 +24,7 @@ sealed trait ItcInstrumentConfig derives Eq:
   val grating: Grating
   def gratingDisplay: Display[Grating]
   def gratingStr: String = gratingDisplay.shortName(grating)
+  def filterStr: String
 
   type FPU
   val fpu: FPU
@@ -57,6 +58,7 @@ object ItcInstrumentConfig:
     type Override = InstrumentOverrides.GmosSpectroscopy
 
     val gratingDisplay: Display[Grating] = Display.byShortName(_.shortName)
+    val filterStr: String                = filter.fold("none")(_.shortName)
     val instrument                       = Instrument.GmosNorth
     val site                             = Site.GN
     val hasFilter                        = filter.isDefined
@@ -73,6 +75,7 @@ object ItcInstrumentConfig:
     type FPU      = GmosSouthFpu
     type Override = InstrumentOverrides.GmosSpectroscopy
     val gratingDisplay: Display[Grating] = Display.byShortName(_.shortName)
+    val filterStr: String                = filter.fold("none")(_.shortName)
     val instrument                       = Instrument.GmosSouth
     val site                             = Site.GS
     val hasFilter                        = filter.isDefined
@@ -88,6 +91,7 @@ object ItcInstrumentConfig:
     type Override = InstrumentOverrides.GmosImaging
 
     val gratingDisplay: Display[Grating] = Display.byShortName(_ => "")
+    val filterStr: String                = filter.shortName
     val instrument                       = Instrument.GmosNorth
     val site                             = Site.GN
     val hasFilter                        = true
@@ -105,6 +109,7 @@ object ItcInstrumentConfig:
     type FPU      = Unit
     type Override = InstrumentOverrides.GmosImaging
     val gratingDisplay: Display[Grating] = Display.byShortName(_ => "")
+    val filterStr: String                = filter.shortName
     val instrument                       = Instrument.GmosSouth
     val site                             = Site.GS
     val hasFilter                        = true
@@ -123,6 +128,7 @@ object ItcInstrumentConfig:
     type FPU      = Flamingos2Fpu
     type Override = Unit
     val gratingDisplay: Display[Grating] = Display.byShortName(_.shortName)
+    val filterStr: String                = filter.shortName
     val instrument                       = Instrument.Flamingos2
     val site                             = Site.GS
     val hasFilter                        = true
@@ -136,6 +142,7 @@ object ItcInstrumentConfig:
     type FPU      = Unit
     type Override = Unit
     val gratingDisplay: Display[Grating] = Display.byShortName(_.shortName)
+    val filterStr: String                = filter.shortName
     val fpu                              = ()
     val instrument                       = Instrument.Gpi
     val site                             = Site.GN
@@ -149,6 +156,7 @@ object ItcInstrumentConfig:
     type FPU      = Unit
     type Override = Unit
     val gratingDisplay: Display[Grating] = Display.byShortName(_.shortName)
+    val filterStr: String                = filter.shortName
     val fpu                              = ()
     val instrument                       = Instrument.Gnirs
     val site                             = Site.GN
@@ -163,6 +171,7 @@ object ItcInstrumentConfig:
     type FPU      = Unit
     type Override = Unit
     val gratingDisplay: Display[Grating] = Display.byShortName(identity)
+    val filterStr: String                = filter.value
     val fpu                              = ()
     val instrument                       = i
     val site                             = Site.GN

--- a/promote.sh
+++ b/promote.sh
@@ -31,10 +31,22 @@ echo "Promote ODB to $TARGET_ENV"
 heroku pipelines:promote -a lucuma-postgres-odb-${SOURCE_ENV} -t lucuma-postgres-odb-${TARGET_ENV}
 
 # Update user preferences
+HASURA_ENDPOINT=""
+case $TARGET_ENV in
+  "production")
+    HASURA_ENDPOINT="https://prefs.gpp.gemini.edu"
+    ;;
+  "staging")
+    HASURA_ENDPOINT="https://gpp-prefs-staging.lucuma.xyz"
+    ;;
+  *)
+    echo "Unknown environment: $TARGET_ENV"
+    exit 1
+    ;;
+esac
 echo "Promote user preferences db to $TARGET_ENV"
 cd hasura/user-prefs
 unset NODE_OPTIONS
-HASURA_ENDPOINT="https://gpp-prefs-${TARGET_ENV}.lucuma.xyz"
 hasura migrate apply --endpoint "$HASURA_ENDPOINT" --database-name default
 hasura metadata apply --endpoint "$HASURA_ENDPOINT"
 hasura metadata reload --endpoint "$HASURA_ENDPOINT"

--- a/promoteDevToStaging.sh
+++ b/promoteDevToStaging.sh
@@ -4,8 +4,8 @@
 # which may not necessarily be in sync with the dev server.
 cd hasura/user-prefs
 unset NODE_OPTIONS
-hasura migrate apply --endpoint https://user-prefs-staging.herokuapp.com --database-name default
-hasura metadata apply --endpoint https://user-prefs-staging.herokuapp.com
-hasura metadata reload --endpoint https://user-prefs-staging.herokuapp.com
+hasura migrate apply --endpoint https://gpp-prefs-staging.lucuma.xyz --database-name default
+hasura metadata apply --endpoint https://gpp-prefs-staging.lucuma.xyz
+hasura metadata reload --endpoint https://gpp-prefs-staging.lucuma.xyz
 cd ../..
 firebase hosting:clone explore-gemini-dev:live explore-gemini-stage:live

--- a/promoteStagingToProduction.sh
+++ b/promoteStagingToProduction.sh
@@ -4,8 +4,8 @@
 # which may not necessarily be in sync with the staging server.
 cd hasura/user-prefs
 unset NODE_OPTIONS
-hasura migrate apply --endpoint https://user-prefs.herokuapp.com --database-name default
-hasura metadata apply --endpoint https://user-prefs.herokuapp.com
-hasura metadata reload --endpoint https://user-prefs.herokuapp.com
+hasura migrate apply --endpoint https://prefs.gpp.gemini.edu --database-name default
+hasura metadata apply --endpoint https://prefs.gpp.gemini.edu
+hasura metadata reload --endpoint https://prefs.gpp.gemini.edu
 cd ../..
 firebase hosting:clone explore-gemini-stage:live explore-gemini-prod:live


### PR DESCRIPTION
This is the first step in the Imaging Modes table. It simply adds the table and shows all of the rows. 

In the following steps I will do things like add the calls to the ITC, allow selection and multi-selection of rows, scroll to selected rows, etc. I will try to extract out more logic common to the spectroscopy modes table.

This PR also updates the `hasura` endpoints for our migration and promotion scripts.

![image](https://github.com/user-attachments/assets/725a4f5a-90ad-4a7c-b98d-a14a88d49624)
