### PR TITLE
Call ITC for the rows of the imaging modes table

### DIFF
--- a/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
@@ -117,7 +117,7 @@ private object BasicConfigurationPanel:
                   )
                 )
             else
-              ImagingConfigurationPanel(imaging, true, props.calibrationRole)
+              ImagingConfigurationPanel(imaging, props.readonly, props.calibrationRole)
                 .unless(isSpectroscopy)
           ),
           props.spectroscopyView
@@ -127,7 +127,7 @@ private object BasicConfigurationPanel:
                 props.selectedConfig,
                 spectroscopy.get,
                 props.constraints,
-                if (props.itcTargets.isEmpty) none else props.itcTargets.some,
+                props.itcTargets,
                 props.baseCoordinates,
                 props.confMatrix.spectroscopy,
                 props.customSedTimestamps,
@@ -135,7 +135,16 @@ private object BasicConfigurationPanel:
               )
             )
             .when(isSpectroscopy),
-          ImagingModesTable(props.userId, props.confMatrix.imaging, props.units)
+          ImagingModesTable(
+            props.userId,
+            imaging.get,
+            props.confMatrix.imaging,
+            props.constraints,
+            props.itcTargets,
+            props.baseCoordinates,
+            props.customSedTimestamps,
+            props.units
+          )
             .unless(isSpectroscopy),
           <.div(ExploreStyles.BasicConfigurationButtons)(
             message.map(Tag(_, severity = Tag.Severity.Success)),

--- a/explore/src/main/scala/explore/itc/ItcResultsCache.scala
+++ b/explore/src/main/scala/explore/itc/ItcResultsCache.scala
@@ -5,10 +5,8 @@ package explore.model.itc
 
 import cats.data.*
 import cats.syntax.all.*
-import explore.model.SupportedInstruments
 import explore.modes.*
 import explore.optics.all.*
-import lucuma.core.enums.*
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.util.Timestamp
@@ -19,9 +17,9 @@ import mouse.boolean.*
 case class ItcResultsCache(
   cache: Map[ItcRequestParams, EitherNec[ItcTargetProblem, ItcResult]]
 ) {
-  def mode(r: SpectroscopyModeRow): EitherNec[ItcQueryProblem, ItcInstrumentConfig] =
+  def mode(r: ModeRow): EitherNec[ItcQueryProblem, ItcInstrumentConfig] =
     Either.fromOption(
-      ItcResultsCache.enabledRow(r).option(r.instrument),
+      r.enabled.option(r.instrument),
       NonEmptyChain.of(ItcQueryProblem.UnsupportedMode)
     )
 
@@ -60,7 +58,7 @@ case class ItcResultsCache(
     c:   ConstraintSet,
     a:   Option[NonEmptyList[ItcTarget]],
     l:   List[Timestamp],
-    r:   SpectroscopyModeRow
+    r:   ModeRow
   ): EitherNec[ItcTargetProblem, ItcResult] =
     (mode(r), targets(a)).parTupled
       .leftMap(_.map(ItcTargetProblem(none, _)))
@@ -77,10 +75,6 @@ case class ItcResultsCache(
 }
 
 object ItcResultsCache:
-
-  def enabledRow(row: SpectroscopyModeRow): Boolean =
-    row.focalPlane === FocalPlane.SingleSlit &&
-      SupportedInstruments.contains_(row.instrument.instrument)
 
   val Empty: ItcResultsCache = ItcResultsCache(Map.empty)
 

--- a/model/shared/src/main/scala/explore/events/ItcMessage.scala
+++ b/model/shared/src/main/scala/explore/events/ItcMessage.scala
@@ -12,7 +12,6 @@ import explore.model.itc.ItcResult
 import explore.model.itc.ItcTarget
 import explore.model.itc.ItcTargetProblem
 import explore.modes.ItcInstrumentConfig
-import explore.modes.SpectroscopyModeRow
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ExposureTimeMode
 import lucuma.core.util.Timestamp
@@ -33,7 +32,7 @@ object ItcMessage extends ItcPicklers:
     constraints:         ConstraintSet,
     asterism:            NonEmptyList[ItcTarget],
     customSedTimestamps: List[Timestamp],
-    modes:               List[SpectroscopyModeRow]
+    modes:               List[ItcInstrumentConfig]
   ) extends Request:
     type ResponseType = Map[ItcRequestParams, EitherNec[ItcTargetProblem, ItcResult]]
 

--- a/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
+++ b/model/shared/src/main/scala/explore/model/boopickle/ItcPickler.scala
@@ -74,6 +74,8 @@ trait ItcPicklers extends CommonPicklers {
 
   given Pickler[InstrumentOverrides.GmosSpectroscopy] = generatePickler
 
+  given Pickler[InstrumentOverrides.GmosImaging] = generatePickler
+
   given Pickler[ItcInstrumentConfig.GmosNorthSpectroscopy] = generatePickler
 
   given Pickler[ItcInstrumentConfig.GmosSouthSpectroscopy] = generatePickler
@@ -86,6 +88,10 @@ trait ItcPicklers extends CommonPicklers {
 
   given Pickler[ItcInstrumentConfig.GenericSpectroscopy] = generatePickler
 
+  given Pickler[ItcInstrumentConfig.GmosNorthImaging] = generatePickler
+
+  given Pickler[ItcInstrumentConfig.GmosSouthImaging] = generatePickler
+
   given Pickler[ItcInstrumentConfig] =
     compositePickler[ItcInstrumentConfig]
       .addConcreteType[ItcInstrumentConfig.GmosNorthSpectroscopy]
@@ -94,6 +100,8 @@ trait ItcPicklers extends CommonPicklers {
       .addConcreteType[ItcInstrumentConfig.GpiSpectroscopy]
       .addConcreteType[ItcInstrumentConfig.GnirsSpectroscopy]
       .addConcreteType[ItcInstrumentConfig.GenericSpectroscopy]
+      .addConcreteType[ItcInstrumentConfig.GmosNorthImaging]
+      .addConcreteType[ItcInstrumentConfig.GmosSouthImaging]
 
   given Pickler[ModeWavelength] = picklerNewType(ModeWavelength)
 

--- a/model/shared/src/main/scala/explore/model/display.scala
+++ b/model/shared/src/main/scala/explore/model/display.scala
@@ -155,6 +155,13 @@ trait DisplayImplicits:
 
   given Display[GmosRoi] = Display.byShortName(_.longName)
 
+  given Display[FilterType] = Display.byShortName:
+    case FilterType.BroadBand     => "Broad Band"
+    case FilterType.NarrowBand    => "Narrow Band"
+    case FilterType.Combination   => "Combination"
+    case FilterType.Spectroscopic => "Spectroscopic"
+    case FilterType.Engineering   => "Engineering"
+
   given Display[Flamingos2Disperser] = Display.by(_.shortName, _.longName)
 
   given Display[Flamingos2Filter] = Display.by(_.shortName, _.longName)

--- a/model/shared/src/main/scala/explore/modes/ImagingModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/ImagingModesMatrix.scala
@@ -6,6 +6,7 @@ package explore.modes
 import cats.Eq
 import cats.derived.*
 import cats.implicits.*
+import explore.model.SupportedInstruments
 import io.circe.Decoder
 import lucuma.core.enums.*
 import lucuma.core.math.Angle
@@ -19,7 +20,8 @@ case class ImagingModeRow(
   instrument: ItcInstrumentConfig,
   ao:         ModeAO,
   fov:        Angle
-)
+) extends ModeRow:
+  val enabled = SupportedInstruments.contains_(instrument.instrument)
 
 object ImagingModeRow {
 

--- a/model/shared/src/main/scala/explore/modes/ItcInstrumentConfig.scala
+++ b/model/shared/src/main/scala/explore/modes/ItcInstrumentConfig.scala
@@ -36,6 +36,8 @@ sealed trait ItcInstrumentConfig derives Eq:
 
   def hasFilter: Boolean
 
+  val mode: ScienceMode
+
   type Override
   def modeOverrides: Option[Override] = None
 
@@ -62,6 +64,7 @@ object ItcInstrumentConfig:
     val instrument                       = Instrument.GmosNorth
     val site                             = Site.GN
     val hasFilter                        = filter.isDefined
+    val mode                             = ScienceMode.Spectroscopy
   }
 
   case class GmosSouthSpectroscopy(
@@ -79,6 +82,7 @@ object ItcInstrumentConfig:
     val instrument                       = Instrument.GmosSouth
     val site                             = Site.GS
     val hasFilter                        = filter.isDefined
+    val mode                             = ScienceMode.Spectroscopy
   }
 
   case class GmosNorthImaging(
@@ -95,6 +99,7 @@ object ItcInstrumentConfig:
     val instrument                       = Instrument.GmosNorth
     val site                             = Site.GN
     val hasFilter                        = true
+    val mode                             = ScienceMode.Imaging
     val grating: Grating                 = ()
     val fpu: FPU                         = ()
   }
@@ -113,6 +118,7 @@ object ItcInstrumentConfig:
     val instrument                       = Instrument.GmosSouth
     val site                             = Site.GS
     val hasFilter                        = true
+    val mode                             = ScienceMode.Imaging
     val grating: Grating                 = ()
     val fpu: FPU                         = ()
 
@@ -132,6 +138,7 @@ object ItcInstrumentConfig:
     val instrument                       = Instrument.Flamingos2
     val site                             = Site.GS
     val hasFilter                        = true
+    val mode                             = ScienceMode.Spectroscopy
 
   }
 
@@ -147,6 +154,7 @@ object ItcInstrumentConfig:
     val instrument                       = Instrument.Gpi
     val site                             = Site.GN
     val hasFilter                        = true
+    val mode                             = ScienceMode.Spectroscopy
   }
 
   case class GnirsSpectroscopy(grating: GnirsDisperser, filter: GnirsFilter)
@@ -161,6 +169,7 @@ object ItcInstrumentConfig:
     val instrument                       = Instrument.Gnirs
     val site                             = Site.GN
     val hasFilter                        = true
+    val mode                             = ScienceMode.Spectroscopy
   }
 
   // Used for Instruments not fully defined
