### PR TITLE
Add scrolling to the imaging modes table

### DIFF
--- a/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
@@ -69,7 +69,7 @@ private object BasicConfigurationPanel:
         // these next 2 are temporary
         imaging         <- useStateView[Imaging](Imaging.Default)
         // selectedConfig above should be replaced by one of these...
-        selectedConfigs <- useStateView(none[ConfigSelection])
+        selectedConfigs <- useStateView(ConfigSelection.Empty)
         creating        <- useStateView(Creating(false))
       yield
         import ctx.given


### PR DESCRIPTION
Add the up/down scroll buttons. With multiple selection, it looks for the nearest selected index above the visible range and below the visible range, if they exist. So, both buttons can be available at the same time. It also scrolls to the top most selected item when things like sort order or itc results change.

I also modifed `ConfigSelection` to allow an empty list so that we can deal with the lack of a selection within the class instead of having to pass an `Option[ConfigSelection]` around and deal with optionality everywhere.

`ConfigSelection` was also modified to include the ITC results to support the next step, which is switch the spectroscopy modes table and friends to use `ConfigSelection`.