### PR TITLE
Add a custom time editor to ensure time is always on a 24h format

### DIFF
--- a/common/src/main/scala/explore/components/ui/ExploreStyles.scala
+++ b/common/src/main/scala/explore/components/ui/ExploreStyles.scala
@@ -165,6 +165,7 @@ object ExploreStyles:
   val TargetTileBody: Css            = Css("target-tile-body")
   val TargetTileEditor: Css          = Css("target-tile-editor")
   val TargetTileObsDuration: Css     = Css("target-tile-obs-duration")
+  val TargetTileTimeEditor: Css      = Css("target-tile-obs-time-editor")
   val TargetObsDefaultDuration: Css  = Css("target-tile-obs-default-duration")
   val TargetTileObsUTC: Css          = Css("target-tile-obs-utc")
   val AddTargetButton: Css           = Css("add-target-button")

--- a/common/src/main/scala/explore/utils/package.scala
+++ b/common/src/main/scala/explore/utils/package.scala
@@ -26,6 +26,7 @@ import lucuma.core.util.NewBoolean
 import lucuma.core.util.TimeSpan
 import lucuma.react.common.style.Css
 import lucuma.ui.components.TimeSpanView
+import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.syntax.all.given
 import lucuma.ui.utils.versionDateFormatter
 import lucuma.ui.utils.versionDateTimeFormatter
@@ -81,6 +82,12 @@ def forceAssign[T, S](mod: Endo[Input[S]] => Endo[T])(base: S): Endo[S] => Endo[
 // See https://github.com/Hacker0x01/react-datepicker/issues/1787
 private def fromDatePickerJsDate(jsDate: js.Date): Instant =
   Instant.ofEpochMilli((jsDate.getTime() - jsDate.getTimezoneOffset() * 60000).toLong)
+
+// TODO Should we move this to lucuma-ui?
+val HMPartialRegEx                  = "\\d*(:\\d{0,2})?".r
+val hmChangeAuditor: ChangeAuditor  = ChangeAuditor.accept.allow(HMPartialRegEx.matches)
+val HMSPartialRegEx                 = "\\d*(:\\d{0,2}(:\\d{0,2})?)?".r
+val hmsChangeAuditor: ChangeAuditor = ChangeAuditor.accept.allow(HMSPartialRegEx.matches)
 
 object IsExpanded extends NewBoolean
 type IsExpanded = IsExpanded.Type

--- a/common/src/main/webapp/sass/explore.scss
+++ b/common/src/main/webapp/sass/explore.scss
@@ -795,6 +795,10 @@ thead tr th.sticky-header {
       font-size: 0.944rem;
     }
   }
+
+  .react-datepicker__tab-loop {
+    display: none;
+  }
 }
 
 .asterism-editor-tile-title {
@@ -874,6 +878,12 @@ thead tr th.sticky-header {
       .target-tile-obs-duration {
         display: flex;
         align-items: baseline;
+      }
+
+      .target-tile-obs-time-editor {
+        input {
+          width: 6ch;
+        }
       }
     }
   }

--- a/explore/src/main/scala/explore/components/Time24HInputView.scala
+++ b/explore/src/main/scala/explore/components/Time24HInputView.scala
@@ -1,0 +1,51 @@
+// Copyright (c) 2016-2025 Association of Universities for Research in Astronomy, Inc. (AURA)
+// For license information see LICENSE or https://opensource.org/licenses/BSD-3-Clause
+
+package explore.components
+
+import crystal.react.*
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.NonEmpty
+import explore.model.formats.*
+import explore.utils.*
+import japgolly.scalajs.react.*
+import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.react.common.Css
+import lucuma.react.common.ReactFnProps
+import lucuma.ui.primereact.FormInputTextView
+import lucuma.ui.primereact.given
+import org.typelevel.cats.time.given
+
+import java.time.LocalTime
+
+import scalajs.js
+
+case class Time24HInputView(
+  id:          String Refined NonEmpty,
+  value:       View[Option[LocalTime]],
+  label:       js.UndefOr[TagMod] = js.undefined,
+  units:       js.UndefOr[String] = js.undefined,
+  groupClass:  js.UndefOr[Css] = js.undefined,
+  inputClass:  js.UndefOr[Css] = js.undefined,
+  disabled:    Boolean = false,
+  placeholder: js.UndefOr[String] = js.undefined
+) extends ReactFnProps[Time24HInputView](Time24HInputView.component)
+
+object Time24HInputView:
+  private type Props = Time24HInputView
+
+  private val component =
+    ScalaFnComponent[Props] { props =>
+      FormInputTextView(
+        id = props.id,
+        value = props.value,
+        units = props.units,
+        groupClass = props.groupClass,
+        inputClass = props.inputClass,
+        validFormat = time24h.optional,
+        changeAuditor = hmChangeAuditor,
+        label = props.label,
+        placeholder = props.placeholder.getOrElse("HH:mm"),
+        disabled = props.disabled
+      )
+    }

