### PR TITLE
Use calculatedWorkflow

### DIFF
--- a/explore/src/clue/scala/queries/common/CalculatedObservationWorkflowSubquery.scala
+++ b/explore/src/clue/scala/queries/common/CalculatedObservationWorkflowSubquery.scala
@@ -1,0 +1,23 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package queries.common
+
+import clue.GraphQLSubquery
+import clue.annotation.GraphQL
+import lucuma.core.model.ObservationWorkflow
+import lucuma.core.util.CalculatedValue
+import lucuma.schemas.ObservationDB
+import lucuma.schemas.decoders.given
+
+@GraphQL
+object CalculatedObservationWorkflowSubquery
+    extends GraphQLSubquery.Typed[ObservationDB, CalculatedValue[ObservationWorkflow]](
+      "CalculatedObservationWorkflow"
+    ):
+  override val subquery: String = s"""
+    {
+      state
+      value $ObservationWorkflowSubquery
+    }
+  """

--- a/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ObsQueriesGQL.scala
@@ -142,8 +142,9 @@ object ObsQueriesGQL:
           value {
             groupId
             execution {
-              digest: calculatedDigest $CalculatedDigestSubquery
+              calculatedDigest $CalculatedDigestSubquery
             }
+            calculatedWorkflow $CalculatedObservationWorkflowSubquery
           }
         }
       }

