### PR TITLE
Validate proposal for submission and show errors in a tile.

### DIFF
--- a/common/src/main/scala/explore/components/Tile.scala
+++ b/common/src/main/scala/explore/components/Tile.scala
@@ -101,6 +101,9 @@ case class Tile[A](
 object Tile:
   type TileId = NonEmptyString
 
+  def dummyTile(id: TileId): Tile[Unit] =
+    Tile(id, "", hidden = true)(_ => EmptyVdom)
+
   private type Props[A] = Tile[A]
 
   private def componentBuilder[A] =

--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -231,6 +231,7 @@ object ExploreStyles:
   val ProposalSubmissionBar: Css   = Css("explore-proposal-submission-line")
   val ProposalDeadline: Css        = Css("explore-proposal-deadline")
   val ProposalAttachmentsTile: Css = Css("explore-proposal-attachments-tile")
+  val ProposalErrorsTile: Css      = Css("explore-proposal-errors-tile")
   val CfpData: Css                 = Css("cfp-data")
 
   val ProgramDescription: Css = Css("explore-program-description")

--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -473,6 +473,7 @@ object ExploreGridLayouts:
     private lazy val UsersHeight: NonNegInt       = 6.refined
     private lazy val AbstractHeight: NonNegInt    = 8.refined
     private lazy val AttachmentsHeight: NonNegInt = 8.refined
+    private lazy val ErrorsHeight: NonNegInt      = 4.refined
 
     private lazy val layoutMedium: Layout = Layout(
       List(
@@ -503,6 +504,13 @@ object ExploreGridLayouts:
           y = (DetailsHeight |+| AbstractHeight).value,
           w = DefaultWidth.value,
           h = AttachmentsHeight.value
+        ),
+        LayoutItem(
+          i = ProposalTabTileIds.ErrorsId.id.value,
+          x = 0,
+          y = (DetailsHeight |+| AbstractHeight |+| AttachmentsHeight).value,
+          w = DefaultWidth.value,
+          h = ErrorsHeight.value
         )
       )
     )

--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -62,6 +62,8 @@ object reusability:
     Reusability.by(_.toList)
 
   given Reusability[ObsIdSet]                = Reusability.byEq
+  given Reusability[Proposal]                = Reusability.byEq
+  given Reusability[ProposalType]            = Reusability.byEq
   given Reusability[TargetEditObsInfo]       = Reusability.byEq
   given Reusability[TargetIdSet]             = Reusability.byEq
   given Reusability[TargetWithId]            = Reusability.byEq

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -3195,6 +3195,14 @@ div.spectroscopy-table-emptymessage {
       }
     }
   }
+
+  .explore-proposal-errors-tile {
+    padding: 1rem;
+
+    svg {
+      margin-right: 0.5rem;
+    }
+  }
 }
 
 .explore-program-description,

--- a/explore/src/clue/scala/queries/common/CallForProposalsSubquery.scala
+++ b/explore/src/clue/scala/queries/common/CallForProposalsSubquery.scala
@@ -26,6 +26,7 @@ object CallForProposalsSubquery
         partner
         submissionDeadline
       }
+      allowsNonPartnerPi
       instruments
       coordinateLimits {
         north $SiteCoordinatesLimitsSubquery

--- a/explore/src/main/scala/explore/proposal/ProposalEditor.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalEditor.scala
@@ -37,6 +37,7 @@ import lucuma.core.model.User
 import lucuma.react.common.ReactFnComponent
 import lucuma.react.common.ReactFnProps
 import lucuma.react.floatingui.syntax.*
+import lucuma.react.primereact.PrimeStyles
 import lucuma.react.resizeDetector.hooks.*
 import lucuma.refined.*
 import lucuma.schemas.ObservationDB.Types.*
@@ -56,6 +57,7 @@ case class ProposalEditor(
   proposal:           UndoSetter[Proposal],
   users:              View[List[ProgramUser]],
   attachments:        View[AttachmentList],
+  errors:             Option[List[String]],
   authToken:          Option[NonEmptyString],
   cfps:               List[CallForProposal],
   layout:             LayoutsMap,
@@ -204,14 +206,30 @@ object ProposalEditor
                     props.programId,
                     token,
                     props.attachments,
+                    props.proposal.get.proposalType,
                     props.proposalOrUserIsReadonly
                   )
                 ),
               (_, _) =>