--- a/explore/src/main/scala/explore/schedulingWindows/SchedulingWindowsTile.scala
+++ b/explore/src/main/scala/explore/schedulingWindows/SchedulingWindowsTile.scala
@@ -188,12 +188,6 @@ object SchedulingWindowsTile:
                   .asView
               )
 
-          // TODO Should we move this to lucuma-ui?
-          val HMPartialRegEx                  = "\\d*(:\\d{0,2})?".r
-          val hmChangeAuditor: ChangeAuditor  = ChangeAuditor.accept.allow(HMPartialRegEx.matches)
-          val HMSPartialRegEx                 = "\\d*(:\\d{0,2}(:\\d{0,2})?)?".r
-          val hmsChangeAuditor: ChangeAuditor = ChangeAuditor.accept.allow(HMSPartialRegEx.matches)
-
           <.div(ExploreStyles.TimingWindowsBody)(
             <.div.withRef(resize.ref)(ExploreStyles.TimingWindowsTable)(
               PrimeTable(

--- a/model-tests/shared/src/test/scala/explore/model/FormatsSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/FormatsSuite.scala
@@ -7,13 +7,16 @@ import cats.syntax.all.*
 import eu.timepit.refined.cats.given
 import explore.model.formats.*
 import lucuma.core.arb.*
+import lucuma.core.arb.ArbTime.given
 import lucuma.core.optics.laws.discipline.ValidWedgeTests
 import lucuma.core.util.TimeSpan
 import lucuma.core.util.arb.ArbTimeSpan.given
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
+import org.typelevel.cats.time.given
 
 import java.time.Duration
+import java.time.LocalTime
 
 class FormatsSuite extends munit.DisciplineSuite:
   override def scalaCheckInitialSeed = "tprrQ0295RsiQ-5mvSW9ajurDGsf3haEulf38PNqa0K="
@@ -158,3 +161,13 @@ class FormatsSuite extends munit.DisciplineSuite:
   )
   assertEquals(durationS.reverseGet(TimeSpan.fromSeconds(60).get), "60")
   assertEquals(durationS.reverseGet(TimeSpan.fromSeconds(70).get), "70")
+
+  assertEquals(parsers.timeHM.parseAll("0:48").toOption, LocalTime.of(0, 48).some)
+  assertEquals(parsers.timeHM.parseAll("21:48").toOption, LocalTime.of(21, 48).some)
+  assertEquals(parsers.timeHM.parseAll("0:0").toOption, LocalTime.of(0, 0).some)
+  assertEquals(parsers.timeHM.parseAll("0").toOption, LocalTime.of(0, 0).some)
+  assertEquals(parsers.timeHM.parseAll("23").toOption, LocalTime.of(23, 0).some)
+  checkAll(
+    "time24h",
+    ValidWedgeTests(time24h).validWedgeLaws
+  )

--- a/model/shared/src/main/scala/explore/model/formats.scala
+++ b/model/shared/src/main/scala/explore/model/formats.scala
@@ -6,6 +6,7 @@ package explore.model
 import cats.syntax.all.*
 import coulomb.*
 import eu.timepit.refined.collection.NonEmpty
+import explore.model.Constants
 import explore.optics.all.*
 import lucuma.core.math.*
 import lucuma.core.math.HourAngle.HMS
@@ -18,6 +19,7 @@ import lucuma.core.validation.*
 import lucuma.refined.*
 
 import java.text.NumberFormat
+import java.time.LocalTime
 import java.util.Locale
 import scala.math.*
 
@@ -157,6 +159,18 @@ trait formats:
           }
           .toEitherErrors,
       ts => f"${ts.toSeconds}%.0f"
+    )
+
+  val time24h: InputValidWedge[LocalTime] =
+    InputValidWedge(
+      s =>
+        parsers.timeHM
+          .parseAll(s)
+          .leftMap { _ =>
+            "time on HH:mm parsing errors".refined[NonEmpty]
+          }
+          .toEitherErrors,
+      time => time.format(Constants.GppTimeFormatter)
     )
 
 object formats extends formats

--- a/model/shared/src/main/scala/explore/model/parsers.scala
+++ b/model/shared/src/main/scala/explore/model/parsers.scala
@@ -15,9 +15,20 @@ import lucuma.core.parser.MiscParsers
 import lucuma.core.util.TimeSpan
 
 import java.time.Duration
+import java.time.LocalTime
 
 trait parsers:
   val colonOrSpace: Parser[Unit] = MiscParsers.colon | sp
+
+  val timeHM: Parser[LocalTime] =
+    (digits ~ MiscParsers.colon.void.? ~ AngleParsers.minutes.?)
+      .mapFilter { case ((h, _), m) =>
+        MiscParsers
+          .catchNFE[(String, Option[Int]), LocalTime] { case (h, m) =>
+            LocalTime.of(h.toInt, m.getOrElse(0))
+          }(h, m)
+      }
+      .withContext("localtime_hm")
 
   val durationHM: Parser[TimeSpan] =
     (digits ~ MiscParsers.colon.void.? ~ AngleParsers.minutes.?)


### PR DESCRIPTION
The current time input is tied to your operating system's time format. Thus, we need to our own custom component to always ensure a 24-hour format. 