--- a/explore/src/clue/scala/queries/common/ObservationSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ObservationSubquery.scala
@@ -63,7 +63,7 @@ object ObservationSubquery extends GraphQLSubquery.Typed[ObservationDB, Observat
           calibrationRole
           scienceBand
           configuration $ConfigurationSubquery
-          workflow $ObservationWorkflowSubquery
+          workflow: calculatedWorkflow $CalculatedObservationWorkflowSubquery
           groupId
           groupIndex
           reference {

--- a/explore/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
+++ b/explore/src/clue/scala/queries/common/ProgramSummaryQueriesGQL.scala
@@ -90,21 +90,6 @@ object ProgramSummaryQueriesGQL {
   }
 
   @GraphQL
-  trait ObservationsWorkflowQuery extends GraphQLOperation[ObservationDB] {
-    val document: String = s"""
-      query($$where: WhereObservation!, $$offset: ObservationId) {
-        observations(WHERE: $$where, OFFSET: $$offset) {
-          matches {
-            id
-            workflow $ObservationWorkflowSubquery
-          }
-          hasMore
-        }
-      }
-    """
-  }
-
-  @GraphQL
   trait GroupTimeRangeQuery extends GraphQLOperation[ObservationDB] {
     val document: String = s"""
       query($$groupId: GroupId!) {

--- a/explore/src/main/scala/explore/config/ObsTimeEditor.scala
+++ b/explore/src/main/scala/explore/config/ObsTimeEditor.scala
@@ -9,6 +9,7 @@ import crystal.react.View
 import explore.Icons
 import explore.components.HelpIcon
 import explore.components.ui.ExploreStyles
+import explore.model.syntax.all.*
 import explore.syntax.ui.*
 import explore.utils.*
 import japgolly.scalajs.react.*

--- a/explore/src/main/scala/explore/config/sequence/SequenceTile.scala
+++ b/explore/src/main/scala/explore/config/sequence/SequenceTile.scala
@@ -18,6 +18,7 @@ import explore.model.ObsTabTileIds
 import explore.model.Observation
 import explore.model.SequenceData
 import explore.model.reusability.given
+import explore.model.syntax.all.*
 import explore.syntax.ui.*
 import explore.utils.*
 import japgolly.scalajs.react.*

--- a/explore/src/main/scala/explore/observationtree/ObsBadge.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsBadge.scala
@@ -14,6 +14,7 @@ import explore.Icons
 import explore.components.ui.ExploreStyles
 import explore.model.Observation
 import explore.model.display.given
+import explore.model.syntax.all.*
 import explore.syntax.ui.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -174,10 +175,10 @@ object ObsBadge:
 
       val validationTooltip =
         if (obs.hasConfigurationRequestError)
-          <.span(obs.workflow.validationErrors.head.messages.head)
+          <.span(obs.workflow.value.validationErrors.head.messages.head)
         else
           <.div(
-            obs.workflow.validationErrors
+            obs.workflow.value.validationErrors
               .toTagMod(using ov => <.div(ov.code.name, <.ul(ov.messages.toList.toTagMod(using i => <.li(i)))))
           )
 
@@ -204,28 +205,28 @@ object ObsBadge:
                   EnumDropdownView(
                     id = NonEmptyString.unsafeFrom(s"obs-status-${obs.id}-2"),
                     value = View[ObservationWorkflowState](
-                      obs.workflow.state,
+                      obs.workflow.value.state,
                       (f, cb) =>
-                        val oldValue = obs.workflow.state
-                        val newValue = f(obs.workflow.state)
+                        val oldValue = obs.workflow.value.state
+                        val newValue = f(obs.workflow.value.state)
                         setStatus(newValue) >> cb(oldValue, newValue)
                     ),
                     size = PlSize.Mini,
                     clazz = ExploreStyles.ObsStateSelect,
                     panelClass = ExploreStyles.ObsStateSelectPanel,
-                    disabled = props.isDisabled,
+                    disabled = props.isDisabled || obs.workflow.isStale,
                     exclude = obs.disabledStates
                   )
                 )(
                   // don't select the observation when changing the status
                   ^.onClick ==> { e => e.preventDefaultCB >> e.stopPropagationCB }
-                )
+                ).withOptionalTooltip(obs.workflow.staleTooltip)
               ),
               props.executionTime.value.map(
                 TimeSpanView(_, tooltip = props.executionTime.staleTooltip)
                   .withMods(props.executionTime.staleClass)
               ),
-              validationIcon.unless(obs.workflow.validationErrors.isEmpty)
+              validationIcon.unless(obs.workflow.value.validationErrors.isEmpty)
             )
           )
         ),

--- a/explore/src/main/scala/explore/programs/TimeAccountingTable.scala
+++ b/explore/src/main/scala/explore/programs/TimeAccountingTable.scala
@@ -11,6 +11,7 @@ import explore.model.CategoryAllocationList
 import explore.model.ProgramTimes
 import explore.model.display.given
 import explore.model.reusability.given
+import explore.model.syntax.all.*
 import explore.syntax.ui.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*

--- a/explore/src/main/scala/explore/proposal/ProposalDetailsTile.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalDetailsTile.scala
@@ -37,6 +37,7 @@ import explore.model.display.given
 import explore.model.enums.TileSizeState
 import explore.model.enums.Visible
 import explore.model.reusability.given
+import explore.model.syntax.all.*
 import explore.syntax.ui.*
 import explore.undo.*
 import japgolly.scalajs.react.*

--- a/explore/src/main/scala/explore/services/OdbObservationApi.scala
+++ b/explore/src/main/scala/explore/services/OdbObservationApi.scala
@@ -24,7 +24,6 @@ import lucuma.schemas.ObservationDB.Types.*
 import lucuma.schemas.model.ObservingMode
 import queries.common.ObsQueriesGQL.ObsCalcSubscription
 import queries.common.ObsQueriesGQL.ProgramObservationsDelta
-import queries.common.ProgramSummaryQueriesGQL.ObservationsWorkflowQuery
 
 import java.time.Instant
 
@@ -100,9 +99,6 @@ trait OdbObservationApi[F[_]]:
     programId: Program.Id
   ): Resource[F, fs2.Stream[F, ProgramObservationsDelta.Data.ObservationEdit]]
   def allProgramObservations(programId:  Program.Id): F[List[Observation]]
-  def observationWorkflows(
-    whereObservation: WhereObservation
-  ): F[List[ObservationsWorkflowQuery.Data.Observations.Matches]]
   def obsCalcSubscription(
     programId: Program.Id
   ): Resource[F, fs2.Stream[F, ObsCalcSubscription.Data.ObscalcUpdate]]

--- a/explore/src/main/scala/explore/services/OdbObservationApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbObservationApiImpl.scala
@@ -34,7 +34,6 @@ import lucuma.schemas.model.ObservingMode
 import lucuma.schemas.odb.input.*
 import queries.common.ObsQueriesGQL.*
 import queries.common.ProgramSummaryQueriesGQL.AllProgramObservations
-import queries.common.ProgramSummaryQueriesGQL.ObservationsWorkflowQuery
 import queries.common.TargetQueriesGQL.SetGuideTargetName
 
 import java.time.Instant
@@ -382,24 +381,6 @@ trait OdbObservationApiImpl[F[_]: Async](using StreamingClient[F, ObservationDB]
           .query(programId.toWhereObservation, offset.orUnassign)
           // We need this because we currently get errors for things like having no targets
           .processNoDataErrors
-          .map(_.observations),
-      _.matches,
-      _.hasMore,
-      _.id
-    )
-
-  def observationWorkflows(
-    whereObservation: WhereObservation
-  ): F[List[ObservationsWorkflowQuery.Data.Observations.Matches]] =
-    drain[
-      ObservationsWorkflowQuery.Data.Observations.Matches,
-      Observation.Id,
-      ObservationsWorkflowQuery.Data.Observations
-    ](
-      offset =>
-        ObservationsWorkflowQuery[F]
-          .query(whereObservation, offset.orUnassign)
-          .processErrors
           .map(_.observations),
       _.matches,
       _.hasMore,

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -283,6 +283,9 @@ object ObsTabContents extends TwoPanels:
                 // Something like .mapValue but for UndoContext
                 val obsUndoSetter =
                   props.observations.zoom(indexValue.getOption.andThen(_.get), indexValue.modify)
+                val obs           = obsUndoSetter.get
+                val obsIsReadonly =
+                  props.readonly || addingObservation.get.value || obs.isCalibration || obs.isExecuted
                 ObsTabTiles(
                   props.vault,
                   props.programId,
@@ -300,7 +303,7 @@ object ObsTabContents extends TwoPanels:
                   resize,
                   props.userPreferences.get,
                   props.globalPreferences,
-                  props.readonly || addingObservation.get.value || obsUndoSetter.get.isExecuted
+                  obsIsReadonly
                 ).withKey(s"${obsId.show}")
               )
           }

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -103,8 +103,6 @@ case class ObsTabTiles(
 ) extends ReactFnProps(ObsTabTiles.component):
   val obsId: Observation.Id = observation.get.id
 
-  val isDisabled: Boolean = readonly || observation.get.isCalibration
-
   val allConstraintSets: Set[ConstraintSet] = programSummaries.constraintGroups.map(_._2).toSet
 
   val targetObservations: Map[Target.Id, SortedSet[Observation.Id]] =
@@ -379,7 +377,7 @@ object ObsTabTiles:
               props.vault.map(_.token),
               props.attachments,
               pa,
-              props.isDisabled,
+              props.readonly,
               hidden = hideTiles
             )
 
@@ -507,7 +505,7 @@ object ObsTabTiles:
               guideStarSelection,
               props.attachments,
               props.vault.map(_.token),
-              props.isDisabled,
+              props.readonly,
               // Any target changes invalidate the sequence
               sequenceChanged.set(pending)
             )
@@ -517,7 +515,7 @@ object ObsTabTiles:
               props.obsId,
               props.observation.model.zoom(Observation.constraints),
               props.allConstraintSets,
-              props.isDisabled
+              props.readonly
             )
 
           // The ExploreStyles.ConstraintsTile css adds a z-index to the constraints tile react-grid wrapper
@@ -538,13 +536,13 @@ object ObsTabTiles:
                   conditionsLikelihood,
                   props.centralWavelength,
                   props.observation.zoom(Observation.constraints),
-                  props.isDisabled
+                  props.readonly
                 ),
               (_, _) => constraintsSelector
             )
 
           val schedulingWindowsTile =
-            SchedulingWindowsTile(schedulingWindows, props.isDisabled, false)
+            SchedulingWindowsTile(schedulingWindows, props.readonly, false)
 
           val configurationTile: Tile[?] =
             ConfigurationTile(
@@ -567,7 +565,7 @@ object ObsTabTiles:
                 case Ready(x) => pending
                 case x        => x
               ,
-              props.isDisabled,
+              props.readonly,
               props.globalPreferences.get.wavelengthUnits,
               props.vault.isStaff
             )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -29,7 +29,6 @@ import explore.plots.ObjectPlotData
 import explore.plots.PlotData
 import explore.shortcuts.*
 import explore.shortcuts.given
-import explore.syntax.ui.*
 import explore.targeteditor.AsterismEditorTile
 import explore.targets.TargetPasteAction
 import explore.targets.TargetSummaryTile

--- a/explore/src/main/scala/explore/validations/ObservationValidationsTable.scala
+++ b/explore/src/main/scala/explore/validations/ObservationValidationsTable.scala
@@ -135,10 +135,10 @@ object ObservationValidationsTableBody {
       .map: obs =>
         Expandable(
           ObsRow(obs),
-          if (obs.workflow.validationErrors.size > 1)
+          if (obs.workflow.value.validationErrors.size > 1)
             // only include the tails for messages and validations. The head will be shown in the "parent" row.
-            messagesTailRows(obs.id, obs.workflow.validationErrors.head) ++
-              obs.workflow.validationErrors.tail
+            messagesTailRows(obs.id, obs.workflow.value.validationErrors.head) ++
+              obs.workflow.value.validationErrors.tail
                 .map(v =>
                   Expandable(
                     ValidationRow(obs.id, v),
@@ -229,8 +229,9 @@ object ObservationValidationsTableBody {
     def category(isExpanded: Boolean): VdomElement =
       fold(
         r =>
-          if (isExpanded) categoryCell(r.obs.workflow.validationErrors.head) // head is safe here
-          else categoryCell(r.obs.workflow.validationErrors*),
+          if (isExpanded)
+            categoryCell(r.obs.workflow.value.validationErrors.head) // head is safe here
+          else categoryCell(r.obs.workflow.value.validationErrors*),
         r => categoryCell(r.validation),
         _ => <.span()
       )
@@ -238,8 +239,9 @@ object ObservationValidationsTableBody {
     def message(isExpanded: Boolean): String =
       fold(
         r =>
-          if (isExpanded) r.obs.workflow.validationErrors.headOption.map(_.messages.head).orEmpty
-          else r.obs.workflow.validationErrors.flatMap(_.messages.toList).mkString(", "),
+          if (isExpanded)
+            r.obs.workflow.value.validationErrors.headOption.map(_.messages.head).orEmpty
+          else r.obs.workflow.value.validationErrors.flatMap(_.messages.toList).mkString(", "),
         r =>
           if (isExpanded) r.validation.messages.head
           else r.validation.messages.mkString_(", "),

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbObservation.scala
@@ -30,7 +30,9 @@ import lucuma.core.model.arb.ArbObservationValidation.given
 import lucuma.core.model.arb.ArbObservationWorkflow.given
 import lucuma.core.model.arb.ArbPosAngleConstraint.given
 import lucuma.core.model.arb.ArbTimingWindow.given
+import lucuma.core.util.CalculatedValue
 import lucuma.core.util.TimeSpan
+import lucuma.core.util.arb.ArbCalculatedValue.given
 import lucuma.core.util.arb.ArbEnumerated.given
 import lucuma.core.util.arb.ArbGid.given
 import lucuma.core.util.arb.ArbTimeSpan.given
@@ -77,7 +79,7 @@ trait ArbObservation:
         calibrationRole     <- arbitrary[Option[CalibrationRole]]
         scienceBand         <- arbitrary[Option[ScienceBand]]
         configuration       <- arbitrary[Option[Configuration]]
-        workflow            <- arbitrary[ObservationWorkflow]
+        workflow            <- arbitrary[CalculatedValue[ObservationWorkflow]]
         groupId             <- arbitrary[Option[Group.Id]]
         groupIndex          <- arbitrary[NonNegShort]
         execution           <- arbitrary[Execution]
@@ -129,7 +131,7 @@ trait ArbObservation:
        Option[CalibrationRole],
        Option[ScienceBand],
        Option[Configuration],
-       ObservationWorkflow,
+       CalculatedValue[ObservationWorkflow],
        Option[Group.Id],
        (Short, Execution)
       )

--- a/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramSummaries.scala
@@ -76,10 +76,10 @@ case class ProgramSummaries(
       .toMap
 
   lazy val hasUndefinedObservations: Boolean =
-    observations.values.exists(_.workflow.state === ObservationWorkflowState.Undefined)
+    observations.values.exists(_.workflow.value.state === ObservationWorkflowState.Undefined)
 
   lazy val hasDefinedObservations: Boolean =
-    observations.values.exists(_.workflow.state === ObservationWorkflowState.Defined)
+    observations.values.exists(_.workflow.value.state === ObservationWorkflowState.Defined)
 
   lazy val obsAttachmentAssignments: ObsAttachmentAssignmentMap =
     observations.toList
@@ -159,7 +159,7 @@ case class ProgramSummaries(
   lazy val configsWithoutRequests: Map[Configuration, NonEmptyList[Observation]] =
     val l = observations.values.toList
       .filter: o =>
-        o.workflow.state =!= ObservationWorkflowState.Inactive &&
+        o.workflow.value.state =!= ObservationWorkflowState.Inactive &&
           o.calibrationRole.isEmpty &&
           o.configuration.fold(false): config =>
             o.hasNotRequestedCode ||
@@ -255,15 +255,15 @@ case class ProgramSummaries(
       .map: (group, obses) =>
         val undefWarning =
           obses
-            .exists(_.workflow.state === ObservationWorkflowState.Undefined)
+            .exists(_.workflow.value.state === ObservationWorkflowState.Undefined)
             .mkSet(GroupWarning.UndefinedObservations)
         val unapproved   =
           obses
-            .exists(_.workflow.state === ObservationWorkflowState.Unapproved)
+            .exists(_.workflow.value.state === ObservationWorkflowState.Unapproved)
             .mkSet(GroupWarning.UnapprovedObservations)
 
         val obs2Check =
-          NonEmptyList.fromList(obses.filterNot(o => ignoreStates.contains(o.workflow.state)))
+          NonEmptyList.fromList(obses.filterNot(o => ignoreStates.contains(o.workflow.value.state)))
 
         val moreWarnings = obs2Check.fold(Set.empty): nel =>
           val bandMismatch = // for all AND groups

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,7 +8,7 @@ object Versions {
   val circeGolden            = "0.3.0"
   val coulomb                = "0.8.0"
   val clue                   = "0.45.0"
-  val crystal                = "0.47.6"
+  val crystal                = "0.49.0"
   val discipline             = "1.7.0"
   val disciplineMUnit        = "2.0.0"
   val fs2                    = "3.12.0"


### PR DESCRIPTION
Most of the time when the workflow is stale, it won't really be changing so I don't make the observation readonly or anything like that. If the user edits it when it WILL be changing (for example to OnGoing) it will still be caught by validations in the ODB. This is really no different than before this PR because we wouldn't be informed of the new workflow until after it was recalculated.

I do disable the dropdown for selecting a new workflow state and put a tooltip there while it is stale. I didn't think this would be too intrusive and would give some indication of what is going on.