### PR TITLE
Handle 'Customized" icon for readonly and calibration observations

### DIFF
--- a/explore/src/main/scala/explore/components/CustomizableEnumGroupedMultiSelect.scala
+++ b/explore/src/main/scala/explore/components/CustomizableEnumGroupedMultiSelect.scala
@@ -27,25 +27,27 @@ import lucuma.ui.syntax.all.given
 import scala.scalajs.js.JSConverters.*
 
 final case class CustomizableEnumGroupedMultiSelect[A](
-  id:                 NonEmptyString,
-  view:               View[List[A]],
-  groupFunctions:     NonEmptyList[(String, A => Boolean)],
-  defaultValue:       List[A],
-  defaultFormatter:   Option[A => String] = None, // if you don't want to use the short name
-  error:              Option[String] = None,
-  tooltip:            Option[String] = None,
-  tooltipOptions:     Option[TooltipOptions] = None,
-  itemTemplate:       Option[SelectItem[A] => VdomNode] = None,
-  maxSelectedLabels:  Option[Int] = None,
-  selectedItemsLabel: Option[String] = None,
-  displayStyle:       MultiSelect.Display = MultiSelect.Display.Chip,
-  filter:             Boolean = true,             // show filter texbox at top
-  showSelectAll:      Boolean = false,
-  showClear:          Boolean = true,
-  disabled:           Boolean,
-  exclude:            Set[A] = Set.empty[A],
-  label:              Option[String] = None,
-  helpId:             Option[Help.Id] = None
+  id:                       NonEmptyString,
+  view:                     View[List[A]],
+  groupFunctions:           NonEmptyList[(String, A => Boolean)],
+  defaultValue:             List[A],
+  defaultFormatter:         Option[A => String] = None, // if you don't want to use the short name
+  error:                    Option[String] = None,
+  tooltip:                  Option[String] = None,
+  tooltipOptions:           Option[TooltipOptions] = None,
+  itemTemplate:             Option[SelectItem[A] => VdomNode] = None,
+  maxSelectedLabels:        Option[Int] = None,
+  selectedItemsLabel:       Option[String] = None,
+  displayStyle:             MultiSelect.Display = MultiSelect.Display.Chip,
+  filter:                   Boolean = true,             // show filter texbox at top
+  showSelectAll:            Boolean = false,
+  showClear:                Boolean = true,
+  disabled:                 Boolean,
+  showCustomization:        Boolean,
+  allowRevertCustomization: Boolean,
+  exclude:                  Set[A] = Set.empty[A],
+  label:                    Option[String] = None,
+  helpId:                   Option[Help.Id] = None
 )(using val display: Display[A], val enumerated: Enumerated[A])
     extends ReactFnProps(CustomizableEnumGroupedMultiSelect.component)
 
@@ -80,8 +82,11 @@ object CustomizableEnumGroupedMultiSelect:
           tooltipOptions = props.tooltipOptions.orUndefined
         ),
         <.span(PrimeStyles.InputGroupAddon,
-               CustomizedGroupAddon(originalText, props.view.set(props.defaultValue))
-        ).when(props.view.get =!= props.defaultValue)
+               CustomizedGroupAddon(originalText,
+                                    props.view.set(props.defaultValue),
+                                    props.allowRevertCustomization
+               )
+        ).when(props.showCustomization && props.view.get =!= props.defaultValue)
       )
     )
   )

--- a/explore/src/main/scala/explore/components/CustomizableEnumSelect.scala
+++ b/explore/src/main/scala/explore/components/CustomizableEnumSelect.scala
@@ -27,13 +27,15 @@ import lucuma.ui.syntax.all.given
  * reverts the value to the default value.
  */
 final case class CustomizableEnumSelect[A](
-  id:           NonEmptyString,
-  view:         View[A],
-  defaultValue: A,
-  disabled:     Boolean,
-  exclude:      Set[A] = Set.empty[A],
-  label:        Option[String] = None,
-  helpId:       Option[Help.Id] = None
+  id:                       NonEmptyString,
+  view:                     View[A],
+  defaultValue:             A,
+  disabled:                 Boolean,
+  showCustomization:        Boolean,
+  allowRevertCustomization: Boolean,
+  exclude:                  Set[A] = Set.empty[A],
+  label:                    Option[String] = None,
+  helpId:                   Option[Help.Id] = None
 )(using val display: Display[A], val enumerated: Enumerated[A])
     extends ReactFnProps(CustomizableEnumSelect.component)
 
