### PR TITLE
Add Fast turnaround reviewer and mentor.

### DIFF
--- a/explore/src/clue/scala/queries/common/ProposalSubquery.scala
+++ b/explore/src/clue/scala/queries/common/ProposalSubquery.scala
@@ -31,6 +31,8 @@ object ProposalSubquery extends GraphQLSubquery.Typed[ObservationDB, Proposal]("
         ... on FastTurnaround {
           toOActivation
           minPercentTime
+          reviewer { id }
+          mentor { id }
         }
         ... on LargeProgram {
           toOActivation

--- a/explore/src/main/scala/explore/common/ProposalOdbExtensions.scala
+++ b/explore/src/main/scala/explore/common/ProposalOdbExtensions.scala
@@ -7,6 +7,7 @@ import clue.data.Input
 import clue.data.Unassign
 import clue.data.syntax.*
 import explore.model.PartnerSplit
+import explore.model.ProgramUser
 import explore.model.Proposal
 import explore.model.ProposalType
 import lucuma.core.enums.CallForProposalsType
@@ -32,25 +33,27 @@ trait ProposalOdbExtensions:
   extension (proposalType: ProposalType)
     def toInput: ProposalTypeInput =
       proposalType match
-        case ProposalType.DemoScience(_, toOActivation, minPercentTime)          =>
+        case ProposalType.DemoScience(_, toOActivation, minPercentTime)                      =>
           ProposalTypeInput(demoScience =
             DemoScienceInput(
               toOActivation = toOActivation.assign,
               minPercentTime = minPercentTime.assign
             ).assign
           )
-        case ProposalType.DirectorsTime(_, toOActivation, minPercentTime)        =>
+        case ProposalType.DirectorsTime(_, toOActivation, minPercentTime)                    =>
           ProposalTypeInput(directorsTime =
             DirectorsTimeInput(
               toOActivation = toOActivation.assign,
               minPercentTime = minPercentTime.assign
             ).assign
           )
-        case ProposalType.FastTurnaround(_, toOActivation, minPercentTime)       =>
+        case ProposalType.FastTurnaround(_, toOActivation, minPercentTime, reviewer, mentor) =>
           ProposalTypeInput(fastTurnaround =
             FastTurnaroundInput(
               toOActivation = toOActivation.assign,
-              minPercentTime = minPercentTime.assign
+              minPercentTime = minPercentTime.assign,
+              reviewerId = reviewer.orUnassign,
+              mentorId = mentor.orUnassign
             ).assign
           )
         case ProposalType.LargeProgram(
@@ -68,7 +71,7 @@ trait ProposalOdbExtensions:
               totalTime = totalTime.toInput.assign
             ).assign
           )
-        case ProposalType.Classical(_, minPercentTime, partnerSplits)            =>
+        case ProposalType.Classical(_, minPercentTime, partnerSplits)                        =>
           ProposalTypeInput(classical =
             ClassicalInput(
               minPercentTime = minPercentTime.assign,
@@ -76,7 +79,7 @@ trait ProposalOdbExtensions:
                 if (partnerSplits.nonEmpty) partnerSplits.map(_.toInput).assign else Unassign
             ).assign
           )
-        case ProposalType.Queue(_, toOActivation, minPercentTime, partnerSplits) =>
+        case ProposalType.Queue(_, toOActivation, minPercentTime, partnerSplits)             =>
           ProposalTypeInput(queue =
             QueueInput(
               toOActivation = toOActivation.assign,
@@ -85,22 +88,23 @@ trait ProposalOdbExtensions:
                 if (partnerSplits.nonEmpty) partnerSplits.map(_.toInput).assign else Unassign
             ).assign
           )
-        case ProposalType.SystemVerification(_, toOActivation, minPercentTime)   =>
+        case ProposalType.SystemVerification(_, toOActivation, minPercentTime)               =>
           ProposalTypeInput(systemVerification =
             SystemVerificationInput(
               toOActivation = toOActivation.assign,
               minPercentTime = minPercentTime.assign
             ).assign
           )
-        case ProposalType.PoorWeather(scienceSubtype)                            =>
+        case ProposalType.PoorWeather(scienceSubtype)                                        =>
           ProposalTypeInput(poorWeather = PoorWeatherInput().assign)
 
   // Used to reset the proposal type when the call changes
   extension (cfpType: CallForProposalsType)
-    def defaultType: ProposalType = cfpType match
+    def defaultType(reviewerId: Option[ProgramUser.Id]): ProposalType = cfpType match
       case CallForProposalsType.DemoScience        => ProposalType.DemoScience.Default
       case CallForProposalsType.DirectorsTime      => ProposalType.DirectorsTime.Default
-      case CallForProposalsType.FastTurnaround     => ProposalType.FastTurnaround.Default
+      case CallForProposalsType.FastTurnaround     =>
+        ProposalType.FastTurnaround.defaultWithReviewer(reviewerId)
       case CallForProposalsType.LargeProgram       => ProposalType.LargeProgram.Default
       case CallForProposalsType.PoorWeather        => ProposalType.PoorWeather.Default
       case CallForProposalsType.RegularSemester    => ProposalType.Queue.Default

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbProgramUser.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbProgramUser.scala
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import explore.model.ProgramUser
+import explore.model.User
+import explore.model.UserInvitation
+import explore.model.arb.ArbUser.given
+import explore.model.arb.ArbUserInvitation.given
+import lucuma.core.enums.EducationalStatus
+import lucuma.core.enums.Gender
+import lucuma.core.enums.ProgramUserRole
+import lucuma.core.model.PartnerLink
+import lucuma.core.model.UserProfile
+import lucuma.core.model.arb.ArbPartnerLink.given
+import lucuma.core.model.arb.ArbUserProfile.given
+import lucuma.core.util.arb.ArbEnumerated.given
+import lucuma.core.util.arb.ArbGid.given
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen.*
+
+trait ArbProgramUser:
+  given Arbitrary[ProgramUser] =
+    Arbitrary {
+      for {
+        id                <- arbitrary[ProgramUser.Id]
+        user              <- arbitrary[Option[User]]
+        partnerLink       <- arbitrary[Option[PartnerLink]]
+        role              <- arbitrary[ProgramUserRole]
+        educationalStatus <- arbitrary[Option[EducationalStatus]]
+        thesis            <- arbitrary[Option[Boolean]]
+        gender            <- arbitrary[Option[Gender]]
+        fallbackProfile   <- arbitrary[UserProfile]
+        invitations       <- arbitrary[List[UserInvitation]]
+        hasDataAccess     <- arbitrary[Boolean]
+      } yield ProgramUser(id,
+                          user,
+                          partnerLink,
+                          role,
+                          educationalStatus,
+                          thesis,
+                          gender,
+                          fallbackProfile,
+                          invitations,
+                          hasDataAccess
+      )
+    }
+
+  given Cogen[ProgramUser] =
+    Cogen[
+      (
+        ProgramUser.Id,
+        Option[User],
+        Option[PartnerLink],
+        ProgramUserRole,
+        Option[EducationalStatus],
+        Option[Boolean],
+        Option[Gender],
+        UserProfile,
+        List[UserInvitation],
+        Boolean
+      )
+    ].contramap(u =>
+      (u.id,
+       u.user,
+       u.partnerLink,
+       u.role,
+       u.educationalStatus,
+       u.thesis,
+       u.gender,
+       u.fallbackProfile,
+       u.invitations,
+       u.hasDataAccess
+      )
+    )
+
+object ArbProgramUser extends ArbProgramUser

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposal.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposal.scala
@@ -3,19 +3,18 @@
 
 package explore.model.arb
 
-import lucuma.core.enums.TacCategory
 import explore.model.CallForProposal
 import explore.model.Proposal
-import lucuma.core.util.arb.ArbEnumerated.given
+import explore.model.ProposalType
+import explore.model.arb.ArbCallForProposal.given
+import explore.model.arb.ArbProposalType.given
+import lucuma.core.enums.TacCategory
+import lucuma.core.model.ProposalReference
 import lucuma.core.model.arb.ArbProposalReference.given
+import lucuma.core.util.arb.ArbEnumerated.given
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
-
-import explore.model.arb.ArbCallForProposal.given
-import explore.model.arb.ArbProposalType.given
-import explore.model.ProposalType
-import lucuma.core.model.ProposalReference
 
 trait ArbProposal:
 

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposalType.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbProposalType.scala
@@ -4,20 +4,21 @@
 package explore.model.arb
 
 import eu.timepit.refined.scalacheck.all.*
+import explore.model.PartnerSplit
+import explore.model.ProgramUser
+import explore.model.ProposalType
+import explore.model.ProposalType.*
+import explore.model.arb.ArbPartnerSplit.given
+import lucuma.core.enums.ScienceSubtype
 import lucuma.core.enums.ToOActivation
 import lucuma.core.model.IntPercent
+import lucuma.core.util.TimeSpan
 import lucuma.core.util.arb.ArbEnumerated.given
+import lucuma.core.util.arb.ArbGid.given
+import lucuma.core.util.arb.ArbTimeSpan.given
 import org.scalacheck.*
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Cogen.*
-
-import explore.model.arb.ArbPartnerSplit.given
-import explore.model.ProposalType
-import explore.model.ProposalType.*
-import explore.model.PartnerSplit
-import lucuma.core.util.TimeSpan
-import lucuma.core.util.arb.ArbTimeSpan.given
-import lucuma.core.enums.ScienceSubtype
 
 trait ArbProposalType:
 
@@ -81,7 +82,9 @@ trait ArbProposalType:
         scienceSubtype <- arbitrary[ScienceSubtype]
         toOActivation  <- arbitrary[ToOActivation]
         minPercentType <- arbitrary[IntPercent]
-      } yield FastTurnaround(scienceSubtype, toOActivation, minPercentType)
+        reviewer       <- arbitrary[Option[ProgramUser.Id]]
+        mentor         <- arbitrary[Option[ProgramUser.Id]]
+      } yield FastTurnaround(scienceSubtype, toOActivation, minPercentType, reviewer, mentor)
     }
 
   given Cogen[FastTurnaround] =
