### PR TITLE
Improve itc graph error handling and flow

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -190,7 +190,6 @@ object ExploreStyles:
   val ItcPlotBody: Css            = Css("itc-plot-body")
   val ItcPlotControls: Css        = Css("itc-plot-controls")
   val ItcTileBody: Css            = Css("explore-itc-tile-body")
-  val ItcTileBodyError: Css       = Css("explore-itc-tile-body-error")
   val ItcTileTitle: Css           = Css("explore-itc-tile-title")
   val ItcTileTargetSelector: Css  = Css("explore-itc-tile-target-selector")
   val ItcErrorIcon: Css           = Css("itc-error-icon")

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -711,7 +711,7 @@ thead tr th.sticky-header {
 .explore-itc-tile-body {
   display: flex;
 
-  &.explore-itc-tile-body-error {
+  &:has(.p-inline-message) {
     justify-content: center;
     flex-grow: 0;
   }

--- a/explore/src/main/scala/explore/itc/ItcSpectroscopyPlotDescription.scala
+++ b/explore/src/main/scala/explore/itc/ItcSpectroscopyPlotDescription.scala
@@ -13,41 +13,40 @@ import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.itc.ItcCcd
 import lucuma.itc.SingleSN
 import lucuma.itc.TotalSN
+import lucuma.react.common.ReactFnComponent
 import lucuma.react.common.ReactFnProps
 import lucuma.ui.syntax.all.given
 import lucuma.ui.utils.*
 
 case class ItcSpectroscopyPlotDescription(
   brightness:   Option[BrightnessValues],
-  exposureTime: Option[ItcExposureTime],
-  ccds:         Option[NonEmptyChain[ItcCcd]],
-  finalSN:      Option[TotalSN],
-  singleSN:     Option[SingleSN]
-) extends ReactFnProps[ItcSpectroscopyPlotDescription](ItcSpectroscopyPlotDescription.component)
+  exposureTime: ItcExposureTime,
+  ccds:         NonEmptyChain[ItcCcd],
+  finalSN:      TotalSN,
+  singleSN:     SingleSN
+) extends ReactFnProps[ItcSpectroscopyPlotDescription](ItcSpectroscopyPlotDescription)
 
-object ItcSpectroscopyPlotDescription {
-  type Props = ItcSpectroscopyPlotDescription
-
-  val component = ScalaFnComponent[Props] { props =>
-    val finalSN: String    = props.finalSN.fold("-")(u => formatSN(u.value))
-    val singleSN: String   = props.singleSN.fold("-")(u => formatSN(u.value))
-    val brightness: String = props.brightness.fold("-")(_.toString)
-
-    <.div(
-      ExploreStyles.ItcPlotDescription,
-      <.label("Integration Time:"),
-      <.span(props.exposureTime.fold("-") { case ItcExposureTime(time, count) =>
+object ItcSpectroscopyPlotDescription
+    extends ReactFnComponent[ItcSpectroscopyPlotDescription](props =>
+      val finalSN: String    = formatSN(props.finalSN.value)
+      val singleSN: String   = formatSN(props.singleSN.value)
+      val brightness: String = props.brightness.fold("-")(_.toString)
+      val exposureTime: String =
         // Not ideal, it needs a fix on lucuma-ui
-        format(time, PosInt.unsafeFrom(count.value))
-      }),
-      <.label("S/N per exposure:"),
-      <.span(singleSN),
-      <.label("Total S/N:"),
-      <.span(finalSN),
-      <.label("Peak (signal + background):"),
-      <.span(formatCcds(props.ccds, ccds => s"${ccds.maxPeakPixelFlux} 𝐞⁻ (${ccds.maxADU} ADU)")),
-      <.label("Input brightness:"),
-      <.span(brightness)
+        format(props.exposureTime.time, PosInt.unsafeFrom(props.exposureTime.count.value))
+      val ccds: String       = s"${props.ccds.maxPeakPixelFlux} 𝐞⁻ (${props.ccds.maxADU} ADU)"
+
+      <.div(
+        ExploreStyles.ItcPlotDescription,
+        <.label("Integration Time:"),
+        <.span(exposureTime),
+        <.label("S/N per exposure:"),
+        <.span(singleSN),
+        <.label("Total S/N:"),
+        <.span(finalSN),
+        <.label("Peak (signal + background):"),
+        <.span(ccds),
+        <.label("Input brightness:"),
+        <.span(brightness)
+      )
     )
-  }
-}

--- a/explore/src/main/scala/explore/itc/package.scala
+++ b/explore/src/main/scala/explore/itc/package.scala
@@ -3,7 +3,6 @@
 
 package explore.itc
 
-import cats.data.NonEmptyChain
 import explore.Icons
 import explore.components.ui.ExploreStyles
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -15,7 +14,6 @@ import lucuma.core.math.LineWidthValue
 import lucuma.core.math.Wavelength
 import lucuma.core.math.dimensional.Units
 import lucuma.core.syntax.display.*
-import lucuma.itc.ItcCcd
 import lucuma.react.fa.*
 import lucuma.react.floatingui.syntax.*
 import lucuma.ui.syntax.all.given
@@ -29,12 +27,6 @@ extension (role: Option[CalibrationRole])
         TextLayer("ITC", clazz = ExploreStyles.RequiredForItcText, inverse = true)
       )
     ).withTooltip("Required for ITC")
-
-protected def formatCcds(
-  ccds:      Option[NonEmptyChain[ItcCcd]],
-  extractor: NonEmptyChain[ItcCcd] => String
-): String =
-  ccds.fold("-")(extractor)
 
 protected enum BrightnessValues:
   case ForBand(band: Band, value: BrightnessValue, units: Units)

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -229,16 +229,19 @@ object ObsTabTiles:
                 _.target.sourceProfile.customSedId.flatMap(attachments.get).map(_.updatedAt)
               ).toList.flattenOption
             )