@@ -55,8 +57,11 @@ object CustomizableEnumSelect:
           disabled = props.disabled
         ),
         <.span(PrimeStyles.InputGroupAddon,
-               CustomizedGroupAddon(originalText, props.view.set(props.defaultValue))
-        ).when(props.view.get =!= props.defaultValue)
+               CustomizedGroupAddon(originalText,
+                                    props.view.set(props.defaultValue),
+                                    props.allowRevertCustomization
+               )
+        ).when(props.showCustomization && props.view.get =!= props.defaultValue)
       )
     )
   )

--- a/explore/src/main/scala/explore/components/CustomizableEnumSelectOptional.scala
+++ b/explore/src/main/scala/explore/components/CustomizableEnumSelectOptional.scala
@@ -27,16 +27,18 @@ import lucuma.ui.syntax.all.given
  * the icon reverts the value to the default value.
  */
 final case class CustomizableEnumSelectOptional[A](
-  id:              NonEmptyString,
-  view:            View[Option[A]],
-  defaultValue:    Option[A],
-  disabled:        Boolean,
-  label:           Option[String] = None,
-  helpId:          Option[Help.Id] = None,
-  exclude:         Set[A] = Set.empty[A],
-  showClear:       Boolean = false,
-  resetToOriginal: Boolean = false, // resets to `none` on false
-  dropdownMods:    TagMod = TagMod.empty
+  id:                       NonEmptyString,
+  view:                     View[Option[A]],
+  defaultValue:             Option[A],
+  disabled:                 Boolean,
+  showCustomization:        Boolean,
+  allowRevertCustomization: Boolean,
+  label:                    Option[String] = None,
+  helpId:                   Option[Help.Id] = None,
+  exclude:                  Set[A] = Set.empty[A],
+  showClear:                Boolean = false,
+  resetToOriginal:          Boolean = false, // resets to `none` on false
+  dropdownMods:             TagMod = TagMod.empty
 )(using val display: Display[A], val enumerated: Enumerated[A])
     extends ReactFnProps(CustomizableEnumSelectOptional.component)
 
@@ -62,10 +64,11 @@ object CustomizableEnumSelectOptional:
           PrimeStyles.InputGroupAddon,
           CustomizedGroupAddon(
             originalText,
-            props.view.set(if (props.resetToOriginal) props.defaultValue else none)
+            props.view.set(if (props.resetToOriginal) props.defaultValue else none),
+            props.allowRevertCustomization
           )
         )
-          .when(props.view.get =!= props.defaultValue)
+          .when(props.showCustomization && props.view.get =!= props.defaultValue)
       )
     )
   )

--- a/explore/src/main/scala/explore/components/CustomizableInputText.scala
+++ b/explore/src/main/scala/explore/components/CustomizableInputText.scala
@@ -25,14 +25,16 @@ import scalajs.js.JSConverters.*
  * default value.
  */
 final case class CustomizableInputText[A](
-  id:            NonEmptyString,
-  value:         View[A],
-  validFormat:   InputValidFormat[A],
-  changeAuditor: ChangeAuditor,
-  label:         TagMod,
-  defaultValue:  A,
-  units:         Option[String],
-  disabled:      Boolean
+  id:                       NonEmptyString,
+  value:                    View[A],
+  validFormat:              InputValidFormat[A],
+  changeAuditor:            ChangeAuditor,
+  label:                    TagMod,
+  defaultValue:             A,
+  units:                    Option[String],
+  disabled:                 Boolean,
+  showCustomization:        Boolean,
+  allowRevertCustomization: Boolean
 )(using val eq: Eq[A])
     extends ReactFnProps(CustomizableInputText.component)
 
@@ -42,9 +44,10 @@ object CustomizableInputText:
 
     val isCustom                    = props.value.get =!= props.defaultValue
     val customAddon: Option[TagMod] =
-      if (isCustom)
+      if (props.showCustomization && isCustom)
         (CustomizedGroupAddon(props.validFormat.reverseGet(props.defaultValue),
-                              props.value.set(props.defaultValue)
+                              props.value.set(props.defaultValue),
+                              props.allowRevertCustomization
         ): TagMod).some
       else none
 