@@ -176,6 +185,7 @@ object ItcInstrumentConfig:
     val instrument                       = i
     val site                             = Site.GN
     val hasFilter                        = true
+    val mode                             = ScienceMode.Spectroscopy
   }
 
   val instrument: Getter[ItcInstrumentConfig, Instrument] =

--- a/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
+++ b/model/shared/src/main/scala/explore/modes/SpectroscopyModesMatrix.scala
@@ -16,6 +16,7 @@ import eu.timepit.refined.cats.*
 import eu.timepit.refined.numeric.*
 import eu.timepit.refined.types.numeric.*
 import eu.timepit.refined.types.string.*
+import explore.model.SupportedInstruments
 import explore.model.syntax.all.*
 import io.circe.Decoder
 import io.circe.refined.*
@@ -90,8 +91,12 @@ case class SpectroscopyModeRow(
   resolution: PosInt,
   slitLength: SlitLength,
   slitWidth:  SlitWidth
-) extends ModeCommonWavelengths derives Eq {
+) extends ModeCommonWavelengths
+    with ModeRow derives Eq {
   inline def hasFilter: Boolean = instrument.hasFilter
+  val enabled                   =
+    focalPlane === FocalPlane.SingleSlit &&
+      SupportedInstruments.contains_(instrument.instrument)
 
   // This `should` always return a `some`, but if the row is wonky for some reason...
   def intervalCenter(cw: Wavelength): Option[CentralWavelength] =

--- a/model/shared/src/main/scala/explore/modes/package.scala
+++ b/model/shared/src/main/scala/explore/modes/package.scala
@@ -12,6 +12,10 @@ import lucuma.core.optics.Wedge
 import lucuma.core.util.NewBoolean
 import lucuma.core.util.NewType
 
+trait ModeRow:
+  def instrument: ItcInstrumentConfig
+  def enabled: Boolean
+
 object ModeWavelength extends NewType[Wavelength]
 type ModeWavelength = ModeWavelength.Type
 

--- a/model/shared/src/main/scala/queries/schemas/itc/syntax.scala
+++ b/model/shared/src/main/scala/queries/schemas/itc/syntax.scala
@@ -46,6 +46,10 @@ trait syntax:
           InstrumentMode
             .Flamingos2Spectroscopy(disperser, filter, fpu)
             .some
+        case ItcInstrumentConfig.GmosNorthImaging(filter, modeOverrides)                    =>
+          InstrumentMode.GmosNorthImaging(filter, none).some
+        case ItcInstrumentConfig.GmosSouthImaging(filter, modeOverrides)                    =>
+          InstrumentMode.GmosSouthImaging(filter, none).some
         case _                                                                              => None
 
   // We may consider adjusting this to consider small variations of RV identical for the


### PR DESCRIPTION
Calls ITC for each of the rows in the imaging modes table. 

Also adds the `Filter Type` column to the table.

Still no row selection or filtering. 