-        itcGraphQuerier      =
-          ItcGraphQuerier(props.observation.get,
-                          selectedConfig.get.headOption,
-                          props.obsTargets,
-                          customSedTimestamps
-          )
-        itcGraphResults     <- useEffectResultWithDeps(itcGraphQuerier):
-                                 itcGraphQuerier => // Compute ITC graph
-                                   import ctx.given
-                                   itcGraphQuerier.requestGraphs
+        itcGraphResults     <- useEffectResultWithDeps(
+                                 (props.observation.get,
+                                  selectedConfig.get.headOption,
+                                  props.obsTargets,
+                                  customSedTimestamps
+                                 )
+                               ): (obs, config, targets, customSedTimestamps) =>
+                                 import ctx.given
+                                 ItcGraphQuerier(obs,
+                                                 config,
+                                                 targets,
+                                                 customSedTimestamps
+                                 ).requestGraphs
         sequenceChanged     <- useStateView(().ready) // Signal that the sequence has changed
         // if the timestamp for a custom sed attachment changes, it means either a new custom sed
         // has been assigned, OR a new version of the custom sed has been uploaded. This is to
@@ -399,7 +402,6 @@ object ObsTabTiles:
             ItcTile(
               props.vault.userId,
               props.obsId,
-              itcGraphQuerier,
               itcGraphResults.value,
               props.globalPreferences
             )

--- a/model/shared/src/main/scala/explore/events/ItcMessage.scala
+++ b/model/shared/src/main/scala/explore/events/ItcMessage.scala
@@ -7,6 +7,7 @@ import boopickle.DefaultBasic.*
 import cats.data.*
 import explore.model.boopickle.ItcPicklers
 import explore.model.itc.ItcAsterismGraphResults
+import explore.model.itc.ItcQueryProblem
 import explore.model.itc.ItcRequestParams
 import explore.model.itc.ItcResult
 import explore.model.itc.ItcTarget
@@ -43,7 +44,7 @@ object ItcMessage extends ItcPicklers:
     customSedTimestamps: List[Timestamp],
     modes:               ItcInstrumentConfig
   ) extends Request:
-    type ResponseType = ItcAsterismGraphResults
+    type ResponseType = EitherNec[ItcQueryProblem, ItcAsterismGraphResults]
 
   private given Pickler[Query] = generatePickler
 