-                <.a(^.href           := Constants.P1TemplatesUrl,
+                // put it in a span so it doesn't take up the full width
+                <.span(
+                  <.a(
+                    ^.href   := Constants.P1TemplatesUrl,
                     ^.target := "_blank",
-                    Icons.ArrowUpRightFromSquare
-                ).withTooltip("Download templates")
+                    Icons.ArrowUpRightFromSquare,
+                    PrimeStyles.Component,
+                    PrimeStyles.Button,
+                    PrimeStyles.ButtonIconOnly,
+                    LucumaPrimeStyles.Tiny,
+                    LucumaPrimeStyles.Compact,
+                    PrimeStyles.ButtonSecondary
+                  ).withTooltip("Download templates")
+                )
+            )
+
+          val errorsTile =
+            props.errors.fold(Tile.dummyTile(ProposalTabTileIds.ErrorsId.id))(
+              ProposalErrorsTile(_)
             )
 
           <.div(ExploreStyles.MultiPanelTile)(
@@ -220,7 +238,7 @@ object ProposalEditor
               resize.width.getOrElse(1),
               defaultLayouts,
               props.layout,
-              List(detailsTile, usersTile, abstractTile, attachmentsTile),
+              List(detailsTile, usersTile, abstractTile, attachmentsTile, errorsTile),
               GridLayoutSection.ProposalLayout,
               storeLayout = true
             )

--- a/explore/src/main/scala/explore/proposal/ProposalErrorsTile.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalErrorsTile.scala
@@ -1,0 +1,33 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.proposal
+
+import explore.Icons
+import explore.components.Tile
+import explore.components.ui.ExploreStyles
+import explore.model.ProposalTabTileIds
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.ReactFnComponent
+import lucuma.react.common.ReactFnProps
+
+object ProposalErrorsTile:
+  def apply(errors: List[String]): Tile[Unit] =
+    Tile(
+      ProposalTabTileIds.ErrorsId.id,
+      s"Errors (${errors.size})"
+    )(_ => Body(errors))
+
+  private case class Body(errors: List[String]) extends ReactFnProps(Body)
+
+  private object Body
+      extends ReactFnComponent[Body](props =>
+        <.div(
+          ExploreStyles.ProposalErrorsTile,
+          props.errors.toTagMod: e =>
+            <.div(
+              Icons.ErrorIcon,
+              e
+            )
+        )
+      )

--- a/explore/src/main/scala/explore/services/OdbProposalApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbProposalApiImpl.scala
@@ -7,6 +7,7 @@ import cats.MonadThrow
 import cats.syntax.all.*
 import clue.FetchClient
 import clue.data.syntax.*
+import clue.model.GraphQLResponse.*
 import explore.common.ProposalOdbExtensions.*
 import explore.model.CallForProposal
 import explore.model.Proposal
@@ -51,5 +52,5 @@ trait OdbProposalApiImpl[F[_]: MonadThrow](using FetchClient[F, ObservationDB])
     SetProposalStatus[F]
       .execute:
         SetProposalStatusInput(programId = programId.assign, status = newStatus)
-      .processNoDataErrors
+      .raiseGraphQLErrorsOnNoData
       .void

--- a/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/OverviewTabContents.scala
@@ -107,8 +107,7 @@ object OverviewTabContents
         // is edited as the abstract on the proposals tab.
         val descriptionTile =
           if (props.detailsUndoSetter.get.programType === ProgramType.Science)
