### PR TITLE
Allow staff to edit ongoing observations from the observation tab

### DIFF
--- a/common/src/main/scala/explore/model/RootModel.scala
+++ b/common/src/main/scala/explore/model/RootModel.scala
@@ -38,7 +38,7 @@ case class RootModel(
   undoStacks:           UndoStacks[IO, ProgramSummaries] = UndoStacks.empty[IO, ProgramSummaries],
   otherUndoStacks:      ModelUndoStacks[IO] = ModelUndoStacks[IO]()
 ) derives Eq:
-  lazy val isStaff = vault.isStaff
+  lazy val isStaffOrAdmin = vault.isStaffOrAdmin
 
 object RootModel:
   val vault                = Focus[RootModel](_.vault)

--- a/common/src/main/scala/explore/model/RootModelViews.scala
+++ b/common/src/main/scala/explore/model/RootModelViews.scala
@@ -28,9 +28,10 @@ case class RootModelViews(
   def hasRole(role: ProgramUserRole): Boolean =
     userProgramRoles.exists(_ === role)
 
+  lazy val userIsStaffOrAdmin: Boolean = rootModel.get.isStaffOrAdmin
+
   lazy val userIsReadonlyCoi: Boolean =
-    val isStaff = rootModel.get.isStaff
-    !isStaff && hasRole(ProgramUserRole.CoiRO) && !(hasRole(
+    !userIsStaffOrAdmin && hasRole(ProgramUserRole.CoiRO) && !(hasRole(
       ProgramUserRole.SupportPrimary
     ) || hasRole(ProgramUserRole.SupportSecondary))
 

--- a/common/src/main/scala/explore/syntax/ui/package.scala
+++ b/common/src/main/scala/explore/syntax/ui/package.scala
@@ -70,7 +70,9 @@ extension (vault: UserVault)
     )
     request
 
-  def isStaff: Boolean = vault.user.role.access === Access.Staff
+  def isStaff: Boolean        = vault.user.role.access === Access.Staff
+  def isAdmin: Boolean        = vault.user.role.access === Access.Admin
+  def isStaffOrAdmin: Boolean = vault.user.role.access >= Access.Staff
 
 extension [F[_]: ApplicativeThrow: ToastCtx, A](f: F[A])
   def toastErrors: F[A] =
@@ -165,7 +167,7 @@ extension (tac: TimeAccountingCategory)
 extension (vault: Option[UserVault])
   def userId: Option[User.Id] = vault.map(_.user).map(_.id)
   def isGuest: Boolean        = vault.map(_.user).map(_.role === GuestRole).getOrElse(true)
-  def isStaff: Boolean        = vault.exists(_.isStaff)
+  def isStaffOrAdmin: Boolean = vault.exists(_.isStaffOrAdmin)
 
 extension [F[_], A](view: ViewF[F, A])
   def zoom[B](getAdjust: GetAdjust[A, B]): ViewF[F, B] =

--- a/explore/src/main/scala/explore/HelpBody.scala
+++ b/explore/src/main/scala/explore/HelpBody.scala
@@ -78,7 +78,7 @@ object HelpBody:
         <.div(ExploreStyles.HelpTitle)(
           <.h4("Help"),
           <.div(
-            TagMod.when(props.userVault.isStaff)(
+            TagMod.when(props.userVault.isStaffOrAdmin)(
               <.a(
                 Button(
                   icon = Icons.Edit,
@@ -113,7 +113,7 @@ object HelpBody:
             case Pot.Error(o) if o.getMessage.contains("404") =>
               <.div(ExploreStyles.HelpMarkdownBody)(
                 "Not found",
-                TagMod.when(props.userVault.isStaff)(
+                TagMod.when(props.userVault.isStaffOrAdmin)(
                   React.Fragment(
                     ", maybe you want to create it ",
                     <.a(^.href := props.newPage.toString(), ^.target := "_blank", Icons.Edit)

--- a/explore/src/main/scala/explore/config/ConfigurationTile.scala
+++ b/explore/src/main/scala/explore/config/ConfigurationTile.scala
@@ -84,7 +84,7 @@ object ConfigurationTile:
     readonly:                 Boolean,
     obsIdSetEditInfo:         ObsIdSetEditInfo,          // for the Position Angle Editor
     units:                    WavelengthUnits,
-    isStaff:                  Boolean
+    isStaffOrAdmin:           Boolean
   ) =
     Tile(
       ObsTabTileIds.ConfigurationId.id,
@@ -109,15 +109,16 @@ object ConfigurationTile:
           readonly,
           obsIdSetEditInfo,
           units,
-          isStaff
+          isStaffOrAdmin
         ),
       (_, _) =>
-        Title(obsId,
-              pacAndMode,
-              observingModeGroups,
-              selectedConfig,
-              revertedInstrumentConfig,
-              readonly || obsIdSetEditInfo.hasExecuted
+        Title(
+          obsId,
+          pacAndMode,
+          observingModeGroups,
+          selectedConfig,
+          revertedInstrumentConfig,
+          readonly || obsIdSetEditInfo.hasExecuted // even staff can't choose a new config if it is executed
         )
     )
 
@@ -212,13 +213,14 @@ object ConfigurationTile:
     readonly:                 Boolean,
     obsIdSetEditInfo:         ObsIdSetEditInfo, // for the Position Angle Editor
     units:                    WavelengthUnits,
-    isStaff:                  Boolean
+    isStaffOrAdmin:           Boolean
   ) extends ReactFnProps(Body.component):
     val mode: UndoSetter[Option[ObservingMode]]  =
       pacAndMode.zoom(PosAngleConstraintAndObsMode.observingMode)
     val posAngle: UndoSetter[PosAngleConstraint] =
       pacAndMode.zoom(PosAngleConstraintAndObsMode.posAngleConstraint)
-    val obsIsReadonly                            = readonly || obsIdSetEditInfo.hasExecuted
+    val obsIsReadonly                            =
+      readonly || (obsIdSetEditInfo.hasExecuted && !isStaffOrAdmin) || obsIdSetEditInfo.hasCompleted
 
   private object Body:
     private type Props = Body
@@ -393,7 +395,7 @@ object ConfigurationTile:
                     agsState,
                     props.readonly, // readonly status is more complicated here...
                     props.obsIdSetEditInfo,
-                    props.isStaff
+                    props.isStaffOrAdmin
                   )
                 ),
               if (optModeView.get.isEmpty)
@@ -503,7 +505,7 @@ object ConfigurationTile:
                       props.sequenceChanged,
                       props.obsIsReadonly,
                       props.units,
-                      props.isStaff
+                      props.isStaffOrAdmin
                     )
                   )
                 )

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -98,7 +98,9 @@ case class ObsTabTiles(
   userPreferences:  View[UserPreferences],
   readonly:         Boolean
 ) extends ReactFnProps(ObsTabTiles.component):
-  val obsIsReadonly         = readonly || observation.get.isExecuted
+  val isStaffOrAdmin        = vault.isStaffOrAdmin
+  val obsIsReadonly         =
+    readonly || (observation.get.isExecuted && !isStaffOrAdmin) || observation.get.isCompleted
   val obsId: Observation.Id = observation.get.id
 
   val allConstraintSets: Set[ConstraintSet] = programSummaries.constraintGroups.map(_._2).toSet
@@ -501,8 +503,9 @@ object ObsTabTiles:
               props.attachments,
               props.vault.map(_.token),
               props.obsIsReadonly,
+              allowEditingOngoing = props.isStaffOrAdmin,
               // Any target changes invalidate the sequence
-              sequenceChanged.set(pending)
+              sequenceChanged = sequenceChanged.set(pending)
             )
 
           val constraintsSelector: VdomNode =
@@ -567,7 +570,7 @@ object ObsTabTiles:
               props.readonly, // execution status is taken care of in the configuration tile
               ObsIdSetEditInfo.of(props.observation.get),
               globalPreferences.get.wavelengthUnits,
-              props.vault.isStaff
+              props.isStaffOrAdmin
             )
 
           val alltiles =

--- a/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/ProgramTabContents.scala
@@ -120,7 +120,7 @@ object ProgramTabContents
             props.undoer,
             props.programDetailsUndoSetter.zoom(ProgramDetails.notes),
             props.userIsReadonlyCoi,
-            props.userVault.isStaff
+            props.userVault.isStaffOrAdmin
           )
 
         val configurationRequestsTile =

--- a/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/SiderealTargetEditorTile.scala
@@ -73,7 +73,9 @@ object SiderealTargetEditorTile:
               guideStarSelection = guideStarSelection,
               attachments = attachments,
               authToken = authToken,
-              readonly = readonly
+              readonly = readonly,
+              allowEditingOngoing =
+                false // don't allow this when editing non-specifically for an observation
             )
           )
         )

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -539,6 +539,8 @@ object TargetTabContents extends TwoPanels:
                 props.attachments,
                 props.authToken,
                 props.readonly,