--- a/explore/src/main/scala/explore/components/CustomizableInputTextOptional.scala
+++ b/explore/src/main/scala/explore/components/CustomizableInputTextOptional.scala
@@ -26,14 +26,16 @@ import scalajs.js.JSConverters.*
  * entering the default value will also set it to None.
  */
 final case class CustomizableInputTextOptional[A](
-  id:            NonEmptyString,
-  value:         View[Option[A]],
-  validFormat:   InputValidFormat[Option[A]],
-  changeAuditor: ChangeAuditor,
-  label:         TagMod,
-  defaultValue:  A,
-  units:         Option[String],
-  disabled:      Boolean
+  id:                       NonEmptyString,
+  value:                    View[Option[A]],
+  validFormat:              InputValidFormat[Option[A]],
+  changeAuditor:            ChangeAuditor,
+  label:                    TagMod,
+  defaultValue:             A,
+  units:                    Option[String],
+  disabled:                 Boolean,
+  showCustomization:        Boolean,
+  allowRevertCustomization: Boolean
 )(using val eq: Eq[A])
     extends ReactFnProps(CustomizableInputTextOptional.component)
 
@@ -43,7 +45,14 @@ object CustomizableInputTextOptional:
 
     val originalText = props.validFormat.reverseGet(props.defaultValue.some)
     val customAddon  =
