### PR TITLE
Prevent editing observations on the constraints and scheduling tabs by execution status

### DIFF
--- a/common/src/main/scala/explore/model/ExploreGridLayouts.scala
+++ b/common/src/main/scala/explore/model/ExploreGridLayouts.scala
@@ -62,8 +62,7 @@ object ExploreGridLayouts:
   private lazy val TileMinWidth: NonNegInt = 8.refined
 
   object constraints:
-    private lazy val ConstraintsHeight: NonNegInt   = 4.refined
-    private lazy val TimingWindowsHeight: NonNegInt = 14.refined
+    private lazy val ConstraintsHeight: NonNegInt = 4.refined
 
     private lazy val layoutMedium: Layout = Layout(
       List(
@@ -73,13 +72,6 @@ object ExploreGridLayouts:
           y = 0,
           w = DefaultWidth.value,
           h = ConstraintsHeight.value
-        ),
-        LayoutItem(
-          i = ObsTabTileIds.TimingWindowsId.id.value,
-          x = 0,
-          y = ConstraintsHeight.value,
-          w = DefaultWidth.value,
-          h = TimingWindowsHeight.value
         )
       )
     )

--- a/explore/src/main/scala/explore/observationtree/SchedulingGroupObsList.scala
+++ b/explore/src/main/scala/explore/observationtree/SchedulingGroupObsList.scala
@@ -6,7 +6,7 @@ package explore.observationtree
 import cats.Order.given
 import cats.effect.IO
 import cats.syntax.all.given
-import crystal.react.View
+import crystal.react.*
 import explore.Icons
 import explore.common.TimingWindowsQueries
 import explore.components.ActionButtons
@@ -15,6 +15,7 @@ import explore.components.undo.UndoButtons
 import explore.model.AppContext
 import explore.model.Focused
 import explore.model.ObsIdSet
+import explore.model.ObsIdSetEditInfo
 import explore.model.Observation
 import explore.model.ObservationList
 import explore.model.SchedulingGroupList
@@ -37,6 +38,7 @@ import lucuma.react.beautifuldnd.*
 import lucuma.react.common.*
 import lucuma.react.fa.FontAwesomeIcon
 import lucuma.react.floatingui.syntax.*
+import lucuma.react.primereact.Message
 import lucuma.ui.primereact.*
 import lucuma.ui.reusability.given
 import lucuma.ui.syntax.render.*
@@ -135,7 +137,7 @@ object SchedulingGroupObsList:
     }
 
   private def onDragEnd(
-    undoCtx:          UndoSetter[ObservationList],
+    observations:     UndoSetter[ObservationList],
     expandedIds:      View[SortedSet[ObsIdSet]],
     focusedObsSet:    Option[ObsIdSet],
     schedulingGroups: SchedulingGroupList
@@ -143,38 +145,45 @@ object SchedulingGroupObsList:
     OdbObservationApi[IO],
     Logger[IO],
     ToastCtx[IO]
-  ): (DropResult, ResponderProvided) => Callback = (result, _) => {
-    val oData = for {
+  ): (DropResult, ResponderProvided) => Callback = (result, _) =>
+    (for
       destination <- result.destination.toOption
       destIds     <- ObsIdSet.fromString.getOption(destination.droppableId)
       draggedIds  <- getDraggedIds(result.draggableId, focusedObsSet)
       if !destIds.intersects(draggedIds)
       newTw       <- schedulingGroups.get(destIds)
-      srcIds      <- schedulingGroups.findContainingObsIds(draggedIds)
-    } yield (newTw, destIds, draggedIds, srcIds.obsIds)
+      grp         <- schedulingGroups.findContainingObsIds(draggedIds)
+    yield
+      val obsEditInfo = ObsIdSetEditInfo.fromObservationList(draggedIds, observations.get)
 
-    val traversal = Iso
-      .id[ObservationList]
-      .filterIndex: (id: Observation.Id) =>
-        oData.exists((_, _, draggedIds, _) => draggedIds.contains(id))
-      .andThen(Observation.timingWindows)
-
-    val twUndoCtx =
-      undoCtx.zoom(traversal.getAll.andThen(_.head), traversal.modify)
-
-    oData.foldMap { case (newTw, destIds, draggedIds, srcIds) =>
-      expandedIds.mod(ids =>
-        val base = ids - draggedIds - destIds + (destIds ++ draggedIds)
-        (srcIds -- draggedIds).fold(base)(base + _)
-      ) >>
-        TimingWindowsQueries
-          .viewWithRemoteMod[IO](
-            draggedIds,
-            twUndoCtx.undoableView(Iso.id.asLens)
+      if (obsEditInfo.completed.nonEmpty)
+        ToastCtx[IO]
+          .showToast(
+            "Cannot modify scheduling windows for completed observations.",
+            Message.Severity.Error,
+            true
           )
-          .set(newTw)
-    }
-  }
+          .runAsync
+      else
+        val traversal = Iso
+          .id[ObservationList]
+          .filterIndex(draggedIds.contains)
+          .andThen(Observation.timingWindows)
+
+        val twUndoCtx =
+          observations.zoom(traversal.getAll.andThen(_.head), traversal.modify)
+
+        expandedIds.mod(ids =>
+          val base = ids - draggedIds - destIds + (destIds ++ draggedIds)
+          (grp.obsIds -- draggedIds).fold(base)(base + _)
+        ) >>
+          TimingWindowsQueries
+            .viewWithRemoteMod[IO](
+              draggedIds,
+              twUndoCtx.undoableView(Iso.id.asLens)
+            )
+            .set(newTw)
+    ).orEmpty
 
   private val component = ScalaFnComponent
     .withHooks[Props]
