### PR TITLE
Improve ITC error message for target problems.

### DIFF
--- a/common/src/main/scala/explore/model/reusability.scala
+++ b/common/src/main/scala/explore/model/reusability.scala
@@ -14,6 +14,7 @@ import explore.model.enums.GroupWarning
 import explore.model.enums.SelectedPanel
 import explore.model.itc.ItcExposureTime
 import explore.model.itc.ItcTarget
+import explore.model.itc.ItcTargetProblem
 import explore.modes.ConfigSelection
 import explore.modes.InstrumentOverrides
 import explore.modes.ItcInstrumentConfig
@@ -55,6 +56,7 @@ object reusability:
   // Model
   given Reusability[ProgramSummaries]                                         = Reusability.byEq
   given Reusability[ItcTarget]                                                = Reusability.byEq
+  given Reusability[ItcTargetProblem]                                         = Reusability.byEq
   given Reusability[PersistentClientStatus]                                   = Reusability.byEq
   given Reusability[AsterismVisualOptions]                                    = Reusability.byEq
   given Reusability[ExpandedIds]                                              = Reusability.byEq

--- a/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
+++ b/explore/src/main/scala/explore/config/BasicConfigurationPanel.scala
@@ -3,6 +3,8 @@
 
 package explore.config
 
+import cats.data.EitherNec
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.all.*
 import crystal.react.*
@@ -18,6 +20,7 @@ import explore.model.ScienceRequirements.Spectroscopy
 import explore.model.display.given
 import explore.model.enums.WavelengthUnits
 import explore.model.itc.ItcTarget
+import explore.model.itc.ItcTargetProblem
 import explore.modes.ConfigSelection
 import explore.modes.ScienceModes
 import explore.syntax.ui.*