--- a/model/shared/src/main/scala/explore/model/Constants.scala
+++ b/model/shared/src/main/scala/explore/model/Constants.scala
@@ -65,7 +65,6 @@ trait Constants:
   val NoGuideStarMessage = "No guidestar available"
   val NoDuration         = "No duration available"
   val NoExposureTimeMode = "No exposure time mode defined"
-  val NoConstraints      = "Constraints not defined"
   val MissingMode        = "Observation is missing observing mode" // Matches odb error message
   val MissingCandidates  = "No catalog stars available"
   val NoTargets          = "No targets available"

--- a/model/shared/src/main/scala/explore/model/itc/package.scala
+++ b/model/shared/src/main/scala/explore/model/itc/package.scala
@@ -9,6 +9,7 @@ import cats.syntax.all.*
 import eu.timepit.refined.cats.refTypeEq
 import eu.timepit.refined.types.numeric.NonNegInt
 import eu.timepit.refined.types.string.NonEmptyString
+import lucuma.core.math.Wavelength
 import lucuma.core.util.TimeSpan
 import lucuma.itc.IntegrationTime
 import lucuma.itc.ItcAxis
@@ -22,7 +23,9 @@ import lucuma.itc.math.roundToSignificantFigures
 import scala.math.*
 
 // Do not turn into enum or compositePickler will break.
-sealed trait ItcQueryProblem(val message: String) derives Eq
+sealed trait ItcQueryProblem(val message: String) derives Eq:
+  def toTargetProblem: ItcTargetProblem = ItcTargetProblem(None, this)
+
 object ItcQueryProblem:
   case object UnsupportedMode          extends ItcQueryProblem("Mode not supported")
   case object MissingWavelength        extends ItcQueryProblem("Wavelength is missing")
@@ -118,5 +121,6 @@ case class ItcGraphResult(target: ItcTarget, timeAndGraphs: TargetTimeAndGraphsR
 
 case class ItcAsterismGraphResults(
   asterismGraphs:  Map[ItcTarget, Either[ItcQueryProblem, ItcGraphResult]],
-  brightestTarget: Option[ItcTarget]
+  brightestTarget: Option[ItcTarget],
+  signalToNoiseAt: Wavelength
 )

--- a/model/shared/src/main/scala/queries/schemas/itc/syntax.scala
+++ b/model/shared/src/main/scala/queries/schemas/itc/syntax.scala
@@ -8,6 +8,7 @@ import cats.data.EitherNec
 import cats.data.NonEmptyList
 import cats.syntax.all.*
 import explore.model.AsterismIds
+import explore.model.Constants
 import explore.model.TargetList
 import explore.model.itc.ItcQueryProblem
 import explore.model.itc.ItcTarget
@@ -85,6 +86,9 @@ trait syntax:
       asterism
         .traverse(_.itcTarget)
         .map(_.hashDistinct)
-        .flatMap(_.toNel.toRightNec(ItcTargetProblem(None, ItcQueryProblem.MissingTargetInfo)))
+        .flatMap(
+          _.toNel
+            .toRightNec(ItcTargetProblem(None, ItcQueryProblem.GenericError(Constants.NoTargets)))
+        )
 
 object syntax extends syntax

--- a/workers/src/main/scala/workers/itc/ITCRequests.scala
+++ b/workers/src/main/scala/workers/itc/ITCRequests.scala
@@ -29,7 +29,7 @@ import queries.schemas.itc.syntax.*
 import workers.*
 
 object ITCRequests:
-  val cacheVersion = CacheVersion(18)
+  val cacheVersion = CacheVersion(19)
 
   val itcErrorToQueryProblems: Error => ItcQueryProblem =
     case Error.SourceTooBright(halfWell) => ItcQueryProblem.SourceTooBright(halfWell)


### PR DESCRIPTION
The main thing I wanted to achieve was having all of the necessary information in the return from `ItcGraphQuerier.requestGraphs`. Before the ItcGraphQuerier itself had to be passed around as well and error messages checked for separately, etc. 

 Also:
- Some errors were handled as an IO error. They are now represented in an EitherNec.
- The target dropdown in the tile title was sometimes empty. It now always has a value.
- The target specific error messages displayed in the high charts chart did not actually updated when the selected target changed.They are now displayed as a Message, like the other errors are.