### PR TITLE
Make the SiderealTargetEditor a TargetEditor

### DIFF
--- a/explore/src/main/scala/explore/tabs/TargetEditorTile.scala
+++ b/explore/src/main/scala/explore/tabs/TargetEditorTile.scala
@@ -17,7 +17,7 @@ import explore.model.OnCloneParameters
 import explore.model.TargetEditObsInfo
 import explore.model.TargetTabTileIds
 import explore.model.UserPreferences
-import explore.targeteditor.SiderealTargetEditor
+import explore.targeteditor.TargetEditor
 import explore.undo.UndoSetter
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
@@ -26,13 +26,13 @@ import lucuma.core.model.Target
 import lucuma.core.model.User
 import lucuma.schemas.model.TargetWithId
 
-object SiderealTargetEditorTile:
+object TargetEditorTile:
 
-  def noObsSiderealTargetEditorTile(
+  def noObsTargetEditorTile(
     programId:          Program.Id,
     userId:             Option[User.Id],
     targetId:           Target.Id,
-    target:             UndoSetter[Target.Sidereal],
+    target:             UndoSetter[Target],
     obsAndTargets:      UndoSetter[ObservationsAndTargets],
     searching:          View[Set[Target.Id]],
     title:              String,
@@ -57,7 +57,7 @@ object SiderealTargetEditorTile:
         <.div(
           ExploreStyles.TargetTileEditor,
           userId.map(uid =>
-            SiderealTargetEditor(
+            TargetEditor(
               programId,
               uid,
               target,

--- a/explore/src/main/scala/explore/tabs/TargetTabContents.scala
+++ b/explore/src/main/scala/explore/tabs/TargetTabContents.scala
@@ -587,9 +587,9 @@ object TargetTabContents extends TwoPanels:
                   (AppTab.Targets, props.programId, Focused.target(params.idToAdd)).some
 
             props.targets
-              .zoom(Iso.id[TargetList].index(targetId).andThen(Target.sidereal))
+              .zoom(Iso.id[TargetList].index(targetId))
               .map: target =>
-                SiderealTargetEditorTile.noObsSiderealTargetEditorTile(
+                TargetEditorTile.noObsTargetEditorTile(
                   props.programId,
                   props.userId,
                   targetId,

--- a/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
+++ b/explore/src/main/scala/explore/targeteditor/AsterismEditorTile.scala
@@ -267,22 +267,18 @@ object AsterismEditorTile:
             // corrected, but we need to not render the target editor before it is corrected.
             (Asterism.fromIdsAndTargets(asterismIds, props.allTargets.get), props.focusedTargetId)
               .mapN: (asterism, focusedTargetId) =>
-                val selectedTargetOpt: Option[UndoSetter[Target]]                  =
+                val selectedTargetOpt: Option[UndoSetter[Target]] =
                   props.allTargets.zoom(Iso.id[TargetList].index(focusedTargetId))
-                val selectedSiderealTargetOpt: Option[UndoSetter[Target.Sidereal]] =
-                  selectedTargetOpt.flatMap(_.zoom(Target.sidereal))
-                val selectedOpportunityOpt: Option[UndoSetter[Target.Opportunity]] =
-                  selectedTargetOpt.flatMap(_.zoom(Target.opportunity))
-                val obsInfo                                                        = props.obsInfo(focusedTargetId)
+                val obsInfo                                       = props.obsInfo(focusedTargetId)
 
-                selectedSiderealTargetOpt
-                  .map: siderealTarget =>
+                selectedTargetOpt
+                  .map: target =>
                     <.div(
                       ExploreStyles.TargetTileEditor,
-                      SiderealTargetEditor(
+                      TargetEditor(
                         props.programId,
                         props.userId,
-                        siderealTarget,
+                        target,
                         props.obsAndTargets,
                         asterism.focusOn(focusedTargetId),
                         props.obsTime,
@@ -300,10 +296,6 @@ object AsterismEditorTile:
                         invalidateSequence = props.sequenceChanged
                       )
                     )
-                  .orElse(selectedOpportunityOpt.map: _ =>
-                    <.div("Targets of Opportunity coming soon..."))
-                  .getOrElse[VdomElement]:
-                    <.div("Non-sidereal targets not supported")
           )
 
   private case class Title(

--- a/explore/src/main/scala/explore/targeteditor/SearchForm.scala
+++ b/explore/src/main/scala/explore/targeteditor/SearchForm.scala
@@ -34,7 +34,7 @@ import scalajs.js.JSConverters.*
 case class SearchForm(
   id:            Target.Id,
   targetName:    View[NonEmptyString],
-  targetSet:     Target.Sidereal => Callback,
+  targetSet:     Target => Callback,
   searching:     View[Set[Target.Id]],
   readonly:      Boolean,
   cloningTarget: Boolean
@@ -112,11 +112,7 @@ object SearchForm:
                 onClick = onButtonClick,
                 modifiers = List(^.untypedRef := buttonRef)
               ).tiny.compact,
-              onSelected = targetWithId =>
-                (targetWithId.target match
-                  case t @ Target.Sidereal(_, _, _, _) => props.targetSet(t)
-                  case _                               => Callback.empty
-                ) >> searchComplete,
+              onSelected = targetWithId => props.targetSet(targetWithId.target) >> searchComplete,
               onCancel = updateNameIfNeeded >> searchComplete,
               initialSearch = term.get.some,
               showCreateEmpty = false


### PR DESCRIPTION
This turns the SiderealTargetEditor into an editor for any target.

Currently for ToOs, only the name and source profile are editable (the fields common to all targets). I was hoping to get the region editor in before I left for vacation, but the API isn't quite right so I didn't get that done.