### PR TITLE
Show correct value for workflow state in obs summary table

### DIFF
--- a/explore/src/main/scala/explore/observationtree/ObsSummaryColumns.scala
+++ b/explore/src/main/scala/explore/observationtree/ObsSummaryColumns.scala
@@ -217,7 +217,7 @@ trait ObsSummaryColumns:
           _.value.flatten.map(groupLink)
         .sortableBy(_.flatMap(_.flatMap(_.name))),
       // TODO: ValidationCheckColumnId
-      obsColumn(StateColumnId, _.obs.workflow.state)
+      obsColumn(StateColumnId, _.obs.workflow.value.state)
         .withCell(_.value.map(_.toString).orEmpty)
         .sortable,
       obsColumn(ScienceBandColumnId, _.obs.scienceBand)


### PR DESCRIPTION
This is related to the change to a CalculatedValue for the workflow. The table was showing the state of the calculation, not the state of the workflow. Both of them have `Ready` states. So, in this case it is good they were all going to `Ready`.