+                allowEditingOngoing =
+                  false, // only allow editing of ongoing observations from the obs tab
                 backButton = backButton.some
               )
 

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
@@ -54,29 +54,30 @@ import java.time.Instant
 
 object AsterismEditorTile:
   def apply(
-    userId:             Option[User.Id],
-    tileId:             Tile.TileId,
-    programId:          Program.Id,
-    obsIds:             ObsIdSet,
-    obsAndTargets:      UndoSetter[ObservationsAndTargets],
-    obsTime:            View[Option[Instant]],
-    obsDuration:        View[Option[TimeSpan]],
-    obsConf:            ObsConfiguration,
-    digest:             CalculatedValue[Option[ExecutionDigest]],
-    currentTarget:      Option[Target.Id],
-    setTarget:          (Option[Target.Id], SetRouteVia) => Callback,
-    onCloneTarget:      OnCloneParameters => Callback,
-    onAsterismUpdate:   OnAsterismUpdateParams => Callback,
-    obsInfo:            Target.Id => TargetEditObsInfo,
-    searching:          View[Set[Target.Id]],
-    title:              String,
-    userPreferences:    View[UserPreferences],
-    guideStarSelection: View[GuideStarSelection],
-    attachments:        View[AttachmentList],
-    authToken:          Option[NonEmptyString],
-    readonly:           Boolean,
-    sequenceChanged:    Callback = Callback.empty,
-    backButton:         Option[VdomNode] = None
+    userId:              Option[User.Id],
+    tileId:              Tile.TileId,
+    programId:           Program.Id,
+    obsIds:              ObsIdSet,
+    obsAndTargets:       UndoSetter[ObservationsAndTargets],
+    obsTime:             View[Option[Instant]],
+    obsDuration:         View[Option[TimeSpan]],
+    obsConf:             ObsConfiguration,
+    digest:              CalculatedValue[Option[ExecutionDigest]],
+    currentTarget:       Option[Target.Id],
+    setTarget:           (Option[Target.Id], SetRouteVia) => Callback,
+    onCloneTarget:       OnCloneParameters => Callback,
+    onAsterismUpdate:    OnAsterismUpdateParams => Callback,
+    obsInfo:             Target.Id => TargetEditObsInfo,
+    searching:           View[Set[Target.Id]],
+    title:               String,
+    userPreferences:     View[UserPreferences],
+    guideStarSelection:  View[GuideStarSelection],
+    attachments:         View[AttachmentList],
+    authToken:           Option[NonEmptyString],
+    readonly:            Boolean,
+    allowEditingOngoing: Boolean,
+    sequenceChanged:     Callback = Callback.empty,
+    backButton:          Option[VdomNode] = None
   )(using odbApi: OdbObservationApi[IO])(using Logger[IO]): Tile[TileState] = {
     // Save the time here. this works for the obs and target tabs
     // It's OK to save the viz time for executed observations, I think.
@@ -139,6 +140,7 @@ object AsterismEditorTile:
             attachments,
             authToken,
             readonly,
+            allowEditingOngoing,
             sequenceChanged,
             tileState.zoom(TileState.columnVisibility),
             tileState.zoom(TileState.obsEditInfo)
@@ -175,26 +177,27 @@ object AsterismEditorTile:
       Focus[TileState](_.obsEditInfo)
 
   private case class Body(
-    programId:          Program.Id,
-    userId:             User.Id,
-    obsIds:             ObsIdSet,
-    obsAndTargets:      UndoSetter[ObservationsAndTargets],
-    obsTime:            Option[Instant],
-    obsConf:            ObsConfiguration,
-    focusedTargetId:    Option[Target.Id],
-    setTarget:          (Option[Target.Id], SetRouteVia) => Callback,
-    onCloneTarget:      OnCloneParameters => Callback,
-    onAsterismUpdate:   OnAsterismUpdateParams => Callback,
-    obsInfo:            Target.Id => TargetEditObsInfo,
-    searching:          View[Set[Target.Id]],
-    userPreferences:    View[UserPreferences],
-    guideStarSelection: View[GuideStarSelection],
-    attachments:        View[AttachmentList],
-    authToken:          Option[NonEmptyString],
-    readonly:           Boolean,
-    sequenceChanged:    Callback,
-    columnVisibility:   View[ColumnVisibility],
-    obsEditInfo:        View[Option[ObsIdSetEditInfo]]
+    programId:           Program.Id,
+    userId:              User.Id,
+    obsIds:              ObsIdSet,
+    obsAndTargets:       UndoSetter[ObservationsAndTargets],
+    obsTime:             Option[Instant],
+    obsConf:             ObsConfiguration,
+    focusedTargetId:     Option[Target.Id],
+    setTarget:           (Option[Target.Id], SetRouteVia) => Callback,
+    onCloneTarget:       OnCloneParameters => Callback,
+    onAsterismUpdate:    OnAsterismUpdateParams => Callback,
+    obsInfo:             Target.Id => TargetEditObsInfo,
+    searching:           View[Set[Target.Id]],
+    userPreferences:     View[UserPreferences],
+    guideStarSelection:  View[GuideStarSelection],
+    attachments:         View[AttachmentList],
+    authToken:           Option[NonEmptyString],
+    readonly:            Boolean,
+    allowEditingOngoing: Boolean,
+    sequenceChanged:     Callback,
+    columnVisibility:    View[ColumnVisibility],
+    obsEditInfo:         View[Option[ObsIdSetEditInfo]]
   ) extends ReactFnProps(Body.component):
     val allTargets: UndoSetter[TargetList] = obsAndTargets.zoom(ObservationsAndTargets.targets)
 
@@ -291,6 +294,7 @@ object AsterismEditorTile:
                         attachments = props.attachments,
                         authToken = props.authToken,
                         readonly = props.readonly,
+                        allowEditingOngoing = props.allowEditingOngoing,
                         invalidateSequence = props.sequenceChanged
                       )
                     )