@@ -89,9 +92,13 @@ trait ArbProposalType:
       (
         ScienceSubtype,
         ToOActivation,
-        IntPercent
+        IntPercent,
+        Option[ProgramUser.Id],
+        Option[ProgramUser.Id]
       )
-    ].contramap(p => (p.scienceSubtype, p.toOActivation, p.minPercentTime))
+    ].contramap(p =>
+      (p.scienceSubtype, p.toOActivation, p.minPercentTime, p.reviewerId, p.mentorId)
+    )
 
   given Arbitrary[LargeProgram] =
     Arbitrary {

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbUser.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbUser.scala
@@ -1,0 +1,35 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import explore.model.User
+import lucuma.core.model.OrcidId
+import lucuma.core.model.UserProfile
+import lucuma.core.model.arb.ArbOrcidId.given
+import lucuma.core.model.arb.ArbUserProfile.given
+import lucuma.core.util.arb.ArbGid.given
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen.*
+
+trait ArbUser:
+  given Arbitrary[User] =
+    Arbitrary {
+      for {
+        id      <- arbitrary[User.Id]
+        orcidId <- arbitrary[Option[OrcidId]]
+        profile <- arbitrary[Option[UserProfile]]
+      } yield User(id, orcidId, profile)
+    }
+
+  given Cogen[User] =
+    Cogen[
+      (
+        User.Id,
+        Option[OrcidId],
+        Option[UserProfile]
+      )
+    ].contramap(u => (u.id, u.orcidId, u.profile))
+
+object ArbUser extends ArbUser

--- a/model-testkit/shared/src/main/scala/explore/model/arb/ArbUserInvitation.scala
+++ b/model-testkit/shared/src/main/scala/explore/model/arb/ArbUserInvitation.scala
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.model.arb
+
+import explore.model.UserInvitation
+import lucuma.core.data.EmailAddress
+import lucuma.core.data.arb.ArbEmailAddress.given
+import lucuma.core.enums.EmailStatus
+import lucuma.core.enums.InvitationStatus
+import lucuma.core.util.arb.ArbEnumerated.given;
+import org.scalacheck.*
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.Cogen.*
+
+trait ArbUserInvitation {
+  given Arbitrary[UserInvitation] =
+    Arbitrary {
+      for {
+        id <- arbitrary[String]
+        em <- arbitrary[EmailAddress]
+        s  <- arbitrary[InvitationStatus]
+        es <- arbitrary[Option[EmailStatus]]
+      } yield UserInvitation(id, em, s, es)
+    }
+
+  given Cogen[UserInvitation] =
+    Cogen[
+      (
+        String,
+        EmailAddress,
+        InvitationStatus,
+        Option[EmailStatus]
+      )
+    ].contramap(u => (u.id, u.email, u.status, u.emailStatus))
+}
+
+object ArbUserInvitation extends ArbUserInvitation

--- a/model/shared/src/main/scala/explore/model/ProgramUser.scala
+++ b/model/shared/src/main/scala/explore/model/ProgramUser.scala
@@ -54,6 +54,7 @@ case class ProgramUser(
 
   lazy val isConfirmed: Boolean         = status === ProgramUser.Status.Confirmed
   lazy val successfullyInvited: Boolean = activeInvitation.exists(!_.deliveryStatus.failed)
+  lazy val hasPhd: Boolean              = educationalStatus.exists(_ === EducationalStatus.PhD)
 
 object ProgramUser:
   type Id = lucuma.core.model.ProgramUser.Id


### PR DESCRIPTION
It might even follow all the rules...

The API says it will default the reviewer to the PI. Explore will always explicitly set it to the PI by default, but it can be unset via the API. I wonder if, instead of requiring the ODB to figure out the default, we should require it to be set in order to submit a proposal, and have the only defaulting be in the UI.