@@ -220,7 +229,17 @@ object SchedulingGroupObsList:
         )(
           getDraggedIds(rubric.draggableId, props.focusedObsSet)
             .flatMap(obsIds =>
-              if (obsIds.size === 1)
+              val obsEditInfo = ObsIdSetEditInfo.fromObservationList(obsIds, props.observations.get)
+
+              if (obsEditInfo.completed.nonEmpty)
+                val m: TagMod =
+                  Message(
+                    text = "Contains completed observations",
+                    severity = Message.Severity.Error,
+                    icon = Icons.ErrorIcon
+                  )
+                m.some
+              else if (obsIds.size === 1)
                 props.observations.get
                   .get(obsIds.head)
                   .map(obs => props.renderObsBadge(obs, ObsBadge.Layout.ConstraintsTab))

--- a/explore/src/main/scala/explore/schedulingWindows/SchedulingWindowsTile.scala
+++ b/explore/src/main/scala/explore/schedulingWindows/SchedulingWindowsTile.scala
@@ -4,8 +4,8 @@
 package explore.schedulingWindows
 
 import cats.Endo
-import cats.Order.given
 import cats.MonadThrow
+import cats.Order.given
 import cats.syntax.all.*
 import crystal.react.*
 import eu.timepit.refined.cats.*
@@ -17,11 +17,11 @@ import explore.components.DatePicker24HTime
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.model.Constants.BadTimingWindow
-import explore.model.Observation
-import explore.model.ObservationList
 import explore.model.ObsIdSet
 import explore.model.ObsIdSetEditInfo
 import explore.model.ObsTabTileIds
+import explore.model.Observation
+import explore.model.ObservationList
 import explore.model.enums.TileSizeState
 import explore.model.formats.*
 import explore.model.reusability.given

--- a/explore/src/main/scala/explore/schedulingWindows/SchedulingWindowsTile.scala
+++ b/explore/src/main/scala/explore/schedulingWindows/SchedulingWindowsTile.scala
@@ -5,24 +5,33 @@ package explore.schedulingWindows
 
 import cats.Endo
 import cats.Order.given
+import cats.MonadThrow
 import cats.syntax.all.*
 import crystal.react.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.types.numeric.PosInt
 import explore.Icons
+import explore.common.TimingWindowsQueries
 import explore.components.DatePicker24HTime
 import explore.components.Tile
 import explore.components.ui.ExploreStyles
 import explore.model.Constants.BadTimingWindow
+import explore.model.Observation
+import explore.model.ObservationList
+import explore.model.ObsIdSet
+import explore.model.ObsIdSetEditInfo
 import explore.model.ObsTabTileIds
 import explore.model.enums.TileSizeState
 import explore.model.formats.*
 import explore.model.reusability.given
 import explore.model.syntax.all.*
 import explore.render.given
+import explore.services.OdbObservationApi
+import explore.undo.UndoSetter
 import explore.utils.*
 import japgolly.scalajs.react.*
+import japgolly.scalajs.react.util.Effect.Dispatch
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.enums.TimingWindowInclusion
 import lucuma.core.model.TimingWindow
@@ -51,6 +60,7 @@ import monocle.Iso
 import monocle.Lens
 import monocle.function.Index
 import monocle.function.Index.*
+import org.typelevel.log4cats.Logger
 
 import java.time.Duration
 import java.time.Instant
@@ -58,20 +68,77 @@ import java.time.ZoneOffset
 import java.time.ZonedDateTime
 
 object SchedulingWindowsTile:
-
   // Helper lens for converting between Timestamp and Instant
   private val timestampToInstant: Lens[Timestamp, Instant] =
     Lens[Timestamp, Instant](_.toInstant)(instant =>
       _ => Timestamp.unsafeFromInstantTruncated(instant)
     )
-  def apply(
+
+  def forObsIdSet[F[_]: OdbObservationApi: MonadThrow: Dispatch: Logger: ToastCtx](
+    obsEditInfo:  ObsIdSetEditInfo,
+    observations: UndoSetter[ObservationList],
+    readOnly:     Boolean,
+    fullSize:     Boolean
+  ) =
+    // We will only execute the incomplete observations, but we noed something to pass
+    // to the timing windows panel. However, if all are complete, it will be readonly
+    val idsToEdit = obsEditInfo.unCompleted.getOrElse(obsEditInfo.editing)
+
+    val obsTraversal = Iso
+      .id[ObservationList]
+      .filterIndex((id: Observation.Id) => idsToEdit.contains(id))
+
+    val twTraversal = obsTraversal.andThen(Observation.timingWindows)
+
+    val timingWindows: View[List[TimingWindow]] =
+      TimingWindowsQueries.viewWithRemoteMod(
+        idsToEdit,
+        observations
+          .undoableView[List[TimingWindow]](
+            twTraversal.getAll.andThen(_.head),
+            twTraversal.modify
+          )
+      )
+    internalApply(obsEditInfo, timingWindows, readOnly, fullSize)
+
+  def forObservation[F[_]: OdbObservationApi: MonadThrow: Dispatch: Logger: ToastCtx](
+    observation: UndoSetter[Observation],
+    readOnly:    Boolean,
+    fullSize:    Boolean
+  ) =
+    val obsEditInfo                             = ObsIdSetEditInfo.of(observation.get)
+    val timingWindows: View[List[TimingWindow]] =
+      TimingWindowsQueries.viewWithRemoteMod(
+        ObsIdSet.one(observation.get.id),
+        observation.undoableView[List[TimingWindow]](Observation.timingWindows)
+      )
+    internalApply(obsEditInfo, timingWindows, readOnly, fullSize)
+
+  private def internalApply(
+    obsEditInfo:   ObsIdSetEditInfo,
     timingWindows: View[List[TimingWindow]],
     readOnly:      Boolean,
     fullSize:      Boolean
   ) =
+
     val base  = "Scheduling Windows"
     val title =
       if (timingWindows.get.isEmpty) base else s"$base (${timingWindows.get.length})"
+
+    val msg: Option[String] =
+      if (readOnly)
+        none
+      else if (obsEditInfo.allAreCompleted)
+        if (obsEditInfo.editing.length > 1)
+          "All of the current observations are completed. Scheduling windows are readonly.".some
+        else "The current observation has been completed. Scheduling windows are readonly.".some
+      else if (obsEditInfo.completed.isDefined)
+        "Some of the current observations are completed. Only uncompleted observations will be modified.".some
+      else
+        none
+
+    val finalReadOnly = readOnly || obsEditInfo.allAreCompleted
+
     Tile(
       ObsTabTileIds.TimingWindowsId.id,
       title,
@@ -79,8 +146,12 @@ object SchedulingWindowsTile:
       canMaximize = !fullSize,
       canMinimize = !fullSize
     )(
-      tileState => Body(timingWindows, readOnly, tileState.set),
-      (tileState, tileSize) => Title(timingWindows, readOnly, tileState.get, tileSize)
+      tileState =>
+        React.Fragment(
+          msg.map(msg => <.div(msg, ExploreStyles.SharedEditWarning)),
+          Body(timingWindows, finalReadOnly, tileState.set)
+        ),
+      (tileState, tileSize) => Title(timingWindows, finalReadOnly, tileState.get, tileSize)
     )
 
   object TileState extends NewType[RowSelection => Callback]:

--- a/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
@@ -14,9 +14,9 @@ import explore.actions.ObservationPasteIntoConstraintSetAction
 import explore.components.FocusedStatus
 import explore.components.Tile
 import explore.components.TileController
+import explore.components.ui.ExploreStyles
 import explore.constraints.ConstraintsPanel
 import explore.constraints.ConstraintsSummaryTile
-import explore.components.ui.ExploreStyles
 import explore.model.*
 import explore.model.enums.AppTab
 import explore.model.enums.GridLayoutSection

--- a/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ConstraintsTabContents.scala
@@ -11,19 +11,18 @@ import crystal.react.hooks.*
 import crystal.react.reuse.*
 import explore.*
 import explore.actions.ObservationPasteIntoConstraintSetAction
-import explore.common.TimingWindowsQueries
 import explore.components.FocusedStatus
 import explore.components.Tile
 import explore.components.TileController
 import explore.constraints.ConstraintsPanel
 import explore.constraints.ConstraintsSummaryTile
+import explore.components.ui.ExploreStyles
 import explore.model.*
 import explore.model.enums.AppTab
 import explore.model.enums.GridLayoutSection
 import explore.model.enums.SelectedPanel
 import explore.model.reusability.given
 import explore.observationtree.ConstraintGroupObsList
-import explore.schedulingWindows.SchedulingWindowsTile
 import explore.shortcuts.*
 import explore.shortcuts.given
 import explore.undo.*
@@ -33,7 +32,6 @@ import japgolly.scalajs.react.extra.router.SetRouteVia
 import japgolly.scalajs.react.vdom.html_<^.*
 import lucuma.core.model.ConstraintSet
 import lucuma.core.model.Program
-import lucuma.core.model.TimingWindow
 import lucuma.core.model.User
 import lucuma.react.common.ReactFnProps
 import lucuma.react.hotkeys.*
@@ -144,101 +142,120 @@ object ConstraintsTabContents extends TwoPanels:
               case (Some(_), _)                 => selected.set(SelectedPanel.Editor)
               case (None, SelectedPanel.Editor) => selected.set(SelectedPanel.Summary)
               case _                            => Callback.empty
+      .useMemoBy((props, _, _, _, _, _) => (props.focusedObsSet, props.observations)):
+        (_, _, _, _, _, _) =>
+          (focused, obsList) => focused.map(ObsIdSetEditInfo.fromObservationList(_, obsList))
       .useResizeDetector() // Measure its size
-      .render: (props, ctx, shadowClipboardObs, copyCallback, pasteCallback, state, resize) =>
-        import ctx.given
+      .render:
+        (props, ctx, shadowClipboardObs, copyCallback, pasteCallback, state, obsEditInfo, resize) =>
 
-        def findConstraintGroup(
-          obsIds: ObsIdSet,
-          cgl:    ConstraintGroupList
-        ): Option[ConstraintGroup] =
-          cgl.find(_._1.intersect(obsIds).nonEmpty).map(ConstraintGroup.fromTuple)
+          def findConstraintGroup(
+            obsIds: ObsIdSet,
+            cgl:    ConstraintGroupList
+          ): Option[ConstraintGroup] =
+            cgl.find(_._1.intersect(obsIds).nonEmpty).map(ConstraintGroup.fromTuple)
 
-        val backButton: VdomNode =
-          makeBackButton(props.programId, AppTab.Constraints, state, ctx)
+          val backButton: VdomNode =
+            makeBackButton(props.programId, AppTab.Constraints, state, ctx)
 
-        val observations: UndoSetter[ObservationList] =
-          props.programSummaries.zoom(ProgramSummaries.observations)
+          val observations: UndoSetter[ObservationList] =
+            props.programSummaries.zoom(ProgramSummaries.observations)
 
-        val rightSide = (_: UseResizeDetectorReturn) =>
-          props.focusedObsSet
-            .flatMap: ids =>
-              findConstraintGroup(ids, props.programSummaries.get.constraintGroups)
-                .map(cg => (ids, cg))
-            .fold[VdomNode](
-              ConstraintsSummaryTile(
-                props.userId,
-                props.programId,
-                props.programSummaries.get.constraintGroups,
-                props.expandedIds,
-                backButton
-              )
-            ) { case (idsToEdit, constraintGroup) =>
-              val obsTraversal = Iso
-                .id[ObservationList]
-                .filterIndex((id: Observation.Id) => idsToEdit.contains(id))
-
-              val csTraversal = obsTraversal.andThen(Observation.constraints)
-
-              val constraintSet: UndoSetter[ConstraintSet] =
-                observations.zoom(csTraversal.getAll.andThen(_.head), csTraversal.modify)
-
-              val constraintsTitle: String = idsToEdit.single match
-                case Some(id) => s"Observation $id"
-                case None     => s"Editing Constraints for ${idsToEdit.size} Observations"
-
-              val constraintsTile: Tile[Option[VdomNode]] =
-                Tile(
-                  ObsTabTileIds.ConstraintsId.id,
-                  constraintsTitle,
-                  backButton.some
-                )(_ => ConstraintsPanel(idsToEdit, none, none, none, constraintSet, props.readonly))
-
-              val twTraversal = obsTraversal.andThen(Observation.timingWindows)
-
-              val timingWindows: View[List[TimingWindow]] =
-                TimingWindowsQueries.viewWithRemoteMod(
-                  idsToEdit,
-                  observations
-                    .undoableView[List[TimingWindow]](
-                      twTraversal.getAll.andThen(_.head),
-                      twTraversal.modify
-                    )
+          val rightSide = (_: UseResizeDetectorReturn) =>
+            obsEditInfo.value
+              .flatMap: editInfo =>
+                findConstraintGroup(editInfo.editing, props.programSummaries.get.constraintGroups)
+                  .map(cg => (editInfo, cg))
+              .fold[VdomNode](
+                ConstraintsSummaryTile(
+                  props.userId,
+                  props.programId,
+                  props.programSummaries.get.constraintGroups,
+                  props.expandedIds,
+                  backButton
                 )
+              ) { case (obsEditInfo, constraintGroup) =>
+                // will only edit the non-executed ones, but we need something to pass to the
+                // constraints panel. However, if all are executed, it will be readonly
+                val idsToEdit    = obsEditInfo.unExecuted.getOrElse(obsEditInfo.editing)
+                val obsTraversal = Iso
+                  .id[ObservationList]
+                  .filterIndex((id: Observation.Id) => idsToEdit.contains(id))
 
-              val schedulingWindowsTile: Tile[SchedulingWindowsTile.TileState] =
-                SchedulingWindowsTile(timingWindows, props.readonly, false)
+                val csTraversal = obsTraversal.andThen(Observation.constraints)
 
-              TileController(
-                props.userId,
-                resize.width.getOrElse(1),
-                ExploreGridLayouts.sectionLayout(GridLayoutSection.ConstraintsLayout),
-                props.userPreferences.constraintsTabLayout,
-                List(constraintsTile, schedulingWindowsTile),
-                GridLayoutSection.ConstraintsLayout,
-                None
-              )
-            }
+                val constraintSet: UndoSetter[ConstraintSet] =
+                  observations.zoom(csTraversal.getAll.andThen(_.head), csTraversal.modify)
 
-        val constraintsTree: VdomNode =
-          ConstraintGroupObsList(
-            props.programId,
-            observations,
-            props.programSummaries,
-            props.programSummaries.get.constraintGroups,
-            props.focusedObsSet,
-            state.set(SelectedPanel.Summary),
-            props.expandedIds,
-            copyCallback,
-            pasteCallback,
-            shadowClipboardObs.value,
-            props.programSummaries.get.allocatedScienceBands,
-            props.readonly
+                val constraintsTitle: String = idsToEdit.single match
+                  case Some(id) => s"Observation $id"
+                  case None     => s"Editing Constraints for ${idsToEdit.size} Observations"
+
+                val constraintsMessage: Option[String] =
+                  if (props.readonly)
+                    none
+                  else if (obsEditInfo.allAreExecuted)
+                    if (obsEditInfo.editing.length > 1)
+                      "All of the current observations are executed. Constraints are readonly.".some
+                    else "The current observation has been executed. Constraints are readonly.".some
+                  else if (obsEditInfo.executed.isDefined)
+                    "Some of the current observations are executed. Only unexecuted observations will be modified.".some
+                  else none
+
+                val constraintsTile: Tile[Option[VdomNode]] =
+                  Tile(
+                    ObsTabTileIds.ConstraintsId.id,
+                    constraintsTitle,
+                    backButton.some
+                  )(_ =>
+                    React.Fragment(
+                      constraintsMessage.map(msg => <.div(msg, ExploreStyles.SharedEditWarning)),
+                      ConstraintsPanel(idsToEdit,
+                                       none,
+                                       none,
+                                       none,
+                                       constraintSet,
+                                       props.readonly || obsEditInfo.allAreExecuted
+                      )
+                    )
+                  )
+
+                TileController(
+                  props.userId,
+                  resize.width.getOrElse(1),
+                  ExploreGridLayouts.sectionLayout(GridLayoutSection.ConstraintsLayout),
+                  props.userPreferences.constraintsTabLayout,
+                  List(constraintsTile),
+                  GridLayoutSection.ConstraintsLayout,
+                  None
+                )
+              }
+
+          val constraintsTree: VdomNode =
+            ConstraintGroupObsList(
+              props.programId,
+              observations,
+              props.programSummaries,
+              props.programSummaries.get.constraintGroups,
+              props.focusedObsSet,
+              state.set(SelectedPanel.Summary),
+              props.expandedIds,
+              copyCallback,
+              pasteCallback,
+              shadowClipboardObs.value,
+              props.programSummaries.get.allocatedScienceBands,
+              props.readonly
+            )
+
+          React.Fragment(
+            if (LinkingInfo.developmentMode)
+              FocusedStatus(AppTab.Constraints, props.programId, Focused(props.focusedObsSet))
+            else EmptyVdom,
+            makeOneOrTwoPanels(
+              state,
+              constraintsTree,
+              rightSide,
+              RightSideCardinality.Multi,
+              resize
+            )
           )
-
-        React.Fragment(
-          if (LinkingInfo.developmentMode)
-            FocusedStatus(AppTab.Constraints, props.programId, Focused(props.focusedObsSet))
-          else EmptyVdom,
-          makeOneOrTwoPanels(state, constraintsTree, rightSide, RightSideCardinality.Multi, resize)
-        )

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -14,7 +14,6 @@ import crystal.react.hooks.*
 import eu.timepit.refined.cats.*
 import eu.timepit.refined.types.string.NonEmptyString
 import explore.*
-import explore.common.TimingWindowsQueries
 import explore.components.Tile
 import explore.components.TileController
 import explore.components.ui.ExploreStyles
@@ -63,7 +62,6 @@ import lucuma.core.model.ObjectTracking
 import lucuma.core.model.PosAngleConstraint
 import lucuma.core.model.Program
 import lucuma.core.model.Target
-import lucuma.core.model.TimingWindow
 import lucuma.core.syntax.all.*
 import lucuma.core.util.TimeSpan
 import lucuma.react.common.ReactFnProps
@@ -406,12 +404,6 @@ object ObsTabTiles:
               props.globalPreferences
             )
 
-          val schedulingWindows: View[List[TimingWindow]] =
-            TimingWindowsQueries.viewWithRemoteMod(
-              ObsIdSet.one(props.obsId),
-              props.observation.undoableView[List[TimingWindow]](Observation.timingWindows)
-            )
-
           val obsConf: ObsConfiguration =
             ObsConfiguration(
               basicConfiguration,
@@ -449,7 +441,7 @@ object ObsTabTiles:
                 props.observation.get.observingMode.map(_.siteFor),
                 obsTimeView.get,
                 obsDuration.map(_.toDuration),
-                schedulingWindows.get,
+                props.observation.get.timingWindows,
                 props.globalPreferences.get,
                 Constants.NoTargetSelected
               )
@@ -541,7 +533,11 @@ object ObsTabTiles:
             )
 
           val schedulingWindowsTile =
-            SchedulingWindowsTile(schedulingWindows, props.readonly, false)
+            SchedulingWindowsTile.forObservation(
+              props.observation,
+              props.readonly,
+              false
+            )
 
           val configurationTile: Tile[?] =
             ConfigurationTile(

--- a/model/shared/src/main/scala/explore/model/ObsIdSetEditInfo.scala
+++ b/model/shared/src/main/scala/explore/model/ObsIdSetEditInfo.scala
@@ -4,22 +4,41 @@
 package explore.model
 
 import cats.Eq
+import cats.Order.*
 import cats.derived.*
 import cats.syntax.all.*
 import explore.model.syntax.all.*
 
+import scala.collection.immutable.SortedSet
+
 case class ObsIdSetEditInfo(
-  editing:     ObsIdSet,
-  executed:    Option[ObsIdSet],
-  asterismIds: AsterismIds
+  editing:   ObsIdSet,
+  ongoing:   Option[ObsIdSet],
+  completed: Option[ObsIdSet]
 ) derives Eq:
+  val hasOngoingButNotCompleted: Boolean = ongoing.isDefined && completed.isEmpty
+
+  val hasCompleted: Boolean         = completed.isDefined
+  val unCompleted: Option[ObsIdSet] = completed.fold(editing.some)(editing.remove)
+  val allAreCompleted: Boolean      = unCompleted.isEmpty
+
+  // many places only care about executed or not, not ongoing vs completed
+  val executed                     = ongoing.fold(completed)(o =>
+    ObsIdSet.fromSortedSet(
+      o.idSet.toSortedSet ++ completed.fold(SortedSet.empty[Observation.Id])(_.idSet.toSortedSet)
+    )
+  )
   val unExecuted: Option[ObsIdSet] = executed.fold(editing.some)(editing.remove)
   val allAreExecuted: Boolean      = unExecuted.isEmpty
 
 object ObsIdSetEditInfo:
   def fromObservationList(editing: ObsIdSet, observations: ObservationList): ObsIdSetEditInfo =
-    val executed    = observations.executedOf(editing)
-    // These are all ids with the same asterism
-    val asterismIds =
-      observations.get(editing.head).fold(AsterismIds.empty)(_.scienceTargetIds)
-    ObsIdSetEditInfo(editing, executed, asterismIds)
+    val ongoing   = observations.ongoingOf(editing)
+    val completed = observations.completedOf(editing)
+    ObsIdSetEditInfo(editing, ongoing, completed)
+
+  def of(obs: Observation): ObsIdSetEditInfo =
+    val ongoing   = if (obs.isOngoing) ObsIdSet.of(obs.id).some else none
+    val completed = if (obs.isCompleted) ObsIdSet.of(obs.id).some else none
+
+    ObsIdSetEditInfo(ObsIdSet.of(obs.id), ongoing, completed)

--- a/model/shared/src/main/scala/explore/model/syntax/package.scala
+++ b/model/shared/src/main/scala/explore/model/syntax/package.scala
@@ -94,6 +94,12 @@ object all:
     def executedOf(obsIds: ObsIdSet): Option[ObsIdSet]                                       =
       val executed = obsIds.idSet.filter(id => observations.get(id).fold(false)(_.isExecuted))
       ObsIdSet.fromSortedSet(executed)
+    def ongoingOf(obsIds: ObsIdSet): Option[ObsIdSet]                                        =
+      val ongoing = obsIds.idSet.filter(id => observations.get(id).fold(false)(_.isOngoing))
+      ObsIdSet.fromSortedSet(ongoing)
+    def completedOf(obsIds: ObsIdSet): Option[ObsIdSet]                                      =
+      val completed = obsIds.idSet.filter(id => observations.get(id).fold(false)(_.isCompleted))
+      ObsIdSet.fromSortedSet(completed)
     def addTargetToObservations(targetId: Target.Id, obsIds: ObsIdSet): ObservationList      =
       obsIds.idSet.foldLeft(observations): (map, obsId) =>
         map.updatedWith(obsId)(_.map(Observation.scienceTargetIds.modify(_ + targetId)))


### PR DESCRIPTION
Also removes the scheduling window tile from the constraints tab.

This also prevents editing via drag and drop.