### PR TITLE
New promotion script logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,4 +272,4 @@ jobs:
         run: |
           # Create a deployment record with commit SHA for tracking
           echo "Recording deployment: ${{ github.sha }} to explore-gemini-dev"
-          curl -X POST https://api.github.com/repos/${{ github.repository }}/deployments -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" -d '{ "ref": "${{ github.sha }}", "environment": "development", "description": "Firebase hosting deployment to dev", "auto_merge": false, "required_contexts": [] }' 
+          curl -X POST https://api.github.com/repos/${{ github.repository }}/deployments -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" -d '{ "ref": "${{ github.sha }}", "environment": "development", "description": "Explore deployment to dev", "auto_merge": false, "required_contexts": [], "task": "deploy:Explore" }' 

--- a/build.sbt
+++ b/build.sbt
@@ -336,7 +336,7 @@ lazy val recordDeploymentMetadata = WorkflowStep.Run(
   List(
     "# Create a deployment record with commit SHA for tracking",
     """echo "Recording deployment: ${{ github.sha }} to explore-gemini-dev"""",
-    """curl -X POST https://api.github.com/repos/${{ github.repository }}/deployments -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" -d '{ "ref": "${{ github.sha }}", "environment": "development", "description": "Firebase hosting deployment to dev", "auto_merge": false, "required_contexts": [] }' """
+    """curl -X POST https://api.github.com/repos/${{ github.repository }}/deployments -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github+json" -d '{ "ref": "${{ github.sha }}", "environment": "development", "description": "Explore deployment to dev", "auto_merge": false, "required_contexts": [], "task": "deploy:Explore" }' """
   ),
   name = Some("Record deployment gha"),
   cond = Some(mainCond)


### PR DESCRIPTION
Docker deployments now use github deployments API to record when they release new images to development. The docker image SHA is included in the record. The images are pushed to all environments but not released to staging and production.

The promotion script now uses said information and pre-pushed images to avoid the need to pull, retag and push them, dramatically increasing the promotion speed. Also, by using specific docker image shas we correctly implement promotion instead of always deploying the latest image to staging and production.

