### PR TITLE
Implement missing part of global error handling

### DIFF
--- a/explore/src/main/scala/explore/TopBar.scala
+++ b/explore/src/main/scala/explore/TopBar.scala
@@ -26,6 +26,7 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.ExecutionEnvironment
 import lucuma.core.model.GuestRole
 import lucuma.core.model.Program
+import lucuma.core.model.StandardRole
 import lucuma.core.util.NewBoolean
 import lucuma.react.common.*
 import lucuma.react.fa.FontAwesomeIcon
@@ -56,6 +57,7 @@ case class TopBar(
   programInfos:               ViewOpt[ProgramInfoList],
   theme:                      View[Theme],
   onLogout:                   IO[Unit],
+  onRoleChange:               StandardRole => IO[Unit],
   globalPreferences:          View[GlobalPreferences]
 ) extends ReactFnProps(TopBar.component)
 
@@ -202,7 +204,7 @@ object TopBar:
               ),
               right = React.Fragment(
                 <.span(LayoutStyles.MainUserName)(user.displayName),
-                RoleSwitch(props.vault, ctx.sso),
+                RoleSwitch(props.vault, ctx.sso, props.onRoleChange),
                 ConnectionsStatus(),
                 Button(
                   icon = Icons.Bars,

--- a/explore/src/main/scala/explore/cache/ProgramCacheController.scala
+++ b/explore/src/main/scala/explore/cache/ProgramCacheController.scala
@@ -35,16 +35,16 @@ import queries.common.ProgramQueriesGQL.GroupEditSubscription
 import scala.concurrent.duration.*
 
 case class ProgramCacheController(
-  programId:           Program.Id,
-  modProgramSummaries: (Pot[ProgramSummaries] => Pot[ProgramSummaries]) => IO[Unit],
-  onLoad:              IO[Unit]
+  programId:                Program.Id,
+  modProgramSummaries:      (Pot[ProgramSummaries] => Pot[ProgramSummaries]) => IO[Unit],
+  onLoad:                   IO[Unit],
+  override val resetSignal: fs2.Stream[IO, ResetType]
 )(using val odbApi: OdbApi[IO], logger: Logger[IO])
 // Do not remove the explicit type parameter below, it confuses the compiler.
     extends ReactFnProps[ProgramCacheController](ProgramCacheController.component)
     with CacheControllerComponent.Props[ProgramSummaries]:
-  val modState                           = modProgramSummaries
-  given Logger[IO]                       = logger
-  val updateSignal: fs2.Stream[IO, Unit] = fs2.Stream.empty
+  val modState     = modProgramSummaries
+  given Logger[IO] = logger
 
 object ProgramCacheController
     extends CacheControllerComponent[ProgramSummaries, ProgramCacheController]


### PR DESCRIPTION
When I implemented global error handling, I changed the way the UI informs the user when it's populating the cache. But I forgot to hook the new mechanism to the cache controller.

I finally remembered how I intended to do this and implemented it here.