-      props.value.get.map(_ => CustomizedGroupAddon(originalText, props.value.set(none)): TagMod)
+      props.value.get
+        .filter(_ => props.showCustomization)
+        .map(_ =>
+          CustomizedGroupAddon(originalText,
+                               props.value.set(none),
+                               props.allowRevertCustomization
+          ): TagMod
+        )
 
     FormInputTextView(
       id = props.id,

--- a/explore/src/main/scala/explore/components/CustomizedGroupAddon.scala
+++ b/explore/src/main/scala/explore/components/CustomizedGroupAddon.scala
@@ -14,20 +14,26 @@ import lucuma.react.primereact.Tooltip
 import lucuma.react.primereact.tooltip.*
 
 final case class CustomizedGroupAddon(
-  original: String,
-  toRevert: Callback
+  original:    String,
+  toRevert:    Callback,
+  allowRevert: Boolean
 ) extends ReactFnProps(CustomizedGroupAddon)
 
 object CustomizedGroupAddon
     extends ReactFnComponent[CustomizedGroupAddon](props =>
+      val tooltip =
+        if (props.allowRevert)
+          <.div("Customized!", <.br, s"Click to revert to '${props.original}'")
+        else <.div(s"Customized from '${props.original}'")
+
       <.span(
         ^.cls := "fa-layers fa-fw",
         Icons.ExclamationDiamond
           .withClass(ExploreStyles.WarningIcon)
           .withSize(IconSize.X1),
-        ^.onClick --> props.toRevert
+        ^.onClick --> props.toRevert.when_(props.allowRevert)
       ).withTooltip(
-        content = <.div("Customized!", <.br, s"Click to revert to '${props.original}'"),
+        content = tooltip,
         position = Tooltip.Position.Left // putting it on the left should always work.
       )
     )

--- a/explore/src/main/scala/explore/config/Flamingos2LongslitConfigPanel.scala
+++ b/explore/src/main/scala/explore/config/Flamingos2LongslitConfigPanel.scala
@@ -61,9 +61,11 @@ object Flamingos2LongslitConfigPanel
       yield
         import ctx.given
 
-        val disableAdvancedEdit = editState.get =!= ConfigEditState.AdvancedEdit || props.readonly
-        val disableSimpleEdit   =
+        val disableAdvancedEdit      = editState.get =!= ConfigEditState.AdvancedEdit || props.readonly
+        val disableSimpleEdit        =
           disableAdvancedEdit && editState.get =!= ConfigEditState.SimpleEdit
+        val showCustomization        = props.calibrationRole.isEmpty
+        val allowRevertCustomization = !props.readonly
 
         val disperserView: View[Flamingos2Disperser] = props.observingMode
           .zoom(
@@ -117,7 +119,9 @@ object Flamingos2LongslitConfigPanel
               defaultValue = props.observingMode.get.initialDisperser,
               label = "Disperser".some,
               helpId = Some("configuration/f2/disperser.md".refined),
-              disabled = disableSimpleEdit
+              disabled = disableSimpleEdit,
+              showCustomization = showCustomization,
+              allowRevertCustomization = allowRevertCustomization
             ),
             CustomizableEnumSelect(
               id = "filter".refined,
@@ -125,7 +129,9 @@ object Flamingos2LongslitConfigPanel
               defaultValue = props.observingMode.get.initialFilter,
               label = "Filter".some,
               helpId = Some("configuration/f2/filter.md".refined),
-              disabled = disableSimpleEdit
+              disabled = disableSimpleEdit,
+              showCustomization = showCustomization,
+              allowRevertCustomization = allowRevertCustomization
             ),
             CustomizableEnumSelect(
               id = "fpu".refined,
@@ -133,7 +139,9 @@ object Flamingos2LongslitConfigPanel
               defaultValue = props.observingMode.get.initialFpu,
               label = "FPU".some,
               helpId = Some("configuration/f2/fpu.md".refined),
-              disabled = disableSimpleEdit
+              disabled = disableSimpleEdit,
+              showCustomization = showCustomization,
+              allowRevertCustomization = allowRevertCustomization
             ),
             CustomizableEnumSelect(
               id = "read-mode".refined,
@@ -141,7 +149,9 @@ object Flamingos2LongslitConfigPanel
               defaultValue = None,
               label = "Read Mode".some,
               helpId = Some("configuration/f2/read-mode.md".refined),
-              disabled = disableSimpleEdit
+              disabled = disableSimpleEdit,
+              showCustomization = showCustomization,
+              allowRevertCustomization = allowRevertCustomization
             )
           ),
           <.div(LucumaPrimeStyles.FormColumnCompact, ExploreStyles.AdvancedConfigurationCol2)(
@@ -164,7 +174,9 @@ object Flamingos2LongslitConfigPanel
                 id = "decker".refined,
                 view = deckerView.withDefault(defaultDecker),
                 defaultValue = defaultDecker.some,
-                disabled = disableAdvancedEdit
+                disabled = disableAdvancedEdit,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               )
             else
               <.label(^.id := "decker",

--- a/explore/src/main/scala/explore/config/GmosImagingConfigPanel.scala
+++ b/explore/src/main/scala/explore/config/GmosImagingConfigPanel.scala
@@ -161,9 +161,11 @@ object GmosImagingConfigPanel {
         } yield
           import ctx.given
 
-          val disableAdvancedEdit = editState.get =!= ConfigEditState.AdvancedEdit || props.readonly
-          val disableSimpleEdit   =
+          val disableAdvancedEdit      = editState.get =!= ConfigEditState.AdvancedEdit || props.readonly
+          val disableSimpleEdit        =
             disableAdvancedEdit && editState.get =!= ConfigEditState.SimpleEdit
+          val showCustomization        = props.calibrationRole.isEmpty
+          val allowRevertCustomization = !props.readonly
 
           val defaultMultipleFiltersMode =
             defaultMultipleFiltersModeLens.get(props.observingMode.get)
@@ -217,7 +219,9 @@ object GmosImagingConfigPanel {
                   selectedItemsLabel = s"${localFiltersView.get.size} selected".some,
                   tooltip = localFiltersView.get.map(Display[Filter].longName).mkString("\n").some,
                   tooltipOptions = TooltipOptions(showOnDisabled = true).some,
-                  disabled = disableSimpleEdit
+                  disabled = disableSimpleEdit,
+                  showCustomization = showCustomization,
+                  allowRevertCustomization = allowRevertCustomization
                 ),
                 CustomizableEnumSelectOptional(
                   id = "explicitMultipleFiltersMode".refined,
@@ -226,7 +230,9 @@ object GmosImagingConfigPanel {
                   defaultValue = defaultMultipleFiltersMode.some,
                   label = "Multiple Filters".some,
                   helpId = Some("configuration/imaging/multiple-filters-mode.md".refined),
-                  disabled = disableSimpleEdit
+                  disabled = disableSimpleEdit,
+                  showCustomization = showCustomization,
+                  allowRevertCustomization = allowRevertCustomization
                 )
               ),
               <.div(LucumaPrimeStyles.FormColumnCompact, ExploreStyles.AdvancedConfigurationCol2)(
@@ -270,7 +276,9 @@ object GmosImagingConfigPanel {
                   label = "Binning".some,
                   helpId = Some("configuration/gmos/binning.md".refined),
                   disabled = disableAdvancedEdit,
-                  dropdownMods = ^.aria.label := "Binning"
+                  dropdownMods = ^.aria.label := "Binning",
+                  showCustomization = showCustomization,
+                  allowRevertCustomization = allowRevertCustomization
                 ),
                 CustomizableEnumSelectOptional(
                   id = "explicitReadMode".refined,
@@ -279,7 +287,9 @@ object GmosImagingConfigPanel {
                   defaultValue = defaultReadModeGain.some,
                   label = "Read Mode".some,
                   helpId = Some("configuration/gmos/read-mode.md".refined),
-                  disabled = disableAdvancedEdit
+                  disabled = disableAdvancedEdit,
+                  showCustomization = showCustomization,
+                  allowRevertCustomization = allowRevertCustomization
                 ),
                 CustomizableEnumSelectOptional(
                   id = "explicitRoi".refined,
@@ -287,7 +297,9 @@ object GmosImagingConfigPanel {
                   defaultValue = defaultRoi.some,
                   label = "ROI".some,
                   helpId = Some("configuration/gmos/roi.md".refined),
-                  disabled = disableAdvancedEdit
+                  disabled = disableAdvancedEdit,
+                  showCustomization = showCustomization,
+                  allowRevertCustomization = allowRevertCustomization
                 )
               ),
               AdvancedConfigButtons(

--- a/explore/src/main/scala/explore/config/GmosLongslitConfigPanel.scala
+++ b/explore/src/main/scala/explore/config/GmosLongslitConfigPanel.scala
@@ -180,9 +180,11 @@ object GmosLongslitConfigPanel {
         yield
           import ctx.given
 
-          val disableAdvancedEdit = editState.get =!= ConfigEditState.AdvancedEdit || props.readonly
-          val disableSimpleEdit   =
+          val disableAdvancedEdit      = editState.get =!= ConfigEditState.AdvancedEdit || props.readonly
+          val disableSimpleEdit        =
             disableAdvancedEdit && editState.get =!= ConfigEditState.SimpleEdit
+          val showCustomization        = props.calibrationRole.isEmpty
+          val allowRevertCustomization = !props.readonly
 
           val centralWavelengthView    = centralWavelength(props.observingMode)
           val initialCentralWavelength = initialCentralWavelengthLens.get(props.observingMode.get)
@@ -221,7 +223,9 @@ object GmosLongslitConfigPanel {
                 .toSequence()
                 .optional,
               units = "nm".some,
-              disabled = disableSimpleEdit
+              disabled = disableSimpleEdit,
+              showCustomization = showCustomization,
+              allowRevertCustomization = allowRevertCustomization
             )
 
           <.div(
@@ -237,7 +241,9 @@ object GmosLongslitConfigPanel {
                 defaultValue = initialGratingLens.get(props.observingMode.get),
                 label = "Grating".some,
                 helpId = Some("configuration/gmos/grating.md".refined),
-                disabled = disableAdvancedEdit
+                disabled = disableAdvancedEdit,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               ),
               CustomizableEnumSelectOptional(
                 id = "filter".refined,
@@ -247,7 +253,9 @@ object GmosLongslitConfigPanel {
                 helpId = Some("configuration/gmos/filter.md".refined),
                 disabled = disableAdvancedEdit,
                 showClear = true,
-                resetToOriginal = true
+                resetToOriginal = true,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               ),
               CustomizableEnumSelect(
                 id = "fpu".refined,
@@ -255,12 +263,17 @@ object GmosLongslitConfigPanel {
                 defaultValue = initialFpuLens.get(props.observingMode.get),
                 label = "FPU".some,
                 helpId = Some("configuration/gmos/fpu.md".refined),
-                disabled = disableAdvancedEdit
+                disabled = disableAdvancedEdit,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               ),
-              OffsetsControl(explicitSpatialOffsets(props.observingMode),
-                             defaultSpatialOffsetsLens.get(props.observingMode.get),
-                             props.sequenceChanged,
-                             disableSimpleEdit
+              OffsetsControl(
+                explicitSpatialOffsets(props.observingMode),
+                defaultSpatialOffsetsLens.get(props.observingMode.get),
+                props.sequenceChanged,
+                disableSimpleEdit,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               )
             ),
             <.div(LucumaPrimeStyles.FormColumnCompact, ExploreStyles.AdvancedConfigurationCol2)(
@@ -274,7 +287,9 @@ object GmosLongslitConfigPanel {
                 validFormat = props.units.toInputFormat,
                 changeAuditor = props.units.toAuditor,
                 defaultValue = initialCentralWavelength,
-                disabled = disableSimpleEdit
+                disabled = disableSimpleEdit,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               ),
               dithersControl(props.sequenceChanged),
               ExposureTimeModeEditor(
@@ -302,7 +317,9 @@ object GmosLongslitConfigPanel {
                   view = explicitXBinning(props.observingMode).withDefault(defaultXBinning),
                   defaultValue = defaultXBinning.some,
                   disabled = disableAdvancedEdit,
-                  dropdownMods = ^.aria.label := "X Binning"
+                  dropdownMods = ^.aria.label := "X Binning",
+                  showCustomization = showCustomization,
+                  allowRevertCustomization = allowRevertCustomization
                 ),
                 <.label("x"),
                 CustomizableEnumSelectOptional(
@@ -310,7 +327,9 @@ object GmosLongslitConfigPanel {
                   view = explicitYBinning(props.observingMode).withDefault(defaultYBinning),
                   defaultValue = defaultYBinning.some,
                   disabled = disableAdvancedEdit,
-                  dropdownMods = ^.aria.label := "Y Binning"
+                  dropdownMods = ^.aria.label := "Y Binning",
+                  showCustomization = showCustomization,
+                  allowRevertCustomization = allowRevertCustomization
                 )
               ),
               CustomizableEnumSelectOptional(
@@ -320,7 +339,9 @@ object GmosLongslitConfigPanel {
                 defaultValue = defaultReadModeGain.some,
                 label = "Read Mode".some,
                 helpId = Some("configuration/gmos/read-mode.md".refined),
-                disabled = disableAdvancedEdit
+                disabled = disableAdvancedEdit,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               ),
               CustomizableEnumSelectOptional(
                 id = "explicitRoi".refined,
@@ -328,7 +349,9 @@ object GmosLongslitConfigPanel {
                 defaultValue = defaultRoi.some,
                 label = "ROI".some,
                 helpId = Some("configuration/gmos/roi.md".refined),
-                disabled = disableAdvancedEdit
+                disabled = disableAdvancedEdit,
+                showCustomization = showCustomization,
+                allowRevertCustomization = allowRevertCustomization
               ),
               LambdaAndIntervalFormValues(
                 modeData = modeData,

--- a/explore/src/main/scala/explore/config/OffsetsControl.scala
+++ b/explore/src/main/scala/explore/config/OffsetsControl.scala
@@ -19,10 +19,12 @@ import lucuma.ui.input.ChangeAuditor
 import lucuma.ui.syntax.all.given
 
 final case class OffsetsControl(
-  view:         View[Option[NonEmptyList[Offset.Q]]],
-  defaultValue: NonEmptyList[Offset.Q],
-  onChange:     Callback,
-  disabled:     Boolean
+  view:                     View[Option[NonEmptyList[Offset.Q]]],
+  defaultValue:             NonEmptyList[Offset.Q],
+  onChange:                 Callback,
+  disabled:                 Boolean,
+  showCustomization:        Boolean,
+  allowRevertCustomization: Boolean
 ) extends ReactFnProps(OffsetsControl)
 
 object OffsetsControl
@@ -41,6 +43,8 @@ object OffsetsControl
           .toSequence()
           .optional,
         units = "arcsec".some,
-        disabled = props.disabled
+        disabled = props.disabled,
+        showCustomization = props.showCustomization,
+        allowRevertCustomization = props.allowRevertCustomization
       )
     )


### PR DESCRIPTION
Removes the `CustomizedGroupAddon` icon from the configuration panel for calibration observations.

There was also a hole in the readonly state of regular observations. If an observation had a customized configuration, those customizations could be reverted via the CustomizedGroupAddon icon even if the observation was readonly.