### PR TITLE
Make proposal itself readonly for NotAccepted proposals

### DIFF
--- a/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
+++ b/explore/src/main/scala/explore/proposal/ProposalTabContents.scala
@@ -52,8 +52,7 @@ case class ProposalTabContents(
   hasUndefinedObservations: Boolean
 ) extends ReactFnProps(ProposalTabContents.component):
   val proposalStatus: ProposalStatus = programDetails.get.proposalStatus
-  val proposalIsReadonly: Boolean    =
-    proposalStatus === ProposalStatus.Submitted || proposalStatus === ProposalStatus.Accepted
+  val proposalIsReadonly: Boolean    = proposalStatus =!= ProposalStatus.NotSubmitted
   val users: View[List[ProgramUser]] =
     programDetails.zoom(ProgramDetails.allUsers)
 


### PR DESCRIPTION
I somehow missed the proposal itself in the previous PR for this story. 🤦 

Really, only un-submitted proposals are editable.