--- a/model-tests/shared/src/test/scala/explore/model/TargetEditCloneInfoSuite.scala
+++ b/model-tests/shared/src/test/scala/explore/model/TargetEditCloneInfoSuite.scala
@@ -117,190 +117,286 @@ class TargetEditCloneInfoSuite extends FunSuite with MyAssertions {
   val threeFour   = ObsIdSet.of(o3, o4)
   val allFour     = ObsIdSet.of(o1, o2, o3, o4)
 
+  import TargetEditCloneInfo.BadType.*
+
   test("at target level, no observations") {
-    val obsInfo   = TargetEditObsInfo(none, none, none)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(none, none, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertNoMessage(cloneInfo)
   }
 
   test("at target level, none are executed") {
-    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, none)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertNoMessage(cloneInfo)
   }
   test("at target level, none are executed 2") {
-    val obsInfo   = TargetEditObsInfo(none, two.some, none)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(none, two.some, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertNoMessage(cloneInfo)
   }
 
   test("at target level, some are executed") {
-    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, three.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, oneTwo.some)
+    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, three.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyNonBadMsg(Executed), oneTwo.some)
   }
 
   test("at target level, some are executed 2") {
-    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, oneThree.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, two.some)
+    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, oneThree.some, three.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyNonBadMsg(Executed), two.some)
+  }
+
+  test("at target level, some are executed and allowEditingOngoing not respected") {
+    val obsInfo   = TargetEditObsInfo(none, oneTwoThree.some, oneThree.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyNonBadMsg(Executed), two.some)
   }
 
   test("at target level, all are executed") {
-    val obsInfo   = TargetEditObsInfo(none, oneThree.some, oneThree.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertReadonly(cloneInfo, TargetEditCloneInfo.allForTargetExecutedMsg)
+    val obsInfo   = TargetEditObsInfo(none, oneThree.some, oneThree.some, oneThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allForTargetBadMsg(Executed))
   }
 
   test("at target level, all are executed 2") {
-    val obsInfo   = TargetEditObsInfo(none, three.some, three.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertReadonly(cloneInfo, TargetEditCloneInfo.allForTargetExecutedMsg)
+    val obsInfo   = TargetEditObsInfo(none, three.some, three.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allForTargetBadMsg(Executed))
+  }
+
+  test("at target level, all are executed and allowEditingOngoing not respected") {
+    val obsInfo   = TargetEditObsInfo(none, three.some, three.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allForTargetBadMsg(Executed))
   }
 
   test("none are executed, all are being edited") {
-    val obsInfo   = TargetEditObsInfo(one.some, one.some, none)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(one.some, one.some, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertNoMessage(cloneInfo)
   }
 
   test("none are executed, all are being edited 2") {
-    val obsInfo   = TargetEditObsInfo(oneThree.some, oneThree.some, none)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(oneThree.some, oneThree.some, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("none are executed, all are being edited - works same with allowEditingOngoing") {
+    val obsInfo   = TargetEditObsInfo(oneThree.some, oneThree.some, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
     assertNoMessage(cloneInfo)
   }
 
   test("none are executed, not all are being edited") {
-    val obsInfo   = TargetEditObsInfo(one.some, oneTwo.some, none)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(one.some, oneTwo.some, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertChoice(
       cloneInfo,
-      TargetEditCloneInfo.otherMessage(1L, false),
+      TargetEditCloneInfo.otherMessage(1L, false, Executed),
       one,
       TargetEditCloneInfo.onlyThisMsg,
       none,
-      TargetEditCloneInfo.allForTargetMsg(false)
+      TargetEditCloneInfo.allForTargetMsg(false, Executed)
     )
   }
 
   test("none are executed, not all are being edited 2") {
-    val obsInfo   = TargetEditObsInfo(oneTwoThree.some, allFour.some, none)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(oneTwoThree.some, allFour.some, none, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertChoice(
       cloneInfo,
-      TargetEditCloneInfo.otherMessage(1L, false),
+      TargetEditCloneInfo.otherMessage(1L, false, Executed),
       oneTwoThree,
       TargetEditCloneInfo.onlyCurrentMsg,
       none,
-      TargetEditCloneInfo.allForTargetMsg(false)
+      TargetEditCloneInfo.allForTargetMsg(false, Executed)
     )
   }
 
   test("some are executed, all are being edited") {
-    val obsInfo   = TargetEditObsInfo(allFour.some, allFour.some, oneThree.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, twoFour.some)
+    val obsInfo   = TargetEditObsInfo(allFour.some, allFour.some, oneThree.some, one.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyNonBadMsg(Executed), twoFour.some)
   }
 
   test("some are executed, all are being edited 2") {
-    val obsInfo   = TargetEditObsInfo(oneTwo.some, oneTwo.some, one.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertSimple(cloneInfo, TargetEditCloneInfo.onlyUnexecutedMsg, two.some)
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, oneTwo.some, one.some, one.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyNonBadMsg(Executed), two.some)
   }
 
   test("some of other executed") {
-    val obsInfo   = TargetEditObsInfo(one.some, oneTwoThree.some, three.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(one.some, oneTwoThree.some, three.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertChoice(
       cloneInfo,
-      TargetEditCloneInfo.otherMessage(1L, true),
+      TargetEditCloneInfo.otherMessage(1L, true, Executed),
       one,
       TargetEditCloneInfo.onlyThisMsg,
       oneTwo.some,
-      TargetEditCloneInfo.allForTargetMsg(true)
+      TargetEditCloneInfo.allForTargetMsg(true, Executed)
     )
   }
 
   test("some of other executed 2") {
-    val obsInfo   = TargetEditObsInfo(one.some, allFour.some, four.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(one.some, allFour.some, four.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertChoice(
       cloneInfo,
-      TargetEditCloneInfo.otherMessage(2L, true),
+      TargetEditCloneInfo.otherMessage(2L, true, Executed),
       one,
       TargetEditCloneInfo.onlyThisMsg,
       oneTwoThree.some,
-      TargetEditCloneInfo.allForTargetMsg(true)
+      TargetEditCloneInfo.allForTargetMsg(true, Executed)
     )
   }
 
   test("some of other executed 3") {
-    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, four.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, four.some, four.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertChoice(
       cloneInfo,
-      TargetEditCloneInfo.otherMessage(1L, true),
+      TargetEditCloneInfo.otherMessage(1L, true, Executed),
       oneTwo,
       TargetEditCloneInfo.onlyCurrentMsg,
       oneTwoThree.some,
-      TargetEditCloneInfo.allForTargetMsg(true)
+      TargetEditCloneInfo.allForTargetMsg(true, Executed)
     )
   }
 
   test("some of current and other executed") {
-    val obsInfo   = TargetEditObsInfo(oneThree.some, allFour.some, three.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(oneThree.some, allFour.some, three.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertChoice(
       cloneInfo,
-      TargetEditCloneInfo.someExecutedMsg,
+      TargetEditCloneInfo.someBadMsg(Executed),
       one,
-      TargetEditCloneInfo.unexecutedOfCurrentMsg,
+      TargetEditCloneInfo.allNonBadOfCurrentMsg(Executed),
       oneTwoFour.some,
-      TargetEditCloneInfo.allUnexectedMsg
+      TargetEditCloneInfo.allNonBadMsg(Executed)
     )
   }
 
   test("some of current and other executed 2") {
-    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, oneThree.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, oneThree.some, oneThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
     assertChoice(
       cloneInfo,
-      TargetEditCloneInfo.someExecutedMsg,
+      TargetEditCloneInfo.someBadMsg(Executed),
       two,
-      TargetEditCloneInfo.unexecutedOfCurrentMsg,
+      TargetEditCloneInfo.allNonBadOfCurrentMsg(Executed),
       twoFour.some,
-      TargetEditCloneInfo.allUnexectedMsg
+      TargetEditCloneInfo.allNonBadMsg(Executed)
     )
   }
 
   test("all besides current are executed") {
-    val obsInfo   = TargetEditObsInfo(oneThree.some, allFour.some, twoFour.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertSimple(cloneInfo, TargetEditCloneInfo.allCurrentMsg, oneThree.some)
+    val obsInfo   = TargetEditObsInfo(oneThree.some, allFour.some, twoFour.some, twoFour.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyTheseGoodMsg(Executed), oneThree.some)
   }
 
   test("all besides current are executed 2") {
-    val obsInfo   = TargetEditObsInfo(three.some, allFour.some, oneTwoFour.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertSimple(cloneInfo, TargetEditCloneInfo.allThisMsg, three.some)
+    val obsInfo   = TargetEditObsInfo(three.some, allFour.some, oneTwoFour.some, two.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyThisGoodMsg(Executed), three.some)
   }
 
   test("all of current are executed") {
-    val obsInfo   = TargetEditObsInfo(two.some, oneTwo.some, two.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertReadonly(cloneInfo, TargetEditCloneInfo.thisExecutedMsg)
+    val obsInfo   = TargetEditObsInfo(two.some, oneTwo.some, two.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.thisBadMsg(Executed))
   }
 
   test("all of current are executed 2") {
-    val obsInfo   = TargetEditObsInfo(twoThree.some, allFour.some, oneTwoThree.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentExecutedMsg)
+    val obsInfo   = TargetEditObsInfo(twoThree.some, allFour.some, oneTwoThree.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentBadMsg(Executed))
   }
 
   test("all of current are executed 3") {
-    val obsInfo   = TargetEditObsInfo(twoThree.some, allFour.some, allFour.some)
-    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo)
-    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentExecutedMsg)
+    val obsInfo   = TargetEditObsInfo(twoThree.some, allFour.some, allFour.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, false)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentBadMsg(Executed))
+  }
+
+  test("allowEditingOngoing - some are ongoing, none are complete, all are being edited") {
+    val obsInfo   = TargetEditObsInfo(one.some, one.some, one.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("allowEditingOngoing - some are ongoing, none are complete, all are being edited 2") {
+    val obsInfo   = TargetEditObsInfo(oneThree.some, oneThree.some, oneThree.some, none)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertNoMessage(cloneInfo)
+  }
+
+  test("allowEditingOngoing - some of other completed") {
+    val obsInfo   = TargetEditObsInfo(one.some, oneTwoThree.some, twoThree.some, three.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.otherMessage(1L, true, Completed),
+      one,
+      TargetEditCloneInfo.onlyThisMsg,
+      oneTwo.some,
+      TargetEditCloneInfo.allForTargetMsg(true, Completed)
+    )
+  }
+
+  test("allowEditingOngoing - some of other completed 2") {
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, twoFour.some, four.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.otherMessage(1L, true, Completed),
+      oneTwo,
+      TargetEditCloneInfo.onlyCurrentMsg,
+      oneTwoThree.some,
+      TargetEditCloneInfo.allForTargetMsg(true, Completed)
+    )
+  }
+
+  test("allowEditingOngoing - some of current and other completed") {
+    val obsInfo   = TargetEditObsInfo(oneTwo.some, allFour.some, allFour.some, twoFour.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertChoice(
+      cloneInfo,
+      TargetEditCloneInfo.someBadMsg(Completed),
+      one,
+      TargetEditCloneInfo.allNonBadOfCurrentMsg(Completed),
+      oneThree.some,
+      TargetEditCloneInfo.allNonBadMsg(Completed)
+    )
+  }
+
+  test("allowEditingOngoing - all besides current are completed") {
+    val obsInfo   = TargetEditObsInfo(oneThree.some, oneTwoThree.some, twoThree.some, two.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyTheseGoodMsg(Completed), oneThree.some)
+  }
+
+  test("allowEditingOngoing - all besides current are completed 2") {
+    val obsInfo   = TargetEditObsInfo(one.some, oneTwoThree.some, twoThree.some, twoThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertSimple(cloneInfo, TargetEditCloneInfo.onlyThisGoodMsg(Completed), one.some)
+  }
+
+  test("allowEditingOngoing - all of current are completed") {
+    val obsInfo   = TargetEditObsInfo(one.some, oneTwoThree.some, oneTwoThree.some, one.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.thisBadMsg(Completed))
+  }
+
+  test("allowEditingOngoing - all of current are completed 2") {
+    val obsInfo   =
+      TargetEditObsInfo(oneTwo.some, oneTwoThree.some, oneTwoThree.some, oneTwoThree.some)
+    val cloneInfo = TargetEditCloneInfo.fromObsInfo(obsInfo, true)
+    assertReadonly(cloneInfo, TargetEditCloneInfo.allCurrentBadMsg(Completed))
   }
 
 }

--- a/model/shared/src/main/scala/explore/model/TargetEditObsInfo.scala
+++ b/model/shared/src/main/scala/explore/model/TargetEditObsInfo.scala
@@ -20,31 +20,45 @@ import lucuma.core.model.Target
  *   The executed observations associated with the target.
  */
 case class TargetEditObsInfo(
-  current:           Option[ObsIdSet],
-  allForTarget:      Option[ObsIdSet],
-  executedForTarget: Option[ObsIdSet]
+  current:            Option[ObsIdSet],
+  allForTarget:       Option[ObsIdSet],
+  executedForTarget:  Option[ObsIdSet],
+  completedForTarget: Option[ObsIdSet]
 ) derives Eq:
   private def unexecuted(fullSet: Option[ObsIdSet]): Option[ObsIdSet] =
     fullSet.flatMap(b => executedForTarget.fold(b.some)(b -- _))
+  private def incomplete(fullSet: Option[ObsIdSet]): Option[ObsIdSet] =
+    fullSet.flatMap(b => completedForTarget.fold(b.some)(b -- _))
 
-  lazy val isReadonly: Boolean                  = current.fold(allForTargetAreExecuted)(_ => allCurrentAreExecuted)
   // the `other*` values only really have meaning if editing is not empty, and if we are editing, we should also have allForTarget
   lazy val otherObs: Option[ObsIdSet]           = (current, allForTarget).flatMapN((e, a) => a -- e)
   lazy val otherObsCount: Long                  = otherObs.fold(0L)(_.size)
   lazy val otherUnexecutedObs: Option[ObsIdSet] = unexecuted(otherObs)
   lazy val otherUnexecutedObsCount: Long        = otherUnexecutedObs.fold(0L)(_.size)
+  lazy val otherIncompleteObs: Option[ObsIdSet] = incomplete(otherObs)
+  lazy val otherIncompleteObsCount: Long        = otherIncompleteObs.fold(0L)(_.size)
 
   lazy val unexecutedForCurrent: Option[ObsIdSet] = unexecuted(current)
   lazy val allCurrentAreExecuted: Boolean         = current.isDefined && unexecutedForCurrent.isEmpty
-  lazy val allCurrentAreOK: Boolean               =
+  lazy val allCurrentAreUnexecuted: Boolean       =
     current.fold(true)(ids =>
       executedForTarget.fold(true)(ex => ids.idSet.intersect(ex.idSet).isEmpty)
     )
 
   lazy val unexecutedForTarget: Option[ObsIdSet] = unexecuted(allForTarget)
   lazy val allForTargetAreExecuted: Boolean      = allForTarget.isDefined && unexecutedForTarget.isEmpty
-  lazy val allForTargetAreOK: Boolean            = executedForTarget.isEmpty
+  lazy val allForTargetAreUnexecuted: Boolean    = executedForTarget.isEmpty
 
+  lazy val incompleteForCurrent: Option[ObsIdSet] = incomplete(current)
+  lazy val allCurrentAreCompleted: Boolean        = current.isDefined && incompleteForCurrent.isEmpty
+  lazy val allCurrentAreIncomplete: Boolean       =
+    current.fold(true)(ids =>
+      completedForTarget.fold(true)(ex => ids.idSet.intersect(ex.idSet).isEmpty)
+    )
+
+  lazy val incompleteForTarget: Option[ObsIdSet] = incomplete(allForTarget)
+  lazy val allForTargetAreCompleted: Boolean     = allForTarget.isDefined && incompleteForTarget.isEmpty
+  lazy val allForTargetAreIncomplete: Boolean    = completedForTarget.isEmpty
 object TargetEditObsInfo:
   def fromProgramSummaries(
     tid:       Target.Id,
@@ -54,8 +68,10 @@ object TargetEditObsInfo:
     val allObsIds = summaries.targetsWithObs.get(tid).map(_.obsIds).flatMap(ObsIdSet.fromSortedSet)
     // we should always find the ids in `observations`
     val executed  = allObsIds.flatMap(summaries.observations.executedOf)
+    val completed = allObsIds.flatMap(summaries.observations.completedOf)
     TargetEditObsInfo(
       current,
       allObsIds,
-      executed
+      executed,
+      completed
     )


### PR DESCRIPTION
Andy requested because an observation goes to `ongoing` after first slew. Problems in the target and observation can be found after this point and they need a way to be able to correct them.

Because the purpose of this is to allow fixing during execution, I limited the ability to edit ongoing observations to when an observation is selected on the observation tab. We'll see if this satisfies the need.

This also had to properly handle the cloning of targets when necessary. 