### PR TITLE
Showed unapproved observation warnings in the warnings table

### DIFF
--- a/model/shared/src/main/scala/explore/model/Observation.scala
+++ b/model/shared/src/main/scala/explore/model/Observation.scala
@@ -272,7 +272,7 @@ case class Observation(
 
   // if it has any of the ConfigurationRequest* errors. We filter these out of the validations table.
   inline def hasConfigurationRequestError: Boolean =
-    hasPendingRequestCode || hasNotRequestedCode || hasDeniedValidationCode
+    hasPendingRequestCode || hasNotRequestedCode // We will show DENIED
 
   // update the validation status to pending and add the configuration request id
   inline def updateToPending(crId: ConfigurationRequest.Id): Observation =


### PR DESCRIPTION
We had excluded configuration request related warnings from the Warnings And Errors table, I guess because they were in the configuration request table? This PR puts the validations for observations with denied configuration requests back.