-            // dummy tile as above
-            Tile(OverviewTabTileIds.DescriptionId.id, "", hidden = true)(_ => EmptyVdom)
+            Tile.dummyTile(OverviewTabTileIds.DescriptionId.id)
           else
             val descriptionAligner: Aligner[Option[NonEmptyString], Input[NonEmptyString]] =
               Aligner(

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -556,9 +556,9 @@ object TargetTabContents extends TwoPanels:
 
           // We still want to render these 2 tiles, even when not shown, so as not to mess up the stored layout.
           val dummyTargetTile: Tile[Unit]    =
-            Tile(TargetTabTileIds.AsterismEditor.id, "", hidden = true)(_ => EmptyVdom)
+            Tile.dummyTile(TargetTabTileIds.AsterismEditor.id)
           val dummyElevationTile: Tile[Unit] =
-            Tile(TargetTabTileIds.ElevationPlot.id, "", hidden = true)(_ => EmptyVdom)
+            Tile.dummyTile(TargetTabTileIds.ElevationPlot.id)
 
           /**
            * Renders a single sidereal target editor without an obs context

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbCallForProposal.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbCallForProposal.scala
@@ -43,20 +43,22 @@ trait ArbCallForProposal {
   given Arbitrary[CallForProposal] =
     Arbitrary {
       for {
-        id       <- arbitrary[CallForProposals.Id]
-        semester <- arbitrary[Semester]
-        title    <- arbitrary[NonEmptyString]
-        cfpType  <- arbitrary[CallForProposalsType]
-        partners <- arbitrary[List[CallPartner]]
-        deadline <- arbitrary[Option[Timestamp]]
-        instr    <- arbitrary[List[Instrument]]
-        limits   <- arbitrary[CallCoordinatesLimits]
-        active   <- arbitrary[DateInterval]
+        id                 <- arbitrary[CallForProposals.Id]
+        semester           <- arbitrary[Semester]
+        title              <- arbitrary[NonEmptyString]
+        cfpType            <- arbitrary[CallForProposalsType]
+        partners           <- arbitrary[List[CallPartner]]
+        allowsNonPartnerPi <- arbitrary[Boolean]
+        deadline           <- arbitrary[Option[Timestamp]]
+        instr              <- arbitrary[List[Instrument]]
+        limits             <- arbitrary[CallCoordinatesLimits]
+        active             <- arbitrary[DateInterval]
       } yield CallForProposal(id,
                               semester,
                               title,
                               cfpType,
                               partners,
+                              allowsNonPartnerPi,
                               deadline,
                               instr,
                               limits,
@@ -71,6 +73,7 @@ trait ArbCallForProposal {
        NonEmptyString,
        CallForProposalsType,
        List[CallPartner],
+       Boolean,
        Option[Timestamp],
        List[Instrument],
        CallCoordinatesLimits,
@@ -82,6 +85,7 @@ trait ArbCallForProposal {
        p.title,
        p.cfpType,
        p.partners,
+       p.allowsNonPartnerPi,
        p.nonPartnerDeadline,
        p.instruments,
        p.coordinateLimits,

--- a/model/shared/src/main/scala/explore/CallForProposal.scala
+++ b/model/shared/src/main/scala/explore/CallForProposal.scala
@@ -38,6 +38,7 @@ case class CallForProposal(
   title:              NonEmptyString,
   cfpType:            CallForProposalsType,
   partners:           List[CallPartner],
+  allowsNonPartnerPi: Boolean,
   nonPartnerDeadline: Option[Timestamp],
   instruments:        List[Instrument],
   coordinateLimits:   CallCoordinatesLimits,

--- a/model/shared/src/main/scala/explore/Proposal.scala
+++ b/model/shared/src/main/scala/explore/Proposal.scala
@@ -6,7 +6,11 @@ package explore.model
 import cats.Eq
 import cats.derived.*
 import cats.syntax.all.*
+import explore.model.syntax.all.*
 import io.circe.Decoder
+import lucuma.core.enums.AttachmentType
+import lucuma.core.enums.Partner
+import lucuma.core.enums.ProgramUserRole
 import lucuma.core.enums.TacCategory
 import lucuma.core.model.PartnerLink
 import lucuma.core.model.ProposalReference
@@ -27,14 +31,122 @@ case class Proposal(
   def deadline(piPartner: Option[PartnerLink]): Option[Timestamp] =
     call.flatMap(_.deadline(piPartner))
 
+  // in reality, should always have a PI
+  extension (users: List[ProgramUser])
+    private def pi: Option[ProgramUser]            =
+      users.find(_.role === ProgramUserRole.Pi)
+    private def hasPi(partner: Partner): Boolean   =
+      pi.exists(_.partnerLink.exists(_.partnerOption.exists(_ === partner)))
+    private def hasUser(partner: Partner): Boolean =
+      users.exists(_.partnerLink.exists(_.partnerOption.exists(_ === partner)))
+
+  private def cfPError(users: List[ProgramUser]): Option[String] =
+    call.fold("Call for Proposal is required.".some)(cfp =>
+      val piAffiliation = users.pi
+        .flatMap(_.partnerLink)
+        // if no partner link, it's unspecified
+        .fold(PartnerLink.HasUnspecifiedPartner)(identity)
+      piAffiliation match
+        case PartnerLink.HasPartner(partner)   =>
+          Option.when(!cfp.partners.exists(_.partner === partner)) {
+            "PI partner not valid for this Call for Proposal."
+          }
+        case PartnerLink.HasNonPartner         =>
+          Option.when(!cfp.allowsNonPartnerPi) {
+            "Non-partner PI is not allowed for this Call for Proposal."
+          }
+        // This gets checked in usersAndTimesErrors
+        case PartnerLink.HasUnspecifiedPartner => none
+    )
+
+  // if this is None, either a CfP has not been selected or they are not required for the proposal type
+  private lazy val partnerSplits: Option[List[PartnerSplit]] =
+    proposalType.flatMap(pt => ProposalType.partnerSplits.getOption(pt))
+
+  private lazy val validatePartnerSplits: Option[String] =
+    partnerSplits.flatMap(splits =>
+      Option.when(splits.foldLeft(0)(_ + _.percent.value) != 100) {
+        "Partner time splits must be specified and sum to 100%."
+      }
+    )
+
+  private def usersAndTimesErrors(users: List[ProgramUser]): List[String] =
+    val partnerError = Option.unless(users.forall(_.partnerLink.exists(_.isSet))) {
+      "Partnership of every investigator must be specified."
+    }
+    (partnerError, validatePartnerSplits) match
+      case (Some(a), None)    => List(a)
+      case (None, Some(b))    => List(b)
+      case (Some(a), Some(b)) => List(a, b)
+      case (None, None)       =>
+        // Make sure every partner split requested has a matching user.
+        // Only verify this if splits and users are all valid.
+        partnerSplits
+          .map(splits =>
+            splits
+              .filter(_.percent.value > 0)
+              .map(ps =>
+                if (ps.partner === Partner.UH && !users.hasPi(Partner.UH))
+                  "Requests for time from UH must have a UH PI.".some
+                else if (ps.partner =!= Partner.US && !users.hasUser(ps.partner))
+                  "Non-US partner time requests must have matching collaborators.".some
+                else none
+              )
+              .flattenOption
+              .distinct
+          )
+          .toList
+          .flatten
+
+  private lazy val isFastTurnaround: Boolean =
+    proposalType.exists {
+      case ProposalType.FastTurnaround(_, _, _, _) => true
+      case _                                       => false
+    }
+
+  private def attachmentErrors(attachments: AttachmentList): List[String] =
+    // only validate if there is a CfP
+    call.foldMap(_ =>
+      val science = Option.unless(attachments.hasForType(AttachmentType.Science))(
+        "Science attachment is required."
+      )
+      val team    = Option.unless(isFastTurnaround || attachments.hasForType(AttachmentType.Team))(
+        "Team attachment is required."
+      )
+      List(science, team).flattenOption
+    )
+
+  private def obsErrors(
+    hasDefinedObservations:   Boolean,
+    hasUndefinedObservations: Boolean
+  ): List[String] =
+    List(
+      Option.unless(hasDefinedObservations)(
+        "Proposal cannot be submitted without at least one defined observation."
+      ),
+      Option.when(hasUndefinedObservations)(
+        "Proposal cannot be submitted with undefined observations. Define them or mark them as inactive."
+      )
+    ).flattenOption
+
+  def errors(
+    users:                    List[ProgramUser],
+    attachments:              AttachmentList,
+    hasDefinedObservations:   Boolean,
+    hasUndefinedObservations: Boolean
+  ): List[String] = List(
+    cfPError(users).toList,
+    usersAndTimesErrors(users),
+    attachmentErrors(attachments),
+    obsErrors(hasDefinedObservations, hasUndefinedObservations)
+  ).flatten
+
 object Proposal:
   val call: Lens[Proposal, Option[CallForProposal]]        =
     Focus[Proposal](_.call)
   val category: Lens[Proposal, Option[TacCategory]]        =
     Focus[Proposal](_.category)
   val proposalType: Lens[Proposal, Option[ProposalType]]   =
-    Focus[Proposal](_.proposalType)
-  val callWithType: Lens[Proposal, Option[ProposalType]]   =
     Focus[Proposal](_.proposalType)
   val reference: Lens[Proposal, Option[ProposalReference]] =
     Focus[Proposal](_.reference)

--- a/model/shared/src/main/scala/explore/model/TileIds.scala
+++ b/model/shared/src/main/scala/explore/model/TileIds.scala
@@ -40,13 +40,14 @@ enum ProgramTabTileIds:
     case DataUsers            => "dataUsers".refined
 
 enum ProposalTabTileIds:
-  case DetailsId, UsersId, AbstractId, AttachmentsId
+  case DetailsId, UsersId, AbstractId, AttachmentsId, ErrorsId
 
   def id: NonEmptyString = this match
     case DetailsId     => "proposalDetails".refined
     case UsersId       => "proposalUsers".refined
     case AbstractId    => "proposalAbstract".refined
     case AttachmentsId => "proposalAttachments".refined
+    case ErrorsId      => "proposalErrors".refined
 
 enum GroupEditTileIds:
   case GroupEditId

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -131,6 +131,8 @@ object all:
       self.map(_._2).filter(_.attachmentType === attachmentType).toList
     def finderList: List[Attachment]                                  =
       listForType(AttachmentType.Finder)
+    def hasForType(attachmentType: AttachmentType): Boolean           =
+      self.exists(_._2.attachmentType === attachmentType)
 
   extension [A](list: Iterable[A])
     def toSortedMap[K: Ordering, V](getKey: A => K, getValue: A => V = identity[A](_)) =


### PR DESCRIPTION
Displays the errors in a very simple format in a new tile on the Proposals Tab.
![image](https://github.com/user-attachments/assets/83efe5b0-708e-4799-9c0b-8418774b8c80)

 Also:
- Fixes the "Download Templates" link in the attachments tile title to look like a button and prevents it from being the full width of the title bar. Before, the tooltip would appear with the mouse anywhere in the middle section of the title bar and was confusing.
- Don't reload the program cache for errors while updating the proposal status. We don't update anything locally unless the call is successful.
- Display errors from updating the proposal status in a toast instead of the error message in the submission bar. We should have eliminated most error responses from the API with our new validations (or will have when the API is updated to properly validate proposal submission). This results in better behavior of the error message as reported in https://app.shortcut.com/lucuma/story/5699/proposal-error-only-cleared-by-page-reload.