@@ -47,7 +50,7 @@ case class BasicConfigurationPanel(
   requirementsView:    View[ScienceRequirements],
   selectedConfig:      View[ConfigSelection],
   constraints:         ConstraintSet,
-  itcTargets:          List[ItcTarget],
+  itcTargets:          EitherNec[ItcTargetProblem, NonEmptyList[ItcTarget]],
   baseCoordinates:     Option[CoordinatesAtVizTime],
   calibrationRole:     Option[CalibrationRole],
   createConfig:        IO[Unit],

--- a/explore/src/main/scala/explore/config/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationTile.scala
@@ -4,6 +4,8 @@
 package explore.config
 
 import cats.Order.given
+import cats.data.EitherNec
+import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.syntax.all.*
 import clue.data.Assign
@@ -34,6 +36,7 @@ import explore.model.TargetList
 import explore.model.enums.PosAngleOptions
 import explore.model.enums.WavelengthUnits
 import explore.model.itc.ItcTarget
+import explore.model.itc.ItcTargetProblem
 import explore.model.syntax.all.*
 import explore.modes.ConfigSelection
 import explore.modes.ItcInstrumentConfig
@@ -95,7 +98,7 @@ object ConfigurationTile:
           requirements,
           pacAndMode,
           obsConf,
-          scienceTargetIds.itcTargets(allTargets),
+          scienceTargetIds.toItcTargets(allTargets),
           baseCoordinates,
           selectedConfig,
           revertedInstrumentConfig,
@@ -197,7 +200,7 @@ object ConfigurationTile:
     requirements:             UndoSetter[ScienceRequirements],
     pacAndMode:               UndoSetter[PosAngleConstraintAndObsMode],
     obsConf:                  ObsConfiguration,
-    itcTargets:               List[ItcTarget],
+    itcTargets:               EitherNec[ItcTargetProblem, NonEmptyList[ItcTarget]],
     baseCoordinates:          Option[CoordinatesAtVizTime],
     selectedConfig:           View[ConfigSelection],
     revertedInstrumentConfig: List[ItcInstrumentConfig],

--- a/explore/src/main/scala/explore/config/ModesTableCommon.scala
+++ b/explore/src/main/scala/explore/config/ModesTableCommon.scala
@@ -25,7 +25,6 @@ import explore.model.SupportedInstruments
 import explore.model.WorkerClients.ItcClient
 import explore.model.boopickle.*
 import explore.model.boopickle.ItcPicklers.given
-import explore.model.display.given
 import explore.model.itc.*
 import explore.model.reusability.given
 import explore.modes.ItcInstrumentConfig
@@ -35,7 +34,6 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.math.SignalToNoise
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.ExposureTimeMode
-import lucuma.core.syntax.all.*
 import lucuma.core.util.NewBoolean
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.Timestamp
@@ -194,16 +192,16 @@ trait ModesTableCommon:
           val content: List[TagMod] =
             errors
               .collect:
-                case ItcTargetProblem(name, s @ SourceTooBright(_)) =>
+                case p @ ItcTargetProblem(name, s @ SourceTooBright(_)) =>
                   <.span(ThemeIcons.SunBright.addClass(ExploreStyles.ItcSourceTooBrightIcon))(
-                    renderName(name) + (s: ItcQueryProblem).shortName
+                    p.format
                   )
-                case ItcTargetProblem(name, GenericError(e))        =>
+                case ItcTargetProblem(name, GenericError(e))            =>
                   e.split("\n")
                     .map(u => <.span(u))
                     .mkTagMod(<.span(renderName(name)), <.br, EmptyVdom)
-                case ItcTargetProblem(name, problem)                =>
-                  <.span(s"${renderName(name)}${problem.message}")
+                case p @ ItcTargetProblem(_, _)                         =>
+                  <.span(p.format)
               .toList
               .intersperse(<.br: VdomNode)
 

--- a/explore/src/main/scala/explore/itc/ItcTile.scala
+++ b/explore/src/main/scala/explore/itc/ItcTile.scala
@@ -243,7 +243,7 @@ object ItcTile:
           val selectedTarget = props.selectedTarget
           val existTargets   = props.itcGraphQuerier.targets.nonEmpty && selectedTarget.get.isDefined
 
-          val itcTargets          = props.itcGraphQuerier.itcTargets.foldMap(_.toList)
+          val itcTargets          = props.itcGraphQuerier.targets
           val idx                 = itcTargets.indexWhere(props.selectedTarget.get.contains)
           val itcTargetsWithIndex = itcTargets.zipWithIndex
 

--- a/model/shared/src/main/scala/explore/model/Constants.scala
+++ b/model/shared/src/main/scala/explore/model/Constants.scala
@@ -68,7 +68,6 @@ trait Constants:
   val NoConstraints      = "Constraints not defined"
   val MissingMode        = "Observation is missing observing mode" // Matches odb error message
   val MissingCandidates  = "No catalog stars available"
-  val MissingCustomSED   = "Missing custom SED timestamps"
   val NoTargets          = "No targets available"
   val NoTargetSelected   = "No target selected"
   val BadTimingWindow    = "Review the dates on this timing window."

--- a/model/shared/src/main/scala/explore/model/display.scala
+++ b/model/shared/src/main/scala/explore/model/display.scala
@@ -6,7 +6,6 @@ package explore.model
 import cats.syntax.all.*
 import eu.timepit.refined.cats.*
 import explore.model.enums.WavelengthUnits
-import explore.model.itc.ItcQueryProblem
 import explore.modes.ItcInstrumentConfig
 import lucuma.core.enums.*
 import lucuma.core.math.BoundedInterval
@@ -231,16 +230,6 @@ trait DisplayImplicits:
     case GraphType.SignalGraph      => "Signal"
     case GraphType.SignalPixelGraph => "Pixel"
     case GraphType.S2NGraph         => "S/N"
-
-  given Display[ItcQueryProblem] = Display.byShortName:
-    case ItcQueryProblem.UnsupportedMode               => "Mode not supported"
-    case ItcQueryProblem.MissingExposureTimeMode       => "Exposure time mode is missing"
-    case ItcQueryProblem.MissingWavelength             => "Provide a wavelength"
-    case ItcQueryProblem.MissingTargetInfo             => "Target information is missing"
-    case ItcQueryProblem.MissingBrightness             => "Target brightness is missing"
-    case ItcQueryProblem.SourceTooBright(halfWellTime) =>
-      f"Source too bright, well half filled in $halfWellTime%.2f seconds"
-    case ItcQueryProblem.GenericError(e)               => e
 
   given Display[ScienceBand] = Display.byShortName:
     case ScienceBand.Band1 => "Band-1"

--- a/model/shared/src/main/scala/explore/model/itc/ItcTarget.scala
+++ b/model/shared/src/main/scala/explore/model/itc/ItcTarget.scala
@@ -4,7 +4,9 @@
 package explore.model.itc
 
 import cats.Eq
+import cats.data.EitherNec
 import cats.derived.*
+import cats.syntax.all.*
 import eu.timepit.refined.cats.given
 import eu.timepit.refined.types.string.NonEmptyString
 import lucuma.core.enums.Band
@@ -41,5 +43,9 @@ case class ItcTarget(name: NonEmptyString, input: TargetInput) derives Eq:
     case SourceProfile.Point(sd)       => canQuerySD(sd)
     case SourceProfile.Uniform(sd)     => canQuerySD(sd)
     case SourceProfile.Gaussian(_, sd) => canQuerySD(sd)
+
+  def orItcProblem: EitherNec[ItcTargetProblem, ItcTarget] =
+    if (canQueryITC) this.rightNec
+    else ItcTargetProblem(name.some, ItcQueryProblem.MissingBrightness).leftNec
 
   def gaiaFree: ItcTarget = copy(input = input.copy(sourceProfile = input.sourceProfile.gaiaFree))

--- a/model/shared/src/main/scala/explore/model/itc/package.scala
+++ b/model/shared/src/main/scala/explore/model/itc/package.scala
@@ -24,16 +24,21 @@ import scala.math.*
 // Do not turn into enum or compositePickler will break.
 sealed trait ItcQueryProblem(val message: String) derives Eq
 object ItcQueryProblem:
-  case object UnsupportedMode          extends ItcQueryProblem("Unsupported mode")
-  case object MissingWavelength        extends ItcQueryProblem("Missing wavelength")
-  case object MissingExposureTimeMode  extends ItcQueryProblem("Missing exposure time mode")
-  case object MissingTargetInfo        extends ItcQueryProblem("Missing target info")
-  case object MissingBrightness        extends ItcQueryProblem("Missing brightness")
+  case object UnsupportedMode          extends ItcQueryProblem("Mode not supported")
+  case object MissingWavelength        extends ItcQueryProblem("Wavelength is missing")
+  case object MissingExposureTimeMode  extends ItcQueryProblem("Exposure time mode is missing")
+  case object MissingTargetInfo        extends ItcQueryProblem("Target information is missing")
+  case object MissingBrightness        extends ItcQueryProblem("Target brightness is missing")
   case class SourceTooBright(wellHalfFilledSeconds: BigDecimal)
-      extends ItcQueryProblem(s"Source too bright")
+      extends ItcQueryProblem(
+        f"Source too bright, well half filled in $wellHalfFilledSeconds%.2f seconds"
+      )
   case class GenericError(msg: String) extends ItcQueryProblem(msg)
 
-case class ItcTargetProblem(targetName: Option[NonEmptyString], problem: ItcQueryProblem) derives Eq
+case class ItcTargetProblem(targetName: Option[NonEmptyString], problem: ItcQueryProblem)
+    derives Eq:
+  def format: String =
+    targetName.fold(problem.message)(name => s"$name: ${problem.message}")
 
 // TODO: move to core
 private given Eq[SignalToNoiseAt] = Eq.by(x => (x.wavelength, x.single, x.total))

--- a/model/shared/src/main/scala/explore/modes/ConfigSelection.scala
+++ b/model/shared/src/main/scala/explore/modes/ConfigSelection.scala
@@ -8,6 +8,7 @@ import cats.data.NonEmptyList
 import cats.derived.*
 import cats.syntax.all.*
 import explore.model.InstrumentConfigAndItcResult
+import explore.model.itc.ItcTargetProblem
 import lucuma.core.enums.ScienceMode
 import lucuma.schemas.model.BasicConfiguration
 
@@ -25,6 +26,13 @@ final case class ConfigSelection private (configs: List[InstrumentConfigAndItcRe
 
   lazy val hasItcErrors: Boolean =
     configs.exists(_.itcResult.exists(_.isLeft))
+
+  lazy val itcErrors: List[ItcTargetProblem] =
+    configs
+      .collect:
+        case InstrumentConfigAndItcResult(_, Some(Left(e))) => e.toList
+      .flatten
+      .distinct
 
   lazy val isMissingSomeItc: Boolean =
     configs.exists(_.itcResult.isEmpty)


### PR DESCRIPTION
This changes a couple of things with respect to errors:

1. Instead of filtering out targets that aren't valid for a call to ITC and continuing on with the remaining ones (if any), an invalid target will prevent a call to the ITC.
2. Instead of just having a `-` in the `Time` or `S/N` columns in the modes tables when the ITC is not called, the warning triangle is placed on each row of the table to make it clear that the modes are not valid. A message is also placed next to the target on the upper right of the table.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/975058b9-c64b-4a5c-94c4-09d80bb1dc19" />
 
I started refactoring the graph querying code (`ItcGraphQuerier` and related), but it was going to complicate this PR a lot. I may do this is a separate PR. I think as the code has changed, the graph querying has become more complicated than it needs to be.