### PR TITLE
Disable (again) submission button on errors

### DIFF
--- a/explore/src/main/scala/explore/observationtree/ObsSummaryTile.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryTile.scala
@@ -13,6 +13,7 @@ import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.model.AppContext
 import explore.model.Asterism
+import explore.model.Constants
 import explore.model.Group
 import explore.model.GroupList
 import explore.model.ObsSummaryTabTileIds
@@ -23,7 +24,6 @@ import explore.model.enums.TableId
 import explore.model.reusability.given
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
-import japgolly.scalajs.react.vdom.TagOf
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.Program
 import lucuma.core.model.Target
@@ -56,6 +56,7 @@ object ObsSummaryTile extends ObsSummaryColumns:
     groups:          View[GroupList],
     allTargets:      TargetList,
     showScienceBand: Boolean,
+    readonly:        Boolean,
     backButton:      VdomNode
   ): Tile[TileState] =
     Tile(
@@ -75,6 +76,7 @@ object ObsSummaryTile extends ObsSummaryColumns:
           groups,
           allTargets,
           showScienceBand,
+          readonly,
           s.zoom(TileState.columnVisibility),
           cb => s.zoom(TileState.toggleAllRowsSelected).set(cb.some)
         ),
@@ -93,6 +95,7 @@ object ObsSummaryTile extends ObsSummaryColumns:
     groups:                   View[GroupList],
     allTargets:               TargetList,
     showScienceBand:          Boolean,
+    readonly:                 Boolean,
     columnVisibility:         View[ColumnVisibility],
     setToggleAllRowsSelected: (Boolean => Callback) => Callback
   ) extends ReactFnProps(Body.component)
@@ -215,18 +218,26 @@ object ObsSummaryTile extends ObsSummaryColumns:
             ^.onClick ==> table
               .getMultiRowSelectedHandler(RowId(row.original.value.obs.id.toString))
           ),
-        emptyMessage = <.span(LucumaStyles.HVCenter)(
-          Button(
-            severity = Button.Severity.Success,
-            icon = Icons.New,
-            disabled = adding.get.value,
-            loading = adding.get.value,
-            label = "Add an observation",
-            clazz = LucumaPrimeStyles.Massive |+| ExploreStyles.ObservationsSummaryAdd,
-            onClick =
-              insertObs(props.programId, none, props.observations, adding, ctx).runAsyncAndForget
-          ).tiny.compact
-        )
+        emptyMessage =
+          if (props.readonly)
+            <.div(Constants.NoObservations)
+          else
+            <.span(LucumaStyles.HVCenter)(
+              Button(
+                severity = Button.Severity.Success,
+                icon = Icons.New,
+                disabled = adding.get.value,
+                loading = adding.get.value,
+                label = "Add an observation",
+                clazz = LucumaPrimeStyles.Massive |+| ExploreStyles.ObservationsSummaryAdd,
+                onClick = insertObs(props.programId,
+                                    none,
+                                    props.observations,
+                                    adding,
+                                    ctx
+                ).runAsyncAndForget
+              ).tiny.compact
+            )
       )
   end Body
 

--- a/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalSubmissionBar.scala
@@ -102,9 +102,9 @@ object ProposalSubmissionBar
                     label = "Submit Proposal",
                     onClick = updateStatus(ProposalStatus.Submitted),
                     disabled =
-                      // Temporarily enable submission even if there are errors for testing against PI validation
-                      // isUpdatingStatus.get.value || props.hasProposalErrors || isDueDeadline
-                      isUpdatingStatus.get.value || isDueDeadline
+                    isUpdatingStatus.get.value || props.hasProposalErrors || isDueDeadline
+                    // Temporarily enable submission even if there are errors for testing against PI validation
+                    // isUpdatingStatus.get.value || isDueDeadline
                   ).compact.tiny,
                   props.deadline.map: deadline =>
                     val (deadlineStr, left): (String, Option[String]) =

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -227,6 +227,7 @@ object ObsTabContents extends TwoPanels:
               props.groups.model,
               props.targets.get,
               props.programSummaries.get.allocatedScienceBands.size > 1,
