### PR TITLE
Add additional proposal validation

### DIFF
--- a/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
@@ -102,7 +102,9 @@ object ProposalSubmissionBar
                     label = "Submit Proposal",
                     onClick = updateStatus(ProposalStatus.Submitted),
                     disabled =
-                      isUpdatingStatus.get.value || props.hasProposalErrors || isDueDeadline
+                      // Temporarily enable submission even if there are errors for testing against PI validation
+                      // isUpdatingStatus.get.value || props.hasProposalErrors || isDueDeadline
+                      isUpdatingStatus.get.value || isDueDeadline
                   ).compact.tiny,
                   props.deadline.map: deadline =>
                     val (deadlineStr, left): (String, Option[String]) =

--- a/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -73,7 +73,9 @@ object ProposalTabContents:
       ctx    <- useContext(AppContext.ctx)
       errors <-
         useMemo(
-          (props.proposalStatus,
+          (props.programDetails.get.name,
+           props.programDetails.get.description,
+           props.proposalStatus,
            props.programDetails.get.proposal,
            props.users.get,
            props.attachments.get,
@@ -82,6 +84,8 @@ object ProposalTabContents:
           )
         ):
           (
+            title,
+            abstrakt,
             status,
             proposal,
             users,
@@ -92,7 +96,13 @@ object ProposalTabContents:
             if (status === ProposalStatus.NotSubmitted)
               proposal
                 .foldMap(
-                  _.errors(users, attachments, hasDefinedObservations, hasUndefinedObservations)
+                  _.errors(title,
+                           abstrakt,
+                           users,
+                           attachments,
+                           hasDefinedObservations,
+                           hasUndefinedObservations
+                  )
                 )
                 .some
             else none

--- a/model/shared/src/main/scala/explore/model/ProgramUser.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramUser.scala
@@ -52,6 +52,9 @@ case class ProgramUser(
           case None      => ProgramUser.Status.NotInvited
           case Some(inv) => ProgramUser.Status.Invited(inv.deliveryStatus)
 
+  lazy val isConfirmed: Boolean         = status === ProgramUser.Status.Confirmed
+  lazy val successfullyInvited: Boolean = activeInvitation.exists(!_.deliveryStatus.failed)
+
 object ProgramUser:
   type Id = lucuma.core.model.ProgramUser.Id
   val Id = lucuma.core.model.ProgramUser.Id

--- a/model/shared/src/main/scala/explore/model/UserInvitation.scala
+++ b/model/shared/src/main/scala/explore/model/UserInvitation.scala
@@ -35,7 +35,11 @@ case class UserInvitation(
       case InvitationStatus.Revoked  => Failed("The invitation has been revoked.")
 
 object UserInvitation:
-  sealed abstract class DeliveryStatus(val message: String)
+  sealed abstract class DeliveryStatus(val message: String):
+    def failed: Boolean = this match
+      case DeliveryStatus.Failed(_) => true
+      case _                        => false
+
   object DeliveryStatus:
     case class Success(override val message: String)    extends DeliveryStatus(message)
     case class InProgress(override val message: String) extends DeliveryStatus(message)


### PR DESCRIPTION
It also keeps the `Submit` button enabled even if there are errors so that Andy can more easily compare against the ODB validations. After he completes testing, this part will be reverted.