### PR TITLE
Don't request ITC for certain calibration, e.g. twilight

### DIFF
--- a/explore/src/main/scala/explore/config/sequence/SequenceTile.scala
+++ b/explore/src/main/scala/explore/config/sequence/SequenceTile.scala
@@ -22,6 +22,7 @@ import explore.syntax.ui.*
 import explore.utils.*
 import japgolly.scalajs.react.*
 import japgolly.scalajs.react.vdom.html_<^.*
+import lucuma.core.enums.CalibrationRole
 import lucuma.core.model.Target
 import lucuma.core.model.sequence.InstrumentExecutionConfig
 import lucuma.core.util.TimeSpan
@@ -41,6 +42,7 @@ object SequenceTile extends SequenceTileHelper:
     obsExecution:        Execution,
     asterismIds:         AsterismIds,
     customSedTimestamps: List[Timestamp],
+    calibrationRole:     Option[CalibrationRole],
     sequenceChanged:     View[Pot[Unit]]
   ) =
     Tile(
@@ -52,6 +54,7 @@ object SequenceTile extends SequenceTileHelper:
           obsId,
           asterismIds.toList,
           customSedTimestamps,
+          calibrationRole,
           sequenceChanged
         ),
       (_, _) => Title(obsExecution)
@@ -61,13 +64,18 @@ object SequenceTile extends SequenceTileHelper:
     obsId:               Observation.Id,
     targetIds:           List[Target.Id],
     customSedTimestamps: List[Timestamp],
+    calibrationRole:     Option[CalibrationRole],
     sequenceChanged:     View[Pot[Unit]]
   ) extends ReactFnProps(Body)
 
   private object Body
       extends ReactFnComponent[Body](props =>
         for
-          liveSequence <- useLiveSequence(props.obsId, props.targetIds, props.customSedTimestamps)
+          liveSequence <- useLiveSequence(props.obsId,
+                                          props.targetIds,
+                                          props.customSedTimestamps,
+                                          props.calibrationRole
+                          )
           _            <- useEffectWithDeps(liveSequence.data): dataPot =>
                             props.sequenceChanged.set(dataPot.void)
         yield props.sequenceChanged.get

--- a/explore/src/main/scala/explore/services/OdbSequenceApi.scala
+++ b/explore/src/main/scala/explore/services/OdbSequenceApi.scala
@@ -7,4 +7,4 @@ import lucuma.core.model.Observation
 import lucuma.ui.sequence.SequenceData
 
 trait OdbSequenceApi[F[_]]:
-  def sequenceData(obsId: Observation.Id): F[Option[SequenceData]]
+  def sequenceData(obsId: Observation.Id, includeItc: Boolean): F[Option[SequenceData]]

--- a/explore/src/main/scala/explore/services/OdbSequenceApiImpl.scala
+++ b/explore/src/main/scala/explore/services/OdbSequenceApiImpl.scala
@@ -5,7 +5,9 @@ package explore.services
 
 import cats.MonadThrow
 import cats.syntax.all.*
+import clue.*
 import clue.FetchClient
+import clue.data.Input
 import clue.syntax.*
 import lucuma.core.model.Observation
 import lucuma.schemas.ObservationDB
@@ -14,8 +16,8 @@ import lucuma.ui.sequence.SequenceData
 
 trait OdbSequenceApiImpl[F[_]: MonadThrow](using FetchClient[F, ObservationDB])
     extends OdbSequenceApi[F]:
-  def sequenceData(obsId: Observation.Id): F[Option[SequenceData]] =
+  def sequenceData(obsId: Observation.Id, includeItc: Boolean): F[Option[SequenceData]] =
     SequenceQuery[F]
-      .query(obsId)
+      .query(obsId, includeItc = Input(includeItc))
       .raiseGraphQLErrors
       .map(SequenceData.fromOdbResponse)

--- a/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
+++ b/explore/src/main/scala/explore/tabs/ObsTabTiles.scala
@@ -400,6 +400,7 @@ object ObsTabTiles:
               props.observation.get.execution,
               asterismIds.get,
               customSedTimestamps,
+              props.calibrationRole,
               sequenceChanged
             )
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -24,7 +24,7 @@ object Versions {
   val lucumaCore             = "0.145.0"
   val lucumaReact            = "0.85.1"
   val lucumaServers          = "0.50.1"
-  val lucumaUI               = "0.168.0"
+  val lucumaUI               = "0.169.0"
   val monocle                = "3.3.0"
   val mouse                  = "1.3.2"
   val mUnit                  = "1.2.0"


### PR DESCRIPTION
Twilights have no target info, only coordinates but no SED or brightnesses thus itc calls will fail

This PR makes requesting itc optional and in particular disabled for twilights