+              props.readonly,
               backButton
             )
 

--- a/explore/src/main/scala/explore/targeteditor/TargetTable.scala
+++ b/explore/src/main/scala/explore/targeteditor/TargetTable.scala
@@ -15,6 +15,7 @@ import explore.components.ui.ExploreStyles
 import explore.model.AladinFullScreen
 import explore.model.AppContext
 import explore.model.AsterismIds
+import explore.model.Constants
 import explore.model.ObsIdSet
 import explore.model.ObservationsAndTargets
 import explore.model.OnAsterismUpdateParams
@@ -164,8 +165,10 @@ object TargetTable extends AsterismModifier:
       yield
         import ctx.given
 
-        React.Fragment(
-          if (rows.isEmpty)
+        if (rows.isEmpty)
+          if (props.readOnly)
+            <.div(LucumaStyles.HVCenter)(Constants.NoTargets)
+          else
             <.div(LucumaStyles.HVCenter)(
               targetSelectionPopup(
                 "Add a target",
@@ -177,24 +180,23 @@ object TargetTable extends AsterismModifier:
                 buttonClass = LucumaPrimeStyles.Massive
               )
             )
-          else
-            <.div(ExploreStyles.ExploreTable |+| ExploreStyles.AsterismTable)(
-              PrimeTable(
-                table,
-                striped = true,
-                compact = Compact.Very,
-                tableMod = ExploreStyles.ExploreTable,
-                headerCellMod = headerCell =>
-                  ColumnClasses
-                    .get(headerCell.column.id)
-                    .orEmpty |+| ExploreStyles.StickyHeader,
-                rowMod = row =>
-                  TagMod(
-                    ExploreStyles.TableRowSelected
-                      .when_(props.selectedTarget.get.exists(_ === row.original.id)),
-                    ^.onClick --> props.selectedTarget.set(row.original.id.some)
-                  ),
-                cellMod = cell => ColumnClasses.get(cell.column.id).orEmpty
-              )
+        else
+          <.div(ExploreStyles.ExploreTable |+| ExploreStyles.AsterismTable)(
+            PrimeTable(
+              table,
+              striped = true,
+              compact = Compact.Very,
+              tableMod = ExploreStyles.ExploreTable,
+              headerCellMod = headerCell =>
+                ColumnClasses
+                  .get(headerCell.column.id)
+                  .orEmpty |+| ExploreStyles.StickyHeader,
+              rowMod = row =>
+                TagMod(
+                  ExploreStyles.TableRowSelected
+                    .when_(props.selectedTarget.get.exists(_ === row.original.id)),
+                  ^.onClick --> props.selectedTarget.set(row.original.id.some)
+                ),
+              cellMod = cell => ColumnClasses.get(cell.column.id).orEmpty
             )
-        )
+          )

--- a/model/shared/src/main/scala/explore/model/Constants.scala
+++ b/model/shared/src/main/scala/explore/model/Constants.scala
@@ -67,6 +67,7 @@ trait Constants:
   val NoExposureTimeMode = "No exposure time mode defined"
   val MissingMode        = "Observation is missing observing mode" // Matches odb error message
   val MissingCandidates  = "No catalog stars available"
+  val NoObservations     = "No observations available"
   val NoTargets          = "No targets available"
   val NoTargetSelected   = "No target selected"
   val BadTimingWindow    = "Review the dates on this timing window."


### PR DESCRIPTION
The submit button was temporarily enabled in the face of proposal errors for testing the ODB. However, users have abused this feature so we are disabling it again until the ODB proposal validations have been modified and need testing again.

It also gets rid of the "Add an Observation" and "Add a target" buttons when they should be readonly. These would have never been visible if the proposal had been valid before submission, but...