### PR TITLE
Fix `Now` button to only update once

### DIFF
--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
@@ -88,11 +88,11 @@ object AsterismEditorTile:
 
     val obsTimeAndDurationView: View[(Option[Instant], Option[TimeSpan])] =
       View(
-        (obsTimeView.get, obsDurationView.get),
+        (obsTime.get, obsDuration.get),
         (mod, cb) =>
-          val oldValue = (obsTimeView.get, obsDurationView.get)
+          val oldValue = (obsTime.get, obsDuration.get)
           val newValue = mod(oldValue)
-          obsTimeView.set(newValue._1) >> obsDurationView.set(newValue._2) >> cb(oldValue, newValue)
+          obsTime.set(newValue._1) >> obsDuration.set(newValue._2) >> cb(oldValue, newValue)
       ).withOnMod: tuple =>
         odbApi
           .updateVisualizationTimeAndDuration(obsIds.toList, tuple._1, tuple._2)


### PR DESCRIPTION
The Observation time/duration `Now` button was calling the ODB 3 times:

1. Update time and duration
2. Update time
3. Update duration

This fixes it so only 1. is performed.