### PR TITLE
Allow position angle to be edited by staff when ongoing.

### DIFF
--- a/explore/src/main/scala/explore/config/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationTile.scala
@@ -24,6 +24,7 @@ import explore.components.ui.ExploreStyles
 import explore.model.AppContext
 import explore.model.AsterismIds
 import explore.model.ObsConfiguration
+import explore.model.ObsIdSetEditInfo
 import explore.model.ObsTabTileIds
 import explore.model.Observation
 import explore.model.ObservingModeGroupList
@@ -81,6 +82,7 @@ object ConfigurationTile:
     observingModeGroups:      ObservingModeGroupList,
     sequenceChanged:          Callback,
     readonly:                 Boolean,
+    obsIdSetEditInfo:         ObsIdSetEditInfo,          // for the Position Angle Editor
     units:                    WavelengthUnits,
     isStaff:                  Boolean
   ) =
@@ -105,6 +107,7 @@ object ConfigurationTile:
           customSedTimestamps,
           sequenceChanged,
           readonly,
+          obsIdSetEditInfo,
           units,
           isStaff
         ),
@@ -114,7 +117,7 @@ object ConfigurationTile:
               observingModeGroups,
               selectedConfig,
               revertedInstrumentConfig,
-              readonly
+              readonly || obsIdSetEditInfo.hasExecuted
         )
     )
 
@@ -207,6 +210,7 @@ object ConfigurationTile:
     customSedTimestamps:      List[Timestamp],
     sequenceChanged:          Callback,
     readonly:                 Boolean,
+    obsIdSetEditInfo:         ObsIdSetEditInfo, // for the Position Angle Editor
     units:                    WavelengthUnits,
     isStaff:                  Boolean
   ) extends ReactFnProps(Body.component):
@@ -214,6 +218,7 @@ object ConfigurationTile:
       pacAndMode.zoom(PosAngleConstraintAndObsMode.observingMode)
     val posAngle: UndoSetter[PosAngleConstraint] =
       pacAndMode.zoom(PosAngleConstraintAndObsMode.posAngleConstraint)
+    val obsIsReadonly                            = readonly || obsIdSetEditInfo.hasExecuted
 
   private object Body:
     private type Props = Body
@@ -386,7 +391,9 @@ object ConfigurationTile:
                     props.obsConf.selectedPA,
                     props.obsConf.averagePA,
                     agsState,
-                    props.readonly
+                    props.readonly, // readonly status is more complicated here...
+                    props.obsIdSetEditInfo,
+                    props.isStaff
                   )
                 ),
               if (optModeView.get.isEmpty)
@@ -412,7 +419,7 @@ object ConfigurationTile:
                         .orEmpty,
                       props.modes,
                       props.customSedTimestamps,
-                      props.readonly,
+                      props.obsIsReadonly,
                       props.units
                     )
                   )
@@ -431,7 +438,7 @@ object ConfigurationTile:
                         revertConfig,
                         props.modes.spectroscopy,
                         props.sequenceChanged,
-                        props.readonly,
+                        props.obsIsReadonly,
                         props.units
                       )
                   ),
@@ -448,7 +455,7 @@ object ConfigurationTile:
                         revertConfig,
                         props.modes.spectroscopy,
                         props.sequenceChanged,
-                        props.readonly,
+                        props.obsIsReadonly,
                         props.units
                       )
                   ),
@@ -472,7 +479,7 @@ object ConfigurationTile:
                       revertConfig,
                       props.modes.spectroscopy,
                       props.sequenceChanged,
-                      props.readonly,
+                      props.obsIsReadonly,
                       props.units,
                       props.isStaff
                     )

--- a/explore/src/main/scala/explore/tabs/ObsTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabContents.scala
@@ -286,7 +286,7 @@ object ObsTabContents extends TwoPanels:
                   props.observations.zoom(indexValue.getOption.andThen(_.get), indexValue.modify)
                 val obs           = obsUndoSetter.get
                 val obsIsReadonly =
-                  props.readonly || addingObservation.get.value || obs.isCalibration || obs.isExecuted
+                  props.readonly || addingObservation.get.value || obs.isCalibration
                 ObsTabTiles(
                   props.vault,
                   props.programId,

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -99,6 +99,7 @@ case class ObsTabTiles(
   globalPreferences: View[GlobalPreferences],
   readonly:          Boolean
 ) extends ReactFnProps(ObsTabTiles.component):
+  val obsIsReadonly         = readonly || observation.get.isExecuted
   val obsId: Observation.Id = observation.get.id
 
   val allConstraintSets: Set[ConstraintSet] = programSummaries.constraintGroups.map(_._2).toSet
@@ -375,7 +376,7 @@ object ObsTabTiles:
               props.vault.map(_.token),
               props.attachments,
               pa,
-              props.readonly,
+              props.readonly || props.observation.get.isCompleted,
               hidden = hideTiles
             )
 
@@ -496,7 +497,7 @@ object ObsTabTiles:
               guideStarSelection,
               props.attachments,
               props.vault.map(_.token),
-              props.readonly,
+              props.obsIsReadonly,
               // Any target changes invalidate the sequence
               sequenceChanged.set(pending)
             )
@@ -506,7 +507,7 @@ object ObsTabTiles:
               props.obsId,
               props.observation.model.zoom(Observation.constraints),
               props.allConstraintSets,
-              props.readonly
+              props.obsIsReadonly
             )
 
           // The ExploreStyles.ConstraintsTile css adds a z-index to the constraints tile react-grid wrapper
@@ -527,7 +528,7 @@ object ObsTabTiles:
                   conditionsLikelihood,
                   props.centralWavelength,
                   props.observation.zoom(Observation.constraints),
-                  props.readonly
+                  props.obsIsReadonly
                 ),
               (_, _) => constraintsSelector
             )
@@ -535,7 +536,7 @@ object ObsTabTiles:
           val schedulingWindowsTile =
             SchedulingWindowsTile.forObservation(
               props.observation,
-              props.readonly,
+              props.obsIsReadonly,
               false
             )
 
@@ -560,7 +561,8 @@ object ObsTabTiles:
                 case Ready(x) => pending
                 case x        => x
               ,
-              props.readonly,
+              props.readonly, // execution status is taken care of in the configuration tile
+              ObsIdSetEditInfo.of(props.observation.get),
               props.globalPreferences.get.wavelengthUnits,
               props.vault.isStaff
             )

--- a/model/shared/src/main/scala/explore/model/ObsIdSetEditInfo.scala
+++ b/model/shared/src/main/scala/explore/model/ObsIdSetEditInfo.scala
@@ -28,6 +28,7 @@ case class ObsIdSetEditInfo(
       o.idSet.toSortedSet ++ completed.fold(SortedSet.empty[Observation.Id])(_.idSet.toSortedSet)
     )
   )
+  val hasExecuted: Boolean         = executed.isDefined
   val unExecuted: Option[ObsIdSet] = executed.fold(editing.some)(editing.remove)
   val allAreExecuted: Boolean      = unExecuted.isEmpty
 


### PR DESCRIPTION
From the story: 

> When an observation is ongoing, staff should be able to edit the position angle, but only to switch between Average parallactic and Parallactic override. If the position angle is neither of those, it should be readonly.

Also [sc-6166]:

> Allow finder charts to be edited until the observation is complete
